### PR TITLE
Added support for dirty-checking collections

### DIFF
--- a/src/EncompassRest.EntityGenerator/EntityGenerator.cs
+++ b/src/EncompassRest.EntityGenerator/EntityGenerator.cs
@@ -96,7 +96,7 @@ namespace {@namespace}
                     propertyType = $"DirtyList<{propertyType}>";
                 }
                 var fieldName = $"_{char.ToLower(propertyName[0])}{propertyName.Substring(1)}";
-                sb.AppendLine($"        private {(isEntity || isCollection ? propertyType : $"Value<{propertyType}>")} {fieldName};");
+                sb.AppendLine($"        private {(isEntity || isCollection ? propertyType : $"DirtyValue<{propertyType}>")} {fieldName};");
                 properties.Add((propertyName, fieldName, isEntity, isCollection));
 
                 sb.AppendLine($"        public {(isCollection ? $"IList<{itemType}>" : propertyType)} {propertyName} {{ get {{ {(isEntity || isCollection ? $"var v = {fieldName}; return v ?? Interlocked.CompareExchange(ref {fieldName}, (v = new {propertyType}()), null) ?? v" : $"return {fieldName}")}; }} set {{ {fieldName} = {(isCollection ? $"new {propertyType}(value)" : "value")}; }} }}");

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -41,10 +41,7 @@ namespace EncompassRest.Tests
         {
             var loan = new Loan();
             var customField = new CustomField { FieldName = "CUST91FV", StringValue = "Initial Value" };
-            loan.CustomFields = new List<CustomField>
-            {
-                customField
-            };
+            loan.CustomFields.Add(customField);
             Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""Initial Value""}]}", loan.ToJson());
             loan.Dirty = false;
             Assert.AreEqual("{}", loan.ToJson());

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using EncompassRest.Loans;
 using EncompassRest.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -33,6 +34,22 @@ namespace EncompassRest.Tests
                 Tltv = null
             };
             Assert.AreEqual(@"{""tltv"":null}", loan.ToJson());
+        }
+
+        [TestMethod]
+        public void Loan_CustomFields_Serialization()
+        {
+            var loan = new Loan();
+            var customField = new CustomField { FieldName = "CUST91FV", StringValue = "Initial Value" };
+            loan.CustomFields = new List<CustomField>
+            {
+                customField
+            };
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""Initial Value""}]}", loan.ToJson());
+            loan.Dirty = false;
+            Assert.AreEqual("{}", loan.ToJson());
+            customField.StringValue = "New Value";
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""New Value""}]}", loan.ToJson());
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using EncompassRest.Loans;
 using EncompassRest.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -42,7 +42,8 @@ namespace EncompassRest.Tests
             var loan = new Loan();
             var customField = new CustomField { FieldName = "CUST91FV", StringValue = "Initial Value" };
             loan.CustomFields.Add(customField);
-            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""Initial Value""}]}", loan.ToJson());
+            loan.CustomFields.Add(new CustomField { FieldName = "CUST92FV", NumericValue = 10.0M });
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""Initial Value""},{""fieldName"":""CUST92FV"",""numericValue"":10.0}]}", loan.ToJson());
             loan.Dirty = false;
             Assert.AreEqual("{}", loan.ToJson());
             customField.StringValue = "New Value";

--- a/src/EncompassRest/DirtyList.cs
+++ b/src/EncompassRest/DirtyList.cs
@@ -134,6 +134,6 @@ namespace EncompassRest
             throw new NotSupportedException();
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => serializer.Serialize(writer, ((DirtyList<T>)value)._list.Where(item => item.Dirty));
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => serializer.Serialize(writer, ((DirtyList<T>)value)._list.Where(item => item.Dirty).Select(item => (T)item));
     }
 }

--- a/src/EncompassRest/DirtyList.cs
+++ b/src/EncompassRest/DirtyList.cs
@@ -1,16 +1,20 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using EncompassRest.Utilities;
 using Newtonsoft.Json;
 
 namespace EncompassRest
 {
+    /// <summary>
+    /// Collection to use for dirty checking.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     [JsonConverter(typeof(DirtyListConverter<>))]
     internal sealed class DirtyList<T> : IList<T>, IDirty
     {
-        internal readonly List<Value<T>> _list;
-        private bool _dirty;
+        internal readonly List<DirtyValue<T>> _list;
 
         public T this[int index]
         {
@@ -20,7 +24,6 @@ namespace EncompassRest
             }
             set
             {
-                _dirty = true;
                 _list[index] = value;
             }
         }
@@ -29,23 +32,10 @@ namespace EncompassRest
         {
             get
             {
-                var dirty = _dirty;
-                if (!dirty)
-                {
-                    foreach (var item in _list)
-                    {
-                        if (item.Dirty)
-                        {
-                            dirty = true;
-                            break;
-                        }
-                    }
-                }
-                return dirty;
+                return _list.Any(item => item.Dirty);
             }
             set
             {
-                _dirty = value;
                 for (var i = 0; i < _list.Count; ++i)
                 {
                     var item = _list[i];
@@ -61,7 +51,7 @@ namespace EncompassRest
 
         public DirtyList()
         {
-            _list = new List<Value<T>>();
+            _list = new List<DirtyValue<T>>();
         }
 
         public DirtyList(IEnumerable<T> list)
@@ -73,17 +63,9 @@ namespace EncompassRest
             }
         }
 
-        public void Add(T item)
-        {
-            _dirty = true;
-            _list.Add(item);
-        }
+        public void Add(T item) => _list.Add(item);
 
-        public void Clear()
-        {
-            _dirty = true;
-            _list.Clear();
-        }
+        public void Clear() => _list.Clear();
 
         public bool Contains(T item) => IndexOf(item) >= 0;
 
@@ -122,7 +104,6 @@ namespace EncompassRest
 
         public void Insert(int index, T item)
         {
-            _dirty = true;
             _list.Insert(index, item);
         }
 
@@ -137,11 +118,7 @@ namespace EncompassRest
             return false;
         }
 
-        public void RemoveAt(int index)
-        {
-            _dirty = true;
-            _list.RemoveAt(index);
-        }
+        public void RemoveAt(int index) => _list.RemoveAt(index);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/EncompassRest/DirtyList.cs
+++ b/src/EncompassRest/DirtyList.cs
@@ -134,18 +134,6 @@ namespace EncompassRest
             throw new NotSupportedException();
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var dirtyList = (DirtyList<T>)value;
-            var listToSerialize = new List<T>();
-            foreach (var item in dirtyList._list)
-            {
-                if (item.Dirty)
-                {
-                    listToSerialize.Add(item);
-                }
-            }
-            serializer.Serialize(writer, listToSerialize);
-        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => serializer.Serialize(writer, ((DirtyList<T>)value)._list.Where(item => item.Dirty));
     }
 }

--- a/src/EncompassRest/DirtyList.cs
+++ b/src/EncompassRest/DirtyList.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using EncompassRest.Utilities;
+using Newtonsoft.Json;
+
+namespace EncompassRest
+{
+    [JsonConverter(typeof(DirtyListConverter<>))]
+    internal sealed class DirtyList<T> : IList<T>, IDirty
+    {
+        internal readonly List<Value<T>> _list;
+        private bool _dirty;
+
+        public T this[int index]
+        {
+            get
+            {
+                return _list[index];
+            }
+            set
+            {
+                _dirty = true;
+                _list[index] = value;
+            }
+        }
+
+        public bool Dirty
+        {
+            get
+            {
+                var dirty = _dirty;
+                if (!dirty)
+                {
+                    foreach (var item in _list)
+                    {
+                        if (item.Dirty)
+                        {
+                            dirty = true;
+                            break;
+                        }
+                    }
+                }
+                return dirty;
+            }
+            set
+            {
+                _dirty = value;
+                for (var i = 0; i < _list.Count; ++i)
+                {
+                    var item = _list[i];
+                    item.Dirty = value;
+                    _list[i] = item;
+                }
+            }
+        }
+
+        public int Count => _list.Count;
+
+        public bool IsReadOnly => false;
+
+        public DirtyList()
+        {
+            _list = new List<Value<T>>();
+        }
+
+        public DirtyList(IEnumerable<T> list)
+            : this()
+        {
+            foreach (var item in list)
+            {
+                Add(item);
+            }
+        }
+
+        public void Add(T item)
+        {
+            _dirty = true;
+            _list.Add(item);
+        }
+
+        public void Clear()
+        {
+            _dirty = true;
+            _list.Clear();
+        }
+
+        public bool Contains(T item) => IndexOf(item) >= 0;
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            Preconditions.NotNull(array, nameof(array));
+            Preconditions.LessThan(arrayIndex, nameof(arrayIndex), array.Length);
+            Preconditions.GreaterThanOrEquals(array.Length - arrayIndex, $"{nameof(array)}.Length - {nameof(arrayIndex)}", Count, nameof(Count));
+            
+            for (var i = 0; i < _list.Count; ++i)
+            {
+                array[arrayIndex + i] = _list[i];
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            foreach (var item in _list)
+            {
+                yield return item;
+            }
+        }
+
+        public int IndexOf(T item)
+        {
+            var equalityComparer = EqualityComparer<T>.Default;
+            for (var i = 0; i < _list.Count; ++i)
+            {
+                if (equalityComparer.Equals(_list[i], item))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        public void Insert(int index, T item)
+        {
+            _dirty = true;
+            _list.Insert(index, item);
+        }
+
+        public bool Remove(T item)
+        {
+            var i = IndexOf(item);
+            if (i >= 0)
+            {
+                RemoveAt(i);
+                return true;
+            }
+            return false;
+        }
+
+        public void RemoveAt(int index)
+        {
+            _dirty = true;
+            _list.RemoveAt(index);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal sealed class DirtyListConverter<T> : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => objectType == TypeData<DirtyList<T>>.Type;
+
+        public override bool CanRead => false;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var dirtyList = (DirtyList<T>)value;
+            var listToSerialize = new List<T>();
+            foreach (var item in dirtyList._list)
+            {
+                if (item.Dirty)
+                {
+                    listToSerialize.Add(item);
+                }
+            }
+            serializer.Serialize(writer, listToSerialize);
+        }
+    }
+}

--- a/src/EncompassRest/DirtyList.cs
+++ b/src/EncompassRest/DirtyList.cs
@@ -72,7 +72,7 @@ namespace EncompassRest
         public void CopyTo(T[] array, int arrayIndex)
         {
             Preconditions.NotNull(array, nameof(array));
-            Preconditions.LessThan(arrayIndex, nameof(arrayIndex), array.Length);
+            Preconditions.LessThan(arrayIndex, nameof(arrayIndex), array.Length, $"{nameof(array)}.Length");
             Preconditions.GreaterThanOrEquals(array.Length - arrayIndex, $"{nameof(array)}.Length - {nameof(arrayIndex)}", Count, nameof(Count));
             
             for (var i = 0; i < _list.Count; ++i)

--- a/src/EncompassRest/DirtyValue.cs
+++ b/src/EncompassRest/DirtyValue.cs
@@ -7,11 +7,11 @@ namespace EncompassRest
     /// Value wrapper to use for dirty checking.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal struct Value<T> : IDirty
+    internal struct DirtyValue<T> : IDirty
     {
-        public static implicit operator T(Value<T> value) => value._value;
+        public static implicit operator T(DirtyValue<T> value) => value._value;
 
-        public static implicit operator Value<T>(T value) => new Value<T>(value);
+        public static implicit operator DirtyValue<T>(T value) => new DirtyValue<T>(value);
 
         private static readonly bool s_tImplementsIDirty = TypeData<T>.Data.TypeInfo.ImplementedInterfaces.Any(implInterface => implInterface == TypeData<IDirty>.Type);
 
@@ -37,7 +37,7 @@ namespace EncompassRest
             }
         }
 
-        public Value(T value)
+        public DirtyValue(T value)
         {
             _value = value;
             _dirty = true;

--- a/src/EncompassRest/EncompassRest.csproj
+++ b/src/EncompassRest/EncompassRest.csproj
@@ -31,6 +31,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/EncompassRest/Loans/ATRQMBorrower.cs
+++ b/src/EncompassRest/Loans/ATRQMBorrower.cs
@@ -8,467 +8,467 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ATRQMBorrower : IDirty
     {
-        private Value<int?> _aTRQMBorrowerIndex;
+        private DirtyValue<int?> _aTRQMBorrowerIndex;
         public int? ATRQMBorrowerIndex { get { return _aTRQMBorrowerIndex; } set { _aTRQMBorrowerIndex = value; } }
-        private Value<string> _aUSRecommendation;
+        private DirtyValue<string> _aUSRecommendation;
         public string AUSRecommendation { get { return _aUSRecommendation; } set { _aUSRecommendation = value; } }
-        private Value<string> _aUSVersion;
+        private DirtyValue<string> _aUSVersion;
         public string AUSVersion { get { return _aUSVersion; } set { _aUSVersion = value; } }
-        private Value<decimal?> _borBonusAverageOvertime;
+        private DirtyValue<decimal?> _borBonusAverageOvertime;
         public decimal? BorBonusAverageOvertime { get { return _borBonusAverageOvertime; } set { _borBonusAverageOvertime = value; } }
-        private Value<decimal?> _borBonusMostRecentAmount;
+        private DirtyValue<decimal?> _borBonusMostRecentAmount;
         public decimal? BorBonusMostRecentAmount { get { return _borBonusMostRecentAmount; } set { _borBonusMostRecentAmount = value; } }
-        private Value<int?> _borBonusMostRecentMonths;
+        private DirtyValue<int?> _borBonusMostRecentMonths;
         public int? BorBonusMostRecentMonths { get { return _borBonusMostRecentMonths; } set { _borBonusMostRecentMonths = value; } }
-        private Value<int?> _borBonusMostRecentYear;
+        private DirtyValue<int?> _borBonusMostRecentYear;
         public int? BorBonusMostRecentYear { get { return _borBonusMostRecentYear; } set { _borBonusMostRecentYear = value; } }
-        private Value<decimal?> _borBonusPreviousAmount1;
+        private DirtyValue<decimal?> _borBonusPreviousAmount1;
         public decimal? BorBonusPreviousAmount1 { get { return _borBonusPreviousAmount1; } set { _borBonusPreviousAmount1 = value; } }
-        private Value<decimal?> _borBonusPreviousAmount2;
+        private DirtyValue<decimal?> _borBonusPreviousAmount2;
         public decimal? BorBonusPreviousAmount2 { get { return _borBonusPreviousAmount2; } set { _borBonusPreviousAmount2 = value; } }
-        private Value<int?> _borBonusPreviousMonths1;
+        private DirtyValue<int?> _borBonusPreviousMonths1;
         public int? BorBonusPreviousMonths1 { get { return _borBonusPreviousMonths1; } set { _borBonusPreviousMonths1 = value; } }
-        private Value<int?> _borBonusPreviousMonths2;
+        private DirtyValue<int?> _borBonusPreviousMonths2;
         public int? BorBonusPreviousMonths2 { get { return _borBonusPreviousMonths2; } set { _borBonusPreviousMonths2 = value; } }
-        private Value<int?> _borBonusPreviousYear1;
+        private DirtyValue<int?> _borBonusPreviousYear1;
         public int? BorBonusPreviousYear1 { get { return _borBonusPreviousYear1; } set { _borBonusPreviousYear1 = value; } }
-        private Value<int?> _borBonusPreviousYear2;
+        private DirtyValue<int?> _borBonusPreviousYear2;
         public int? BorBonusPreviousYear2 { get { return _borBonusPreviousYear2; } set { _borBonusPreviousYear2 = value; } }
-        private Value<decimal?> _borCommissionAverageOvertime;
+        private DirtyValue<decimal?> _borCommissionAverageOvertime;
         public decimal? BorCommissionAverageOvertime { get { return _borCommissionAverageOvertime; } set { _borCommissionAverageOvertime = value; } }
-        private Value<decimal?> _borCommissionMostRecentAmount;
+        private DirtyValue<decimal?> _borCommissionMostRecentAmount;
         public decimal? BorCommissionMostRecentAmount { get { return _borCommissionMostRecentAmount; } set { _borCommissionMostRecentAmount = value; } }
-        private Value<int?> _borCommissionMostRecentMonths;
+        private DirtyValue<int?> _borCommissionMostRecentMonths;
         public int? BorCommissionMostRecentMonths { get { return _borCommissionMostRecentMonths; } set { _borCommissionMostRecentMonths = value; } }
-        private Value<int?> _borCommissionMostRecentYear;
+        private DirtyValue<int?> _borCommissionMostRecentYear;
         public int? BorCommissionMostRecentYear { get { return _borCommissionMostRecentYear; } set { _borCommissionMostRecentYear = value; } }
-        private Value<decimal?> _borCommissionPreviousAmount1;
+        private DirtyValue<decimal?> _borCommissionPreviousAmount1;
         public decimal? BorCommissionPreviousAmount1 { get { return _borCommissionPreviousAmount1; } set { _borCommissionPreviousAmount1 = value; } }
-        private Value<decimal?> _borCommissionPreviousAmount2;
+        private DirtyValue<decimal?> _borCommissionPreviousAmount2;
         public decimal? BorCommissionPreviousAmount2 { get { return _borCommissionPreviousAmount2; } set { _borCommissionPreviousAmount2 = value; } }
-        private Value<int?> _borCommissionPreviousMonths1;
+        private DirtyValue<int?> _borCommissionPreviousMonths1;
         public int? BorCommissionPreviousMonths1 { get { return _borCommissionPreviousMonths1; } set { _borCommissionPreviousMonths1 = value; } }
-        private Value<int?> _borCommissionPreviousMonths2;
+        private DirtyValue<int?> _borCommissionPreviousMonths2;
         public int? BorCommissionPreviousMonths2 { get { return _borCommissionPreviousMonths2; } set { _borCommissionPreviousMonths2 = value; } }
-        private Value<int?> _borCommissionPreviousYear1;
+        private DirtyValue<int?> _borCommissionPreviousYear1;
         public int? BorCommissionPreviousYear1 { get { return _borCommissionPreviousYear1; } set { _borCommissionPreviousYear1 = value; } }
-        private Value<int?> _borCommissionPreviousYear2;
+        private DirtyValue<int?> _borCommissionPreviousYear2;
         public int? BorCommissionPreviousYear2 { get { return _borCommissionPreviousYear2; } set { _borCommissionPreviousYear2 = value; } }
-        private Value<decimal?> _borContingentLiabilitiesLiabilityAmount1;
+        private DirtyValue<decimal?> _borContingentLiabilitiesLiabilityAmount1;
         public decimal? BorContingentLiabilitiesLiabilityAmount1 { get { return _borContingentLiabilitiesLiabilityAmount1; } set { _borContingentLiabilitiesLiabilityAmount1 = value; } }
-        private Value<decimal?> _borContingentLiabilitiesLiabilityAmount2;
+        private DirtyValue<decimal?> _borContingentLiabilitiesLiabilityAmount2;
         public decimal? BorContingentLiabilitiesLiabilityAmount2 { get { return _borContingentLiabilitiesLiabilityAmount2; } set { _borContingentLiabilitiesLiabilityAmount2 = value; } }
-        private Value<decimal?> _borContingentLiabilitiesLiabilityAmount3;
+        private DirtyValue<decimal?> _borContingentLiabilitiesLiabilityAmount3;
         public decimal? BorContingentLiabilitiesLiabilityAmount3 { get { return _borContingentLiabilitiesLiabilityAmount3; } set { _borContingentLiabilitiesLiabilityAmount3 = value; } }
-        private Value<string> _borContingentLiabilitiesLiabilityDescription1;
+        private DirtyValue<string> _borContingentLiabilitiesLiabilityDescription1;
         public string BorContingentLiabilitiesLiabilityDescription1 { get { return _borContingentLiabilitiesLiabilityDescription1; } set { _borContingentLiabilitiesLiabilityDescription1 = value; } }
-        private Value<string> _borContingentLiabilitiesLiabilityDescription2;
+        private DirtyValue<string> _borContingentLiabilitiesLiabilityDescription2;
         public string BorContingentLiabilitiesLiabilityDescription2 { get { return _borContingentLiabilitiesLiabilityDescription2; } set { _borContingentLiabilitiesLiabilityDescription2 = value; } }
-        private Value<string> _borContingentLiabilitiesLiabilityDescription3;
+        private DirtyValue<string> _borContingentLiabilitiesLiabilityDescription3;
         public string BorContingentLiabilitiesLiabilityDescription3 { get { return _borContingentLiabilitiesLiabilityDescription3; } set { _borContingentLiabilitiesLiabilityDescription3 = value; } }
-        private Value<decimal?> _borContingentLiabilitiesTotalLiabilityAmount;
+        private DirtyValue<decimal?> _borContingentLiabilitiesTotalLiabilityAmount;
         public decimal? BorContingentLiabilitiesTotalLiabilityAmount { get { return _borContingentLiabilitiesTotalLiabilityAmount; } set { _borContingentLiabilitiesTotalLiabilityAmount = value; } }
-        private Value<decimal?> _borCosignedObligationsCarLoanPayment;
+        private DirtyValue<decimal?> _borCosignedObligationsCarLoanPayment;
         public decimal? BorCosignedObligationsCarLoanPayment { get { return _borCosignedObligationsCarLoanPayment; } set { _borCosignedObligationsCarLoanPayment = value; } }
-        private Value<decimal?> _borCosignedObligationsMortgagePayment;
+        private DirtyValue<decimal?> _borCosignedObligationsMortgagePayment;
         public decimal? BorCosignedObligationsMortgagePayment { get { return _borCosignedObligationsMortgagePayment; } set { _borCosignedObligationsMortgagePayment = value; } }
-        private Value<decimal?> _borCosignedObligationsOtherPayment;
+        private DirtyValue<decimal?> _borCosignedObligationsOtherPayment;
         public decimal? BorCosignedObligationsOtherPayment { get { return _borCosignedObligationsOtherPayment; } set { _borCosignedObligationsOtherPayment = value; } }
-        private Value<string> _borCosignedObligationsOtherPaymentDescription;
+        private DirtyValue<string> _borCosignedObligationsOtherPaymentDescription;
         public string BorCosignedObligationsOtherPaymentDescription { get { return _borCosignedObligationsOtherPaymentDescription; } set { _borCosignedObligationsOtherPaymentDescription = value; } }
-        private Value<decimal?> _borCosignedObligationsStudentLoanPayment;
+        private DirtyValue<decimal?> _borCosignedObligationsStudentLoanPayment;
         public decimal? BorCosignedObligationsStudentLoanPayment { get { return _borCosignedObligationsStudentLoanPayment; } set { _borCosignedObligationsStudentLoanPayment = value; } }
-        private Value<decimal?> _borCosignedObligationsTotalCoMortgagorLiabilities;
+        private DirtyValue<decimal?> _borCosignedObligationsTotalCoMortgagorLiabilities;
         public decimal? BorCosignedObligationsTotalCoMortgagorLiabilities { get { return _borCosignedObligationsTotalCoMortgagorLiabilities; } set { _borCosignedObligationsTotalCoMortgagorLiabilities = value; } }
-        private Value<decimal?> _borDividendAverageDividend;
+        private DirtyValue<decimal?> _borDividendAverageDividend;
         public decimal? BorDividendAverageDividend { get { return _borDividendAverageDividend; } set { _borDividendAverageDividend = value; } }
-        private Value<decimal?> _borDividendPreviousAmount1;
+        private DirtyValue<decimal?> _borDividendPreviousAmount1;
         public decimal? BorDividendPreviousAmount1 { get { return _borDividendPreviousAmount1; } set { _borDividendPreviousAmount1 = value; } }
-        private Value<decimal?> _borDividendPreviousAmount2;
+        private DirtyValue<decimal?> _borDividendPreviousAmount2;
         public decimal? BorDividendPreviousAmount2 { get { return _borDividendPreviousAmount2; } set { _borDividendPreviousAmount2 = value; } }
-        private Value<int?> _borDividendPreviousMonths1;
+        private DirtyValue<int?> _borDividendPreviousMonths1;
         public int? BorDividendPreviousMonths1 { get { return _borDividendPreviousMonths1; } set { _borDividendPreviousMonths1 = value; } }
-        private Value<int?> _borDividendPreviousMonths2;
+        private DirtyValue<int?> _borDividendPreviousMonths2;
         public int? BorDividendPreviousMonths2 { get { return _borDividendPreviousMonths2; } set { _borDividendPreviousMonths2 = value; } }
-        private Value<int?> _borDividendPreviousYear1;
+        private DirtyValue<int?> _borDividendPreviousYear1;
         public int? BorDividendPreviousYear1 { get { return _borDividendPreviousYear1; } set { _borDividendPreviousYear1 = value; } }
-        private Value<int?> _borDividendPreviousYear2;
+        private DirtyValue<int?> _borDividendPreviousYear2;
         public int? BorDividendPreviousYear2 { get { return _borDividendPreviousYear2; } set { _borDividendPreviousYear2 = value; } }
-        private Value<decimal?> _borDividendRequiredForCashAmount;
+        private DirtyValue<decimal?> _borDividendRequiredForCashAmount;
         public decimal? BorDividendRequiredForCashAmount { get { return _borDividendRequiredForCashAmount; } set { _borDividendRequiredForCashAmount = value; } }
-        private Value<decimal?> _borInterestAverageDividend;
+        private DirtyValue<decimal?> _borInterestAverageDividend;
         public decimal? BorInterestAverageDividend { get { return _borInterestAverageDividend; } set { _borInterestAverageDividend = value; } }
-        private Value<decimal?> _borInterestPreviousAmount1;
+        private DirtyValue<decimal?> _borInterestPreviousAmount1;
         public decimal? BorInterestPreviousAmount1 { get { return _borInterestPreviousAmount1; } set { _borInterestPreviousAmount1 = value; } }
-        private Value<decimal?> _borInterestPreviousAmount2;
+        private DirtyValue<decimal?> _borInterestPreviousAmount2;
         public decimal? BorInterestPreviousAmount2 { get { return _borInterestPreviousAmount2; } set { _borInterestPreviousAmount2 = value; } }
-        private Value<int?> _borInterestPreviousMonths1;
+        private DirtyValue<int?> _borInterestPreviousMonths1;
         public int? BorInterestPreviousMonths1 { get { return _borInterestPreviousMonths1; } set { _borInterestPreviousMonths1 = value; } }
-        private Value<int?> _borInterestPreviousMonths2;
+        private DirtyValue<int?> _borInterestPreviousMonths2;
         public int? BorInterestPreviousMonths2 { get { return _borInterestPreviousMonths2; } set { _borInterestPreviousMonths2 = value; } }
-        private Value<int?> _borInterestPreviousYear1;
+        private DirtyValue<int?> _borInterestPreviousYear1;
         public int? BorInterestPreviousYear1 { get { return _borInterestPreviousYear1; } set { _borInterestPreviousYear1 = value; } }
-        private Value<int?> _borInterestPreviousYear2;
+        private DirtyValue<int?> _borInterestPreviousYear2;
         public int? BorInterestPreviousYear2 { get { return _borInterestPreviousYear2; } set { _borInterestPreviousYear2 = value; } }
-        private Value<decimal?> _borInterestRequiredForCashAmount;
+        private DirtyValue<decimal?> _borInterestRequiredForCashAmount;
         public decimal? BorInterestRequiredForCashAmount { get { return _borInterestRequiredForCashAmount; } set { _borInterestRequiredForCashAmount = value; } }
-        private Value<decimal?> _borMilitaryAllowanceClothingAllowance;
+        private DirtyValue<decimal?> _borMilitaryAllowanceClothingAllowance;
         public decimal? BorMilitaryAllowanceClothingAllowance { get { return _borMilitaryAllowanceClothingAllowance; } set { _borMilitaryAllowanceClothingAllowance = value; } }
-        private Value<decimal?> _borMilitaryAllowanceOtherAllowance;
+        private DirtyValue<decimal?> _borMilitaryAllowanceOtherAllowance;
         public decimal? BorMilitaryAllowanceOtherAllowance { get { return _borMilitaryAllowanceOtherAllowance; } set { _borMilitaryAllowanceOtherAllowance = value; } }
-        private Value<string> _borMilitaryAllowanceOtherAllowanceDescription;
+        private DirtyValue<string> _borMilitaryAllowanceOtherAllowanceDescription;
         public string BorMilitaryAllowanceOtherAllowanceDescription { get { return _borMilitaryAllowanceOtherAllowanceDescription; } set { _borMilitaryAllowanceOtherAllowanceDescription = value; } }
-        private Value<decimal?> _borMilitaryAllowanceQuartersAllowance;
+        private DirtyValue<decimal?> _borMilitaryAllowanceQuartersAllowance;
         public decimal? BorMilitaryAllowanceQuartersAllowance { get { return _borMilitaryAllowanceQuartersAllowance; } set { _borMilitaryAllowanceQuartersAllowance = value; } }
-        private Value<decimal?> _borMilitaryAllowanceRationsAllowance;
+        private DirtyValue<decimal?> _borMilitaryAllowanceRationsAllowance;
         public decimal? BorMilitaryAllowanceRationsAllowance { get { return _borMilitaryAllowanceRationsAllowance; } set { _borMilitaryAllowanceRationsAllowance = value; } }
-        private Value<decimal?> _borMilitaryAllowanceTotalAllowance;
+        private DirtyValue<decimal?> _borMilitaryAllowanceTotalAllowance;
         public decimal? BorMilitaryAllowanceTotalAllowance { get { return _borMilitaryAllowanceTotalAllowance; } set { _borMilitaryAllowanceTotalAllowance = value; } }
-        private Value<decimal?> _borMilitaryAllowanceVariableHousingAllowance;
+        private DirtyValue<decimal?> _borMilitaryAllowanceVariableHousingAllowance;
         public decimal? BorMilitaryAllowanceVariableHousingAllowance { get { return _borMilitaryAllowanceVariableHousingAllowance; } set { _borMilitaryAllowanceVariableHousingAllowance = value; } }
-        private Value<decimal?> _borMilitaryBasePay;
+        private DirtyValue<decimal?> _borMilitaryBasePay;
         public decimal? BorMilitaryBasePay { get { return _borMilitaryBasePay; } set { _borMilitaryBasePay = value; } }
-        private Value<decimal?> _borMilitaryCombatPay;
+        private DirtyValue<decimal?> _borMilitaryCombatPay;
         public decimal? BorMilitaryCombatPay { get { return _borMilitaryCombatPay; } set { _borMilitaryCombatPay = value; } }
-        private Value<decimal?> _borMilitaryFlightPay;
+        private DirtyValue<decimal?> _borMilitaryFlightPay;
         public decimal? BorMilitaryFlightPay { get { return _borMilitaryFlightPay; } set { _borMilitaryFlightPay = value; } }
-        private Value<decimal?> _borMilitaryHazardPay;
+        private DirtyValue<decimal?> _borMilitaryHazardPay;
         public decimal? BorMilitaryHazardPay { get { return _borMilitaryHazardPay; } set { _borMilitaryHazardPay = value; } }
-        private Value<decimal?> _borMilitaryOverseasPay;
+        private DirtyValue<decimal?> _borMilitaryOverseasPay;
         public decimal? BorMilitaryOverseasPay { get { return _borMilitaryOverseasPay; } set { _borMilitaryOverseasPay = value; } }
-        private Value<decimal?> _borMilitaryPropPay;
+        private DirtyValue<decimal?> _borMilitaryPropPay;
         public decimal? BorMilitaryPropPay { get { return _borMilitaryPropPay; } set { _borMilitaryPropPay = value; } }
-        private Value<decimal?> _borMilitaryTotalPay;
+        private DirtyValue<decimal?> _borMilitaryTotalPay;
         public decimal? BorMilitaryTotalPay { get { return _borMilitaryTotalPay; } set { _borMilitaryTotalPay = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeBaseIncome;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeBaseIncome;
         public decimal? BorMonthlyEmplymentIncomeBaseIncome { get { return _borMonthlyEmplymentIncomeBaseIncome; } set { _borMonthlyEmplymentIncomeBaseIncome = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeBonuseIncome;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeBonuseIncome;
         public decimal? BorMonthlyEmplymentIncomeBonuseIncome { get { return _borMonthlyEmplymentIncomeBonuseIncome; } set { _borMonthlyEmplymentIncomeBonuseIncome = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeCommissionIncome;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeCommissionIncome;
         public decimal? BorMonthlyEmplymentIncomeCommissionIncome { get { return _borMonthlyEmplymentIncomeCommissionIncome; } set { _borMonthlyEmplymentIncomeCommissionIncome = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeDividendInterestIncome;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeDividendInterestIncome;
         public decimal? BorMonthlyEmplymentIncomeDividendInterestIncome { get { return _borMonthlyEmplymentIncomeDividendInterestIncome; } set { _borMonthlyEmplymentIncomeDividendInterestIncome = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeOtherIncome1;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeOtherIncome1;
         public decimal? BorMonthlyEmplymentIncomeOtherIncome1 { get { return _borMonthlyEmplymentIncomeOtherIncome1; } set { _borMonthlyEmplymentIncomeOtherIncome1 = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeOtherIncome2;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeOtherIncome2;
         public decimal? BorMonthlyEmplymentIncomeOtherIncome2 { get { return _borMonthlyEmplymentIncomeOtherIncome2; } set { _borMonthlyEmplymentIncomeOtherIncome2 = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeOvertimeIncome;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeOvertimeIncome;
         public decimal? BorMonthlyEmplymentIncomeOvertimeIncome { get { return _borMonthlyEmplymentIncomeOvertimeIncome; } set { _borMonthlyEmplymentIncomeOvertimeIncome = value; } }
-        private Value<decimal?> _borMonthlyEmplymentIncomeTotalEmploymentIncome;
+        private DirtyValue<decimal?> _borMonthlyEmplymentIncomeTotalEmploymentIncome;
         public decimal? BorMonthlyEmplymentIncomeTotalEmploymentIncome { get { return _borMonthlyEmplymentIncomeTotalEmploymentIncome; } set { _borMonthlyEmplymentIncomeTotalEmploymentIncome = value; } }
-        private Value<decimal?> _borNonEmploymentIncomeGovtAssitProgramIncome;
+        private DirtyValue<decimal?> _borNonEmploymentIncomeGovtAssitProgramIncome;
         public decimal? BorNonEmploymentIncomeGovtAssitProgramIncome { get { return _borNonEmploymentIncomeGovtAssitProgramIncome; } set { _borNonEmploymentIncomeGovtAssitProgramIncome = value; } }
-        private Value<decimal?> _borNonEmploymentIncomeHomeownSubsidyIncome;
+        private DirtyValue<decimal?> _borNonEmploymentIncomeHomeownSubsidyIncome;
         public decimal? BorNonEmploymentIncomeHomeownSubsidyIncome { get { return _borNonEmploymentIncomeHomeownSubsidyIncome; } set { _borNonEmploymentIncomeHomeownSubsidyIncome = value; } }
-        private Value<bool?> _borNonEmploymentIncomeIsOffsetHomeownSubsidyIncome;
+        private DirtyValue<bool?> _borNonEmploymentIncomeIsOffsetHomeownSubsidyIncome;
         public bool? BorNonEmploymentIncomeIsOffsetHomeownSubsidyIncome { get { return _borNonEmploymentIncomeIsOffsetHomeownSubsidyIncome; } set { _borNonEmploymentIncomeIsOffsetHomeownSubsidyIncome = value; } }
-        private Value<bool?> _borNonEmploymentIncomeIsOffsetMtgCreditCertificateIncome;
+        private DirtyValue<bool?> _borNonEmploymentIncomeIsOffsetMtgCreditCertificateIncome;
         public bool? BorNonEmploymentIncomeIsOffsetMtgCreditCertificateIncome { get { return _borNonEmploymentIncomeIsOffsetMtgCreditCertificateIncome; } set { _borNonEmploymentIncomeIsOffsetMtgCreditCertificateIncome = value; } }
-        private Value<decimal?> _borNonEmploymentIncomeMilitaryIncome;
+        private DirtyValue<decimal?> _borNonEmploymentIncomeMilitaryIncome;
         public decimal? BorNonEmploymentIncomeMilitaryIncome { get { return _borNonEmploymentIncomeMilitaryIncome; } set { _borNonEmploymentIncomeMilitaryIncome = value; } }
-        private Value<decimal?> _borNonEmploymentIncomeMtgCreditCertificateIncome;
+        private DirtyValue<decimal?> _borNonEmploymentIncomeMtgCreditCertificateIncome;
         public decimal? BorNonEmploymentIncomeMtgCreditCertificateIncome { get { return _borNonEmploymentIncomeMtgCreditCertificateIncome; } set { _borNonEmploymentIncomeMtgCreditCertificateIncome = value; } }
-        private Value<decimal?> _borNonEmploymentIncomeTotalNonEmploymentIncome;
+        private DirtyValue<decimal?> _borNonEmploymentIncomeTotalNonEmploymentIncome;
         public decimal? BorNonEmploymentIncomeTotalNonEmploymentIncome { get { return _borNonEmploymentIncomeTotalNonEmploymentIncome; } set { _borNonEmploymentIncomeTotalNonEmploymentIncome = value; } }
-        private Value<decimal?> _borNonEmploymentIncomeVABenefitIncome;
+        private DirtyValue<decimal?> _borNonEmploymentIncomeVABenefitIncome;
         public decimal? BorNonEmploymentIncomeVABenefitIncome { get { return _borNonEmploymentIncomeVABenefitIncome; } set { _borNonEmploymentIncomeVABenefitIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomeChildSupportIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeChildSupportIncome;
         public decimal? BorNonTaxableIncomeChildSupportIncome { get { return _borNonTaxableIncomeChildSupportIncome; } set { _borNonTaxableIncomeChildSupportIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomeDisabilityIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeDisabilityIncome;
         public decimal? BorNonTaxableIncomeDisabilityIncome { get { return _borNonTaxableIncomeDisabilityIncome; } set { _borNonTaxableIncomeDisabilityIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomeFedGovtEmplRetirementIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeFedGovtEmplRetirementIncome;
         public decimal? BorNonTaxableIncomeFedGovtEmplRetirementIncome { get { return _borNonTaxableIncomeFedGovtEmplRetirementIncome; } set { _borNonTaxableIncomeFedGovtEmplRetirementIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomeMilitaryAllowances;
+        private DirtyValue<decimal?> _borNonTaxableIncomeMilitaryAllowances;
         public decimal? BorNonTaxableIncomeMilitaryAllowances { get { return _borNonTaxableIncomeMilitaryAllowances; } set { _borNonTaxableIncomeMilitaryAllowances = value; } }
-        private Value<decimal?> _borNonTaxableIncomeOtherIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeOtherIncome;
         public decimal? BorNonTaxableIncomeOtherIncome { get { return _borNonTaxableIncomeOtherIncome; } set { _borNonTaxableIncomeOtherIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomePublicAssistPayments;
+        private DirtyValue<decimal?> _borNonTaxableIncomePublicAssistPayments;
         public decimal? BorNonTaxableIncomePublicAssistPayments { get { return _borNonTaxableIncomePublicAssistPayments; } set { _borNonTaxableIncomePublicAssistPayments = value; } }
-        private Value<decimal?> _borNonTaxableIncomeRailroadRetirementBenefits;
+        private DirtyValue<decimal?> _borNonTaxableIncomeRailroadRetirementBenefits;
         public decimal? BorNonTaxableIncomeRailroadRetirementBenefits { get { return _borNonTaxableIncomeRailroadRetirementBenefits; } set { _borNonTaxableIncomeRailroadRetirementBenefits = value; } }
-        private Value<decimal?> _borNonTaxableIncomeSocialSecurityIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeSocialSecurityIncome;
         public decimal? BorNonTaxableIncomeSocialSecurityIncome { get { return _borNonTaxableIncomeSocialSecurityIncome; } set { _borNonTaxableIncomeSocialSecurityIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomeStateGovtEmplRetirementIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeStateGovtEmplRetirementIncome;
         public decimal? BorNonTaxableIncomeStateGovtEmplRetirementIncome { get { return _borNonTaxableIncomeStateGovtEmplRetirementIncome; } set { _borNonTaxableIncomeStateGovtEmplRetirementIncome = value; } }
-        private Value<decimal?> _borNonTaxableIncomeTotalNonTaxableIncome;
+        private DirtyValue<decimal?> _borNonTaxableIncomeTotalNonTaxableIncome;
         public decimal? BorNonTaxableIncomeTotalNonTaxableIncome { get { return _borNonTaxableIncomeTotalNonTaxableIncome; } set { _borNonTaxableIncomeTotalNonTaxableIncome = value; } }
-        private Value<decimal?> _borOtherNotesReceivableIncome;
+        private DirtyValue<decimal?> _borOtherNotesReceivableIncome;
         public decimal? BorOtherNotesReceivableIncome { get { return _borOtherNotesReceivableIncome; } set { _borOtherNotesReceivableIncome = value; } }
-        private Value<decimal?> _borOtherOtherIncome;
+        private DirtyValue<decimal?> _borOtherOtherIncome;
         public decimal? BorOtherOtherIncome { get { return _borOtherOtherIncome; } set { _borOtherOtherIncome = value; } }
-        private Value<decimal?> _borOtherParttimeIncome;
+        private DirtyValue<decimal?> _borOtherParttimeIncome;
         public decimal? BorOtherParttimeIncome { get { return _borOtherParttimeIncome; } set { _borOtherParttimeIncome = value; } }
-        private Value<decimal?> _borOtherRetirementIncome;
+        private DirtyValue<decimal?> _borOtherRetirementIncome;
         public decimal? BorOtherRetirementIncome { get { return _borOtherRetirementIncome; } set { _borOtherRetirementIncome = value; } }
-        private Value<decimal?> _borOtherSeasonalIncome;
+        private DirtyValue<decimal?> _borOtherSeasonalIncome;
         public decimal? BorOtherSeasonalIncome { get { return _borOtherSeasonalIncome; } set { _borOtherSeasonalIncome = value; } }
-        private Value<decimal?> _borOtherSocialSecurityIncome;
+        private DirtyValue<decimal?> _borOtherSocialSecurityIncome;
         public decimal? BorOtherSocialSecurityIncome { get { return _borOtherSocialSecurityIncome; } set { _borOtherSocialSecurityIncome = value; } }
-        private Value<decimal?> _borOtherTipIncome;
+        private DirtyValue<decimal?> _borOtherTipIncome;
         public decimal? BorOtherTipIncome { get { return _borOtherTipIncome; } set { _borOtherTipIncome = value; } }
-        private Value<decimal?> _borOtherTrustIncome;
+        private DirtyValue<decimal?> _borOtherTrustIncome;
         public decimal? BorOtherTrustIncome { get { return _borOtherTrustIncome; } set { _borOtherTrustIncome = value; } }
-        private Value<decimal?> _borOtherUnemploymentIncome;
+        private DirtyValue<decimal?> _borOtherUnemploymentIncome;
         public decimal? BorOtherUnemploymentIncome { get { return _borOtherUnemploymentIncome; } set { _borOtherUnemploymentIncome = value; } }
-        private Value<decimal?> _borOvertimeAverageOvertime;
+        private DirtyValue<decimal?> _borOvertimeAverageOvertime;
         public decimal? BorOvertimeAverageOvertime { get { return _borOvertimeAverageOvertime; } set { _borOvertimeAverageOvertime = value; } }
-        private Value<decimal?> _borOvertimeMostRecentAmount;
+        private DirtyValue<decimal?> _borOvertimeMostRecentAmount;
         public decimal? BorOvertimeMostRecentAmount { get { return _borOvertimeMostRecentAmount; } set { _borOvertimeMostRecentAmount = value; } }
-        private Value<int?> _borOvertimeMostRecentMonths;
+        private DirtyValue<int?> _borOvertimeMostRecentMonths;
         public int? BorOvertimeMostRecentMonths { get { return _borOvertimeMostRecentMonths; } set { _borOvertimeMostRecentMonths = value; } }
-        private Value<int?> _borOvertimeMostRecentYear;
+        private DirtyValue<int?> _borOvertimeMostRecentYear;
         public int? BorOvertimeMostRecentYear { get { return _borOvertimeMostRecentYear; } set { _borOvertimeMostRecentYear = value; } }
-        private Value<decimal?> _borOvertimePreviousAmount1;
+        private DirtyValue<decimal?> _borOvertimePreviousAmount1;
         public decimal? BorOvertimePreviousAmount1 { get { return _borOvertimePreviousAmount1; } set { _borOvertimePreviousAmount1 = value; } }
-        private Value<decimal?> _borOvertimePreviousAmount2;
+        private DirtyValue<decimal?> _borOvertimePreviousAmount2;
         public decimal? BorOvertimePreviousAmount2 { get { return _borOvertimePreviousAmount2; } set { _borOvertimePreviousAmount2 = value; } }
-        private Value<int?> _borOvertimePreviousMonths1;
+        private DirtyValue<int?> _borOvertimePreviousMonths1;
         public int? BorOvertimePreviousMonths1 { get { return _borOvertimePreviousMonths1; } set { _borOvertimePreviousMonths1 = value; } }
-        private Value<int?> _borOvertimePreviousMonths2;
+        private DirtyValue<int?> _borOvertimePreviousMonths2;
         public int? BorOvertimePreviousMonths2 { get { return _borOvertimePreviousMonths2; } set { _borOvertimePreviousMonths2 = value; } }
-        private Value<int?> _borOvertimePreviousYear1;
+        private DirtyValue<int?> _borOvertimePreviousYear1;
         public int? BorOvertimePreviousYear1 { get { return _borOvertimePreviousYear1; } set { _borOvertimePreviousYear1 = value; } }
-        private Value<int?> _borOvertimePreviousYear2;
+        private DirtyValue<int?> _borOvertimePreviousYear2;
         public int? BorOvertimePreviousYear2 { get { return _borOvertimePreviousYear2; } set { _borOvertimePreviousYear2 = value; } }
-        private Value<decimal?> _borProjectedIncomeProjectedBonuses;
+        private DirtyValue<decimal?> _borProjectedIncomeProjectedBonuses;
         public decimal? BorProjectedIncomeProjectedBonuses { get { return _borProjectedIncomeProjectedBonuses; } set { _borProjectedIncomeProjectedBonuses = value; } }
-        private Value<decimal?> _borProjectedIncomeProjectedCostLivingAdjustment;
+        private DirtyValue<decimal?> _borProjectedIncomeProjectedCostLivingAdjustment;
         public decimal? BorProjectedIncomeProjectedCostLivingAdjustment { get { return _borProjectedIncomeProjectedCostLivingAdjustment; } set { _borProjectedIncomeProjectedCostLivingAdjustment = value; } }
-        private Value<decimal?> _borProjectedIncomeProjectedNewJobIncome;
+        private DirtyValue<decimal?> _borProjectedIncomeProjectedNewJobIncome;
         public decimal? BorProjectedIncomeProjectedNewJobIncome { get { return _borProjectedIncomeProjectedNewJobIncome; } set { _borProjectedIncomeProjectedNewJobIncome = value; } }
-        private Value<decimal?> _borProjectedIncomeProjectedPerformanceRaises;
+        private DirtyValue<decimal?> _borProjectedIncomeProjectedPerformanceRaises;
         public decimal? BorProjectedIncomeProjectedPerformanceRaises { get { return _borProjectedIncomeProjectedPerformanceRaises; } set { _borProjectedIncomeProjectedPerformanceRaises = value; } }
-        private Value<decimal?> _borProjectedIncomeTotalProjectedIncome;
+        private DirtyValue<decimal?> _borProjectedIncomeTotalProjectedIncome;
         public decimal? BorProjectedIncomeTotalProjectedIncome { get { return _borProjectedIncomeTotalProjectedIncome; } set { _borProjectedIncomeTotalProjectedIncome = value; } }
-        private Value<decimal?> _cobBonusAverageOvertime;
+        private DirtyValue<decimal?> _cobBonusAverageOvertime;
         public decimal? CobBonusAverageOvertime { get { return _cobBonusAverageOvertime; } set { _cobBonusAverageOvertime = value; } }
-        private Value<decimal?> _cobBonusMostRecentAmount;
+        private DirtyValue<decimal?> _cobBonusMostRecentAmount;
         public decimal? CobBonusMostRecentAmount { get { return _cobBonusMostRecentAmount; } set { _cobBonusMostRecentAmount = value; } }
-        private Value<int?> _cobBonusMostRecentMonths;
+        private DirtyValue<int?> _cobBonusMostRecentMonths;
         public int? CobBonusMostRecentMonths { get { return _cobBonusMostRecentMonths; } set { _cobBonusMostRecentMonths = value; } }
-        private Value<int?> _cobBonusMostRecentYear;
+        private DirtyValue<int?> _cobBonusMostRecentYear;
         public int? CobBonusMostRecentYear { get { return _cobBonusMostRecentYear; } set { _cobBonusMostRecentYear = value; } }
-        private Value<decimal?> _cobBonusPreviousAmount1;
+        private DirtyValue<decimal?> _cobBonusPreviousAmount1;
         public decimal? CobBonusPreviousAmount1 { get { return _cobBonusPreviousAmount1; } set { _cobBonusPreviousAmount1 = value; } }
-        private Value<decimal?> _cobBonusPreviousAmount2;
+        private DirtyValue<decimal?> _cobBonusPreviousAmount2;
         public decimal? CobBonusPreviousAmount2 { get { return _cobBonusPreviousAmount2; } set { _cobBonusPreviousAmount2 = value; } }
-        private Value<int?> _cobBonusPreviousMonths1;
+        private DirtyValue<int?> _cobBonusPreviousMonths1;
         public int? CobBonusPreviousMonths1 { get { return _cobBonusPreviousMonths1; } set { _cobBonusPreviousMonths1 = value; } }
-        private Value<int?> _cobBonusPreviousMonths2;
+        private DirtyValue<int?> _cobBonusPreviousMonths2;
         public int? CobBonusPreviousMonths2 { get { return _cobBonusPreviousMonths2; } set { _cobBonusPreviousMonths2 = value; } }
-        private Value<int?> _cobBonusPreviousYear1;
+        private DirtyValue<int?> _cobBonusPreviousYear1;
         public int? CobBonusPreviousYear1 { get { return _cobBonusPreviousYear1; } set { _cobBonusPreviousYear1 = value; } }
-        private Value<int?> _cobBonusPreviousYear2;
+        private DirtyValue<int?> _cobBonusPreviousYear2;
         public int? CobBonusPreviousYear2 { get { return _cobBonusPreviousYear2; } set { _cobBonusPreviousYear2 = value; } }
-        private Value<decimal?> _cobCommissionAverageOvertime;
+        private DirtyValue<decimal?> _cobCommissionAverageOvertime;
         public decimal? CobCommissionAverageOvertime { get { return _cobCommissionAverageOvertime; } set { _cobCommissionAverageOvertime = value; } }
-        private Value<decimal?> _cobCommissionMostRecentAmount;
+        private DirtyValue<decimal?> _cobCommissionMostRecentAmount;
         public decimal? CobCommissionMostRecentAmount { get { return _cobCommissionMostRecentAmount; } set { _cobCommissionMostRecentAmount = value; } }
-        private Value<int?> _cobCommissionMostRecentMonths;
+        private DirtyValue<int?> _cobCommissionMostRecentMonths;
         public int? CobCommissionMostRecentMonths { get { return _cobCommissionMostRecentMonths; } set { _cobCommissionMostRecentMonths = value; } }
-        private Value<int?> _cobCommissionMostRecentYear;
+        private DirtyValue<int?> _cobCommissionMostRecentYear;
         public int? CobCommissionMostRecentYear { get { return _cobCommissionMostRecentYear; } set { _cobCommissionMostRecentYear = value; } }
-        private Value<decimal?> _cobCommissionPreviousAmount1;
+        private DirtyValue<decimal?> _cobCommissionPreviousAmount1;
         public decimal? CobCommissionPreviousAmount1 { get { return _cobCommissionPreviousAmount1; } set { _cobCommissionPreviousAmount1 = value; } }
-        private Value<decimal?> _cobCommissionPreviousAmount2;
+        private DirtyValue<decimal?> _cobCommissionPreviousAmount2;
         public decimal? CobCommissionPreviousAmount2 { get { return _cobCommissionPreviousAmount2; } set { _cobCommissionPreviousAmount2 = value; } }
-        private Value<int?> _cobCommissionPreviousMonths1;
+        private DirtyValue<int?> _cobCommissionPreviousMonths1;
         public int? CobCommissionPreviousMonths1 { get { return _cobCommissionPreviousMonths1; } set { _cobCommissionPreviousMonths1 = value; } }
-        private Value<int?> _cobCommissionPreviousMonths2;
+        private DirtyValue<int?> _cobCommissionPreviousMonths2;
         public int? CobCommissionPreviousMonths2 { get { return _cobCommissionPreviousMonths2; } set { _cobCommissionPreviousMonths2 = value; } }
-        private Value<int?> _cobCommissionPreviousYear1;
+        private DirtyValue<int?> _cobCommissionPreviousYear1;
         public int? CobCommissionPreviousYear1 { get { return _cobCommissionPreviousYear1; } set { _cobCommissionPreviousYear1 = value; } }
-        private Value<int?> _cobCommissionPreviousYear2;
+        private DirtyValue<int?> _cobCommissionPreviousYear2;
         public int? CobCommissionPreviousYear2 { get { return _cobCommissionPreviousYear2; } set { _cobCommissionPreviousYear2 = value; } }
-        private Value<decimal?> _cobDividendAverageDividend;
+        private DirtyValue<decimal?> _cobDividendAverageDividend;
         public decimal? CobDividendAverageDividend { get { return _cobDividendAverageDividend; } set { _cobDividendAverageDividend = value; } }
-        private Value<decimal?> _cobDividendPreviousAmount1;
+        private DirtyValue<decimal?> _cobDividendPreviousAmount1;
         public decimal? CobDividendPreviousAmount1 { get { return _cobDividendPreviousAmount1; } set { _cobDividendPreviousAmount1 = value; } }
-        private Value<decimal?> _cobDividendPreviousAmount2;
+        private DirtyValue<decimal?> _cobDividendPreviousAmount2;
         public decimal? CobDividendPreviousAmount2 { get { return _cobDividendPreviousAmount2; } set { _cobDividendPreviousAmount2 = value; } }
-        private Value<int?> _cobDividendPreviousMonths1;
+        private DirtyValue<int?> _cobDividendPreviousMonths1;
         public int? CobDividendPreviousMonths1 { get { return _cobDividendPreviousMonths1; } set { _cobDividendPreviousMonths1 = value; } }
-        private Value<int?> _cobDividendPreviousMonths2;
+        private DirtyValue<int?> _cobDividendPreviousMonths2;
         public int? CobDividendPreviousMonths2 { get { return _cobDividendPreviousMonths2; } set { _cobDividendPreviousMonths2 = value; } }
-        private Value<int?> _cobDividendPreviousYear1;
+        private DirtyValue<int?> _cobDividendPreviousYear1;
         public int? CobDividendPreviousYear1 { get { return _cobDividendPreviousYear1; } set { _cobDividendPreviousYear1 = value; } }
-        private Value<int?> _cobDividendPreviousYear2;
+        private DirtyValue<int?> _cobDividendPreviousYear2;
         public int? CobDividendPreviousYear2 { get { return _cobDividendPreviousYear2; } set { _cobDividendPreviousYear2 = value; } }
-        private Value<decimal?> _cobDividendRequiredForCashAmount;
+        private DirtyValue<decimal?> _cobDividendRequiredForCashAmount;
         public decimal? CobDividendRequiredForCashAmount { get { return _cobDividendRequiredForCashAmount; } set { _cobDividendRequiredForCashAmount = value; } }
-        private Value<decimal?> _cobInterestAverageDividend;
+        private DirtyValue<decimal?> _cobInterestAverageDividend;
         public decimal? CobInterestAverageDividend { get { return _cobInterestAverageDividend; } set { _cobInterestAverageDividend = value; } }
-        private Value<decimal?> _cobInterestPreviousAmount1;
+        private DirtyValue<decimal?> _cobInterestPreviousAmount1;
         public decimal? CobInterestPreviousAmount1 { get { return _cobInterestPreviousAmount1; } set { _cobInterestPreviousAmount1 = value; } }
-        private Value<decimal?> _cobInterestPreviousAmount2;
+        private DirtyValue<decimal?> _cobInterestPreviousAmount2;
         public decimal? CobInterestPreviousAmount2 { get { return _cobInterestPreviousAmount2; } set { _cobInterestPreviousAmount2 = value; } }
-        private Value<int?> _cobInterestPreviousMonths1;
+        private DirtyValue<int?> _cobInterestPreviousMonths1;
         public int? CobInterestPreviousMonths1 { get { return _cobInterestPreviousMonths1; } set { _cobInterestPreviousMonths1 = value; } }
-        private Value<int?> _cobInterestPreviousMonths2;
+        private DirtyValue<int?> _cobInterestPreviousMonths2;
         public int? CobInterestPreviousMonths2 { get { return _cobInterestPreviousMonths2; } set { _cobInterestPreviousMonths2 = value; } }
-        private Value<int?> _cobInterestPreviousYear1;
+        private DirtyValue<int?> _cobInterestPreviousYear1;
         public int? CobInterestPreviousYear1 { get { return _cobInterestPreviousYear1; } set { _cobInterestPreviousYear1 = value; } }
-        private Value<int?> _cobInterestPreviousYear2;
+        private DirtyValue<int?> _cobInterestPreviousYear2;
         public int? CobInterestPreviousYear2 { get { return _cobInterestPreviousYear2; } set { _cobInterestPreviousYear2 = value; } }
-        private Value<decimal?> _cobInterestRequiredForCashAmount;
+        private DirtyValue<decimal?> _cobInterestRequiredForCashAmount;
         public decimal? CobInterestRequiredForCashAmount { get { return _cobInterestRequiredForCashAmount; } set { _cobInterestRequiredForCashAmount = value; } }
-        private Value<decimal?> _cobMilitaryAllowanceClothingAllowance;
+        private DirtyValue<decimal?> _cobMilitaryAllowanceClothingAllowance;
         public decimal? CobMilitaryAllowanceClothingAllowance { get { return _cobMilitaryAllowanceClothingAllowance; } set { _cobMilitaryAllowanceClothingAllowance = value; } }
-        private Value<decimal?> _cobMilitaryAllowanceOtherAllowance;
+        private DirtyValue<decimal?> _cobMilitaryAllowanceOtherAllowance;
         public decimal? CobMilitaryAllowanceOtherAllowance { get { return _cobMilitaryAllowanceOtherAllowance; } set { _cobMilitaryAllowanceOtherAllowance = value; } }
-        private Value<decimal?> _cobMilitaryAllowanceQuartersAllowance;
+        private DirtyValue<decimal?> _cobMilitaryAllowanceQuartersAllowance;
         public decimal? CobMilitaryAllowanceQuartersAllowance { get { return _cobMilitaryAllowanceQuartersAllowance; } set { _cobMilitaryAllowanceQuartersAllowance = value; } }
-        private Value<decimal?> _cobMilitaryAllowanceRationsAllowance;
+        private DirtyValue<decimal?> _cobMilitaryAllowanceRationsAllowance;
         public decimal? CobMilitaryAllowanceRationsAllowance { get { return _cobMilitaryAllowanceRationsAllowance; } set { _cobMilitaryAllowanceRationsAllowance = value; } }
-        private Value<decimal?> _cobMilitaryAllowanceTotalAllowance;
+        private DirtyValue<decimal?> _cobMilitaryAllowanceTotalAllowance;
         public decimal? CobMilitaryAllowanceTotalAllowance { get { return _cobMilitaryAllowanceTotalAllowance; } set { _cobMilitaryAllowanceTotalAllowance = value; } }
-        private Value<decimal?> _cobMilitaryAllowanceVariableHousingAllowance;
+        private DirtyValue<decimal?> _cobMilitaryAllowanceVariableHousingAllowance;
         public decimal? CobMilitaryAllowanceVariableHousingAllowance { get { return _cobMilitaryAllowanceVariableHousingAllowance; } set { _cobMilitaryAllowanceVariableHousingAllowance = value; } }
-        private Value<decimal?> _cobMilitaryBasePay;
+        private DirtyValue<decimal?> _cobMilitaryBasePay;
         public decimal? CobMilitaryBasePay { get { return _cobMilitaryBasePay; } set { _cobMilitaryBasePay = value; } }
-        private Value<decimal?> _cobMilitaryCombatPay;
+        private DirtyValue<decimal?> _cobMilitaryCombatPay;
         public decimal? CobMilitaryCombatPay { get { return _cobMilitaryCombatPay; } set { _cobMilitaryCombatPay = value; } }
-        private Value<decimal?> _cobMilitaryFlightPay;
+        private DirtyValue<decimal?> _cobMilitaryFlightPay;
         public decimal? CobMilitaryFlightPay { get { return _cobMilitaryFlightPay; } set { _cobMilitaryFlightPay = value; } }
-        private Value<decimal?> _cobMilitaryHazardPay;
+        private DirtyValue<decimal?> _cobMilitaryHazardPay;
         public decimal? CobMilitaryHazardPay { get { return _cobMilitaryHazardPay; } set { _cobMilitaryHazardPay = value; } }
-        private Value<decimal?> _cobMilitaryOverseasPay;
+        private DirtyValue<decimal?> _cobMilitaryOverseasPay;
         public decimal? CobMilitaryOverseasPay { get { return _cobMilitaryOverseasPay; } set { _cobMilitaryOverseasPay = value; } }
-        private Value<decimal?> _cobMilitaryPropPay;
+        private DirtyValue<decimal?> _cobMilitaryPropPay;
         public decimal? CobMilitaryPropPay { get { return _cobMilitaryPropPay; } set { _cobMilitaryPropPay = value; } }
-        private Value<decimal?> _cobMilitaryTotalPay;
+        private DirtyValue<decimal?> _cobMilitaryTotalPay;
         public decimal? CobMilitaryTotalPay { get { return _cobMilitaryTotalPay; } set { _cobMilitaryTotalPay = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeBaseIncome;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeBaseIncome;
         public decimal? CobMonthlyEmplymentIncomeBaseIncome { get { return _cobMonthlyEmplymentIncomeBaseIncome; } set { _cobMonthlyEmplymentIncomeBaseIncome = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeBonuseIncome;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeBonuseIncome;
         public decimal? CobMonthlyEmplymentIncomeBonuseIncome { get { return _cobMonthlyEmplymentIncomeBonuseIncome; } set { _cobMonthlyEmplymentIncomeBonuseIncome = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeCommissionIncome;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeCommissionIncome;
         public decimal? CobMonthlyEmplymentIncomeCommissionIncome { get { return _cobMonthlyEmplymentIncomeCommissionIncome; } set { _cobMonthlyEmplymentIncomeCommissionIncome = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeDividendInterestIncome;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeDividendInterestIncome;
         public decimal? CobMonthlyEmplymentIncomeDividendInterestIncome { get { return _cobMonthlyEmplymentIncomeDividendInterestIncome; } set { _cobMonthlyEmplymentIncomeDividendInterestIncome = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeOtherIncome1;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeOtherIncome1;
         public decimal? CobMonthlyEmplymentIncomeOtherIncome1 { get { return _cobMonthlyEmplymentIncomeOtherIncome1; } set { _cobMonthlyEmplymentIncomeOtherIncome1 = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeOtherIncome2;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeOtherIncome2;
         public decimal? CobMonthlyEmplymentIncomeOtherIncome2 { get { return _cobMonthlyEmplymentIncomeOtherIncome2; } set { _cobMonthlyEmplymentIncomeOtherIncome2 = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeOvertimeIncome;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeOvertimeIncome;
         public decimal? CobMonthlyEmplymentIncomeOvertimeIncome { get { return _cobMonthlyEmplymentIncomeOvertimeIncome; } set { _cobMonthlyEmplymentIncomeOvertimeIncome = value; } }
-        private Value<decimal?> _cobMonthlyEmplymentIncomeTotalEmploymentIncome;
+        private DirtyValue<decimal?> _cobMonthlyEmplymentIncomeTotalEmploymentIncome;
         public decimal? CobMonthlyEmplymentIncomeTotalEmploymentIncome { get { return _cobMonthlyEmplymentIncomeTotalEmploymentIncome; } set { _cobMonthlyEmplymentIncomeTotalEmploymentIncome = value; } }
-        private Value<decimal?> _cobNonEmploymentIncomeGovtAssitProgramIncome;
+        private DirtyValue<decimal?> _cobNonEmploymentIncomeGovtAssitProgramIncome;
         public decimal? CobNonEmploymentIncomeGovtAssitProgramIncome { get { return _cobNonEmploymentIncomeGovtAssitProgramIncome; } set { _cobNonEmploymentIncomeGovtAssitProgramIncome = value; } }
-        private Value<decimal?> _cobNonEmploymentIncomeHomeownSubsidyIncome;
+        private DirtyValue<decimal?> _cobNonEmploymentIncomeHomeownSubsidyIncome;
         public decimal? CobNonEmploymentIncomeHomeownSubsidyIncome { get { return _cobNonEmploymentIncomeHomeownSubsidyIncome; } set { _cobNonEmploymentIncomeHomeownSubsidyIncome = value; } }
-        private Value<decimal?> _cobNonEmploymentIncomeMilitaryIncome;
+        private DirtyValue<decimal?> _cobNonEmploymentIncomeMilitaryIncome;
         public decimal? CobNonEmploymentIncomeMilitaryIncome { get { return _cobNonEmploymentIncomeMilitaryIncome; } set { _cobNonEmploymentIncomeMilitaryIncome = value; } }
-        private Value<decimal?> _cobNonEmploymentIncomeMtgCreditCertificateIncome;
+        private DirtyValue<decimal?> _cobNonEmploymentIncomeMtgCreditCertificateIncome;
         public decimal? CobNonEmploymentIncomeMtgCreditCertificateIncome { get { return _cobNonEmploymentIncomeMtgCreditCertificateIncome; } set { _cobNonEmploymentIncomeMtgCreditCertificateIncome = value; } }
-        private Value<decimal?> _cobNonEmploymentIncomeTotalNonEmploymentIncome;
+        private DirtyValue<decimal?> _cobNonEmploymentIncomeTotalNonEmploymentIncome;
         public decimal? CobNonEmploymentIncomeTotalNonEmploymentIncome { get { return _cobNonEmploymentIncomeTotalNonEmploymentIncome; } set { _cobNonEmploymentIncomeTotalNonEmploymentIncome = value; } }
-        private Value<decimal?> _cobNonEmploymentIncomeVABenefitIncome;
+        private DirtyValue<decimal?> _cobNonEmploymentIncomeVABenefitIncome;
         public decimal? CobNonEmploymentIncomeVABenefitIncome { get { return _cobNonEmploymentIncomeVABenefitIncome; } set { _cobNonEmploymentIncomeVABenefitIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeChildSupportIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeChildSupportIncome;
         public decimal? CobNonTaxableIncomeChildSupportIncome { get { return _cobNonTaxableIncomeChildSupportIncome; } set { _cobNonTaxableIncomeChildSupportIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeDisabilityIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeDisabilityIncome;
         public decimal? CobNonTaxableIncomeDisabilityIncome { get { return _cobNonTaxableIncomeDisabilityIncome; } set { _cobNonTaxableIncomeDisabilityIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeFedGovtEmplRetirementIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeFedGovtEmplRetirementIncome;
         public decimal? CobNonTaxableIncomeFedGovtEmplRetirementIncome { get { return _cobNonTaxableIncomeFedGovtEmplRetirementIncome; } set { _cobNonTaxableIncomeFedGovtEmplRetirementIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeMilitaryAllowances;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeMilitaryAllowances;
         public decimal? CobNonTaxableIncomeMilitaryAllowances { get { return _cobNonTaxableIncomeMilitaryAllowances; } set { _cobNonTaxableIncomeMilitaryAllowances = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeOtherIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeOtherIncome;
         public decimal? CobNonTaxableIncomeOtherIncome { get { return _cobNonTaxableIncomeOtherIncome; } set { _cobNonTaxableIncomeOtherIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomePublicAssistPayments;
+        private DirtyValue<decimal?> _cobNonTaxableIncomePublicAssistPayments;
         public decimal? CobNonTaxableIncomePublicAssistPayments { get { return _cobNonTaxableIncomePublicAssistPayments; } set { _cobNonTaxableIncomePublicAssistPayments = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeRailroadRetirementBenefits;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeRailroadRetirementBenefits;
         public decimal? CobNonTaxableIncomeRailroadRetirementBenefits { get { return _cobNonTaxableIncomeRailroadRetirementBenefits; } set { _cobNonTaxableIncomeRailroadRetirementBenefits = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeSocialSecurityIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeSocialSecurityIncome;
         public decimal? CobNonTaxableIncomeSocialSecurityIncome { get { return _cobNonTaxableIncomeSocialSecurityIncome; } set { _cobNonTaxableIncomeSocialSecurityIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeStateGovtEmplRetirementIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeStateGovtEmplRetirementIncome;
         public decimal? CobNonTaxableIncomeStateGovtEmplRetirementIncome { get { return _cobNonTaxableIncomeStateGovtEmplRetirementIncome; } set { _cobNonTaxableIncomeStateGovtEmplRetirementIncome = value; } }
-        private Value<decimal?> _cobNonTaxableIncomeTotalNonTaxableIncome;
+        private DirtyValue<decimal?> _cobNonTaxableIncomeTotalNonTaxableIncome;
         public decimal? CobNonTaxableIncomeTotalNonTaxableIncome { get { return _cobNonTaxableIncomeTotalNonTaxableIncome; } set { _cobNonTaxableIncomeTotalNonTaxableIncome = value; } }
-        private Value<decimal?> _cobOtherNotesReceivableIncome;
+        private DirtyValue<decimal?> _cobOtherNotesReceivableIncome;
         public decimal? CobOtherNotesReceivableIncome { get { return _cobOtherNotesReceivableIncome; } set { _cobOtherNotesReceivableIncome = value; } }
-        private Value<decimal?> _cobOtherOtherIncome;
+        private DirtyValue<decimal?> _cobOtherOtherIncome;
         public decimal? CobOtherOtherIncome { get { return _cobOtherOtherIncome; } set { _cobOtherOtherIncome = value; } }
-        private Value<decimal?> _cobOtherParttimeIncome;
+        private DirtyValue<decimal?> _cobOtherParttimeIncome;
         public decimal? CobOtherParttimeIncome { get { return _cobOtherParttimeIncome; } set { _cobOtherParttimeIncome = value; } }
-        private Value<decimal?> _cobOtherRetirementIncome;
+        private DirtyValue<decimal?> _cobOtherRetirementIncome;
         public decimal? CobOtherRetirementIncome { get { return _cobOtherRetirementIncome; } set { _cobOtherRetirementIncome = value; } }
-        private Value<decimal?> _cobOtherSeasonalIncome;
+        private DirtyValue<decimal?> _cobOtherSeasonalIncome;
         public decimal? CobOtherSeasonalIncome { get { return _cobOtherSeasonalIncome; } set { _cobOtherSeasonalIncome = value; } }
-        private Value<decimal?> _cobOtherSocialSecurityIncome;
+        private DirtyValue<decimal?> _cobOtherSocialSecurityIncome;
         public decimal? CobOtherSocialSecurityIncome { get { return _cobOtherSocialSecurityIncome; } set { _cobOtherSocialSecurityIncome = value; } }
-        private Value<decimal?> _cobOtherTipIncome;
+        private DirtyValue<decimal?> _cobOtherTipIncome;
         public decimal? CobOtherTipIncome { get { return _cobOtherTipIncome; } set { _cobOtherTipIncome = value; } }
-        private Value<decimal?> _cobOtherTrustIncome;
+        private DirtyValue<decimal?> _cobOtherTrustIncome;
         public decimal? CobOtherTrustIncome { get { return _cobOtherTrustIncome; } set { _cobOtherTrustIncome = value; } }
-        private Value<decimal?> _cobOtherUnemploymentIncome;
+        private DirtyValue<decimal?> _cobOtherUnemploymentIncome;
         public decimal? CobOtherUnemploymentIncome { get { return _cobOtherUnemploymentIncome; } set { _cobOtherUnemploymentIncome = value; } }
-        private Value<decimal?> _cobOvertimeAverageOvertime;
+        private DirtyValue<decimal?> _cobOvertimeAverageOvertime;
         public decimal? CobOvertimeAverageOvertime { get { return _cobOvertimeAverageOvertime; } set { _cobOvertimeAverageOvertime = value; } }
-        private Value<decimal?> _cobOvertimeMostRecentAmount;
+        private DirtyValue<decimal?> _cobOvertimeMostRecentAmount;
         public decimal? CobOvertimeMostRecentAmount { get { return _cobOvertimeMostRecentAmount; } set { _cobOvertimeMostRecentAmount = value; } }
-        private Value<int?> _cobOvertimeMostRecentMonths;
+        private DirtyValue<int?> _cobOvertimeMostRecentMonths;
         public int? CobOvertimeMostRecentMonths { get { return _cobOvertimeMostRecentMonths; } set { _cobOvertimeMostRecentMonths = value; } }
-        private Value<int?> _cobOvertimeMostRecentYear;
+        private DirtyValue<int?> _cobOvertimeMostRecentYear;
         public int? CobOvertimeMostRecentYear { get { return _cobOvertimeMostRecentYear; } set { _cobOvertimeMostRecentYear = value; } }
-        private Value<decimal?> _cobOvertimePreviousAmount1;
+        private DirtyValue<decimal?> _cobOvertimePreviousAmount1;
         public decimal? CobOvertimePreviousAmount1 { get { return _cobOvertimePreviousAmount1; } set { _cobOvertimePreviousAmount1 = value; } }
-        private Value<decimal?> _cobOvertimePreviousAmount2;
+        private DirtyValue<decimal?> _cobOvertimePreviousAmount2;
         public decimal? CobOvertimePreviousAmount2 { get { return _cobOvertimePreviousAmount2; } set { _cobOvertimePreviousAmount2 = value; } }
-        private Value<int?> _cobOvertimePreviousMonths1;
+        private DirtyValue<int?> _cobOvertimePreviousMonths1;
         public int? CobOvertimePreviousMonths1 { get { return _cobOvertimePreviousMonths1; } set { _cobOvertimePreviousMonths1 = value; } }
-        private Value<int?> _cobOvertimePreviousMonths2;
+        private DirtyValue<int?> _cobOvertimePreviousMonths2;
         public int? CobOvertimePreviousMonths2 { get { return _cobOvertimePreviousMonths2; } set { _cobOvertimePreviousMonths2 = value; } }
-        private Value<int?> _cobOvertimePreviousYear1;
+        private DirtyValue<int?> _cobOvertimePreviousYear1;
         public int? CobOvertimePreviousYear1 { get { return _cobOvertimePreviousYear1; } set { _cobOvertimePreviousYear1 = value; } }
-        private Value<int?> _cobOvertimePreviousYear2;
+        private DirtyValue<int?> _cobOvertimePreviousYear2;
         public int? CobOvertimePreviousYear2 { get { return _cobOvertimePreviousYear2; } set { _cobOvertimePreviousYear2 = value; } }
-        private Value<decimal?> _cobProjectedIncomeProjectedBonuses;
+        private DirtyValue<decimal?> _cobProjectedIncomeProjectedBonuses;
         public decimal? CobProjectedIncomeProjectedBonuses { get { return _cobProjectedIncomeProjectedBonuses; } set { _cobProjectedIncomeProjectedBonuses = value; } }
-        private Value<decimal?> _cobProjectedIncomeProjectedCostLivingAdjustment;
+        private DirtyValue<decimal?> _cobProjectedIncomeProjectedCostLivingAdjustment;
         public decimal? CobProjectedIncomeProjectedCostLivingAdjustment { get { return _cobProjectedIncomeProjectedCostLivingAdjustment; } set { _cobProjectedIncomeProjectedCostLivingAdjustment = value; } }
-        private Value<decimal?> _cobProjectedIncomeProjectedNewJobIncome;
+        private DirtyValue<decimal?> _cobProjectedIncomeProjectedNewJobIncome;
         public decimal? CobProjectedIncomeProjectedNewJobIncome { get { return _cobProjectedIncomeProjectedNewJobIncome; } set { _cobProjectedIncomeProjectedNewJobIncome = value; } }
-        private Value<decimal?> _cobProjectedIncomeProjectedPerformanceRaises;
+        private DirtyValue<decimal?> _cobProjectedIncomeProjectedPerformanceRaises;
         public decimal? CobProjectedIncomeProjectedPerformanceRaises { get { return _cobProjectedIncomeProjectedPerformanceRaises; } set { _cobProjectedIncomeProjectedPerformanceRaises = value; } }
-        private Value<decimal?> _cobProjectedIncomeTotalProjectedIncome;
+        private DirtyValue<decimal?> _cobProjectedIncomeTotalProjectedIncome;
         public decimal? CobProjectedIncomeTotalProjectedIncome { get { return _cobProjectedIncomeTotalProjectedIncome; } set { _cobProjectedIncomeTotalProjectedIncome = value; } }
-        private Value<string> _dUCaseIDorLPAUSKey;
+        private DirtyValue<string> _dUCaseIDorLPAUSKey;
         public string DUCaseIDorLPAUSKey { get { return _dUCaseIDorLPAUSKey; } set { _dUCaseIDorLPAUSKey = value; } }
-        private Value<DateTime?> _firstSubmissionDate;
+        private DirtyValue<DateTime?> _firstSubmissionDate;
         public DateTime? FirstSubmissionDate { get { return _firstSubmissionDate; } set { _firstSubmissionDate = value; } }
-        private Value<string> _firstSubmissionTime;
+        private DirtyValue<string> _firstSubmissionTime;
         public string FirstSubmissionTime { get { return _firstSubmissionTime; } set { _firstSubmissionTime = value; } }
-        private Value<string> _freddieDocClass;
+        private DirtyValue<string> _freddieDocClass;
         public string FreddieDocClass { get { return _freddieDocClass; } set { _freddieDocClass = value; } }
-        private Value<decimal?> _housingRatio;
+        private DirtyValue<decimal?> _housingRatio;
         public decimal? HousingRatio { get { return _housingRatio; } set { _housingRatio = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEmpty;
+        private DirtyValue<bool?> _isEmpty;
         public bool? IsEmpty { get { return _isEmpty; } set { _isEmpty = value; } }
-        private Value<DateTime?> _submissionDate;
+        private DirtyValue<DateTime?> _submissionDate;
         public DateTime? SubmissionDate { get { return _submissionDate; } set { _submissionDate = value; } }
-        private Value<string> _submissionNumber;
+        private DirtyValue<string> _submissionNumber;
         public string SubmissionNumber { get { return _submissionNumber; } set { _submissionNumber = value; } }
-        private Value<string> _submissionTime;
+        private DirtyValue<string> _submissionTime;
         public string SubmissionTime { get { return _submissionTime; } set { _submissionTime = value; } }
-        private Value<string> _submittedBy;
+        private DirtyValue<string> _submittedBy;
         public string SubmittedBy { get { return _submittedBy; } set { _submittedBy = value; } }
-        private Value<decimal?> _totalExpenseRatio;
+        private DirtyValue<decimal?> _totalExpenseRatio;
         public decimal? TotalExpenseRatio { get { return _totalExpenseRatio; } set { _totalExpenseRatio = value; } }
-        private Value<decimal?> _totalHousingPayment;
+        private DirtyValue<decimal?> _totalHousingPayment;
         public decimal? TotalHousingPayment { get { return _totalHousingPayment; } set { _totalHousingPayment = value; } }
-        private Value<decimal?> _totalMonthlyAssets;
+        private DirtyValue<decimal?> _totalMonthlyAssets;
         public decimal? TotalMonthlyAssets { get { return _totalMonthlyAssets; } set { _totalMonthlyAssets = value; } }
-        private Value<decimal?> _totalMonthlyDebt;
+        private DirtyValue<decimal?> _totalMonthlyDebt;
         public decimal? TotalMonthlyDebt { get { return _totalMonthlyDebt; } set { _totalMonthlyDebt = value; } }
-        private Value<decimal?> _totalMonthlyIncome;
+        private DirtyValue<decimal?> _totalMonthlyIncome;
         public decimal? TotalMonthlyIncome { get { return _totalMonthlyIncome; } set { _totalMonthlyIncome = value; } }
-        private Value<string> _underwritingRiskAssessOther;
+        private DirtyValue<string> _underwritingRiskAssessOther;
         public string UnderwritingRiskAssessOther { get { return _underwritingRiskAssessOther; } set { _underwritingRiskAssessOther = value; } }
-        private Value<string> _underwritingRiskAssessType;
+        private DirtyValue<string> _underwritingRiskAssessType;
         public string UnderwritingRiskAssessType { get { return _underwritingRiskAssessType; } set { _underwritingRiskAssessType = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ATRQMCommon.cs
+++ b/src/EncompassRest/Loans/ATRQMCommon.cs
@@ -8,417 +8,417 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ATRQMCommon : IDirty
     {
-        private Value<decimal?> _affiliatesFees;
+        private DirtyValue<decimal?> _affiliatesFees;
         public decimal? AffiliatesFees { get { return _affiliatesFees; } set { _affiliatesFees = value; } }
-        private Value<decimal?> _aPORMaxBonaFideDiscountPoint;
+        private DirtyValue<decimal?> _aPORMaxBonaFideDiscountPoint;
         public decimal? APORMaxBonaFideDiscountPoint { get { return _aPORMaxBonaFideDiscountPoint; } set { _aPORMaxBonaFideDiscountPoint = value; } }
-        private Value<DateTime?> _aRMRecastDate;
+        private DirtyValue<DateTime?> _aRMRecastDate;
         public DateTime? ARMRecastDate { get { return _aRMRecastDate; } set { _aRMRecastDate = value; } }
-        private Value<decimal?> _aRMRecastMonthlyPayment;
+        private DirtyValue<decimal?> _aRMRecastMonthlyPayment;
         public decimal? ARMRecastMonthlyPayment { get { return _aRMRecastMonthlyPayment; } set { _aRMRecastMonthlyPayment = value; } }
-        private Value<string> _aTRLoanType;
+        private DirtyValue<string> _aTRLoanType;
         public string ATRLoanType { get { return _aTRLoanType; } set { _aTRLoanType = value; } }
-        private Value<string> _aUSDataDiscrepencyResolutionComments;
+        private DirtyValue<string> _aUSDataDiscrepencyResolutionComments;
         public string AUSDataDiscrepencyResolutionComments { get { return _aUSDataDiscrepencyResolutionComments; } set { _aUSDataDiscrepencyResolutionComments = value; } }
-        private Value<DateTime?> _aUSDataDiscrepencyResolutionDate;
+        private DirtyValue<DateTime?> _aUSDataDiscrepencyResolutionDate;
         public DateTime? AUSDataDiscrepencyResolutionDate { get { return _aUSDataDiscrepencyResolutionDate; } set { _aUSDataDiscrepencyResolutionDate = value; } }
-        private Value<string> _aUSDataDiscrepencyResolvedBy;
+        private DirtyValue<string> _aUSDataDiscrepencyResolvedBy;
         public string AUSDataDiscrepencyResolvedBy { get { return _aUSDataDiscrepencyResolvedBy; } set { _aUSDataDiscrepencyResolvedBy = value; } }
-        private Value<decimal?> _bonaFideDiscountPoint;
+        private DirtyValue<decimal?> _bonaFideDiscountPoint;
         public decimal? BonaFideDiscountPoint { get { return _bonaFideDiscountPoint; } set { _bonaFideDiscountPoint = value; } }
-        private Value<decimal?> _bonaFideDiscountPointAmount;
+        private DirtyValue<decimal?> _bonaFideDiscountPointAmount;
         public decimal? BonaFideDiscountPointAmount { get { return _bonaFideDiscountPointAmount; } set { _bonaFideDiscountPointAmount = value; } }
-        private Value<bool?> _brokerCompensationWhenRateSet;
+        private DirtyValue<bool?> _brokerCompensationWhenRateSet;
         public bool? BrokerCompensationWhenRateSet { get { return _brokerCompensationWhenRateSet; } set { _brokerCompensationWhenRateSet = value; } }
-        private Value<string> _collateralRepandWarrReliefEligibilityType;
+        private DirtyValue<string> _collateralRepandWarrReliefEligibilityType;
         public string CollateralRepandWarrReliefEligibilityType { get { return _collateralRepandWarrReliefEligibilityType; } set { _collateralRepandWarrReliefEligibilityType = value; } }
-        private Value<decimal?> _compensationPTBFees;
+        private DirtyValue<decimal?> _compensationPTBFees;
         public decimal? CompensationPTBFees { get { return _compensationPTBFees; } set { _compensationPTBFees = value; } }
-        private Value<decimal?> _creditInsPremiumFees;
+        private DirtyValue<decimal?> _creditInsPremiumFees;
         public decimal? CreditInsPremiumFees { get { return _creditInsPremiumFees; } set { _creditInsPremiumFees = value; } }
-        private Value<bool?> _creditorType;
+        private DirtyValue<bool?> _creditorType;
         public bool? CreditorType { get { return _creditorType; } set { _creditorType = value; } }
-        private Value<string> _creditorTypeDescription;
+        private DirtyValue<string> _creditorTypeDescription;
         public string CreditorTypeDescription { get { return _creditorTypeDescription; } set { _creditorTypeDescription = value; } }
-        private Value<bool?> _creditType;
+        private DirtyValue<bool?> _creditType;
         public bool? CreditType { get { return _creditType; } set { _creditType = value; } }
-        private Value<decimal?> _currentQMFeeThresholdAmt;
+        private DirtyValue<decimal?> _currentQMFeeThresholdAmt;
         public decimal? CurrentQMFeeThresholdAmt { get { return _currentQMFeeThresholdAmt; } set { _currentQMFeeThresholdAmt = value; } }
-        private Value<decimal?> _currentQMFeeThresholdPercent;
+        private DirtyValue<decimal?> _currentQMFeeThresholdPercent;
         public decimal? CurrentQMFeeThresholdPercent { get { return _currentQMFeeThresholdPercent; } set { _currentQMFeeThresholdPercent = value; } }
-        private Value<DateTime?> _dateOfLastMonthlyPayment;
+        private DirtyValue<DateTime?> _dateOfLastMonthlyPayment;
         public DateTime? DateOfLastMonthlyPayment { get { return _dateOfLastMonthlyPayment; } set { _dateOfLastMonthlyPayment = value; } }
-        private Value<decimal?> _discountPointAmount;
+        private DirtyValue<decimal?> _discountPointAmount;
         public decimal? DiscountPointAmount { get { return _discountPointAmount; } set { _discountPointAmount = value; } }
-        private Value<decimal?> _discountPointFees;
+        private DirtyValue<decimal?> _discountPointFees;
         public decimal? DiscountPointFees { get { return _discountPointFees; } set { _discountPointFees = value; } }
-        private Value<decimal?> _discountPointPercentage;
+        private DirtyValue<decimal?> _discountPointPercentage;
         public decimal? DiscountPointPercentage { get { return _discountPointPercentage; } set { _discountPointPercentage = value; } }
-        private Value<string> _documentationGuidelineMessages4V;
+        private DirtyValue<string> _documentationGuidelineMessages4V;
         public string DocumentationGuidelineMessages4V { get { return _documentationGuidelineMessages4V; } set { _documentationGuidelineMessages4V = value; } }
-        private Value<string> _documentationGuidelineMessages5C;
+        private DirtyValue<string> _documentationGuidelineMessages5C;
         public string DocumentationGuidelineMessages5C { get { return _documentationGuidelineMessages5C; } set { _documentationGuidelineMessages5C = value; } }
-        private Value<string> _documentationGuidelineMessages8Y;
+        private DirtyValue<string> _documentationGuidelineMessages8Y;
         public string DocumentationGuidelineMessages8Y { get { return _documentationGuidelineMessages8Y; } set { _documentationGuidelineMessages8Y = value; } }
-        private Value<string> _documentationGuidelineMessagesCN;
+        private DirtyValue<string> _documentationGuidelineMessagesCN;
         public string DocumentationGuidelineMessagesCN { get { return _documentationGuidelineMessagesCN; } set { _documentationGuidelineMessagesCN = value; } }
-        private Value<string> _documentationGuidelineMessagesCP;
+        private DirtyValue<string> _documentationGuidelineMessagesCP;
         public string DocumentationGuidelineMessagesCP { get { return _documentationGuidelineMessagesCP; } set { _documentationGuidelineMessagesCP = value; } }
-        private Value<string> _documentationGuidelineMessagesCV;
+        private DirtyValue<string> _documentationGuidelineMessagesCV;
         public string DocumentationGuidelineMessagesCV { get { return _documentationGuidelineMessagesCV; } set { _documentationGuidelineMessagesCV = value; } }
-        private Value<string> _documentationGuidelineMessagesCY;
+        private DirtyValue<string> _documentationGuidelineMessagesCY;
         public string DocumentationGuidelineMessagesCY { get { return _documentationGuidelineMessagesCY; } set { _documentationGuidelineMessagesCY = value; } }
-        private Value<string> _documentationGuidelineMessagesCZ;
+        private DirtyValue<string> _documentationGuidelineMessagesCZ;
         public string DocumentationGuidelineMessagesCZ { get { return _documentationGuidelineMessagesCZ; } set { _documentationGuidelineMessagesCZ = value; } }
-        private Value<string> _documentationGuidelineMessagesDP;
+        private DirtyValue<string> _documentationGuidelineMessagesDP;
         public string DocumentationGuidelineMessagesDP { get { return _documentationGuidelineMessagesDP; } set { _documentationGuidelineMessagesDP = value; } }
-        private Value<string> _documentationGuidelineMessagesDZ;
+        private DirtyValue<string> _documentationGuidelineMessagesDZ;
         public string DocumentationGuidelineMessagesDZ { get { return _documentationGuidelineMessagesDZ; } set { _documentationGuidelineMessagesDZ = value; } }
-        private Value<string> _documentationGuidelineMessagesE5;
+        private DirtyValue<string> _documentationGuidelineMessagesE5;
         public string DocumentationGuidelineMessagesE5 { get { return _documentationGuidelineMessagesE5; } set { _documentationGuidelineMessagesE5 = value; } }
-        private Value<string> _documentationGuidelineMessagesIM;
+        private DirtyValue<string> _documentationGuidelineMessagesIM;
         public string DocumentationGuidelineMessagesIM { get { return _documentationGuidelineMessagesIM; } set { _documentationGuidelineMessagesIM = value; } }
-        private Value<string> _documentationGuidelineMessagesIQ;
+        private DirtyValue<string> _documentationGuidelineMessagesIQ;
         public string DocumentationGuidelineMessagesIQ { get { return _documentationGuidelineMessagesIQ; } set { _documentationGuidelineMessagesIQ = value; } }
-        private Value<string> _documentationGuidelineMessagesJF;
+        private DirtyValue<string> _documentationGuidelineMessagesJF;
         public string DocumentationGuidelineMessagesJF { get { return _documentationGuidelineMessagesJF; } set { _documentationGuidelineMessagesJF = value; } }
-        private Value<string> _documentationGuidelineMessagesQJ;
+        private DirtyValue<string> _documentationGuidelineMessagesQJ;
         public string DocumentationGuidelineMessagesQJ { get { return _documentationGuidelineMessagesQJ; } set { _documentationGuidelineMessagesQJ = value; } }
-        private Value<string> _documentationGuidelineMessagesQN;
+        private DirtyValue<string> _documentationGuidelineMessagesQN;
         public string DocumentationGuidelineMessagesQN { get { return _documentationGuidelineMessagesQN; } set { _documentationGuidelineMessagesQN = value; } }
-        private Value<string> _documentationGuidelineMessagesQQ;
+        private DirtyValue<string> _documentationGuidelineMessagesQQ;
         public string DocumentationGuidelineMessagesQQ { get { return _documentationGuidelineMessagesQQ; } set { _documentationGuidelineMessagesQQ = value; } }
-        private Value<string> _documentationGuidelineMessagesQS;
+        private DirtyValue<string> _documentationGuidelineMessagesQS;
         public string DocumentationGuidelineMessagesQS { get { return _documentationGuidelineMessagesQS; } set { _documentationGuidelineMessagesQS = value; } }
-        private Value<string> _documentationGuidelineMessagesU7;
+        private DirtyValue<string> _documentationGuidelineMessagesU7;
         public string DocumentationGuidelineMessagesU7 { get { return _documentationGuidelineMessagesU7; } set { _documentationGuidelineMessagesU7 = value; } }
-        private Value<string> _documentationGuidelineMessagesX1;
+        private DirtyValue<string> _documentationGuidelineMessagesX1;
         public string DocumentationGuidelineMessagesX1 { get { return _documentationGuidelineMessagesX1; } set { _documentationGuidelineMessagesX1 = value; } }
-        private Value<string> _documentationGuidelineMessagesX3;
+        private DirtyValue<string> _documentationGuidelineMessagesX3;
         public string DocumentationGuidelineMessagesX3 { get { return _documentationGuidelineMessagesX3; } set { _documentationGuidelineMessagesX3 = value; } }
-        private Value<string> _documentationGuidelineMessagesX5;
+        private DirtyValue<string> _documentationGuidelineMessagesX5;
         public string DocumentationGuidelineMessagesX5 { get { return _documentationGuidelineMessagesX5; } set { _documentationGuidelineMessagesX5 = value; } }
-        private Value<string> _documentationGuidelineMessagesX7;
+        private DirtyValue<string> _documentationGuidelineMessagesX7;
         public string DocumentationGuidelineMessagesX7 { get { return _documentationGuidelineMessagesX7; } set { _documentationGuidelineMessagesX7 = value; } }
-        private Value<string> _documentationGuidelineMessagesXA;
+        private DirtyValue<string> _documentationGuidelineMessagesXA;
         public string DocumentationGuidelineMessagesXA { get { return _documentationGuidelineMessagesXA; } set { _documentationGuidelineMessagesXA = value; } }
-        private Value<string> _documentationGuidelineMessagesXM;
+        private DirtyValue<string> _documentationGuidelineMessagesXM;
         public string DocumentationGuidelineMessagesXM { get { return _documentationGuidelineMessagesXM; } set { _documentationGuidelineMessagesXM = value; } }
-        private Value<string> _documentationGuidelineMessagesXP;
+        private DirtyValue<string> _documentationGuidelineMessagesXP;
         public string DocumentationGuidelineMessagesXP { get { return _documentationGuidelineMessagesXP; } set { _documentationGuidelineMessagesXP = value; } }
-        private Value<string> _documentationGuidelineMessagesXR;
+        private DirtyValue<string> _documentationGuidelineMessagesXR;
         public string DocumentationGuidelineMessagesXR { get { return _documentationGuidelineMessagesXR; } set { _documentationGuidelineMessagesXR = value; } }
-        private Value<string> _documentationGuidelineMessagesXT;
+        private DirtyValue<string> _documentationGuidelineMessagesXT;
         public string DocumentationGuidelineMessagesXT { get { return _documentationGuidelineMessagesXT; } set { _documentationGuidelineMessagesXT = value; } }
-        private Value<string> _documentationGuidelineMessagesY8;
+        private DirtyValue<string> _documentationGuidelineMessagesY8;
         public string DocumentationGuidelineMessagesY8 { get { return _documentationGuidelineMessagesY8; } set { _documentationGuidelineMessagesY8 = value; } }
-        private Value<string> _documentationGuidelineMessagesYG;
+        private DirtyValue<string> _documentationGuidelineMessagesYG;
         public string DocumentationGuidelineMessagesYG { get { return _documentationGuidelineMessagesYG; } set { _documentationGuidelineMessagesYG = value; } }
-        private Value<string> _documentationGuidelineMessagesYJ;
+        private DirtyValue<string> _documentationGuidelineMessagesYJ;
         public string DocumentationGuidelineMessagesYJ { get { return _documentationGuidelineMessagesYJ; } set { _documentationGuidelineMessagesYJ = value; } }
-        private Value<string> _documentationGuidelineMessagesYY;
+        private DirtyValue<string> _documentationGuidelineMessagesYY;
         public string DocumentationGuidelineMessagesYY { get { return _documentationGuidelineMessagesYY; } set { _documentationGuidelineMessagesYY = value; } }
-        private Value<string> _documentationGuidelineMessagesYZ;
+        private DirtyValue<string> _documentationGuidelineMessagesYZ;
         public string DocumentationGuidelineMessagesYZ { get { return _documentationGuidelineMessagesYZ; } set { _documentationGuidelineMessagesYZ = value; } }
-        private Value<string> _eligibleNonStandardToStandard;
+        private DirtyValue<string> _eligibleNonStandardToStandard;
         public string EligibleNonStandardToStandard { get { return _eligibleNonStandardToStandard; } set { _eligibleNonStandardToStandard = value; } }
-        private Value<decimal?> _financeChargeFees;
+        private DirtyValue<decimal?> _financeChargeFees;
         public decimal? FinanceChargeFees { get { return _financeChargeFees; } set { _financeChargeFees = value; } }
-        private Value<int?> _firstChangeRecase;
+        private DirtyValue<int?> _firstChangeRecase;
         public int? FirstChangeRecase { get { return _firstChangeRecase; } set { _firstChangeRecase = value; } }
-        private Value<DateTime?> _firstPmtDateAfterRecast;
+        private DirtyValue<DateTime?> _firstPmtDateAfterRecast;
         public DateTime? FirstPmtDateAfterRecast { get { return _firstPmtDateAfterRecast; } set { _firstPmtDateAfterRecast = value; } }
-        private Value<decimal?> _fullPaymentAfterInterestOnly;
+        private DirtyValue<decimal?> _fullPaymentAfterInterestOnly;
         public decimal? FullPaymentAfterInterestOnly { get { return _fullPaymentAfterInterestOnly; } set { _fullPaymentAfterInterestOnly = value; } }
-        private Value<decimal?> _fullyARMPaymentAfterNegAm;
+        private DirtyValue<decimal?> _fullyARMPaymentAfterNegAm;
         public decimal? FullyARMPaymentAfterNegAm { get { return _fullyARMPaymentAfterNegAm; } set { _fullyARMPaymentAfterNegAm = value; } }
-        private Value<decimal?> _fullyIndexRateHousingRatio;
+        private DirtyValue<decimal?> _fullyIndexRateHousingRatio;
         public decimal? FullyIndexRateHousingRatio { get { return _fullyIndexRateHousingRatio; } set { _fullyIndexRateHousingRatio = value; } }
-        private Value<decimal?> _fullyIndexRateMaxTotalPayment;
+        private DirtyValue<decimal?> _fullyIndexRateMaxTotalPayment;
         public decimal? FullyIndexRateMaxTotalPayment { get { return _fullyIndexRateMaxTotalPayment; } set { _fullyIndexRateMaxTotalPayment = value; } }
-        private Value<decimal?> _fullyIndexRateMonthlyPayment;
+        private DirtyValue<decimal?> _fullyIndexRateMonthlyPayment;
         public decimal? FullyIndexRateMonthlyPayment { get { return _fullyIndexRateMonthlyPayment; } set { _fullyIndexRateMonthlyPayment = value; } }
-        private Value<decimal?> _fullyIndexRateTotalDebtRatio;
+        private DirtyValue<decimal?> _fullyIndexRateTotalDebtRatio;
         public decimal? FullyIndexRateTotalDebtRatio { get { return _fullyIndexRateTotalDebtRatio; } set { _fullyIndexRateTotalDebtRatio = value; } }
-        private Value<string> _generalATR_Status_Alimony;
+        private DirtyValue<string> _generalATR_Status_Alimony;
         public string GeneralATR_Status_Alimony { get { return _generalATR_Status_Alimony; } set { _generalATR_Status_Alimony = value; } }
-        private Value<string> _generalATR_Status_Assets;
+        private DirtyValue<string> _generalATR_Status_Assets;
         public string GeneralATR_Status_Assets { get { return _generalATR_Status_Assets; } set { _generalATR_Status_Assets = value; } }
-        private Value<string> _generalATR_Status_ChildSupport;
+        private DirtyValue<string> _generalATR_Status_ChildSupport;
         public string GeneralATR_Status_ChildSupport { get { return _generalATR_Status_ChildSupport; } set { _generalATR_Status_ChildSupport = value; } }
-        private Value<string> _generalATR_Status_CoveredLoan;
+        private DirtyValue<string> _generalATR_Status_CoveredLoan;
         public string GeneralATR_Status_CoveredLoan { get { return _generalATR_Status_CoveredLoan; } set { _generalATR_Status_CoveredLoan = value; } }
-        private Value<string> _generalATR_Status_CreditHistory;
+        private DirtyValue<string> _generalATR_Status_CreditHistory;
         public string GeneralATR_Status_CreditHistory { get { return _generalATR_Status_CreditHistory; } set { _generalATR_Status_CreditHistory = value; } }
-        private Value<string> _generalATR_Status_DebtObligations;
+        private DirtyValue<string> _generalATR_Status_DebtObligations;
         public string GeneralATR_Status_DebtObligations { get { return _generalATR_Status_DebtObligations; } set { _generalATR_Status_DebtObligations = value; } }
-        private Value<string> _generalATR_Status_DTI;
+        private DirtyValue<string> _generalATR_Status_DTI;
         public string GeneralATR_Status_DTI { get { return _generalATR_Status_DTI; } set { _generalATR_Status_DTI = value; } }
-        private Value<string> _generalATR_Status_Employment;
+        private DirtyValue<string> _generalATR_Status_Employment;
         public string GeneralATR_Status_Employment { get { return _generalATR_Status_Employment; } set { _generalATR_Status_Employment = value; } }
-        private Value<string> _generalATR_Status_Income;
+        private DirtyValue<string> _generalATR_Status_Income;
         public string GeneralATR_Status_Income { get { return _generalATR_Status_Income; } set { _generalATR_Status_Income = value; } }
-        private Value<string> _generalATR_Status_MtgRelatedObligations;
+        private DirtyValue<string> _generalATR_Status_MtgRelatedObligations;
         public string GeneralATR_Status_MtgRelatedObligations { get { return _generalATR_Status_MtgRelatedObligations; } set { _generalATR_Status_MtgRelatedObligations = value; } }
-        private Value<string> _generalATR_Status_Overall;
+        private DirtyValue<string> _generalATR_Status_Overall;
         public string GeneralATR_Status_Overall { get { return _generalATR_Status_Overall; } set { _generalATR_Status_Overall = value; } }
-        private Value<string> _generalATR_Status_ResidualIncome;
+        private DirtyValue<string> _generalATR_Status_ResidualIncome;
         public string GeneralATR_Status_ResidualIncome { get { return _generalATR_Status_ResidualIncome; } set { _generalATR_Status_ResidualIncome = value; } }
-        private Value<string> _generalATR_Status_SimultaneousLoan;
+        private DirtyValue<string> _generalATR_Status_SimultaneousLoan;
         public string GeneralATR_Status_SimultaneousLoan { get { return _generalATR_Status_SimultaneousLoan; } set { _generalATR_Status_SimultaneousLoan = value; } }
-        private Value<decimal?> _gSEAgencyQM_CalculatedThreshold;
+        private DirtyValue<decimal?> _gSEAgencyQM_CalculatedThreshold;
         public decimal? GSEAgencyQM_CalculatedThreshold { get { return _gSEAgencyQM_CalculatedThreshold; } set { _gSEAgencyQM_CalculatedThreshold = value; } }
-        private Value<string> _gSEAgencyQM_Status_Alimony;
+        private DirtyValue<string> _gSEAgencyQM_Status_Alimony;
         public string GSEAgencyQM_Status_Alimony { get { return _gSEAgencyQM_Status_Alimony; } set { _gSEAgencyQM_Status_Alimony = value; } }
-        private Value<string> _gSEAgencyQM_Status_Assets;
+        private DirtyValue<string> _gSEAgencyQM_Status_Assets;
         public string GSEAgencyQM_Status_Assets { get { return _gSEAgencyQM_Status_Assets; } set { _gSEAgencyQM_Status_Assets = value; } }
-        private Value<string> _gSEAgencyQM_Status_BalloonPayment;
+        private DirtyValue<string> _gSEAgencyQM_Status_BalloonPayment;
         public string GSEAgencyQM_Status_BalloonPayment { get { return _gSEAgencyQM_Status_BalloonPayment; } set { _gSEAgencyQM_Status_BalloonPayment = value; } }
-        private Value<string> _gSEAgencyQM_Status_ChildSupport;
+        private DirtyValue<string> _gSEAgencyQM_Status_ChildSupport;
         public string GSEAgencyQM_Status_ChildSupport { get { return _gSEAgencyQM_Status_ChildSupport; } set { _gSEAgencyQM_Status_ChildSupport = value; } }
-        private Value<string> _gSEAgencyQM_Status_CoveredLoan;
+        private DirtyValue<string> _gSEAgencyQM_Status_CoveredLoan;
         public string GSEAgencyQM_Status_CoveredLoan { get { return _gSEAgencyQM_Status_CoveredLoan; } set { _gSEAgencyQM_Status_CoveredLoan = value; } }
-        private Value<string> _gSEAgencyQM_Status_CreditHistory;
+        private DirtyValue<string> _gSEAgencyQM_Status_CreditHistory;
         public string GSEAgencyQM_Status_CreditHistory { get { return _gSEAgencyQM_Status_CreditHistory; } set { _gSEAgencyQM_Status_CreditHistory = value; } }
-        private Value<string> _gSEAgencyQM_Status_DebtObligations;
+        private DirtyValue<string> _gSEAgencyQM_Status_DebtObligations;
         public string GSEAgencyQM_Status_DebtObligations { get { return _gSEAgencyQM_Status_DebtObligations; } set { _gSEAgencyQM_Status_DebtObligations = value; } }
-        private Value<string> _gSEAgencyQM_Status_DTI;
+        private DirtyValue<string> _gSEAgencyQM_Status_DTI;
         public string GSEAgencyQM_Status_DTI { get { return _gSEAgencyQM_Status_DTI; } set { _gSEAgencyQM_Status_DTI = value; } }
-        private Value<string> _gSEAgencyQM_Status_Employment;
+        private DirtyValue<string> _gSEAgencyQM_Status_Employment;
         public string GSEAgencyQM_Status_Employment { get { return _gSEAgencyQM_Status_Employment; } set { _gSEAgencyQM_Status_Employment = value; } }
-        private Value<string> _gSEAgencyQM_Status_Income;
+        private DirtyValue<string> _gSEAgencyQM_Status_Income;
         public string GSEAgencyQM_Status_Income { get { return _gSEAgencyQM_Status_Income; } set { _gSEAgencyQM_Status_Income = value; } }
-        private Value<string> _gSEAgencyQM_Status_InterestOnly;
+        private DirtyValue<string> _gSEAgencyQM_Status_InterestOnly;
         public string GSEAgencyQM_Status_InterestOnly { get { return _gSEAgencyQM_Status_InterestOnly; } set { _gSEAgencyQM_Status_InterestOnly = value; } }
-        private Value<string> _gSEAgencyQM_Status_LoanTerm;
+        private DirtyValue<string> _gSEAgencyQM_Status_LoanTerm;
         public string GSEAgencyQM_Status_LoanTerm { get { return _gSEAgencyQM_Status_LoanTerm; } set { _gSEAgencyQM_Status_LoanTerm = value; } }
-        private Value<string> _gSEAgencyQM_Status_MtgRelatedObligations;
+        private DirtyValue<string> _gSEAgencyQM_Status_MtgRelatedObligations;
         public string GSEAgencyQM_Status_MtgRelatedObligations { get { return _gSEAgencyQM_Status_MtgRelatedObligations; } set { _gSEAgencyQM_Status_MtgRelatedObligations = value; } }
-        private Value<string> _gSEAgencyQM_Status_NegativeAmortization;
+        private DirtyValue<string> _gSEAgencyQM_Status_NegativeAmortization;
         public string GSEAgencyQM_Status_NegativeAmortization { get { return _gSEAgencyQM_Status_NegativeAmortization; } set { _gSEAgencyQM_Status_NegativeAmortization = value; } }
-        private Value<string> _gSEAgencyQM_Status_Overall;
+        private DirtyValue<string> _gSEAgencyQM_Status_Overall;
         public string GSEAgencyQM_Status_Overall { get { return _gSEAgencyQM_Status_Overall; } set { _gSEAgencyQM_Status_Overall = value; } }
-        private Value<string> _gSEAgencyQM_Status_PointsFeesLimit;
+        private DirtyValue<string> _gSEAgencyQM_Status_PointsFeesLimit;
         public string GSEAgencyQM_Status_PointsFeesLimit { get { return _gSEAgencyQM_Status_PointsFeesLimit; } set { _gSEAgencyQM_Status_PointsFeesLimit = value; } }
-        private Value<string> _gSEAgencyQM_Status_PrepaymentPenalty;
+        private DirtyValue<string> _gSEAgencyQM_Status_PrepaymentPenalty;
         public string GSEAgencyQM_Status_PrepaymentPenalty { get { return _gSEAgencyQM_Status_PrepaymentPenalty; } set { _gSEAgencyQM_Status_PrepaymentPenalty = value; } }
-        private Value<string> _gSEAgencyQM_Status_ResidualIncome;
+        private DirtyValue<string> _gSEAgencyQM_Status_ResidualIncome;
         public string GSEAgencyQM_Status_ResidualIncome { get { return _gSEAgencyQM_Status_ResidualIncome; } set { _gSEAgencyQM_Status_ResidualIncome = value; } }
-        private Value<string> _gSEAgencyQM_Status_SafeHarborEligibility;
+        private DirtyValue<string> _gSEAgencyQM_Status_SafeHarborEligibility;
         public string GSEAgencyQM_Status_SafeHarborEligibility { get { return _gSEAgencyQM_Status_SafeHarborEligibility; } set { _gSEAgencyQM_Status_SafeHarborEligibility = value; } }
-        private Value<string> _gSEAgencyQM_Status_SimultaneousLoan;
+        private DirtyValue<string> _gSEAgencyQM_Status_SimultaneousLoan;
         public string GSEAgencyQM_Status_SimultaneousLoan { get { return _gSEAgencyQM_Status_SimultaneousLoan; } set { _gSEAgencyQM_Status_SimultaneousLoan = value; } }
-        private Value<bool?> _has30DayLatePayment;
+        private DirtyValue<bool?> _has30DayLatePayment;
         public bool? Has30DayLatePayment { get { return _has30DayLatePayment; } set { _has30DayLatePayment = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _initialMaxTotalPayment;
+        private DirtyValue<decimal?> _initialMaxTotalPayment;
         public decimal? InitialMaxTotalPayment { get { return _initialMaxTotalPayment; } set { _initialMaxTotalPayment = value; } }
-        private Value<decimal?> _initialRateHousingRatio;
+        private DirtyValue<decimal?> _initialRateHousingRatio;
         public decimal? InitialRateHousingRatio { get { return _initialRateHousingRatio; } set { _initialRateHousingRatio = value; } }
-        private Value<decimal?> _initialRateMonthlyPayment;
+        private DirtyValue<decimal?> _initialRateMonthlyPayment;
         public decimal? InitialRateMonthlyPayment { get { return _initialRateMonthlyPayment; } set { _initialRateMonthlyPayment = value; } }
-        private Value<decimal?> _initialRateTotalDebtRatio;
+        private DirtyValue<decimal?> _initialRateTotalDebtRatio;
         public decimal? InitialRateTotalDebtRatio { get { return _initialRateTotalDebtRatio; } set { _initialRateTotalDebtRatio = value; } }
-        private Value<int?> _interestOnlyMonths;
+        private DirtyValue<int?> _interestOnlyMonths;
         public int? InterestOnlyMonths { get { return _interestOnlyMonths; } set { _interestOnlyMonths = value; } }
-        private Value<DateTime?> _interestOnlyRecastDate;
+        private DirtyValue<DateTime?> _interestOnlyRecastDate;
         public DateTime? InterestOnlyRecastDate { get { return _interestOnlyRecastDate; } set { _interestOnlyRecastDate = value; } }
-        private Value<bool?> _isConsumerLiklyDefault;
+        private DirtyValue<bool?> _isConsumerLiklyDefault;
         public bool? IsConsumerLiklyDefault { get { return _isConsumerLiklyDefault; } set { _isConsumerLiklyDefault = value; } }
-        private Value<string> _isEligibleForSafeHarbor;
+        private DirtyValue<string> _isEligibleForSafeHarbor;
         public string IsEligibleForSafeHarbor { get { return _isEligibleForSafeHarbor; } set { _isEligibleForSafeHarbor = value; } }
-        private Value<bool?> _isEvaluatedAlimonyObligations;
+        private DirtyValue<bool?> _isEvaluatedAlimonyObligations;
         public bool? IsEvaluatedAlimonyObligations { get { return _isEvaluatedAlimonyObligations; } set { _isEvaluatedAlimonyObligations = value; } }
-        private Value<bool?> _isEvaluatedChildSupportObligations;
+        private DirtyValue<bool?> _isEvaluatedChildSupportObligations;
         public bool? IsEvaluatedChildSupportObligations { get { return _isEvaluatedChildSupportObligations; } set { _isEvaluatedChildSupportObligations = value; } }
-        private Value<bool?> _isEvaluatedCreditHistory;
+        private DirtyValue<bool?> _isEvaluatedCreditHistory;
         public bool? IsEvaluatedCreditHistory { get { return _isEvaluatedCreditHistory; } set { _isEvaluatedCreditHistory = value; } }
-        private Value<bool?> _isEvaluatedCurrentEmploymentStatus;
+        private DirtyValue<bool?> _isEvaluatedCurrentEmploymentStatus;
         public bool? IsEvaluatedCurrentEmploymentStatus { get { return _isEvaluatedCurrentEmploymentStatus; } set { _isEvaluatedCurrentEmploymentStatus = value; } }
-        private Value<bool?> _isEvaluatedCurrentExpectedAssets;
+        private DirtyValue<bool?> _isEvaluatedCurrentExpectedAssets;
         public bool? IsEvaluatedCurrentExpectedAssets { get { return _isEvaluatedCurrentExpectedAssets; } set { _isEvaluatedCurrentExpectedAssets = value; } }
-        private Value<bool?> _isEvaluatedCurrentExpectedIncome;
+        private DirtyValue<bool?> _isEvaluatedCurrentExpectedIncome;
         public bool? IsEvaluatedCurrentExpectedIncome { get { return _isEvaluatedCurrentExpectedIncome; } set { _isEvaluatedCurrentExpectedIncome = value; } }
-        private Value<bool?> _isEvaluatedDebtObligations;
+        private DirtyValue<bool?> _isEvaluatedDebtObligations;
         public bool? IsEvaluatedDebtObligations { get { return _isEvaluatedDebtObligations; } set { _isEvaluatedDebtObligations = value; } }
-        private Value<bool?> _isEvaluatedDebtToIncomeRatio;
+        private DirtyValue<bool?> _isEvaluatedDebtToIncomeRatio;
         public bool? IsEvaluatedDebtToIncomeRatio { get { return _isEvaluatedDebtToIncomeRatio; } set { _isEvaluatedDebtToIncomeRatio = value; } }
-        private Value<bool?> _isEvaluatedMonthlyCoveredLoanPayment;
+        private DirtyValue<bool?> _isEvaluatedMonthlyCoveredLoanPayment;
         public bool? IsEvaluatedMonthlyCoveredLoanPayment { get { return _isEvaluatedMonthlyCoveredLoanPayment; } set { _isEvaluatedMonthlyCoveredLoanPayment = value; } }
-        private Value<bool?> _isEvaluatedMonthlyMortgageRelatedObligations;
+        private DirtyValue<bool?> _isEvaluatedMonthlyMortgageRelatedObligations;
         public bool? IsEvaluatedMonthlyMortgageRelatedObligations { get { return _isEvaluatedMonthlyMortgageRelatedObligations; } set { _isEvaluatedMonthlyMortgageRelatedObligations = value; } }
-        private Value<bool?> _isEvaluatedMonthlySimultaneousLoanPayment;
+        private DirtyValue<bool?> _isEvaluatedMonthlySimultaneousLoanPayment;
         public bool? IsEvaluatedMonthlySimultaneousLoanPayment { get { return _isEvaluatedMonthlySimultaneousLoanPayment; } set { _isEvaluatedMonthlySimultaneousLoanPayment = value; } }
-        private Value<bool?> _isEvaluatedResidualIncome;
+        private DirtyValue<bool?> _isEvaluatedResidualIncome;
         public bool? IsEvaluatedResidualIncome { get { return _isEvaluatedResidualIncome; } set { _isEvaluatedResidualIncome = value; } }
-        private Value<string> _isHigherPricedLoan;
+        private DirtyValue<string> _isHigherPricedLoan;
         public string IsHigherPricedLoan { get { return _isHigherPricedLoan; } set { _isHigherPricedLoan = value; } }
-        private Value<string> _loanProcessingInformationD4;
+        private DirtyValue<string> _loanProcessingInformationD4;
         public string LoanProcessingInformationD4 { get { return _loanProcessingInformationD4; } set { _loanProcessingInformationD4 = value; } }
-        private Value<string> _loanProcessingInformationGO;
+        private DirtyValue<string> _loanProcessingInformationGO;
         public string LoanProcessingInformationGO { get { return _loanProcessingInformationGO; } set { _loanProcessingInformationGO = value; } }
-        private Value<string> _loanProcessingInformationHA;
+        private DirtyValue<string> _loanProcessingInformationHA;
         public string LoanProcessingInformationHA { get { return _loanProcessingInformationHA; } set { _loanProcessingInformationHA = value; } }
-        private Value<string> _loanProcessingInformationLE;
+        private DirtyValue<string> _loanProcessingInformationLE;
         public string LoanProcessingInformationLE { get { return _loanProcessingInformationLE; } set { _loanProcessingInformationLE = value; } }
-        private Value<string> _loanProcessingInformationLF;
+        private DirtyValue<string> _loanProcessingInformationLF;
         public string LoanProcessingInformationLF { get { return _loanProcessingInformationLF; } set { _loanProcessingInformationLF = value; } }
-        private Value<string> _loanProcessingInformationMA;
+        private DirtyValue<string> _loanProcessingInformationMA;
         public string LoanProcessingInformationMA { get { return _loanProcessingInformationMA; } set { _loanProcessingInformationMA = value; } }
-        private Value<bool?> _loanProgram;
+        private DirtyValue<bool?> _loanProgram;
         public bool? LoanProgram { get { return _loanProgram; } set { _loanProgram = value; } }
-        private Value<string> _loanProgramDescription;
+        private DirtyValue<string> _loanProgramDescription;
         public string LoanProgramDescription { get { return _loanProgramDescription; } set { _loanProgramDescription = value; } }
-        private Value<bool?> _loanRateFixedin5Years;
+        private DirtyValue<bool?> _loanRateFixedin5Years;
         public bool? LoanRateFixedin5Years { get { return _loanRateFixedin5Years; } set { _loanRateFixedin5Years = value; } }
-        private Value<decimal?> _lOBrokerCompensationAmount;
+        private DirtyValue<decimal?> _lOBrokerCompensationAmount;
         public decimal? LOBrokerCompensationAmount { get { return _lOBrokerCompensationAmount; } set { _lOBrokerCompensationAmount = value; } }
-        private Value<decimal?> _max5YrsHousingRatio;
+        private DirtyValue<decimal?> _max5YrsHousingRatio;
         public decimal? Max5YrsHousingRatio { get { return _max5YrsHousingRatio; } set { _max5YrsHousingRatio = value; } }
-        private Value<decimal?> _max5YrsPrincipleAndInterest;
+        private DirtyValue<decimal?> _max5YrsPrincipleAndInterest;
         public decimal? Max5YrsPrincipleAndInterest { get { return _max5YrsPrincipleAndInterest; } set { _max5YrsPrincipleAndInterest = value; } }
-        private Value<decimal?> _max5YrsTotalDebtRatio;
+        private DirtyValue<decimal?> _max5YrsTotalDebtRatio;
         public decimal? Max5YrsTotalDebtRatio { get { return _max5YrsTotalDebtRatio; } set { _max5YrsTotalDebtRatio = value; } }
-        private Value<decimal?> _max5YrsTotalPayment;
+        private DirtyValue<decimal?> _max5YrsTotalPayment;
         public decimal? Max5YrsTotalPayment { get { return _max5YrsTotalPayment; } set { _max5YrsTotalPayment = value; } }
-        private Value<decimal?> _maxPrepaymentPenaltyFees;
+        private DirtyValue<decimal?> _maxPrepaymentPenaltyFees;
         public decimal? MaxPrepaymentPenaltyFees { get { return _maxPrepaymentPenaltyFees; } set { _maxPrepaymentPenaltyFees = value; } }
-        private Value<DateTime?> _negAmRecastDate;
+        private DirtyValue<DateTime?> _negAmRecastDate;
         public DateTime? NegAmRecastDate { get { return _negAmRecastDate; } set { _negAmRecastDate = value; } }
-        private Value<bool?> _paymentDecreasedBy10Percent;
+        private DirtyValue<bool?> _paymentDecreasedBy10Percent;
         public bool? PaymentDecreasedBy10Percent { get { return _paymentDecreasedBy10Percent; } set { _paymentDecreasedBy10Percent = value; } }
-        private Value<bool?> _pointsFeesThresholdMet;
+        private DirtyValue<bool?> _pointsFeesThresholdMet;
         public bool? PointsFeesThresholdMet { get { return _pointsFeesThresholdMet; } set { _pointsFeesThresholdMet = value; } }
-        private Value<decimal?> _prepaymentPenaltyPayoffFees;
+        private DirtyValue<decimal?> _prepaymentPenaltyPayoffFees;
         public decimal? PrepaymentPenaltyPayoffFees { get { return _prepaymentPenaltyPayoffFees; } set { _prepaymentPenaltyPayoffFees = value; } }
-        private Value<decimal?> _prepayPenaltyPercentage;
+        private DirtyValue<decimal?> _prepayPenaltyPercentage;
         public decimal? PrepayPenaltyPercentage { get { return _prepayPenaltyPercentage; } set { _prepayPenaltyPercentage = value; } }
-        private Value<bool?> _preventConsumersDefault;
+        private DirtyValue<bool?> _preventConsumersDefault;
         public bool? PreventConsumersDefault { get { return _preventConsumersDefault; } set { _preventConsumersDefault = value; } }
-        private Value<bool?> _principalBalanceIncreased;
+        private DirtyValue<bool?> _principalBalanceIncreased;
         public bool? PrincipalBalanceIncreased { get { return _principalBalanceIncreased; } set { _principalBalanceIncreased = value; } }
-        private Value<bool?> _principalHasDeferred;
+        private DirtyValue<bool?> _principalHasDeferred;
         public bool? PrincipalHasDeferred { get { return _principalHasDeferred; } set { _principalHasDeferred = value; } }
-        private Value<string> _qMLoanType;
+        private DirtyValue<string> _qMLoanType;
         public string QMLoanType { get { return _qMLoanType; } set { _qMLoanType = value; } }
-        private Value<decimal?> _rateReductionBasisPoints;
+        private DirtyValue<decimal?> _rateReductionBasisPoints;
         public decimal? RateReductionBasisPoints { get { return _rateReductionBasisPoints; } set { _rateReductionBasisPoints = value; } }
-        private Value<decimal?> _rateReductionDiscountPoints;
+        private DirtyValue<decimal?> _rateReductionDiscountPoints;
         public decimal? RateReductionDiscountPoints { get { return _rateReductionDiscountPoints; } set { _rateReductionDiscountPoints = value; } }
-        private Value<decimal?> _rateReductionMaxBonaFideDiscountPoint;
+        private DirtyValue<decimal?> _rateReductionMaxBonaFideDiscountPoint;
         public decimal? RateReductionMaxBonaFideDiscountPoint { get { return _rateReductionMaxBonaFideDiscountPoint; } set { _rateReductionMaxBonaFideDiscountPoint = value; } }
-        private Value<decimal?> _realEstateFees;
+        private DirtyValue<decimal?> _realEstateFees;
         public decimal? RealEstateFees { get { return _realEstateFees; } set { _realEstateFees = value; } }
-        private Value<decimal?> _recastDifferencePayment;
+        private DirtyValue<decimal?> _recastDifferencePayment;
         public decimal? RecastDifferencePayment { get { return _recastDifferencePayment; } set { _recastDifferencePayment = value; } }
-        private Value<decimal?> _regZTotalLoanAmount;
+        private DirtyValue<decimal?> _regZTotalLoanAmount;
         public decimal? RegZTotalLoanAmount { get { return _regZTotalLoanAmount; } set { _regZTotalLoanAmount = value; } }
-        private Value<decimal?> _requiredServicesLenderSelectedAmt;
+        private DirtyValue<decimal?> _requiredServicesLenderSelectedAmt;
         public decimal? RequiredServicesLenderSelectedAmt { get { return _requiredServicesLenderSelectedAmt; } set { _requiredServicesLenderSelectedAmt = value; } }
-        private Value<decimal?> _smallCreditorQM_CalculatedThreshold;
+        private DirtyValue<decimal?> _smallCreditorQM_CalculatedThreshold;
         public decimal? SmallCreditorQM_CalculatedThreshold { get { return _smallCreditorQM_CalculatedThreshold; } set { _smallCreditorQM_CalculatedThreshold = value; } }
-        private Value<string> _smallCreditorQM_Status_Alimony;
+        private DirtyValue<string> _smallCreditorQM_Status_Alimony;
         public string SmallCreditorQM_Status_Alimony { get { return _smallCreditorQM_Status_Alimony; } set { _smallCreditorQM_Status_Alimony = value; } }
-        private Value<string> _smallCreditorQM_Status_Assets;
+        private DirtyValue<string> _smallCreditorQM_Status_Assets;
         public string SmallCreditorQM_Status_Assets { get { return _smallCreditorQM_Status_Assets; } set { _smallCreditorQM_Status_Assets = value; } }
-        private Value<string> _smallCreditorQM_Status_BalloonPayment;
+        private DirtyValue<string> _smallCreditorQM_Status_BalloonPayment;
         public string SmallCreditorQM_Status_BalloonPayment { get { return _smallCreditorQM_Status_BalloonPayment; } set { _smallCreditorQM_Status_BalloonPayment = value; } }
-        private Value<string> _smallCreditorQM_Status_ChildSupport;
+        private DirtyValue<string> _smallCreditorQM_Status_ChildSupport;
         public string SmallCreditorQM_Status_ChildSupport { get { return _smallCreditorQM_Status_ChildSupport; } set { _smallCreditorQM_Status_ChildSupport = value; } }
-        private Value<string> _smallCreditorQM_Status_CoveredLoan;
+        private DirtyValue<string> _smallCreditorQM_Status_CoveredLoan;
         public string SmallCreditorQM_Status_CoveredLoan { get { return _smallCreditorQM_Status_CoveredLoan; } set { _smallCreditorQM_Status_CoveredLoan = value; } }
-        private Value<string> _smallCreditorQM_Status_DebtObligations;
+        private DirtyValue<string> _smallCreditorQM_Status_DebtObligations;
         public string SmallCreditorQM_Status_DebtObligations { get { return _smallCreditorQM_Status_DebtObligations; } set { _smallCreditorQM_Status_DebtObligations = value; } }
-        private Value<string> _smallCreditorQM_Status_DTI;
+        private DirtyValue<string> _smallCreditorQM_Status_DTI;
         public string SmallCreditorQM_Status_DTI { get { return _smallCreditorQM_Status_DTI; } set { _smallCreditorQM_Status_DTI = value; } }
-        private Value<string> _smallCreditorQM_Status_Income;
+        private DirtyValue<string> _smallCreditorQM_Status_Income;
         public string SmallCreditorQM_Status_Income { get { return _smallCreditorQM_Status_Income; } set { _smallCreditorQM_Status_Income = value; } }
-        private Value<string> _smallCreditorQM_Status_InterestOnly;
+        private DirtyValue<string> _smallCreditorQM_Status_InterestOnly;
         public string SmallCreditorQM_Status_InterestOnly { get { return _smallCreditorQM_Status_InterestOnly; } set { _smallCreditorQM_Status_InterestOnly = value; } }
-        private Value<string> _smallCreditorQM_Status_LoanTerm;
+        private DirtyValue<string> _smallCreditorQM_Status_LoanTerm;
         public string SmallCreditorQM_Status_LoanTerm { get { return _smallCreditorQM_Status_LoanTerm; } set { _smallCreditorQM_Status_LoanTerm = value; } }
-        private Value<string> _smallCreditorQM_Status_MtgRelatedObligations;
+        private DirtyValue<string> _smallCreditorQM_Status_MtgRelatedObligations;
         public string SmallCreditorQM_Status_MtgRelatedObligations { get { return _smallCreditorQM_Status_MtgRelatedObligations; } set { _smallCreditorQM_Status_MtgRelatedObligations = value; } }
-        private Value<string> _smallCreditorQM_Status_NegativeAmortization;
+        private DirtyValue<string> _smallCreditorQM_Status_NegativeAmortization;
         public string SmallCreditorQM_Status_NegativeAmortization { get { return _smallCreditorQM_Status_NegativeAmortization; } set { _smallCreditorQM_Status_NegativeAmortization = value; } }
-        private Value<string> _smallCreditorQM_Status_Overall;
+        private DirtyValue<string> _smallCreditorQM_Status_Overall;
         public string SmallCreditorQM_Status_Overall { get { return _smallCreditorQM_Status_Overall; } set { _smallCreditorQM_Status_Overall = value; } }
-        private Value<string> _smallCreditorQM_Status_PointsFeesLimit;
+        private DirtyValue<string> _smallCreditorQM_Status_PointsFeesLimit;
         public string SmallCreditorQM_Status_PointsFeesLimit { get { return _smallCreditorQM_Status_PointsFeesLimit; } set { _smallCreditorQM_Status_PointsFeesLimit = value; } }
-        private Value<string> _smallCreditorQM_Status_PrepaymentPenalty;
+        private DirtyValue<string> _smallCreditorQM_Status_PrepaymentPenalty;
         public string SmallCreditorQM_Status_PrepaymentPenalty { get { return _smallCreditorQM_Status_PrepaymentPenalty; } set { _smallCreditorQM_Status_PrepaymentPenalty = value; } }
-        private Value<string> _smallCreditorQM_Status_ResidualIncome;
+        private DirtyValue<string> _smallCreditorQM_Status_ResidualIncome;
         public string SmallCreditorQM_Status_ResidualIncome { get { return _smallCreditorQM_Status_ResidualIncome; } set { _smallCreditorQM_Status_ResidualIncome = value; } }
-        private Value<string> _smallCreditorQM_Status_SafeHarborEligibility;
+        private DirtyValue<string> _smallCreditorQM_Status_SafeHarborEligibility;
         public string SmallCreditorQM_Status_SafeHarborEligibility { get { return _smallCreditorQM_Status_SafeHarborEligibility; } set { _smallCreditorQM_Status_SafeHarborEligibility = value; } }
-        private Value<decimal?> _standardQM_CalculatedThreshold;
+        private DirtyValue<decimal?> _standardQM_CalculatedThreshold;
         public decimal? StandardQM_CalculatedThreshold { get { return _standardQM_CalculatedThreshold; } set { _standardQM_CalculatedThreshold = value; } }
-        private Value<string> _standardQM_Status_Alimony;
+        private DirtyValue<string> _standardQM_Status_Alimony;
         public string StandardQM_Status_Alimony { get { return _standardQM_Status_Alimony; } set { _standardQM_Status_Alimony = value; } }
-        private Value<string> _standardQM_Status_Assets;
+        private DirtyValue<string> _standardQM_Status_Assets;
         public string StandardQM_Status_Assets { get { return _standardQM_Status_Assets; } set { _standardQM_Status_Assets = value; } }
-        private Value<string> _standardQM_Status_BalloonPayment;
+        private DirtyValue<string> _standardQM_Status_BalloonPayment;
         public string StandardQM_Status_BalloonPayment { get { return _standardQM_Status_BalloonPayment; } set { _standardQM_Status_BalloonPayment = value; } }
-        private Value<string> _standardQM_Status_ChildSupport;
+        private DirtyValue<string> _standardQM_Status_ChildSupport;
         public string StandardQM_Status_ChildSupport { get { return _standardQM_Status_ChildSupport; } set { _standardQM_Status_ChildSupport = value; } }
-        private Value<string> _standardQM_Status_CoveredLoan;
+        private DirtyValue<string> _standardQM_Status_CoveredLoan;
         public string StandardQM_Status_CoveredLoan { get { return _standardQM_Status_CoveredLoan; } set { _standardQM_Status_CoveredLoan = value; } }
-        private Value<string> _standardQM_Status_CreditHistory;
+        private DirtyValue<string> _standardQM_Status_CreditHistory;
         public string StandardQM_Status_CreditHistory { get { return _standardQM_Status_CreditHistory; } set { _standardQM_Status_CreditHistory = value; } }
-        private Value<string> _standardQM_Status_DebtObligations;
+        private DirtyValue<string> _standardQM_Status_DebtObligations;
         public string StandardQM_Status_DebtObligations { get { return _standardQM_Status_DebtObligations; } set { _standardQM_Status_DebtObligations = value; } }
-        private Value<string> _standardQM_Status_DTI;
+        private DirtyValue<string> _standardQM_Status_DTI;
         public string StandardQM_Status_DTI { get { return _standardQM_Status_DTI; } set { _standardQM_Status_DTI = value; } }
-        private Value<string> _standardQM_Status_Employment;
+        private DirtyValue<string> _standardQM_Status_Employment;
         public string StandardQM_Status_Employment { get { return _standardQM_Status_Employment; } set { _standardQM_Status_Employment = value; } }
-        private Value<string> _standardQM_Status_Income;
+        private DirtyValue<string> _standardQM_Status_Income;
         public string StandardQM_Status_Income { get { return _standardQM_Status_Income; } set { _standardQM_Status_Income = value; } }
-        private Value<string> _standardQM_Status_InterestOnly;
+        private DirtyValue<string> _standardQM_Status_InterestOnly;
         public string StandardQM_Status_InterestOnly { get { return _standardQM_Status_InterestOnly; } set { _standardQM_Status_InterestOnly = value; } }
-        private Value<string> _standardQM_Status_LoanTerm;
+        private DirtyValue<string> _standardQM_Status_LoanTerm;
         public string StandardQM_Status_LoanTerm { get { return _standardQM_Status_LoanTerm; } set { _standardQM_Status_LoanTerm = value; } }
-        private Value<string> _standardQM_Status_MtgRelatedObligations;
+        private DirtyValue<string> _standardQM_Status_MtgRelatedObligations;
         public string StandardQM_Status_MtgRelatedObligations { get { return _standardQM_Status_MtgRelatedObligations; } set { _standardQM_Status_MtgRelatedObligations = value; } }
-        private Value<string> _standardQM_Status_NegativeAmortization;
+        private DirtyValue<string> _standardQM_Status_NegativeAmortization;
         public string StandardQM_Status_NegativeAmortization { get { return _standardQM_Status_NegativeAmortization; } set { _standardQM_Status_NegativeAmortization = value; } }
-        private Value<string> _standardQM_Status_Overall;
+        private DirtyValue<string> _standardQM_Status_Overall;
         public string StandardQM_Status_Overall { get { return _standardQM_Status_Overall; } set { _standardQM_Status_Overall = value; } }
-        private Value<string> _standardQM_Status_PointsFeesLimit;
+        private DirtyValue<string> _standardQM_Status_PointsFeesLimit;
         public string StandardQM_Status_PointsFeesLimit { get { return _standardQM_Status_PointsFeesLimit; } set { _standardQM_Status_PointsFeesLimit = value; } }
-        private Value<string> _standardQM_Status_PrepaymentPenalty;
+        private DirtyValue<string> _standardQM_Status_PrepaymentPenalty;
         public string StandardQM_Status_PrepaymentPenalty { get { return _standardQM_Status_PrepaymentPenalty; } set { _standardQM_Status_PrepaymentPenalty = value; } }
-        private Value<string> _standardQM_Status_ResidualIncome;
+        private DirtyValue<string> _standardQM_Status_ResidualIncome;
         public string StandardQM_Status_ResidualIncome { get { return _standardQM_Status_ResidualIncome; } set { _standardQM_Status_ResidualIncome = value; } }
-        private Value<string> _standardQM_Status_SafeHarborEligibility;
+        private DirtyValue<string> _standardQM_Status_SafeHarborEligibility;
         public string StandardQM_Status_SafeHarborEligibility { get { return _standardQM_Status_SafeHarborEligibility; } set { _standardQM_Status_SafeHarborEligibility = value; } }
-        private Value<string> _standardQM_Status_SimultaneousLoan;
+        private DirtyValue<string> _standardQM_Status_SimultaneousLoan;
         public string StandardQM_Status_SimultaneousLoan { get { return _standardQM_Status_SimultaneousLoan; } set { _standardQM_Status_SimultaneousLoan = value; } }
-        private Value<decimal?> _startingAdjustedRateMaxBonaFideDiscountPoint;
+        private DirtyValue<decimal?> _startingAdjustedRateMaxBonaFideDiscountPoint;
         public decimal? StartingAdjustedRateMaxBonaFideDiscountPoint { get { return _startingAdjustedRateMaxBonaFideDiscountPoint; } set { _startingAdjustedRateMaxBonaFideDiscountPoint = value; } }
-        private Value<string> _status_CreditHistory;
+        private DirtyValue<string> _status_CreditHistory;
         public string Status_CreditHistory { get { return _status_CreditHistory; } set { _status_CreditHistory = value; } }
-        private Value<string> _status_SimultaneousLoan;
+        private DirtyValue<string> _status_SimultaneousLoan;
         public string Status_SimultaneousLoan { get { return _status_SimultaneousLoan; } set { _status_SimultaneousLoan = value; } }
-        private Value<string> _thresholdExceedsQM;
+        private DirtyValue<string> _thresholdExceedsQM;
         public string ThresholdExceedsQM { get { return _thresholdExceedsQM; } set { _thresholdExceedsQM = value; } }
-        private Value<decimal?> _titleServicesLenderTitleinsuranceFee;
+        private DirtyValue<decimal?> _titleServicesLenderTitleinsuranceFee;
         public decimal? TitleServicesLenderTitleinsuranceFee { get { return _titleServicesLenderTitleinsuranceFee; } set { _titleServicesLenderTitleinsuranceFee = value; } }
-        private Value<decimal?> _totalCoMortgagorIncome;
+        private DirtyValue<decimal?> _totalCoMortgagorIncome;
         public decimal? TotalCoMortgagorIncome { get { return _totalCoMortgagorIncome; } set { _totalCoMortgagorIncome = value; } }
-        private Value<decimal?> _totalIncome;
+        private DirtyValue<decimal?> _totalIncome;
         public decimal? TotalIncome { get { return _totalIncome; } set { _totalIncome = value; } }
-        private Value<decimal?> _totalPointsFeesSec32Percent;
+        private DirtyValue<decimal?> _totalPointsFeesSec32Percent;
         public decimal? TotalPointsFeesSec32Percent { get { return _totalPointsFeesSec32Percent; } set { _totalPointsFeesSec32Percent = value; } }
-        private Value<bool?> _transactionExemptFromRegZ;
+        private DirtyValue<bool?> _transactionExemptFromRegZ;
         public bool? TransactionExemptFromRegZ { get { return _transactionExemptFromRegZ; } set { _transactionExemptFromRegZ = value; } }
-        private Value<bool?> _unitCount;
+        private DirtyValue<bool?> _unitCount;
         public bool? UnitCount { get { return _unitCount; } set { _unitCount = value; } }
-        private Value<decimal?> _upfrontPMIFees;
+        private DirtyValue<decimal?> _upfrontPMIFees;
         public decimal? UpfrontPMIFees { get { return _upfrontPMIFees; } set { _upfrontPMIFees = value; } }
-        private Value<bool?> _withOriginalCreditor;
+        private DirtyValue<bool?> _withOriginalCreditor;
         public bool? WithOriginalCreditor { get { return _withOriginalCreditor; } set { _withOriginalCreditor = value; } }
-        private Value<DateTime?> _writtenApplicationDate;
+        private DirtyValue<DateTime?> _writtenApplicationDate;
         public DateTime? WrittenApplicationDate { get { return _writtenApplicationDate; } set { _writtenApplicationDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/AUSTrackingLog.cs
+++ b/src/EncompassRest/Loans/AUSTrackingLog.cs
@@ -8,435 +8,435 @@ namespace EncompassRest.Loans
 {
     public sealed partial class AUSTrackingLog : IDirty
     {
-        private Value<int?> _aUSTrackingLogIndex;
+        private DirtyValue<int?> _aUSTrackingLogIndex;
         public int? AUSTrackingLogIndex { get { return _aUSTrackingLogIndex; } set { _aUSTrackingLogIndex = value; } }
-        private Value<string> _batchDocumentRefId;
+        private DirtyValue<string> _batchDocumentRefId;
         public string BatchDocumentRefId { get { return _batchDocumentRefId; } set { _batchDocumentRefId = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEmpty;
+        private DirtyValue<bool?> _isEmpty;
         public bool? IsEmpty { get { return _isEmpty; } set { _isEmpty = value; } }
-        private Value<bool?> _isHistory;
+        private DirtyValue<bool?> _isHistory;
         public bool? IsHistory { get { return _isHistory; } set { _isHistory = value; } }
-        private Value<string> _log_AcceptPlusEligible;
+        private DirtyValue<string> _log_AcceptPlusEligible;
         public string Log_AcceptPlusEligible { get { return _log_AcceptPlusEligible; } set { _log_AcceptPlusEligible = value; } }
-        private Value<string> _log_AffordableProductType;
+        private DirtyValue<string> _log_AffordableProductType;
         public string Log_AffordableProductType { get { return _log_AffordableProductType; } set { _log_AffordableProductType = value; } }
-        private Value<decimal?> _log_AllOtherPayments;
+        private DirtyValue<decimal?> _log_AllOtherPayments;
         public decimal? Log_AllOtherPayments { get { return _log_AllOtherPayments; } set { _log_AllOtherPayments = value; } }
-        private Value<int?> _log_AmortizationMonths;
+        private DirtyValue<int?> _log_AmortizationMonths;
         public int? Log_AmortizationMonths { get { return _log_AmortizationMonths; } set { _log_AmortizationMonths = value; } }
-        private Value<string> _log_AmortizationType;
+        private DirtyValue<string> _log_AmortizationType;
         public string Log_AmortizationType { get { return _log_AmortizationType; } set { _log_AmortizationType = value; } }
-        private Value<decimal?> _log_AmtSubordinateFin;
+        private DirtyValue<decimal?> _log_AmtSubordinateFin;
         public decimal? Log_AmtSubordinateFin { get { return _log_AmtSubordinateFin; } set { _log_AmtSubordinateFin = value; } }
-        private Value<string> _log_AppraisalTypeMAF;
+        private DirtyValue<string> _log_AppraisalTypeMAF;
         public string Log_AppraisalTypeMAF { get { return _log_AppraisalTypeMAF; } set { _log_AppraisalTypeMAF = value; } }
-        private Value<int?> _log_AppraisedValue;
+        private DirtyValue<int?> _log_AppraisedValue;
         public int? Log_AppraisedValue { get { return _log_AppraisedValue; } set { _log_AppraisedValue = value; } }
-        private Value<decimal?> _log_ARMQualifyingRate;
+        private DirtyValue<decimal?> _log_ARMQualifyingRate;
         public decimal? Log_ARMQualifyingRate { get { return _log_ARMQualifyingRate; } set { _log_ARMQualifyingRate = value; } }
-        private Value<string> _log_AssessmentType;
+        private DirtyValue<string> _log_AssessmentType;
         public string Log_AssessmentType { get { return _log_AssessmentType; } set { _log_AssessmentType = value; } }
-        private Value<string> _log_AUSRecommendation;
+        private DirtyValue<string> _log_AUSRecommendation;
         public string Log_AUSRecommendation { get { return _log_AUSRecommendation; } set { _log_AUSRecommendation = value; } }
-        private Value<string> _log_AUSStatus;
+        private DirtyValue<string> _log_AUSStatus;
         public string Log_AUSStatus { get { return _log_AUSStatus; } set { _log_AUSStatus = value; } }
-        private Value<string> _log_AUSTrackingType;
+        private DirtyValue<string> _log_AUSTrackingType;
         public string Log_AUSTrackingType { get { return _log_AUSTrackingType; } set { _log_AUSTrackingType = value; } }
-        private Value<string> _log_AUSTransactionID;
+        private DirtyValue<string> _log_AUSTransactionID;
         public string Log_AUSTransactionID { get { return _log_AUSTransactionID; } set { _log_AUSTransactionID = value; } }
-        private Value<string> _log_AUSVersion;
+        private DirtyValue<string> _log_AUSVersion;
         public string Log_AUSVersion { get { return _log_AUSVersion; } set { _log_AUSVersion = value; } }
-        private Value<string> _log_Balloon;
+        private DirtyValue<string> _log_Balloon;
         public string Log_Balloon { get { return _log_Balloon; } set { _log_Balloon = value; } }
-        private Value<int?> _log_BalloonTerm;
+        private DirtyValue<int?> _log_BalloonTerm;
         public int? Log_BalloonTerm { get { return _log_BalloonTerm; } set { _log_BalloonTerm = value; } }
-        private Value<decimal?> _log_BorrowerAssetAmount;
+        private DirtyValue<decimal?> _log_BorrowerAssetAmount;
         public decimal? Log_BorrowerAssetAmount { get { return _log_BorrowerAssetAmount; } set { _log_BorrowerAssetAmount = value; } }
-        private Value<string> _log_BorrowerAssetName;
+        private DirtyValue<string> _log_BorrowerAssetName;
         public string Log_BorrowerAssetName { get { return _log_BorrowerAssetName; } set { _log_BorrowerAssetName = value; } }
-        private Value<string> _log_BorrowerAssetType;
+        private DirtyValue<string> _log_BorrowerAssetType;
         public string Log_BorrowerAssetType { get { return _log_BorrowerAssetType; } set { _log_BorrowerAssetType = value; } }
-        private Value<string> _log_BorrowerCreditScore1;
+        private DirtyValue<string> _log_BorrowerCreditScore1;
         public string Log_BorrowerCreditScore1 { get { return _log_BorrowerCreditScore1; } set { _log_BorrowerCreditScore1 = value; } }
-        private Value<string> _log_BorrowerCreditScore2;
+        private DirtyValue<string> _log_BorrowerCreditScore2;
         public string Log_BorrowerCreditScore2 { get { return _log_BorrowerCreditScore2; } set { _log_BorrowerCreditScore2 = value; } }
-        private Value<string> _log_BorrowerCreditScore3;
+        private DirtyValue<string> _log_BorrowerCreditScore3;
         public string Log_BorrowerCreditScore3 { get { return _log_BorrowerCreditScore3; } set { _log_BorrowerCreditScore3 = value; } }
-        private Value<string> _log_BorrowerEquifaxBEACON;
+        private DirtyValue<string> _log_BorrowerEquifaxBEACON;
         public string Log_BorrowerEquifaxBEACON { get { return _log_BorrowerEquifaxBEACON; } set { _log_BorrowerEquifaxBEACON = value; } }
-        private Value<string> _log_BorrowerExperianFICO;
+        private DirtyValue<string> _log_BorrowerExperianFICO;
         public string Log_BorrowerExperianFICO { get { return _log_BorrowerExperianFICO; } set { _log_BorrowerExperianFICO = value; } }
-        private Value<decimal?> _log_BorrowerIncomeAmount;
+        private DirtyValue<decimal?> _log_BorrowerIncomeAmount;
         public decimal? Log_BorrowerIncomeAmount { get { return _log_BorrowerIncomeAmount; } set { _log_BorrowerIncomeAmount = value; } }
-        private Value<string> _log_BorrowerIncomeName;
+        private DirtyValue<string> _log_BorrowerIncomeName;
         public string Log_BorrowerIncomeName { get { return _log_BorrowerIncomeName; } set { _log_BorrowerIncomeName = value; } }
-        private Value<string> _log_BorrowerIncomeType;
+        private DirtyValue<string> _log_BorrowerIncomeType;
         public string Log_BorrowerIncomeType { get { return _log_BorrowerIncomeType; } set { _log_BorrowerIncomeType = value; } }
-        private Value<string> _log_BorrowerInstitutionName;
+        private DirtyValue<string> _log_BorrowerInstitutionName;
         public string Log_BorrowerInstitutionName { get { return _log_BorrowerInstitutionName; } set { _log_BorrowerInstitutionName = value; } }
-        private Value<string> _log_BorrowerName;
+        private DirtyValue<string> _log_BorrowerName;
         public string Log_BorrowerName { get { return _log_BorrowerName; } set { _log_BorrowerName = value; } }
-        private Value<string> _log_BorrowerScoreName;
+        private DirtyValue<string> _log_BorrowerScoreName;
         public string Log_BorrowerScoreName { get { return _log_BorrowerScoreName; } set { _log_BorrowerScoreName = value; } }
-        private Value<string> _log_BorrowerTransUnionEmpirica;
+        private DirtyValue<string> _log_BorrowerTransUnionEmpirica;
         public string Log_BorrowerTransUnionEmpirica { get { return _log_BorrowerTransUnionEmpirica; } set { _log_BorrowerTransUnionEmpirica = value; } }
-        private Value<string> _log_BorrowerType1;
+        private DirtyValue<string> _log_BorrowerType1;
         public string Log_BorrowerType1 { get { return _log_BorrowerType1; } set { _log_BorrowerType1 = value; } }
-        private Value<string> _log_BorrowerType2;
+        private DirtyValue<string> _log_BorrowerType2;
         public string Log_BorrowerType2 { get { return _log_BorrowerType2; } set { _log_BorrowerType2 = value; } }
-        private Value<decimal?> _log_BoughtDownRate;
+        private DirtyValue<decimal?> _log_BoughtDownRate;
         public decimal? Log_BoughtDownRate { get { return _log_BoughtDownRate; } set { _log_BoughtDownRate = value; } }
-        private Value<string> _log_Buydown;
+        private DirtyValue<string> _log_Buydown;
         public string Log_Buydown { get { return _log_Buydown; } set { _log_Buydown = value; } }
-        private Value<decimal?> _log_CashBack;
+        private DirtyValue<decimal?> _log_CashBack;
         public decimal? Log_CashBack { get { return _log_CashBack; } set { _log_CashBack = value; } }
-        private Value<decimal?> _log_CashOutAmount;
+        private DirtyValue<decimal?> _log_CashOutAmount;
         public decimal? Log_CashOutAmount { get { return _log_CashOutAmount; } set { _log_CashOutAmount = value; } }
-        private Value<decimal?> _log_CLTV;
+        private DirtyValue<decimal?> _log_CLTV;
         public decimal? Log_CLTV { get { return _log_CLTV; } set { _log_CLTV = value; } }
-        private Value<decimal?> _log_CoBorrowerAssetAmount;
+        private DirtyValue<decimal?> _log_CoBorrowerAssetAmount;
         public decimal? Log_CoBorrowerAssetAmount { get { return _log_CoBorrowerAssetAmount; } set { _log_CoBorrowerAssetAmount = value; } }
-        private Value<string> _log_CoBorrowerAssetName;
+        private DirtyValue<string> _log_CoBorrowerAssetName;
         public string Log_CoBorrowerAssetName { get { return _log_CoBorrowerAssetName; } set { _log_CoBorrowerAssetName = value; } }
-        private Value<string> _log_CoBorrowerAssetType;
+        private DirtyValue<string> _log_CoBorrowerAssetType;
         public string Log_CoBorrowerAssetType { get { return _log_CoBorrowerAssetType; } set { _log_CoBorrowerAssetType = value; } }
-        private Value<string> _log_CoBorrowerCreditScore1;
+        private DirtyValue<string> _log_CoBorrowerCreditScore1;
         public string Log_CoBorrowerCreditScore1 { get { return _log_CoBorrowerCreditScore1; } set { _log_CoBorrowerCreditScore1 = value; } }
-        private Value<string> _log_CoBorrowerCreditScore2;
+        private DirtyValue<string> _log_CoBorrowerCreditScore2;
         public string Log_CoBorrowerCreditScore2 { get { return _log_CoBorrowerCreditScore2; } set { _log_CoBorrowerCreditScore2 = value; } }
-        private Value<string> _log_CoBorrowerCreditScore3;
+        private DirtyValue<string> _log_CoBorrowerCreditScore3;
         public string Log_CoBorrowerCreditScore3 { get { return _log_CoBorrowerCreditScore3; } set { _log_CoBorrowerCreditScore3 = value; } }
-        private Value<string> _log_CoBorrowerEquifaxBEACON;
+        private DirtyValue<string> _log_CoBorrowerEquifaxBEACON;
         public string Log_CoBorrowerEquifaxBEACON { get { return _log_CoBorrowerEquifaxBEACON; } set { _log_CoBorrowerEquifaxBEACON = value; } }
-        private Value<string> _log_CoBorrowerExperianFICO;
+        private DirtyValue<string> _log_CoBorrowerExperianFICO;
         public string Log_CoBorrowerExperianFICO { get { return _log_CoBorrowerExperianFICO; } set { _log_CoBorrowerExperianFICO = value; } }
-        private Value<decimal?> _log_CoBorrowerIncomeAmount;
+        private DirtyValue<decimal?> _log_CoBorrowerIncomeAmount;
         public decimal? Log_CoBorrowerIncomeAmount { get { return _log_CoBorrowerIncomeAmount; } set { _log_CoBorrowerIncomeAmount = value; } }
-        private Value<string> _log_CoBorrowerIncomeName;
+        private DirtyValue<string> _log_CoBorrowerIncomeName;
         public string Log_CoBorrowerIncomeName { get { return _log_CoBorrowerIncomeName; } set { _log_CoBorrowerIncomeName = value; } }
-        private Value<string> _log_CoBorrowerIncomeType;
+        private DirtyValue<string> _log_CoBorrowerIncomeType;
         public string Log_CoBorrowerIncomeType { get { return _log_CoBorrowerIncomeType; } set { _log_CoBorrowerIncomeType = value; } }
-        private Value<string> _log_CoBorrowerInstitutionName;
+        private DirtyValue<string> _log_CoBorrowerInstitutionName;
         public string Log_CoBorrowerInstitutionName { get { return _log_CoBorrowerInstitutionName; } set { _log_CoBorrowerInstitutionName = value; } }
-        private Value<string> _log_CoborrowerName;
+        private DirtyValue<string> _log_CoborrowerName;
         public string Log_CoborrowerName { get { return _log_CoborrowerName; } set { _log_CoborrowerName = value; } }
-        private Value<string> _log_CoBorrowerScoreName;
+        private DirtyValue<string> _log_CoBorrowerScoreName;
         public string Log_CoBorrowerScoreName { get { return _log_CoBorrowerScoreName; } set { _log_CoBorrowerScoreName = value; } }
-        private Value<string> _log_CoBorrowerTransUnionEmpirica;
+        private DirtyValue<string> _log_CoBorrowerTransUnionEmpirica;
         public string Log_CoBorrowerTransUnionEmpirica { get { return _log_CoBorrowerTransUnionEmpirica; } set { _log_CoBorrowerTransUnionEmpirica = value; } }
-        private Value<string> _log_Code1;
+        private DirtyValue<string> _log_Code1;
         public string Log_Code1 { get { return _log_Code1; } set { _log_Code1 = value; } }
-        private Value<string> _log_Code2;
+        private DirtyValue<string> _log_Code2;
         public string Log_Code2 { get { return _log_Code2; } set { _log_Code2 = value; } }
-        private Value<string> _log_CodeDescription1;
+        private DirtyValue<string> _log_CodeDescription1;
         public string Log_CodeDescription1 { get { return _log_CodeDescription1; } set { _log_CodeDescription1 = value; } }
-        private Value<string> _log_CodeDescription2;
+        private DirtyValue<string> _log_CodeDescription2;
         public string Log_CodeDescription2 { get { return _log_CodeDescription2; } set { _log_CodeDescription2 = value; } }
-        private Value<string> _log_CommunityLending;
+        private DirtyValue<string> _log_CommunityLending;
         public string Log_CommunityLending { get { return _log_CommunityLending; } set { _log_CommunityLending = value; } }
-        private Value<DateTime?> _log_CreatedOn;
+        private DirtyValue<DateTime?> _log_CreatedOn;
         public DateTime? Log_CreatedOn { get { return _log_CreatedOn; } set { _log_CreatedOn = value; } }
-        private Value<string> _log_CreditAgency1;
+        private DirtyValue<string> _log_CreditAgency1;
         public string Log_CreditAgency1 { get { return _log_CreditAgency1; } set { _log_CreditAgency1 = value; } }
-        private Value<string> _log_CreditAgency2;
+        private DirtyValue<string> _log_CreditAgency2;
         public string Log_CreditAgency2 { get { return _log_CreditAgency2; } set { _log_CreditAgency2 = value; } }
-        private Value<DateTime?> _log_CreditReportDate1;
+        private DirtyValue<DateTime?> _log_CreditReportDate1;
         public DateTime? Log_CreditReportDate1 { get { return _log_CreditReportDate1; } set { _log_CreditReportDate1 = value; } }
-        private Value<DateTime?> _log_CreditReportDate2;
+        private DirtyValue<DateTime?> _log_CreditReportDate2;
         public DateTime? Log_CreditReportDate2 { get { return _log_CreditReportDate2; } set { _log_CreditReportDate2 = value; } }
-        private Value<string> _log_CreditReportID1;
+        private DirtyValue<string> _log_CreditReportID1;
         public string Log_CreditReportID1 { get { return _log_CreditReportID1; } set { _log_CreditReportID1 = value; } }
-        private Value<string> _log_CreditReportID2;
+        private DirtyValue<string> _log_CreditReportID2;
         public string Log_CreditReportID2 { get { return _log_CreditReportID2; } set { _log_CreditReportID2 = value; } }
-        private Value<string> _log_CuredAmortizationType;
+        private DirtyValue<string> _log_CuredAmortizationType;
         public string Log_CuredAmortizationType { get { return _log_CuredAmortizationType; } set { _log_CuredAmortizationType = value; } }
-        private Value<int?> _log_CuredAppraisedValue;
+        private DirtyValue<int?> _log_CuredAppraisedValue;
         public int? Log_CuredAppraisedValue { get { return _log_CuredAppraisedValue; } set { _log_CuredAppraisedValue = value; } }
-        private Value<decimal?> _log_CuredCLTV;
+        private DirtyValue<decimal?> _log_CuredCLTV;
         public decimal? Log_CuredCLTV { get { return _log_CuredCLTV; } set { _log_CuredCLTV = value; } }
-        private Value<decimal?> _log_CuredHousingExpenseRatio;
+        private DirtyValue<decimal?> _log_CuredHousingExpenseRatio;
         public decimal? Log_CuredHousingExpenseRatio { get { return _log_CuredHousingExpenseRatio; } set { _log_CuredHousingExpenseRatio = value; } }
-        private Value<string> _log_CuredLoanPurpose;
+        private DirtyValue<string> _log_CuredLoanPurpose;
         public string Log_CuredLoanPurpose { get { return _log_CuredLoanPurpose; } set { _log_CuredLoanPurpose = value; } }
-        private Value<int?> _log_CuredLoanTerm;
+        private DirtyValue<int?> _log_CuredLoanTerm;
         public int? Log_CuredLoanTerm { get { return _log_CuredLoanTerm; } set { _log_CuredLoanTerm = value; } }
-        private Value<string> _log_CuredLoanType;
+        private DirtyValue<string> _log_CuredLoanType;
         public string Log_CuredLoanType { get { return _log_CuredLoanType; } set { _log_CuredLoanType = value; } }
-        private Value<decimal?> _log_CuredLTV;
+        private DirtyValue<decimal?> _log_CuredLTV;
         public decimal? Log_CuredLTV { get { return _log_CuredLTV; } set { _log_CuredLTV = value; } }
-        private Value<decimal?> _log_CuredNoteRate;
+        private DirtyValue<decimal?> _log_CuredNoteRate;
         public decimal? Log_CuredNoteRate { get { return _log_CuredNoteRate; } set { _log_CuredNoteRate = value; } }
-        private Value<decimal?> _log_CuredProposedTotalHousingPayment;
+        private DirtyValue<decimal?> _log_CuredProposedTotalHousingPayment;
         public decimal? Log_CuredProposedTotalHousingPayment { get { return _log_CuredProposedTotalHousingPayment; } set { _log_CuredProposedTotalHousingPayment = value; } }
-        private Value<string> _log_CuredRefinancePurpose;
+        private DirtyValue<string> _log_CuredRefinancePurpose;
         public string Log_CuredRefinancePurpose { get { return _log_CuredRefinancePurpose; } set { _log_CuredRefinancePurpose = value; } }
-        private Value<decimal?> _log_CuredTotalExpenseRatio;
+        private DirtyValue<decimal?> _log_CuredTotalExpenseRatio;
         public decimal? Log_CuredTotalExpenseRatio { get { return _log_CuredTotalExpenseRatio; } set { _log_CuredTotalExpenseRatio = value; } }
-        private Value<decimal?> _log_CuredTotalLoanAmount;
+        private DirtyValue<decimal?> _log_CuredTotalLoanAmount;
         public decimal? Log_CuredTotalLoanAmount { get { return _log_CuredTotalLoanAmount; } set { _log_CuredTotalLoanAmount = value; } }
-        private Value<decimal?> _log_CuredTotalMonthlyIncome;
+        private DirtyValue<decimal?> _log_CuredTotalMonthlyIncome;
         public decimal? Log_CuredTotalMonthlyIncome { get { return _log_CuredTotalMonthlyIncome; } set { _log_CuredTotalMonthlyIncome = value; } }
-        private Value<string> _log_DateTimeAssessed;
+        private DirtyValue<string> _log_DateTimeAssessed;
         public string Log_DateTimeAssessed { get { return _log_DateTimeAssessed; } set { _log_DateTimeAssessed = value; } }
-        private Value<string> _log_DateTimeRequested;
+        private DirtyValue<string> _log_DateTimeRequested;
         public string Log_DateTimeRequested { get { return _log_DateTimeRequested; } set { _log_DateTimeRequested = value; } }
-        private Value<decimal?> _log_DebtRatio;
+        private DirtyValue<decimal?> _log_DebtRatio;
         public decimal? Log_DebtRatio { get { return _log_DebtRatio; } set { _log_DebtRatio = value; } }
-        private Value<string> _log_DocumentationLevel;
+        private DirtyValue<string> _log_DocumentationLevel;
         public string Log_DocumentationLevel { get { return _log_DocumentationLevel; } set { _log_DocumentationLevel = value; } }
-        private Value<string> _log_DUCaseIDorLPAUSKey;
+        private DirtyValue<string> _log_DUCaseIDorLPAUSKey;
         public string Log_DUCaseIDorLPAUSKey { get { return _log_DUCaseIDorLPAUSKey; } set { _log_DUCaseIDorLPAUSKey = value; } }
-        private Value<string> _log_DUPropertyType;
+        private DirtyValue<string> _log_DUPropertyType;
         public string Log_DUPropertyType { get { return _log_DUPropertyType; } set { _log_DUPropertyType = value; } }
-        private Value<string> _log_eFolderGUID;
+        private DirtyValue<string> _log_eFolderGUID;
         public string Log_eFolderGUID { get { return _log_eFolderGUID; } set { _log_eFolderGUID = value; } }
-        private Value<decimal?> _log_ExcessAvailableAssetsNoVerified;
+        private DirtyValue<decimal?> _log_ExcessAvailableAssetsNoVerified;
         public decimal? Log_ExcessAvailableAssetsNoVerified { get { return _log_ExcessAvailableAssetsNoVerified; } set { _log_ExcessAvailableAssetsNoVerified = value; } }
-        private Value<decimal?> _log_FinancedMIAmount;
+        private DirtyValue<decimal?> _log_FinancedMIAmount;
         public decimal? Log_FinancedMIAmount { get { return _log_FinancedMIAmount; } set { _log_FinancedMIAmount = value; } }
-        private Value<decimal?> _log_FirstPandI;
+        private DirtyValue<decimal?> _log_FirstPandI;
         public decimal? Log_FirstPandI { get { return _log_FirstPandI; } set { _log_FirstPandI = value; } }
-        private Value<DateTime?> _log_FirstSubmissionDate;
+        private DirtyValue<DateTime?> _log_FirstSubmissionDate;
         public DateTime? Log_FirstSubmissionDate { get { return _log_FirstSubmissionDate; } set { _log_FirstSubmissionDate = value; } }
-        private Value<string> _log_FirstSubmissionTime;
+        private DirtyValue<string> _log_FirstSubmissionTime;
         public string Log_FirstSubmissionTime { get { return _log_FirstSubmissionTime; } set { _log_FirstSubmissionTime = value; } }
-        private Value<string> _log_FreddieDocClass;
+        private DirtyValue<string> _log_FreddieDocClass;
         public string Log_FreddieDocClass { get { return _log_FreddieDocClass; } set { _log_FreddieDocClass = value; } }
-        private Value<decimal?> _log_FundsRequiredClose;
+        private DirtyValue<decimal?> _log_FundsRequiredClose;
         public decimal? Log_FundsRequiredClose { get { return _log_FundsRequiredClose; } set { _log_FundsRequiredClose = value; } }
-        private Value<string> _log_GUID;
+        private DirtyValue<string> _log_GUID;
         public string Log_GUID { get { return _log_GUID; } set { _log_GUID = value; } }
-        private Value<decimal?> _log_HLCTV;
+        private DirtyValue<decimal?> _log_HLCTV;
         public decimal? Log_HLCTV { get { return _log_HLCTV; } set { _log_HLCTV = value; } }
-        private Value<decimal?> _log_HousingExpense;
+        private DirtyValue<decimal?> _log_HousingExpense;
         public decimal? Log_HousingExpense { get { return _log_HousingExpense; } set { _log_HousingExpense = value; } }
-        private Value<decimal?> _log_HousingExpenseRatio;
+        private DirtyValue<decimal?> _log_HousingExpenseRatio;
         public decimal? Log_HousingExpenseRatio { get { return _log_HousingExpenseRatio; } set { _log_HousingExpenseRatio = value; } }
-        private Value<decimal?> _log_HousingRatio;
+        private DirtyValue<decimal?> _log_HousingRatio;
         public decimal? Log_HousingRatio { get { return _log_HousingRatio; } set { _log_HousingRatio = value; } }
-        private Value<decimal?> _log_HTLTV;
+        private DirtyValue<decimal?> _log_HTLTV;
         public decimal? Log_HTLTV { get { return _log_HTLTV; } set { _log_HTLTV = value; } }
-        private Value<string> _log_IncludingLess10Mos;
+        private DirtyValue<string> _log_IncludingLess10Mos;
         public string Log_IncludingLess10Mos { get { return _log_IncludingLess10Mos; } set { _log_IncludingLess10Mos = value; } }
-        private Value<decimal?> _log_IncomeAssetBase;
+        private DirtyValue<decimal?> _log_IncomeAssetBase;
         public decimal? Log_IncomeAssetBase { get { return _log_IncomeAssetBase; } set { _log_IncomeAssetBase = value; } }
-        private Value<decimal?> _log_IncomeAssetBonus;
+        private DirtyValue<decimal?> _log_IncomeAssetBonus;
         public decimal? Log_IncomeAssetBonus { get { return _log_IncomeAssetBonus; } set { _log_IncomeAssetBonus = value; } }
-        private Value<decimal?> _log_IncomeAssetCommission;
+        private DirtyValue<decimal?> _log_IncomeAssetCommission;
         public decimal? Log_IncomeAssetCommission { get { return _log_IncomeAssetCommission; } set { _log_IncomeAssetCommission = value; } }
-        private Value<decimal?> _log_IncomeAssetOther;
+        private DirtyValue<decimal?> _log_IncomeAssetOther;
         public decimal? Log_IncomeAssetOther { get { return _log_IncomeAssetOther; } set { _log_IncomeAssetOther = value; } }
-        private Value<decimal?> _log_IncomeAssetOvertime;
+        private DirtyValue<decimal?> _log_IncomeAssetOvertime;
         public decimal? Log_IncomeAssetOvertime { get { return _log_IncomeAssetOvertime; } set { _log_IncomeAssetOvertime = value; } }
-        private Value<decimal?> _log_IncomeAssetPosCashFlow;
+        private DirtyValue<decimal?> _log_IncomeAssetPosCashFlow;
         public decimal? Log_IncomeAssetPosCashFlow { get { return _log_IncomeAssetPosCashFlow; } set { _log_IncomeAssetPosCashFlow = value; } }
-        private Value<decimal?> _log_IncomeAssetPositiveNetRental;
+        private DirtyValue<decimal?> _log_IncomeAssetPositiveNetRental;
         public decimal? Log_IncomeAssetPositiveNetRental { get { return _log_IncomeAssetPositiveNetRental; } set { _log_IncomeAssetPositiveNetRental = value; } }
-        private Value<string> _log_IndicatorScore;
+        private DirtyValue<string> _log_IndicatorScore;
         public string Log_IndicatorScore { get { return _log_IndicatorScore; } set { _log_IndicatorScore = value; } }
-        private Value<string> _log_IntendedUseofProperty;
+        private DirtyValue<string> _log_IntendedUseofProperty;
         public string Log_IntendedUseofProperty { get { return _log_IntendedUseofProperty; } set { _log_IntendedUseofProperty = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceConclusion1;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceConclusion1;
         public string Log_LCLAEvaluatedServiceConclusion1 { get { return _log_LCLAEvaluatedServiceConclusion1; } set { _log_LCLAEvaluatedServiceConclusion1 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceConclusion2;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceConclusion2;
         public string Log_LCLAEvaluatedServiceConclusion2 { get { return _log_LCLAEvaluatedServiceConclusion2; } set { _log_LCLAEvaluatedServiceConclusion2 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceConclusion3;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceConclusion3;
         public string Log_LCLAEvaluatedServiceConclusion3 { get { return _log_LCLAEvaluatedServiceConclusion3; } set { _log_LCLAEvaluatedServiceConclusion3 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceConclusion4;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceConclusion4;
         public string Log_LCLAEvaluatedServiceConclusion4 { get { return _log_LCLAEvaluatedServiceConclusion4; } set { _log_LCLAEvaluatedServiceConclusion4 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceType1;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceType1;
         public string Log_LCLAEvaluatedServiceType1 { get { return _log_LCLAEvaluatedServiceType1; } set { _log_LCLAEvaluatedServiceType1 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceType2;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceType2;
         public string Log_LCLAEvaluatedServiceType2 { get { return _log_LCLAEvaluatedServiceType2; } set { _log_LCLAEvaluatedServiceType2 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceType3;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceType3;
         public string Log_LCLAEvaluatedServiceType3 { get { return _log_LCLAEvaluatedServiceType3; } set { _log_LCLAEvaluatedServiceType3 = value; } }
-        private Value<string> _log_LCLAEvaluatedServiceType4;
+        private DirtyValue<string> _log_LCLAEvaluatedServiceType4;
         public string Log_LCLAEvaluatedServiceType4 { get { return _log_LCLAEvaluatedServiceType4; } set { _log_LCLAEvaluatedServiceType4 = value; } }
-        private Value<string> _log_LenderLoan;
+        private DirtyValue<string> _log_LenderLoan;
         public string Log_LenderLoan { get { return _log_LenderLoan; } set { _log_LenderLoan = value; } }
-        private Value<string> _log_LienType;
+        private DirtyValue<string> _log_LienType;
         public string Log_LienType { get { return _log_LienType; } set { _log_LienType = value; } }
-        private Value<decimal?> _log_LoanAmount;
+        private DirtyValue<decimal?> _log_LoanAmount;
         public decimal? Log_LoanAmount { get { return _log_LoanAmount; } set { _log_LoanAmount = value; } }
-        private Value<string> _log_LoanApplicationID;
+        private DirtyValue<string> _log_LoanApplicationID;
         public string Log_LoanApplicationID { get { return _log_LoanApplicationID; } set { _log_LoanApplicationID = value; } }
-        private Value<string> _log_LoanProcessingStage;
+        private DirtyValue<string> _log_LoanProcessingStage;
         public string Log_LoanProcessingStage { get { return _log_LoanProcessingStage; } set { _log_LoanProcessingStage = value; } }
-        private Value<string> _log_LoanProspectorID;
+        private DirtyValue<string> _log_LoanProspectorID;
         public string Log_LoanProspectorID { get { return _log_LoanProspectorID; } set { _log_LoanProspectorID = value; } }
-        private Value<string> _log_LoanPurpose;
+        private DirtyValue<string> _log_LoanPurpose;
         public string Log_LoanPurpose { get { return _log_LoanPurpose; } set { _log_LoanPurpose = value; } }
-        private Value<int?> _log_LoanTerm;
+        private DirtyValue<int?> _log_LoanTerm;
         public int? Log_LoanTerm { get { return _log_LoanTerm; } set { _log_LoanTerm = value; } }
-        private Value<string> _log_LoanType;
+        private DirtyValue<string> _log_LoanType;
         public string Log_LoanType { get { return _log_LoanType; } set { _log_LoanType = value; } }
-        private Value<DateTime?> _log_LPAssmtExpDate;
+        private DirtyValue<DateTime?> _log_LPAssmtExpDate;
         public DateTime? Log_LPAssmtExpDate { get { return _log_LPAssmtExpDate; } set { _log_LPAssmtExpDate = value; } }
-        private Value<string> _log_LPPropertyType;
+        private DirtyValue<string> _log_LPPropertyType;
         public string Log_LPPropertyType { get { return _log_LPPropertyType; } set { _log_LPPropertyType = value; } }
-        private Value<string> _log_LPVersion;
+        private DirtyValue<string> _log_LPVersion;
         public string Log_LPVersion { get { return _log_LPVersion; } set { _log_LPVersion = value; } }
-        private Value<string> _log_LQACollateralRepWarrantyServiceConclusion;
+        private DirtyValue<string> _log_LQACollateralRepWarrantyServiceConclusion;
         public string Log_LQACollateralRepWarrantyServiceConclusion { get { return _log_LQACollateralRepWarrantyServiceConclusion; } set { _log_LQACollateralRepWarrantyServiceConclusion = value; } }
-        private Value<string> _log_LQACreditRiskAssessmentConclusion;
+        private DirtyValue<string> _log_LQACreditRiskAssessmentConclusion;
         public string Log_LQACreditRiskAssessmentConclusion { get { return _log_LQACreditRiskAssessmentConclusion; } set { _log_LQACreditRiskAssessmentConclusion = value; } }
-        private Value<string> _log_LQADataCompareFieldConclusion;
+        private DirtyValue<string> _log_LQADataCompareFieldConclusion;
         public string Log_LQADataCompareFieldConclusion { get { return _log_LQADataCompareFieldConclusion; } set { _log_LQADataCompareFieldConclusion = value; } }
-        private Value<string> _log_LQADataCompareFieldName;
+        private DirtyValue<string> _log_LQADataCompareFieldName;
         public string Log_LQADataCompareFieldName { get { return _log_LQADataCompareFieldName; } set { _log_LQADataCompareFieldName = value; } }
-        private Value<string> _log_LQADataCompareResult;
+        private DirtyValue<string> _log_LQADataCompareResult;
         public string Log_LQADataCompareResult { get { return _log_LQADataCompareResult; } set { _log_LQADataCompareResult = value; } }
-        private Value<string> _log_LQALPKey;
+        private DirtyValue<string> _log_LQALPKey;
         public string Log_LQALPKey { get { return _log_LQALPKey; } set { _log_LQALPKey = value; } }
-        private Value<string> _log_LQAPurchaseEligibilityResult;
+        private DirtyValue<string> _log_LQAPurchaseEligibilityResult;
         public string Log_LQAPurchaseEligibilityResult { get { return _log_LQAPurchaseEligibilityResult; } set { _log_LQAPurchaseEligibilityResult = value; } }
-        private Value<string> _log_LQARiskAssessmentKey;
+        private DirtyValue<string> _log_LQARiskAssessmentKey;
         public string Log_LQARiskAssessmentKey { get { return _log_LQARiskAssessmentKey; } set { _log_LQARiskAssessmentKey = value; } }
-        private Value<DateTime?> _log_LQASubmissionDateTime;
+        private DirtyValue<DateTime?> _log_LQASubmissionDateTime;
         public DateTime? Log_LQASubmissionDateTime { get { return _log_LQASubmissionDateTime; } set { _log_LQASubmissionDateTime = value; } }
-        private Value<decimal?> _log_LTV;
+        private DirtyValue<decimal?> _log_LTV;
         public decimal? Log_LTV { get { return _log_LTV; } set { _log_LTV = value; } }
-        private Value<decimal?> _log_MaxMortgageLimit;
+        private DirtyValue<decimal?> _log_MaxMortgageLimit;
         public decimal? Log_MaxMortgageLimit { get { return _log_MaxMortgageLimit; } set { _log_MaxMortgageLimit = value; } }
-        private Value<string> _log_MIDecision;
+        private DirtyValue<string> _log_MIDecision;
         public string Log_MIDecision { get { return _log_MIDecision; } set { _log_MIDecision = value; } }
-        private Value<string> _log_MortgageType;
+        private DirtyValue<string> _log_MortgageType;
         public string Log_MortgageType { get { return _log_MortgageType; } set { _log_MortgageType = value; } }
-        private Value<string> _log_NegAmortizationType;
+        private DirtyValue<string> _log_NegAmortizationType;
         public string Log_NegAmortizationType { get { return _log_NegAmortizationType; } set { _log_NegAmortizationType = value; } }
-        private Value<decimal?> _log_NegativeNetRental;
+        private DirtyValue<decimal?> _log_NegativeNetRental;
         public decimal? Log_NegativeNetRental { get { return _log_NegativeNetRental; } set { _log_NegativeNetRental = value; } }
-        private Value<decimal?> _log_NetCashBack;
+        private DirtyValue<decimal?> _log_NetCashBack;
         public decimal? Log_NetCashBack { get { return _log_NetCashBack; } set { _log_NetCashBack = value; } }
-        private Value<string> _log_NewConstruction;
+        private DirtyValue<string> _log_NewConstruction;
         public string Log_NewConstruction { get { return _log_NewConstruction; } set { _log_NewConstruction = value; } }
-        private Value<decimal?> _log_NoteRate;
+        private DirtyValue<decimal?> _log_NoteRate;
         public decimal? Log_NoteRate { get { return _log_NoteRate; } set { _log_NoteRate = value; } }
-        private Value<string> _log_NOTPNumber;
+        private DirtyValue<string> _log_NOTPNumber;
         public string Log_NOTPNumber { get { return _log_NOTPNumber; } set { _log_NOTPNumber = value; } }
-        private Value<int?> _log_NoUnits;
+        private DirtyValue<int?> _log_NoUnits;
         public int? Log_NoUnits { get { return _log_NoUnits; } set { _log_NoUnits = value; } }
-        private Value<string> _log_NumberOfSubmissions;
+        private DirtyValue<string> _log_NumberOfSubmissions;
         public string Log_NumberOfSubmissions { get { return _log_NumberOfSubmissions; } set { _log_NumberOfSubmissions = value; } }
-        private Value<string> _log_OccupancyStatus;
+        private DirtyValue<string> _log_OccupancyStatus;
         public string Log_OccupancyStatus { get { return _log_OccupancyStatus; } set { _log_OccupancyStatus = value; } }
-        private Value<decimal?> _log_OccupantDebtRatio;
+        private DirtyValue<decimal?> _log_OccupantDebtRatio;
         public decimal? Log_OccupantDebtRatio { get { return _log_OccupantDebtRatio; } set { _log_OccupantDebtRatio = value; } }
-        private Value<decimal?> _log_OccupantHousingRatio;
+        private DirtyValue<decimal?> _log_OccupantHousingRatio;
         public decimal? Log_OccupantHousingRatio { get { return _log_OccupantHousingRatio; } set { _log_OccupantHousingRatio = value; } }
-        private Value<string> _log_OfferingIdentifier;
+        private DirtyValue<string> _log_OfferingIdentifier;
         public string Log_OfferingIdentifier { get { return _log_OfferingIdentifier; } set { _log_OfferingIdentifier = value; } }
-        private Value<string> _log_OriginatingCompany;
+        private DirtyValue<string> _log_OriginatingCompany;
         public string Log_OriginatingCompany { get { return _log_OriginatingCompany; } set { _log_OriginatingCompany = value; } }
-        private Value<decimal?> _log_OwnerExistingMtg;
+        private DirtyValue<decimal?> _log_OwnerExistingMtg;
         public decimal? Log_OwnerExistingMtg { get { return _log_OwnerExistingMtg; } set { _log_OwnerExistingMtg = value; } }
-        private Value<decimal?> _log_PandI;
+        private DirtyValue<decimal?> _log_PandI;
         public decimal? Log_PandI { get { return _log_PandI; } set { _log_PandI = value; } }
-        private Value<int?> _log_PaymentFrequency;
+        private DirtyValue<int?> _log_PaymentFrequency;
         public int? Log_PaymentFrequency { get { return _log_PaymentFrequency; } set { _log_PaymentFrequency = value; } }
-        private Value<string> _log_PresentAddress;
+        private DirtyValue<string> _log_PresentAddress;
         public string Log_PresentAddress { get { return _log_PresentAddress; } set { _log_PresentAddress = value; } }
-        private Value<string> _log_PresentAddressCity;
+        private DirtyValue<string> _log_PresentAddressCity;
         public string Log_PresentAddressCity { get { return _log_PresentAddressCity; } set { _log_PresentAddressCity = value; } }
-        private Value<string> _log_PresentAddressState;
+        private DirtyValue<string> _log_PresentAddressState;
         public string Log_PresentAddressState { get { return _log_PresentAddressState; } set { _log_PresentAddressState = value; } }
-        private Value<string> _log_PresentAddressZipCode;
+        private DirtyValue<string> _log_PresentAddressZipCode;
         public string Log_PresentAddressZipCode { get { return _log_PresentAddressZipCode; } set { _log_PresentAddressZipCode = value; } }
-        private Value<decimal?> _log_PresentHousingExpense;
+        private DirtyValue<decimal?> _log_PresentHousingExpense;
         public decimal? Log_PresentHousingExpense { get { return _log_PresentHousingExpense; } set { _log_PresentHousingExpense = value; } }
-        private Value<decimal?> _log_PresentPrincipalHousingPayment;
+        private DirtyValue<decimal?> _log_PresentPrincipalHousingPayment;
         public decimal? Log_PresentPrincipalHousingPayment { get { return _log_PresentPrincipalHousingPayment; } set { _log_PresentPrincipalHousingPayment = value; } }
-        private Value<string> _log_PropertyAddress;
+        private DirtyValue<string> _log_PropertyAddress;
         public string Log_PropertyAddress { get { return _log_PropertyAddress; } set { _log_PropertyAddress = value; } }
-        private Value<string> _log_PropertyCity;
+        private DirtyValue<string> _log_PropertyCity;
         public string Log_PropertyCity { get { return _log_PropertyCity; } set { _log_PropertyCity = value; } }
-        private Value<string> _log_PropertyState;
+        private DirtyValue<string> _log_PropertyState;
         public string Log_PropertyState { get { return _log_PropertyState; } set { _log_PropertyState = value; } }
-        private Value<string> _log_PropertyZipcode;
+        private DirtyValue<string> _log_PropertyZipcode;
         public string Log_PropertyZipcode { get { return _log_PropertyZipcode; } set { _log_PropertyZipcode = value; } }
-        private Value<decimal?> _log_ProposedHazardInsurance;
+        private DirtyValue<decimal?> _log_ProposedHazardInsurance;
         public decimal? Log_ProposedHazardInsurance { get { return _log_ProposedHazardInsurance; } set { _log_ProposedHazardInsurance = value; } }
-        private Value<decimal?> _log_ProposedHOAFees;
+        private DirtyValue<decimal?> _log_ProposedHOAFees;
         public decimal? Log_ProposedHOAFees { get { return _log_ProposedHOAFees; } set { _log_ProposedHOAFees = value; } }
-        private Value<decimal?> _log_ProposedHousingPITI;
+        private DirtyValue<decimal?> _log_ProposedHousingPITI;
         public decimal? Log_ProposedHousingPITI { get { return _log_ProposedHousingPITI; } set { _log_ProposedHousingPITI = value; } }
-        private Value<decimal?> _log_ProposedMortgageInsurance;
+        private DirtyValue<decimal?> _log_ProposedMortgageInsurance;
         public decimal? Log_ProposedMortgageInsurance { get { return _log_ProposedMortgageInsurance; } set { _log_ProposedMortgageInsurance = value; } }
-        private Value<decimal?> _log_ProposedOtherPayment;
+        private DirtyValue<decimal?> _log_ProposedOtherPayment;
         public decimal? Log_ProposedOtherPayment { get { return _log_ProposedOtherPayment; } set { _log_ProposedOtherPayment = value; } }
-        private Value<decimal?> _log_ProposedTaxes;
+        private DirtyValue<decimal?> _log_ProposedTaxes;
         public decimal? Log_ProposedTaxes { get { return _log_ProposedTaxes; } set { _log_ProposedTaxes = value; } }
-        private Value<decimal?> _log_ProposedTotalHousingPayment;
+        private DirtyValue<decimal?> _log_ProposedTotalHousingPayment;
         public decimal? Log_ProposedTotalHousingPayment { get { return _log_ProposedTotalHousingPayment; } set { _log_ProposedTotalHousingPayment = value; } }
-        private Value<decimal?> _log_ProposedTotalMonthlyDebt;
+        private DirtyValue<decimal?> _log_ProposedTotalMonthlyDebt;
         public decimal? Log_ProposedTotalMonthlyDebt { get { return _log_ProposedTotalMonthlyDebt; } set { _log_ProposedTotalMonthlyDebt = value; } }
-        private Value<string> _log_PurchaseEligibility;
+        private DirtyValue<string> _log_PurchaseEligibility;
         public string Log_PurchaseEligibility { get { return _log_PurchaseEligibility; } set { _log_PurchaseEligibility = value; } }
-        private Value<decimal?> _log_QualifyingRate;
+        private DirtyValue<decimal?> _log_QualifyingRate;
         public decimal? Log_QualifyingRate { get { return _log_QualifyingRate; } set { _log_QualifyingRate = value; } }
-        private Value<string> _log_RecordType;
+        private DirtyValue<string> _log_RecordType;
         public string Log_RecordType { get { return _log_RecordType; } set { _log_RecordType = value; } }
-        private Value<string> _log_RefinancePurpose;
+        private DirtyValue<string> _log_RefinancePurpose;
         public string Log_RefinancePurpose { get { return _log_RefinancePurpose; } set { _log_RefinancePurpose = value; } }
-        private Value<decimal?> _log_Reserves;
+        private DirtyValue<decimal?> _log_Reserves;
         public decimal? Log_Reserves { get { return _log_Reserves; } set { _log_Reserves = value; } }
-        private Value<decimal?> _log_ReservesRequiredVerified;
+        private DirtyValue<decimal?> _log_ReservesRequiredVerified;
         public decimal? Log_ReservesRequiredVerified { get { return _log_ReservesRequiredVerified; } set { _log_ReservesRequiredVerified = value; } }
-        private Value<string> _log_RiskClass;
+        private DirtyValue<string> _log_RiskClass;
         public string Log_RiskClass { get { return _log_RiskClass; } set { _log_RiskClass = value; } }
-        private Value<string> _log_SalesConcessions;
+        private DirtyValue<string> _log_SalesConcessions;
         public string Log_SalesConcessions { get { return _log_SalesConcessions; } set { _log_SalesConcessions = value; } }
-        private Value<decimal?> _log_SalesPrice;
+        private DirtyValue<decimal?> _log_SalesPrice;
         public decimal? Log_SalesPrice { get { return _log_SalesPrice; } set { _log_SalesPrice = value; } }
-        private Value<decimal?> _log_SecondPandI;
+        private DirtyValue<decimal?> _log_SecondPandI;
         public decimal? Log_SecondPandI { get { return _log_SecondPandI; } set { _log_SecondPandI = value; } }
-        private Value<string> _log_SelectedBorrower;
+        private DirtyValue<string> _log_SelectedBorrower;
         public string Log_SelectedBorrower { get { return _log_SelectedBorrower; } set { _log_SelectedBorrower = value; } }
-        private Value<string> _log_SelectedRepository;
+        private DirtyValue<string> _log_SelectedRepository;
         public string Log_SelectedRepository { get { return _log_SelectedRepository; } set { _log_SelectedRepository = value; } }
-        private Value<string> _log_SellerNumber;
+        private DirtyValue<string> _log_SellerNumber;
         public string Log_SellerNumber { get { return _log_SellerNumber; } set { _log_SellerNumber = value; } }
-        private Value<decimal?> _log_SubjNegCashFlow;
+        private DirtyValue<decimal?> _log_SubjNegCashFlow;
         public decimal? Log_SubjNegCashFlow { get { return _log_SubjNegCashFlow; } set { _log_SubjNegCashFlow = value; } }
-        private Value<DateTime?> _log_SubmissionDate;
+        private DirtyValue<DateTime?> _log_SubmissionDate;
         public DateTime? Log_SubmissionDate { get { return _log_SubmissionDate; } set { _log_SubmissionDate = value; } }
-        private Value<string> _log_SubmissionNumber;
+        private DirtyValue<string> _log_SubmissionNumber;
         public string Log_SubmissionNumber { get { return _log_SubmissionNumber; } set { _log_SubmissionNumber = value; } }
-        private Value<string> _log_SubmissionTime;
+        private DirtyValue<string> _log_SubmissionTime;
         public string Log_SubmissionTime { get { return _log_SubmissionTime; } set { _log_SubmissionTime = value; } }
-        private Value<string> _log_SubmittedBy;
+        private DirtyValue<string> _log_SubmittedBy;
         public string Log_SubmittedBy { get { return _log_SubmittedBy; } set { _log_SubmittedBy = value; } }
-        private Value<string> _log_SubmittingCompany;
+        private DirtyValue<string> _log_SubmittingCompany;
         public string Log_SubmittingCompany { get { return _log_SubmittingCompany; } set { _log_SubmittingCompany = value; } }
-        private Value<string> _log_TemporarySubsidyBuydown;
+        private DirtyValue<string> _log_TemporarySubsidyBuydown;
         public string Log_TemporarySubsidyBuydown { get { return _log_TemporarySubsidyBuydown; } set { _log_TemporarySubsidyBuydown = value; } }
-        private Value<decimal?> _log_TLTV;
+        private DirtyValue<decimal?> _log_TLTV;
         public decimal? Log_TLTV { get { return _log_TLTV; } set { _log_TLTV = value; } }
-        private Value<decimal?> _log_TotalAsset;
+        private DirtyValue<decimal?> _log_TotalAsset;
         public decimal? Log_TotalAsset { get { return _log_TotalAsset; } set { _log_TotalAsset = value; } }
-        private Value<decimal?> _log_TotalExpense;
+        private DirtyValue<decimal?> _log_TotalExpense;
         public decimal? Log_TotalExpense { get { return _log_TotalExpense; } set { _log_TotalExpense = value; } }
-        private Value<decimal?> _log_TotalExpensePmt;
+        private DirtyValue<decimal?> _log_TotalExpensePmt;
         public decimal? Log_TotalExpensePmt { get { return _log_TotalExpensePmt; } set { _log_TotalExpensePmt = value; } }
-        private Value<decimal?> _log_TotalExpenseRatio;
+        private DirtyValue<decimal?> _log_TotalExpenseRatio;
         public decimal? Log_TotalExpenseRatio { get { return _log_TotalExpenseRatio; } set { _log_TotalExpenseRatio = value; } }
-        private Value<decimal?> _log_TotalFundsVerified;
+        private DirtyValue<decimal?> _log_TotalFundsVerified;
         public decimal? Log_TotalFundsVerified { get { return _log_TotalFundsVerified; } set { _log_TotalFundsVerified = value; } }
-        private Value<decimal?> _log_TotalLoanAmount;
+        private DirtyValue<decimal?> _log_TotalLoanAmount;
         public decimal? Log_TotalLoanAmount { get { return _log_TotalLoanAmount; } set { _log_TotalLoanAmount = value; } }
-        private Value<decimal?> _log_TotalMonthlyIncome;
+        private DirtyValue<decimal?> _log_TotalMonthlyIncome;
         public decimal? Log_TotalMonthlyIncome { get { return _log_TotalMonthlyIncome; } set { _log_TotalMonthlyIncome = value; } }
-        private Value<string> _log_TPONumber;
+        private DirtyValue<string> _log_TPONumber;
         public string Log_TPONumber { get { return _log_TPONumber; } set { _log_TPONumber = value; } }
-        private Value<string> _log_TransactionID;
+        private DirtyValue<string> _log_TransactionID;
         public string Log_TransactionID { get { return _log_TransactionID; } set { _log_TransactionID = value; } }
-        private Value<string> _log_UnderwritingRiskAssessOther;
+        private DirtyValue<string> _log_UnderwritingRiskAssessOther;
         public string Log_UnderwritingRiskAssessOther { get { return _log_UnderwritingRiskAssessOther; } set { _log_UnderwritingRiskAssessOther = value; } }
-        private Value<string> _log_UnderwritingRiskAssessType;
+        private DirtyValue<string> _log_UnderwritingRiskAssessType;
         public string Log_UnderwritingRiskAssessType { get { return _log_UnderwritingRiskAssessType; } set { _log_UnderwritingRiskAssessType = value; } }
-        private Value<string> _log_WithUndisclosedDebt;
+        private DirtyValue<string> _log_WithUndisclosedDebt;
         public string Log_WithUndisclosedDebt { get { return _log_WithUndisclosedDebt; } set { _log_WithUndisclosedDebt = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/AdditionalRequests.cs
+++ b/src/EncompassRest/Loans/AdditionalRequests.cs
@@ -8,81 +8,81 @@ namespace EncompassRest.Loans
 {
     public sealed partial class AdditionalRequests : IDirty
     {
-        private Value<string> _appraisalContactCellPhone;
+        private DirtyValue<string> _appraisalContactCellPhone;
         public string AppraisalContactCellPhone { get { return _appraisalContactCellPhone; } set { _appraisalContactCellPhone = value; } }
-        private Value<string> _appraisalContactEmail;
+        private DirtyValue<string> _appraisalContactEmail;
         public string AppraisalContactEmail { get { return _appraisalContactEmail; } set { _appraisalContactEmail = value; } }
-        private Value<string> _appraisalContactForEntry;
+        private DirtyValue<string> _appraisalContactForEntry;
         public string AppraisalContactForEntry { get { return _appraisalContactForEntry; } set { _appraisalContactForEntry = value; } }
-        private Value<string> _appraisalContactHomePhone;
+        private DirtyValue<string> _appraisalContactHomePhone;
         public string AppraisalContactHomePhone { get { return _appraisalContactHomePhone; } set { _appraisalContactHomePhone = value; } }
-        private Value<string> _appraisalContactName;
+        private DirtyValue<string> _appraisalContactName;
         public string AppraisalContactName { get { return _appraisalContactName; } set { _appraisalContactName = value; } }
-        private Value<string> _appraisalContactWorkPhone;
+        private DirtyValue<string> _appraisalContactWorkPhone;
         public string AppraisalContactWorkPhone { get { return _appraisalContactWorkPhone; } set { _appraisalContactWorkPhone = value; } }
-        private Value<DateTime?> _appraisalDateOrdered;
+        private DirtyValue<DateTime?> _appraisalDateOrdered;
         public DateTime? AppraisalDateOrdered { get { return _appraisalDateOrdered; } set { _appraisalDateOrdered = value; } }
-        private Value<string> _appraisalDescription1;
+        private DirtyValue<string> _appraisalDescription1;
         public string AppraisalDescription1 { get { return _appraisalDescription1; } set { _appraisalDescription1 = value; } }
-        private Value<string> _appraisalDescription2;
+        private DirtyValue<string> _appraisalDescription2;
         public string AppraisalDescription2 { get { return _appraisalDescription2; } set { _appraisalDescription2 = value; } }
-        private Value<string> _appraisalDescription3;
+        private DirtyValue<string> _appraisalDescription3;
         public string AppraisalDescription3 { get { return _appraisalDescription3; } set { _appraisalDescription3 = value; } }
-        private Value<bool?> _appraisalKeyPickUp;
+        private DirtyValue<bool?> _appraisalKeyPickUp;
         public bool? AppraisalKeyPickUp { get { return _appraisalKeyPickUp; } set { _appraisalKeyPickUp = value; } }
-        private Value<bool?> _appraisalLockBox;
+        private DirtyValue<bool?> _appraisalLockBox;
         public bool? AppraisalLockBox { get { return _appraisalLockBox; } set { _appraisalLockBox = value; } }
-        private Value<bool?> _appraisalVacant;
+        private DirtyValue<bool?> _appraisalVacant;
         public bool? AppraisalVacant { get { return _appraisalVacant; } set { _appraisalVacant = value; } }
-        private Value<string> _floodDescription1;
+        private DirtyValue<string> _floodDescription1;
         public string FloodDescription1 { get { return _floodDescription1; } set { _floodDescription1 = value; } }
-        private Value<string> _floodDescription2;
+        private DirtyValue<string> _floodDescription2;
         public string FloodDescription2 { get { return _floodDescription2; } set { _floodDescription2 = value; } }
-        private Value<string> _floodDescription3;
+        private DirtyValue<string> _floodDescription3;
         public string FloodDescription3 { get { return _floodDescription3; } set { _floodDescription3 = value; } }
-        private Value<bool?> _floodInsuranceEscrowed;
+        private DirtyValue<bool?> _floodInsuranceEscrowed;
         public bool? FloodInsuranceEscrowed { get { return _floodInsuranceEscrowed; } set { _floodInsuranceEscrowed = value; } }
-        private Value<string> _floodReplacementValue;
+        private DirtyValue<string> _floodReplacementValue;
         public string FloodReplacementValue { get { return _floodReplacementValue; } set { _floodReplacementValue = value; } }
-        private Value<string> _hazardDescription1;
+        private DirtyValue<string> _hazardDescription1;
         public string HazardDescription1 { get { return _hazardDescription1; } set { _hazardDescription1 = value; } }
-        private Value<string> _hazardDescription2;
+        private DirtyValue<string> _hazardDescription2;
         public string HazardDescription2 { get { return _hazardDescription2; } set { _hazardDescription2 = value; } }
-        private Value<string> _hazardDescription3;
+        private DirtyValue<string> _hazardDescription3;
         public string HazardDescription3 { get { return _hazardDescription3; } set { _hazardDescription3 = value; } }
-        private Value<bool?> _hazardInsuranceEscrowed;
+        private DirtyValue<bool?> _hazardInsuranceEscrowed;
         public bool? HazardInsuranceEscrowed { get { return _hazardInsuranceEscrowed; } set { _hazardInsuranceEscrowed = value; } }
-        private Value<string> _hazardReplacementValue;
+        private DirtyValue<string> _hazardReplacementValue;
         public string HazardReplacementValue { get { return _hazardReplacementValue; } set { _hazardReplacementValue = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _maximumDeductibleFloodAmount;
+        private DirtyValue<decimal?> _maximumDeductibleFloodAmount;
         public decimal? MaximumDeductibleFloodAmount { get { return _maximumDeductibleFloodAmount; } set { _maximumDeductibleFloodAmount = value; } }
-        private Value<decimal?> _maximumDeductibleFloodPercentage;
+        private DirtyValue<decimal?> _maximumDeductibleFloodPercentage;
         public decimal? MaximumDeductibleFloodPercentage { get { return _maximumDeductibleFloodPercentage; } set { _maximumDeductibleFloodPercentage = value; } }
-        private Value<decimal?> _maximumDeductibleHazardAmount;
+        private DirtyValue<decimal?> _maximumDeductibleHazardAmount;
         public decimal? MaximumDeductibleHazardAmount { get { return _maximumDeductibleHazardAmount; } set { _maximumDeductibleHazardAmount = value; } }
-        private Value<decimal?> _maximumDeductibleHazardPercentage;
+        private DirtyValue<decimal?> _maximumDeductibleHazardPercentage;
         public decimal? MaximumDeductibleHazardPercentage { get { return _maximumDeductibleHazardPercentage; } set { _maximumDeductibleHazardPercentage = value; } }
-        private Value<bool?> _titleContract;
+        private DirtyValue<bool?> _titleContract;
         public bool? TitleContract { get { return _titleContract; } set { _titleContract = value; } }
-        private Value<string> _titleDescription1;
+        private DirtyValue<string> _titleDescription1;
         public string TitleDescription1 { get { return _titleDescription1; } set { _titleDescription1 = value; } }
-        private Value<string> _titleDescription2;
+        private DirtyValue<string> _titleDescription2;
         public string TitleDescription2 { get { return _titleDescription2; } set { _titleDescription2 = value; } }
-        private Value<string> _titleDescription3;
+        private DirtyValue<string> _titleDescription3;
         public string TitleDescription3 { get { return _titleDescription3; } set { _titleDescription3 = value; } }
-        private Value<bool?> _titleInsRequirements;
+        private DirtyValue<bool?> _titleInsRequirements;
         public bool? TitleInsRequirements { get { return _titleInsRequirements; } set { _titleInsRequirements = value; } }
-        private Value<bool?> _titleMailAway;
+        private DirtyValue<bool?> _titleMailAway;
         public bool? TitleMailAway { get { return _titleMailAway; } set { _titleMailAway = value; } }
-        private Value<bool?> _titlePriorTitlePolicy;
+        private DirtyValue<bool?> _titlePriorTitlePolicy;
         public bool? TitlePriorTitlePolicy { get { return _titlePriorTitlePolicy; } set { _titlePriorTitlePolicy = value; } }
-        private Value<bool?> _titleSurvey;
+        private DirtyValue<bool?> _titleSurvey;
         public bool? TitleSurvey { get { return _titleSurvey; } set { _titleSurvey = value; } }
-        private Value<string> _titleTypeOfProperty;
+        private DirtyValue<string> _titleTypeOfProperty;
         public string TitleTypeOfProperty { get { return _titleTypeOfProperty; } set { _titleTypeOfProperty = value; } }
-        private Value<bool?> _titleWarrantyDeed;
+        private DirtyValue<bool?> _titleWarrantyDeed;
         public bool? TitleWarrantyDeed { get { return _titleWarrantyDeed; } set { _titleWarrantyDeed = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/AdditionalStateDisclosure.cs
+++ b/src/EncompassRest/Loans/AdditionalStateDisclosure.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class AdditionalStateDisclosure : IDirty
     {
-        private Value<string> _disclosureName;
+        private DirtyValue<string> _disclosureName;
         public string DisclosureName { get { return _disclosureName; } set { _disclosureName = value; } }
-        private Value<string> _disclosureValue;
+        private DirtyValue<string> _disclosureValue;
         public string DisclosureValue { get { return _disclosureValue; } set { _disclosureValue = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _stateCode;
+        private DirtyValue<string> _stateCode;
         public string StateCode { get { return _stateCode; } set { _stateCode = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/AffiliatedBusinessArrangement.cs
+++ b/src/EncompassRest/Loans/AffiliatedBusinessArrangement.cs
@@ -8,65 +8,65 @@ namespace EncompassRest.Loans
 {
     public sealed partial class AffiliatedBusinessArrangement : IDirty
     {
-        private Value<int?> _affiliatedBusinessArrangementIndex;
+        private DirtyValue<int?> _affiliatedBusinessArrangementIndex;
         public int? AffiliatedBusinessArrangementIndex { get { return _affiliatedBusinessArrangementIndex; } set { _affiliatedBusinessArrangementIndex = value; } }
-        private Value<string> _affiliateName;
+        private DirtyValue<string> _affiliateName;
         public string AffiliateName { get { return _affiliateName; } set { _affiliateName = value; } }
-        private Value<string> _chargeRangeChargesDescription1;
+        private DirtyValue<string> _chargeRangeChargesDescription1;
         public string ChargeRangeChargesDescription1 { get { return _chargeRangeChargesDescription1; } set { _chargeRangeChargesDescription1 = value; } }
-        private Value<string> _chargeRangeChargesDescription2;
+        private DirtyValue<string> _chargeRangeChargesDescription2;
         public string ChargeRangeChargesDescription2 { get { return _chargeRangeChargesDescription2; } set { _chargeRangeChargesDescription2 = value; } }
-        private Value<string> _chargeRangeChargesDescription3;
+        private DirtyValue<string> _chargeRangeChargesDescription3;
         public string ChargeRangeChargesDescription3 { get { return _chargeRangeChargesDescription3; } set { _chargeRangeChargesDescription3 = value; } }
-        private Value<string> _chargeRangeChargesDescription4;
+        private DirtyValue<string> _chargeRangeChargesDescription4;
         public string ChargeRangeChargesDescription4 { get { return _chargeRangeChargesDescription4; } set { _chargeRangeChargesDescription4 = value; } }
-        private Value<string> _chargeRangeChargesDescription5;
+        private DirtyValue<string> _chargeRangeChargesDescription5;
         public string ChargeRangeChargesDescription5 { get { return _chargeRangeChargesDescription5; } set { _chargeRangeChargesDescription5 = value; } }
-        private Value<string> _chargeRangeChargesDescription6;
+        private DirtyValue<string> _chargeRangeChargesDescription6;
         public string ChargeRangeChargesDescription6 { get { return _chargeRangeChargesDescription6; } set { _chargeRangeChargesDescription6 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lenderAddress;
+        private DirtyValue<string> _lenderAddress;
         public string LenderAddress { get { return _lenderAddress; } set { _lenderAddress = value; } }
-        private Value<string> _lenderAddressCity;
+        private DirtyValue<string> _lenderAddressCity;
         public string LenderAddressCity { get { return _lenderAddressCity; } set { _lenderAddressCity = value; } }
-        private Value<string> _lenderAddressState;
+        private DirtyValue<string> _lenderAddressState;
         public string LenderAddressState { get { return _lenderAddressState; } set { _lenderAddressState = value; } }
-        private Value<string> _lenderAddressZipcode;
+        private DirtyValue<string> _lenderAddressZipcode;
         public string LenderAddressZipcode { get { return _lenderAddressZipcode; } set { _lenderAddressZipcode = value; } }
-        private Value<string> _lenderName;
+        private DirtyValue<string> _lenderName;
         public string LenderName { get { return _lenderName; } set { _lenderName = value; } }
-        private Value<string> _natureOfRelationship;
+        private DirtyValue<string> _natureOfRelationship;
         public string NatureOfRelationship { get { return _natureOfRelationship; } set { _natureOfRelationship = value; } }
-        private Value<decimal?> _percentOwnershipInterest;
+        private DirtyValue<decimal?> _percentOwnershipInterest;
         public decimal? PercentOwnershipInterest { get { return _percentOwnershipInterest; } set { _percentOwnershipInterest = value; } }
-        private Value<bool?> _purchaseSaleRefinanceIndicator;
+        private DirtyValue<bool?> _purchaseSaleRefinanceIndicator;
         public bool? PurchaseSaleRefinanceIndicator { get { return _purchaseSaleRefinanceIndicator; } set { _purchaseSaleRefinanceIndicator = value; } }
-        private Value<bool?> _requiredUseIndicator1;
+        private DirtyValue<bool?> _requiredUseIndicator1;
         public bool? RequiredUseIndicator1 { get { return _requiredUseIndicator1; } set { _requiredUseIndicator1 = value; } }
-        private Value<bool?> _requiredUseIndicator2;
+        private DirtyValue<bool?> _requiredUseIndicator2;
         public bool? RequiredUseIndicator2 { get { return _requiredUseIndicator2; } set { _requiredUseIndicator2 = value; } }
-        private Value<bool?> _requiredUseIndicator3;
+        private DirtyValue<bool?> _requiredUseIndicator3;
         public bool? RequiredUseIndicator3 { get { return _requiredUseIndicator3; } set { _requiredUseIndicator3 = value; } }
-        private Value<bool?> _requiredUseIndicator4;
+        private DirtyValue<bool?> _requiredUseIndicator4;
         public bool? RequiredUseIndicator4 { get { return _requiredUseIndicator4; } set { _requiredUseIndicator4 = value; } }
-        private Value<bool?> _requiredUseIndicator5;
+        private DirtyValue<bool?> _requiredUseIndicator5;
         public bool? RequiredUseIndicator5 { get { return _requiredUseIndicator5; } set { _requiredUseIndicator5 = value; } }
-        private Value<bool?> _requiredUseIndicator6;
+        private DirtyValue<bool?> _requiredUseIndicator6;
         public bool? RequiredUseIndicator6 { get { return _requiredUseIndicator6; } set { _requiredUseIndicator6 = value; } }
-        private Value<string> _serviceDescription1;
+        private DirtyValue<string> _serviceDescription1;
         public string ServiceDescription1 { get { return _serviceDescription1; } set { _serviceDescription1 = value; } }
-        private Value<string> _serviceDescription2;
+        private DirtyValue<string> _serviceDescription2;
         public string ServiceDescription2 { get { return _serviceDescription2; } set { _serviceDescription2 = value; } }
-        private Value<string> _serviceDescription3;
+        private DirtyValue<string> _serviceDescription3;
         public string ServiceDescription3 { get { return _serviceDescription3; } set { _serviceDescription3 = value; } }
-        private Value<string> _serviceDescription4;
+        private DirtyValue<string> _serviceDescription4;
         public string ServiceDescription4 { get { return _serviceDescription4; } set { _serviceDescription4 = value; } }
-        private Value<string> _serviceDescription5;
+        private DirtyValue<string> _serviceDescription5;
         public string ServiceDescription5 { get { return _serviceDescription5; } set { _serviceDescription5 = value; } }
-        private Value<string> _serviceDescription6;
+        private DirtyValue<string> _serviceDescription6;
         public string ServiceDescription6 { get { return _serviceDescription6; } set { _serviceDescription6 = value; } }
-        private Value<bool?> _settlementIndicator;
+        private DirtyValue<bool?> _settlementIndicator;
         public bool? SettlementIndicator { get { return _settlementIndicator; } set { _settlementIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/AntiSteeringLoanOption.cs
+++ b/src/EncompassRest/Loans/AntiSteeringLoanOption.cs
@@ -8,109 +8,109 @@ namespace EncompassRest.Loans
 {
     public sealed partial class AntiSteeringLoanOption : IDirty
     {
-        private Value<int?> _antiSteeringLoanOptionIndex;
+        private DirtyValue<int?> _antiSteeringLoanOptionIndex;
         public int? AntiSteeringLoanOptionIndex { get { return _antiSteeringLoanOptionIndex; } set { _antiSteeringLoanOptionIndex = value; } }
-        private Value<decimal?> _brokerCompensationFeeAmount;
+        private DirtyValue<decimal?> _brokerCompensationFeeAmount;
         public decimal? BrokerCompensationFeeAmount { get { return _brokerCompensationFeeAmount; } set { _brokerCompensationFeeAmount = value; } }
-        private Value<decimal?> _brokerCompensationFeeBorPaidAmount;
+        private DirtyValue<decimal?> _brokerCompensationFeeBorPaidAmount;
         public decimal? BrokerCompensationFeeBorPaidAmount { get { return _brokerCompensationFeeBorPaidAmount; } set { _brokerCompensationFeeBorPaidAmount = value; } }
-        private Value<decimal?> _brokerCompensationFeePercentage;
+        private DirtyValue<decimal?> _brokerCompensationFeePercentage;
         public decimal? BrokerCompensationFeePercentage { get { return _brokerCompensationFeePercentage; } set { _brokerCompensationFeePercentage = value; } }
-        private Value<decimal?> _brokerFeeAmount;
+        private DirtyValue<decimal?> _brokerFeeAmount;
         public decimal? BrokerFeeAmount { get { return _brokerFeeAmount; } set { _brokerFeeAmount = value; } }
-        private Value<decimal?> _brokerFeeBorPaidAmount;
+        private DirtyValue<decimal?> _brokerFeeBorPaidAmount;
         public decimal? BrokerFeeBorPaidAmount { get { return _brokerFeeBorPaidAmount; } set { _brokerFeeBorPaidAmount = value; } }
-        private Value<decimal?> _brokerFeePercentage;
+        private DirtyValue<decimal?> _brokerFeePercentage;
         public decimal? BrokerFeePercentage { get { return _brokerFeePercentage; } set { _brokerFeePercentage = value; } }
-        private Value<decimal?> _brokerFeeSellerPaidAmount;
+        private DirtyValue<decimal?> _brokerFeeSellerPaidAmount;
         public decimal? BrokerFeeSellerPaidAmount { get { return _brokerFeeSellerPaidAmount; } set { _brokerFeeSellerPaidAmount = value; } }
-        private Value<string> _creditorName;
+        private DirtyValue<string> _creditorName;
         public string CreditorName { get { return _creditorName; } set { _creditorName = value; } }
-        private Value<decimal?> _discountAdditionalAmount;
+        private DirtyValue<decimal?> _discountAdditionalAmount;
         public decimal? DiscountAdditionalAmount { get { return _discountAdditionalAmount; } set { _discountAdditionalAmount = value; } }
-        private Value<decimal?> _discountAmount;
+        private DirtyValue<decimal?> _discountAmount;
         public decimal? DiscountAmount { get { return _discountAmount; } set { _discountAmount = value; } }
-        private Value<decimal?> _discountFeeBorPaidAmount;
+        private DirtyValue<decimal?> _discountFeeBorPaidAmount;
         public decimal? DiscountFeeBorPaidAmount { get { return _discountFeeBorPaidAmount; } set { _discountFeeBorPaidAmount = value; } }
-        private Value<decimal?> _discountFeeSellerPaidAmount;
+        private DirtyValue<decimal?> _discountFeeSellerPaidAmount;
         public decimal? DiscountFeeSellerPaidAmount { get { return _discountFeeSellerPaidAmount; } set { _discountFeeSellerPaidAmount = value; } }
-        private Value<decimal?> _discountPercentage;
+        private DirtyValue<decimal?> _discountPercentage;
         public decimal? DiscountPercentage { get { return _discountPercentage; } set { _discountPercentage = value; } }
-        private Value<decimal?> _discountPoints;
+        private DirtyValue<decimal?> _discountPoints;
         public decimal? DiscountPoints { get { return _discountPoints; } set { _discountPoints = value; } }
-        private Value<int?> _fixedRatePeriod;
+        private DirtyValue<int?> _fixedRatePeriod;
         public int? FixedRatePeriod { get { return _fixedRatePeriod; } set { _fixedRatePeriod = value; } }
-        private Value<string> _haveDemandFeature;
+        private DirtyValue<string> _haveDemandFeature;
         public string HaveDemandFeature { get { return _haveDemandFeature; } set { _haveDemandFeature = value; } }
-        private Value<bool?> _havePrepaymentPenalty;
+        private DirtyValue<bool?> _havePrepaymentPenalty;
         public bool? HavePrepaymentPenalty { get { return _havePrepaymentPenalty; } set { _havePrepaymentPenalty = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _inspectionFeeBorPaidAmount;
+        private DirtyValue<decimal?> _inspectionFeeBorPaidAmount;
         public decimal? InspectionFeeBorPaidAmount { get { return _inspectionFeeBorPaidAmount; } set { _inspectionFeeBorPaidAmount = value; } }
-        private Value<decimal?> _inspectionFeeSellerPaidAmount;
+        private DirtyValue<decimal?> _inspectionFeeSellerPaidAmount;
         public decimal? InspectionFeeSellerPaidAmount { get { return _inspectionFeeSellerPaidAmount; } set { _inspectionFeeSellerPaidAmount = value; } }
-        private Value<decimal?> _interestRate;
+        private DirtyValue<decimal?> _interestRate;
         public decimal? InterestRate { get { return _interestRate; } set { _interestRate = value; } }
-        private Value<string> _isBalloonPaymentIn7Years;
+        private DirtyValue<string> _isBalloonPaymentIn7Years;
         public string IsBalloonPaymentIn7Years { get { return _isBalloonPaymentIn7Years; } set { _isBalloonPaymentIn7Years = value; } }
-        private Value<string> _isInterestOnlyLoan;
+        private DirtyValue<string> _isInterestOnlyLoan;
         public string IsInterestOnlyLoan { get { return _isInterestOnlyLoan; } set { _isInterestOnlyLoan = value; } }
-        private Value<bool?> _isNegativeAmortization;
+        private DirtyValue<bool?> _isNegativeAmortization;
         public bool? IsNegativeAmortization { get { return _isNegativeAmortization; } set { _isNegativeAmortization = value; } }
-        private Value<int?> _loanTerm;
+        private DirtyValue<int?> _loanTerm;
         public int? LoanTerm { get { return _loanTerm; } set { _loanTerm = value; } }
-        private Value<string> _loanType;
+        private DirtyValue<string> _loanType;
         public string LoanType { get { return _loanType; } set { _loanType = value; } }
-        private Value<decimal?> _originationFeeBorPaidAmount;
+        private DirtyValue<decimal?> _originationFeeBorPaidAmount;
         public decimal? OriginationFeeBorPaidAmount { get { return _originationFeeBorPaidAmount; } set { _originationFeeBorPaidAmount = value; } }
-        private Value<decimal?> _originationFeePercentage;
+        private DirtyValue<decimal?> _originationFeePercentage;
         public decimal? OriginationFeePercentage { get { return _originationFeePercentage; } set { _originationFeePercentage = value; } }
-        private Value<decimal?> _originationFeeSellerPaidAmount;
+        private DirtyValue<decimal?> _originationFeeSellerPaidAmount;
         public decimal? OriginationFeeSellerPaidAmount { get { return _originationFeeSellerPaidAmount; } set { _originationFeeSellerPaidAmount = value; } }
-        private Value<decimal?> _originationPointsFees;
+        private DirtyValue<decimal?> _originationPointsFees;
         public decimal? OriginationPointsFees { get { return _originationPointsFees; } set { _originationPointsFees = value; } }
-        private Value<decimal?> _originationPointsPercetange;
+        private DirtyValue<decimal?> _originationPointsPercetange;
         public decimal? OriginationPointsPercetange { get { return _originationPointsPercetange; } set { _originationPointsPercetange = value; } }
-        private Value<decimal?> _processingFeeBorPaidAmount;
+        private DirtyValue<decimal?> _processingFeeBorPaidAmount;
         public decimal? ProcessingFeeBorPaidAmount { get { return _processingFeeBorPaidAmount; } set { _processingFeeBorPaidAmount = value; } }
-        private Value<decimal?> _processingFeeSellerPaidAmount;
+        private DirtyValue<decimal?> _processingFeeSellerPaidAmount;
         public decimal? ProcessingFeeSellerPaidAmount { get { return _processingFeeSellerPaidAmount; } set { _processingFeeSellerPaidAmount = value; } }
-        private Value<decimal?> _totalOriginationDiscountAmount;
+        private DirtyValue<decimal?> _totalOriginationDiscountAmount;
         public decimal? TotalOriginationDiscountAmount { get { return _totalOriginationDiscountAmount; } set { _totalOriginationDiscountAmount = value; } }
-        private Value<decimal?> _underwritingFeeBorPaidAmount;
+        private DirtyValue<decimal?> _underwritingFeeBorPaidAmount;
         public decimal? UnderwritingFeeBorPaidAmount { get { return _underwritingFeeBorPaidAmount; } set { _underwritingFeeBorPaidAmount = value; } }
-        private Value<decimal?> _underwritingFeeSellerPaidAmount;
+        private DirtyValue<decimal?> _underwritingFeeSellerPaidAmount;
         public decimal? UnderwritingFeeSellerPaidAmount { get { return _underwritingFeeSellerPaidAmount; } set { _underwritingFeeSellerPaidAmount = value; } }
-        private Value<decimal?> _userDefinedFee1BorPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee1BorPaidAmount;
         public decimal? UserDefinedFee1BorPaidAmount { get { return _userDefinedFee1BorPaidAmount; } set { _userDefinedFee1BorPaidAmount = value; } }
-        private Value<string> _userDefinedFee1Description;
+        private DirtyValue<string> _userDefinedFee1Description;
         public string UserDefinedFee1Description { get { return _userDefinedFee1Description; } set { _userDefinedFee1Description = value; } }
-        private Value<decimal?> _userDefinedFee1SellerPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee1SellerPaidAmount;
         public decimal? UserDefinedFee1SellerPaidAmount { get { return _userDefinedFee1SellerPaidAmount; } set { _userDefinedFee1SellerPaidAmount = value; } }
-        private Value<decimal?> _userDefinedFee2BorPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee2BorPaidAmount;
         public decimal? UserDefinedFee2BorPaidAmount { get { return _userDefinedFee2BorPaidAmount; } set { _userDefinedFee2BorPaidAmount = value; } }
-        private Value<string> _userDefinedFee2Description;
+        private DirtyValue<string> _userDefinedFee2Description;
         public string UserDefinedFee2Description { get { return _userDefinedFee2Description; } set { _userDefinedFee2Description = value; } }
-        private Value<decimal?> _userDefinedFee2SellerPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee2SellerPaidAmount;
         public decimal? UserDefinedFee2SellerPaidAmount { get { return _userDefinedFee2SellerPaidAmount; } set { _userDefinedFee2SellerPaidAmount = value; } }
-        private Value<decimal?> _userDefinedFee3BorPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee3BorPaidAmount;
         public decimal? UserDefinedFee3BorPaidAmount { get { return _userDefinedFee3BorPaidAmount; } set { _userDefinedFee3BorPaidAmount = value; } }
-        private Value<string> _userDefinedFee3Description;
+        private DirtyValue<string> _userDefinedFee3Description;
         public string UserDefinedFee3Description { get { return _userDefinedFee3Description; } set { _userDefinedFee3Description = value; } }
-        private Value<decimal?> _userDefinedFee3SellerPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee3SellerPaidAmount;
         public decimal? UserDefinedFee3SellerPaidAmount { get { return _userDefinedFee3SellerPaidAmount; } set { _userDefinedFee3SellerPaidAmount = value; } }
-        private Value<decimal?> _userDefinedFee4BorPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee4BorPaidAmount;
         public decimal? UserDefinedFee4BorPaidAmount { get { return _userDefinedFee4BorPaidAmount; } set { _userDefinedFee4BorPaidAmount = value; } }
-        private Value<string> _userDefinedFee4Description;
+        private DirtyValue<string> _userDefinedFee4Description;
         public string UserDefinedFee4Description { get { return _userDefinedFee4Description; } set { _userDefinedFee4Description = value; } }
-        private Value<decimal?> _userDefinedFee4SellerPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee4SellerPaidAmount;
         public decimal? UserDefinedFee4SellerPaidAmount { get { return _userDefinedFee4SellerPaidAmount; } set { _userDefinedFee4SellerPaidAmount = value; } }
-        private Value<decimal?> _userDefinedFee5BorPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee5BorPaidAmount;
         public decimal? UserDefinedFee5BorPaidAmount { get { return _userDefinedFee5BorPaidAmount; } set { _userDefinedFee5BorPaidAmount = value; } }
-        private Value<string> _userDefinedFee5Description;
+        private DirtyValue<string> _userDefinedFee5Description;
         public string UserDefinedFee5Description { get { return _userDefinedFee5Description; } set { _userDefinedFee5Description = value; } }
-        private Value<decimal?> _userDefinedFee5SellerPaidAmount;
+        private DirtyValue<decimal?> _userDefinedFee5SellerPaidAmount;
         public decimal? UserDefinedFee5SellerPaidAmount { get { return _userDefinedFee5SellerPaidAmount; } set { _userDefinedFee5SellerPaidAmount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Application.cs
+++ b/src/EncompassRest/Loans/Application.cs
@@ -20,23 +20,26 @@ namespace EncompassRest.Loans
         public int? ApplicationIndex { get { return _applicationIndex; } set { _applicationIndex = value; } }
         private Value<DateTime?> _applicationSignedDate;
         public DateTime? ApplicationSignedDate { get { return _applicationSignedDate; } set { _applicationSignedDate = value; } }
-        private Value<List<Asset>> _assets;
-        public List<Asset> Assets { get { return _assets; } set { _assets = value; } }
+        private DirtyList<Asset> _assets;
+        public IList<Asset> Assets { get { var v = _assets; return v ?? Interlocked.CompareExchange(ref _assets, (v = new DirtyList<Asset>()), null) ?? v; } set { _assets = new DirtyList<Asset>(value); } }
         private Value<decimal?> _assetsAvailableAmount;
         public decimal? AssetsAvailableAmount { get { return _assetsAvailableAmount; } set { _assetsAvailableAmount = value; } }
-        public ATRQMBorrower ATRQMBorrower { get; set; }
-        private Value<List<ATRQMBorrower>> _aTRQMBorrowers;
-        public List<ATRQMBorrower> ATRQMBorrowers { get { return _aTRQMBorrowers; } set { _aTRQMBorrowers = value; } }
-        private Value<List<AUSTrackingLog>> _aUSTrackingLogs;
-        public List<AUSTrackingLog> AUSTrackingLogs { get { return _aUSTrackingLogs; } set { _aUSTrackingLogs = value; } }
+        private ATRQMBorrower _aTRQMBorrower;
+        public ATRQMBorrower ATRQMBorrower { get { var v = _aTRQMBorrower; return v ?? Interlocked.CompareExchange(ref _aTRQMBorrower, (v = new ATRQMBorrower()), null) ?? v; } set { _aTRQMBorrower = value; } }
+        private DirtyList<ATRQMBorrower> _aTRQMBorrowers;
+        public IList<ATRQMBorrower> ATRQMBorrowers { get { var v = _aTRQMBorrowers; return v ?? Interlocked.CompareExchange(ref _aTRQMBorrowers, (v = new DirtyList<ATRQMBorrower>()), null) ?? v; } set { _aTRQMBorrowers = new DirtyList<ATRQMBorrower>(value); } }
+        private DirtyList<AUSTrackingLog> _aUSTrackingLogs;
+        public IList<AUSTrackingLog> AUSTrackingLogs { get { var v = _aUSTrackingLogs; return v ?? Interlocked.CompareExchange(ref _aUSTrackingLogs, (v = new DirtyList<AUSTrackingLog>()), null) ?? v; } set { _aUSTrackingLogs = new DirtyList<AUSTrackingLog>(value); } }
         private Value<decimal?> _balanceAvailableFamilySupportGuideline;
         public decimal? BalanceAvailableFamilySupportGuideline { get { return _balanceAvailableFamilySupportGuideline; } set { _balanceAvailableFamilySupportGuideline = value; } }
-        public Borrower Borrower { get; set; }
+        private Borrower _borrower;
+        public Borrower Borrower { get { var v = _borrower; return v ?? Interlocked.CompareExchange(ref _borrower, (v = new Borrower()), null) ?? v; } set { _borrower = value; } }
         private Value<decimal?> _bottomRatioPercent;
         public decimal? BottomRatioPercent { get { return _bottomRatioPercent; } set { _bottomRatioPercent = value; } }
         private Value<decimal?> _brwCoBrwTotalTaxDeductions;
         public decimal? BrwCoBrwTotalTaxDeductions { get { return _brwCoBrwTotalTaxDeductions; } set { _brwCoBrwTotalTaxDeductions = value; } }
-        public Borrower Coborrower { get; set; }
+        private Borrower _coborrower;
+        public Borrower Coborrower { get { var v = _coborrower; return v ?? Interlocked.CompareExchange(ref _coborrower, (v = new Borrower()), null) ?? v; } set { _coborrower = value; } }
         private Value<string> _creditAliasName1;
         public string CreditAliasName1 { get { return _creditAliasName1; } set { _creditAliasName1 = value; } }
         private Value<string> _creditAliasName2;
@@ -47,8 +50,8 @@ namespace EncompassRest.Loans
         public string CreditorName2 { get { return _creditorName2; } set { _creditorName2 = value; } }
         private Value<string> _creditReportReferenceIdentifier;
         public string CreditReportReferenceIdentifier { get { return _creditReportReferenceIdentifier; } set { _creditReportReferenceIdentifier = value; } }
-        private Value<List<Employment>> _employment;
-        public List<Employment> Employment { get { return _employment; } set { _employment = value; } }
+        private DirtyList<Employment> _employment;
+        public IList<Employment> Employment { get { var v = _employment; return v ?? Interlocked.CompareExchange(ref _employment, (v = new DirtyList<Employment>()), null) ?? v; } set { _employment = new DirtyList<Employment>(value); } }
         private Value<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
         private Value<string> _equifaxAddress;
@@ -197,16 +200,16 @@ namespace EncompassRest.Loans
         public decimal? HudRealEstatePresentBalance2 { get { return _hudRealEstatePresentBalance2; } set { _hudRealEstatePresentBalance2 = value; } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<List<Income>> _income;
-        public List<Income> Income { get { return _income; } set { _income = value; } }
+        private DirtyList<Income> _income;
+        public IList<Income> Income { get { var v = _income; return v ?? Interlocked.CompareExchange(ref _income, (v = new DirtyList<Income>()), null) ?? v; } set { _income = new DirtyList<Income>(value); } }
         private Value<bool?> _incomeOfBorrowersSpouseUsedIndicator;
         public bool? IncomeOfBorrowersSpouseUsedIndicator { get { return _incomeOfBorrowersSpouseUsedIndicator; } set { _incomeOfBorrowersSpouseUsedIndicator = value; } }
         private Value<bool?> _incomeOtherThanBorrowerUsedIndicator;
         public bool? IncomeOtherThanBorrowerUsedIndicator { get { return _incomeOtherThanBorrowerUsedIndicator; } set { _incomeOtherThanBorrowerUsedIndicator = value; } }
         private Value<bool?> _jointAssetLiabilityReportingIndicator;
         public bool? JointAssetLiabilityReportingIndicator { get { return _jointAssetLiabilityReportingIndicator; } set { _jointAssetLiabilityReportingIndicator = value; } }
-        private Value<List<Liability>> _liabilities;
-        public List<Liability> Liabilities { get { return _liabilities; } set { _liabilities = value; } }
+        private DirtyList<Liability> _liabilities;
+        public IList<Liability> Liabilities { get { var v = _liabilities; return v ?? Interlocked.CompareExchange(ref _liabilities, (v = new DirtyList<Liability>()), null) ?? v; } set { _liabilities = new DirtyList<Liability>(value); } }
         private Value<decimal?> _liquidAssetsComortSet;
         public decimal? LiquidAssetsComortSet { get { return _liquidAssetsComortSet; } set { _liquidAssetsComortSet = value; } }
         private Value<decimal?> _mcawBorrowerOtherMonthlyIncomeAmount;
@@ -283,8 +286,8 @@ namespace EncompassRest.Loans
         public string RealEstateTaxAmount { get { return _realEstateTaxAmount; } set { _realEstateTaxAmount = value; } }
         private Value<decimal?> _rentAmount;
         public decimal? RentAmount { get { return _rentAmount; } set { _rentAmount = value; } }
-        private Value<List<ReoProperty>> _reoProperties;
-        public List<ReoProperty> ReoProperties { get { return _reoProperties; } set { _reoProperties = value; } }
+        private DirtyList<ReoProperty> _reoProperties;
+        public IList<ReoProperty> ReoProperties { get { var v = _reoProperties; return v ?? Interlocked.CompareExchange(ref _reoProperties, (v = new DirtyList<ReoProperty>()), null) ?? v; } set { _reoProperties = new DirtyList<ReoProperty>(value); } }
         private Value<decimal?> _reoTotalGrossRentalIncomeAmount;
         public decimal? ReoTotalGrossRentalIncomeAmount { get { return _reoTotalGrossRentalIncomeAmount; } set { _reoTotalGrossRentalIncomeAmount = value; } }
         private Value<decimal?> _reoTotalMaintenanceAmount;
@@ -297,10 +300,10 @@ namespace EncompassRest.Loans
         public decimal? ReoTotalMortgagesAndLiensAmount { get { return _reoTotalMortgagesAndLiensAmount; } set { _reoTotalMortgagesAndLiensAmount = value; } }
         private Value<int?> _reoTotalNetRentalIncomeAmount;
         public int? ReoTotalNetRentalIncomeAmount { get { return _reoTotalNetRentalIncomeAmount; } set { _reoTotalNetRentalIncomeAmount = value; } }
-        private Value<List<Residence>> _residences;
-        public List<Residence> Residences { get { return _residences; } set { _residences = value; } }
-        private Value<List<SelfEmployedIncome>> _selfEmployedIncomes;
-        public List<SelfEmployedIncome> SelfEmployedIncomes { get { return _selfEmployedIncomes; } set { _selfEmployedIncomes = value; } }
+        private DirtyList<Residence> _residences;
+        public IList<Residence> Residences { get { var v = _residences; return v ?? Interlocked.CompareExchange(ref _residences, (v = new DirtyList<Residence>()), null) ?? v; } set { _residences = new DirtyList<Residence>(value); } }
+        private DirtyList<SelfEmployedIncome> _selfEmployedIncomes;
+        public IList<SelfEmployedIncome> SelfEmployedIncomes { get { var v = _selfEmployedIncomes; return v ?? Interlocked.CompareExchange(ref _selfEmployedIncomes, (v = new DirtyList<SelfEmployedIncome>()), null) ?? v; } set { _selfEmployedIncomes = new DirtyList<SelfEmployedIncome>(value); } }
         private Value<string> _sofDBorrowerAddress;
         public string SofDBorrowerAddress { get { return _sofDBorrowerAddress; } set { _sofDBorrowerAddress = value; } }
         private Value<string> _sofDBorrowerAddressCity;
@@ -323,8 +326,8 @@ namespace EncompassRest.Loans
         public string SofDCoBorrowerAddressZipcode { get { return _sofDCoBorrowerAddressZipcode; } set { _sofDCoBorrowerAddressZipcode = value; } }
         private Value<bool?> _spouseIncomeConsider;
         public bool? SpouseIncomeConsider { get { return _spouseIncomeConsider; } set { _spouseIncomeConsider = value; } }
-        private Value<List<Tax4506>> _tax4506s;
-        public List<Tax4506> Tax4506s { get { return _tax4506s; } set { _tax4506s = value; } }
+        private DirtyList<Tax4506> _tax4506s;
+        public IList<Tax4506> Tax4506s { get { var v = _tax4506s; return v ?? Interlocked.CompareExchange(ref _tax4506s, (v = new DirtyList<Tax4506>()), null) ?? v; } set { _tax4506s = new DirtyList<Tax4506>(value); } }
         private Value<decimal?> _topRatioPercent;
         public decimal? TopRatioPercent { get { return _topRatioPercent; } set { _topRatioPercent = value; } }
         private Value<decimal?> _totalAssetsAmount;
@@ -369,8 +372,8 @@ namespace EncompassRest.Loans
         public decimal? TotalReoMarketValueAmount { get { return _totalReoMarketValueAmount; } set { _totalReoMarketValueAmount = value; } }
         private Value<decimal?> _totalUserDefinedIncome;
         public decimal? TotalUserDefinedIncome { get { return _totalUserDefinedIncome; } set { _totalUserDefinedIncome = value; } }
-        private Value<List<TQLReportInformation>> _tQLReports;
-        public List<TQLReportInformation> TQLReports { get { return _tQLReports; } set { _tQLReports = value; } }
+        private DirtyList<TQLReportInformation> _tQLReports;
+        public IList<TQLReportInformation> TQLReports { get { var v = _tQLReports; return v ?? Interlocked.CompareExchange(ref _tQLReports, (v = new DirtyList<TQLReportInformation>()), null) ?? v; } set { _tQLReports = new DirtyList<TQLReportInformation>(value); } }
         private Value<string> _transUnionAddress;
         public string TransUnionAddress { get { return _transUnionAddress; } set { _transUnionAddress = value; } }
         private Value<string> _transUnionCity;
@@ -416,10 +419,7 @@ namespace EncompassRest.Loans
                     || _applicationId.Dirty
                     || _applicationIndex.Dirty
                     || _applicationSignedDate.Dirty
-                    || _assets.Dirty
                     || _assetsAvailableAmount.Dirty
-                    || _aTRQMBorrowers.Dirty
-                    || _aUSTrackingLogs.Dirty
                     || _balanceAvailableFamilySupportGuideline.Dirty
                     || _bottomRatioPercent.Dirty
                     || _brwCoBrwTotalTaxDeductions.Dirty
@@ -428,7 +428,6 @@ namespace EncompassRest.Loans
                     || _creditorName1.Dirty
                     || _creditorName2.Dirty
                     || _creditReportReferenceIdentifier.Dirty
-                    || _employment.Dirty
                     || _entityDeleted.Dirty
                     || _equifaxAddress.Dirty
                     || _equifaxCity.Dirty
@@ -503,11 +502,9 @@ namespace EncompassRest.Loans
                     || _hudRealEstatePresentBalance1.Dirty
                     || _hudRealEstatePresentBalance2.Dirty
                     || _id.Dirty
-                    || _income.Dirty
                     || _incomeOfBorrowersSpouseUsedIndicator.Dirty
                     || _incomeOtherThanBorrowerUsedIndicator.Dirty
                     || _jointAssetLiabilityReportingIndicator.Dirty
-                    || _liabilities.Dirty
                     || _liquidAssetsComortSet.Dirty
                     || _mcawBorrowerOtherMonthlyIncomeAmount.Dirty
                     || _mcawCoborrowerOtherMonthlyIncomeAmount.Dirty
@@ -546,15 +543,12 @@ namespace EncompassRest.Loans
                     || _proposedRealEstateTaxesAmount.Dirty
                     || _realEstateTaxAmount.Dirty
                     || _rentAmount.Dirty
-                    || _reoProperties.Dirty
                     || _reoTotalGrossRentalIncomeAmount.Dirty
                     || _reoTotalMaintenanceAmount.Dirty
                     || _reoTotalMarketValueAmount.Dirty
                     || _reoTotalMortgagePaymentsAmount.Dirty
                     || _reoTotalMortgagesAndLiensAmount.Dirty
                     || _reoTotalNetRentalIncomeAmount.Dirty
-                    || _residences.Dirty
-                    || _selfEmployedIncomes.Dirty
                     || _sofDBorrowerAddress.Dirty
                     || _sofDBorrowerAddressCity.Dirty
                     || _sofDBorrowerAddressState.Dirty
@@ -566,7 +560,6 @@ namespace EncompassRest.Loans
                     || _sofDCoBorrowerAddressType.Dirty
                     || _sofDCoBorrowerAddressZipcode.Dirty
                     || _spouseIncomeConsider.Dirty
-                    || _tax4506s.Dirty
                     || _topRatioPercent.Dirty
                     || _totalAssetsAmount.Dirty
                     || _totalBaseIncomeAmount.Dirty
@@ -589,7 +582,6 @@ namespace EncompassRest.Loans
                     || _totalPrimaryHousingExpenseAmount.Dirty
                     || _totalReoMarketValueAmount.Dirty
                     || _totalUserDefinedIncome.Dirty
-                    || _tQLReports.Dirty
                     || _transUnionAddress.Dirty
                     || _transUnionCity.Dirty
                     || _transUnionFax.Dirty
@@ -606,9 +598,20 @@ namespace EncompassRest.Loans
                     || _vACreditStandards.Dirty
                     || _vaSummarySpouseIncomeAmount.Dirty
                     || _vaSummaryTotalMonthlyGrossIncomeAmount.Dirty
-                    || ATRQMBorrower?.Dirty == true
-                    || Borrower?.Dirty == true
-                    || Coborrower?.Dirty == true;
+                    || _assets?.Dirty == true
+                    || _aTRQMBorrower?.Dirty == true
+                    || _aTRQMBorrowers?.Dirty == true
+                    || _aUSTrackingLogs?.Dirty == true
+                    || _borrower?.Dirty == true
+                    || _coborrower?.Dirty == true
+                    || _employment?.Dirty == true
+                    || _income?.Dirty == true
+                    || _liabilities?.Dirty == true
+                    || _reoProperties?.Dirty == true
+                    || _residences?.Dirty == true
+                    || _selfEmployedIncomes?.Dirty == true
+                    || _tax4506s?.Dirty == true
+                    || _tQLReports?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -621,10 +624,7 @@ namespace EncompassRest.Loans
                 _applicationId.Dirty = value;
                 _applicationIndex.Dirty = value;
                 _applicationSignedDate.Dirty = value;
-                _assets.Dirty = value;
                 _assetsAvailableAmount.Dirty = value;
-                _aTRQMBorrowers.Dirty = value;
-                _aUSTrackingLogs.Dirty = value;
                 _balanceAvailableFamilySupportGuideline.Dirty = value;
                 _bottomRatioPercent.Dirty = value;
                 _brwCoBrwTotalTaxDeductions.Dirty = value;
@@ -633,7 +633,6 @@ namespace EncompassRest.Loans
                 _creditorName1.Dirty = value;
                 _creditorName2.Dirty = value;
                 _creditReportReferenceIdentifier.Dirty = value;
-                _employment.Dirty = value;
                 _entityDeleted.Dirty = value;
                 _equifaxAddress.Dirty = value;
                 _equifaxCity.Dirty = value;
@@ -708,11 +707,9 @@ namespace EncompassRest.Loans
                 _hudRealEstatePresentBalance1.Dirty = value;
                 _hudRealEstatePresentBalance2.Dirty = value;
                 _id.Dirty = value;
-                _income.Dirty = value;
                 _incomeOfBorrowersSpouseUsedIndicator.Dirty = value;
                 _incomeOtherThanBorrowerUsedIndicator.Dirty = value;
                 _jointAssetLiabilityReportingIndicator.Dirty = value;
-                _liabilities.Dirty = value;
                 _liquidAssetsComortSet.Dirty = value;
                 _mcawBorrowerOtherMonthlyIncomeAmount.Dirty = value;
                 _mcawCoborrowerOtherMonthlyIncomeAmount.Dirty = value;
@@ -751,15 +748,12 @@ namespace EncompassRest.Loans
                 _proposedRealEstateTaxesAmount.Dirty = value;
                 _realEstateTaxAmount.Dirty = value;
                 _rentAmount.Dirty = value;
-                _reoProperties.Dirty = value;
                 _reoTotalGrossRentalIncomeAmount.Dirty = value;
                 _reoTotalMaintenanceAmount.Dirty = value;
                 _reoTotalMarketValueAmount.Dirty = value;
                 _reoTotalMortgagePaymentsAmount.Dirty = value;
                 _reoTotalMortgagesAndLiensAmount.Dirty = value;
                 _reoTotalNetRentalIncomeAmount.Dirty = value;
-                _residences.Dirty = value;
-                _selfEmployedIncomes.Dirty = value;
                 _sofDBorrowerAddress.Dirty = value;
                 _sofDBorrowerAddressCity.Dirty = value;
                 _sofDBorrowerAddressState.Dirty = value;
@@ -771,7 +765,6 @@ namespace EncompassRest.Loans
                 _sofDCoBorrowerAddressType.Dirty = value;
                 _sofDCoBorrowerAddressZipcode.Dirty = value;
                 _spouseIncomeConsider.Dirty = value;
-                _tax4506s.Dirty = value;
                 _topRatioPercent.Dirty = value;
                 _totalAssetsAmount.Dirty = value;
                 _totalBaseIncomeAmount.Dirty = value;
@@ -794,7 +787,6 @@ namespace EncompassRest.Loans
                 _totalPrimaryHousingExpenseAmount.Dirty = value;
                 _totalReoMarketValueAmount.Dirty = value;
                 _totalUserDefinedIncome.Dirty = value;
-                _tQLReports.Dirty = value;
                 _transUnionAddress.Dirty = value;
                 _transUnionCity.Dirty = value;
                 _transUnionFax.Dirty = value;
@@ -811,9 +803,20 @@ namespace EncompassRest.Loans
                 _vACreditStandards.Dirty = value;
                 _vaSummarySpouseIncomeAmount.Dirty = value;
                 _vaSummaryTotalMonthlyGrossIncomeAmount.Dirty = value;
-                if (ATRQMBorrower != null) ATRQMBorrower.Dirty = value;
-                if (Borrower != null) Borrower.Dirty = value;
-                if (Coborrower != null) Coborrower.Dirty = value;
+                if (_assets != null) _assets.Dirty = value;
+                if (_aTRQMBorrower != null) _aTRQMBorrower.Dirty = value;
+                if (_aTRQMBorrowers != null) _aTRQMBorrowers.Dirty = value;
+                if (_aUSTrackingLogs != null) _aUSTrackingLogs.Dirty = value;
+                if (_borrower != null) _borrower.Dirty = value;
+                if (_coborrower != null) _coborrower.Dirty = value;
+                if (_employment != null) _employment.Dirty = value;
+                if (_income != null) _income.Dirty = value;
+                if (_liabilities != null) _liabilities.Dirty = value;
+                if (_reoProperties != null) _reoProperties.Dirty = value;
+                if (_residences != null) _residences.Dirty = value;
+                if (_selfEmployedIncomes != null) _selfEmployedIncomes.Dirty = value;
+                if (_tax4506s != null) _tax4506s.Dirty = value;
+                if (_tQLReports != null) _tQLReports.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Application.cs
+++ b/src/EncompassRest/Loans/Application.cs
@@ -8,21 +8,21 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Application : IDirty
     {
-        private Value<string> _accountNumber1;
+        private DirtyValue<string> _accountNumber1;
         public string AccountNumber1 { get { return _accountNumber1; } set { _accountNumber1 = value; } }
-        private Value<string> _accountNumber2;
+        private DirtyValue<string> _accountNumber2;
         public string AccountNumber2 { get { return _accountNumber2; } set { _accountNumber2 = value; } }
-        private Value<decimal?> _allOtherPaymentsAmount;
+        private DirtyValue<decimal?> _allOtherPaymentsAmount;
         public decimal? AllOtherPaymentsAmount { get { return _allOtherPaymentsAmount; } set { _allOtherPaymentsAmount = value; } }
-        private Value<string> _applicationId;
+        private DirtyValue<string> _applicationId;
         public string ApplicationId { get { return _applicationId; } set { _applicationId = value; } }
-        private Value<int?> _applicationIndex;
+        private DirtyValue<int?> _applicationIndex;
         public int? ApplicationIndex { get { return _applicationIndex; } set { _applicationIndex = value; } }
-        private Value<DateTime?> _applicationSignedDate;
+        private DirtyValue<DateTime?> _applicationSignedDate;
         public DateTime? ApplicationSignedDate { get { return _applicationSignedDate; } set { _applicationSignedDate = value; } }
         private DirtyList<Asset> _assets;
         public IList<Asset> Assets { get { var v = _assets; return v ?? Interlocked.CompareExchange(ref _assets, (v = new DirtyList<Asset>()), null) ?? v; } set { _assets = new DirtyList<Asset>(value); } }
-        private Value<decimal?> _assetsAvailableAmount;
+        private DirtyValue<decimal?> _assetsAvailableAmount;
         public decimal? AssetsAvailableAmount { get { return _assetsAvailableAmount; } set { _assetsAvailableAmount = value; } }
         private ATRQMBorrower _aTRQMBorrower;
         public ATRQMBorrower ATRQMBorrower { get { var v = _aTRQMBorrower; return v ?? Interlocked.CompareExchange(ref _aTRQMBorrower, (v = new ATRQMBorrower()), null) ?? v; } set { _aTRQMBorrower = value; } }
@@ -30,381 +30,381 @@ namespace EncompassRest.Loans
         public IList<ATRQMBorrower> ATRQMBorrowers { get { var v = _aTRQMBorrowers; return v ?? Interlocked.CompareExchange(ref _aTRQMBorrowers, (v = new DirtyList<ATRQMBorrower>()), null) ?? v; } set { _aTRQMBorrowers = new DirtyList<ATRQMBorrower>(value); } }
         private DirtyList<AUSTrackingLog> _aUSTrackingLogs;
         public IList<AUSTrackingLog> AUSTrackingLogs { get { var v = _aUSTrackingLogs; return v ?? Interlocked.CompareExchange(ref _aUSTrackingLogs, (v = new DirtyList<AUSTrackingLog>()), null) ?? v; } set { _aUSTrackingLogs = new DirtyList<AUSTrackingLog>(value); } }
-        private Value<decimal?> _balanceAvailableFamilySupportGuideline;
+        private DirtyValue<decimal?> _balanceAvailableFamilySupportGuideline;
         public decimal? BalanceAvailableFamilySupportGuideline { get { return _balanceAvailableFamilySupportGuideline; } set { _balanceAvailableFamilySupportGuideline = value; } }
         private Borrower _borrower;
         public Borrower Borrower { get { var v = _borrower; return v ?? Interlocked.CompareExchange(ref _borrower, (v = new Borrower()), null) ?? v; } set { _borrower = value; } }
-        private Value<decimal?> _bottomRatioPercent;
+        private DirtyValue<decimal?> _bottomRatioPercent;
         public decimal? BottomRatioPercent { get { return _bottomRatioPercent; } set { _bottomRatioPercent = value; } }
-        private Value<decimal?> _brwCoBrwTotalTaxDeductions;
+        private DirtyValue<decimal?> _brwCoBrwTotalTaxDeductions;
         public decimal? BrwCoBrwTotalTaxDeductions { get { return _brwCoBrwTotalTaxDeductions; } set { _brwCoBrwTotalTaxDeductions = value; } }
         private Borrower _coborrower;
         public Borrower Coborrower { get { var v = _coborrower; return v ?? Interlocked.CompareExchange(ref _coborrower, (v = new Borrower()), null) ?? v; } set { _coborrower = value; } }
-        private Value<string> _creditAliasName1;
+        private DirtyValue<string> _creditAliasName1;
         public string CreditAliasName1 { get { return _creditAliasName1; } set { _creditAliasName1 = value; } }
-        private Value<string> _creditAliasName2;
+        private DirtyValue<string> _creditAliasName2;
         public string CreditAliasName2 { get { return _creditAliasName2; } set { _creditAliasName2 = value; } }
-        private Value<string> _creditorName1;
+        private DirtyValue<string> _creditorName1;
         public string CreditorName1 { get { return _creditorName1; } set { _creditorName1 = value; } }
-        private Value<string> _creditorName2;
+        private DirtyValue<string> _creditorName2;
         public string CreditorName2 { get { return _creditorName2; } set { _creditorName2 = value; } }
-        private Value<string> _creditReportReferenceIdentifier;
+        private DirtyValue<string> _creditReportReferenceIdentifier;
         public string CreditReportReferenceIdentifier { get { return _creditReportReferenceIdentifier; } set { _creditReportReferenceIdentifier = value; } }
         private DirtyList<Employment> _employment;
         public IList<Employment> Employment { get { var v = _employment; return v ?? Interlocked.CompareExchange(ref _employment, (v = new DirtyList<Employment>()), null) ?? v; } set { _employment = new DirtyList<Employment>(value); } }
-        private Value<bool?> _entityDeleted;
+        private DirtyValue<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
-        private Value<string> _equifaxAddress;
+        private DirtyValue<string> _equifaxAddress;
         public string EquifaxAddress { get { return _equifaxAddress; } set { _equifaxAddress = value; } }
-        private Value<string> _equifaxCity;
+        private DirtyValue<string> _equifaxCity;
         public string EquifaxCity { get { return _equifaxCity; } set { _equifaxCity = value; } }
-        private Value<string> _equifaxFax;
+        private DirtyValue<string> _equifaxFax;
         public string EquifaxFax { get { return _equifaxFax; } set { _equifaxFax = value; } }
-        private Value<string> _equifaxModel;
+        private DirtyValue<string> _equifaxModel;
         public string EquifaxModel { get { return _equifaxModel; } set { _equifaxModel = value; } }
-        private Value<string> _equifaxName;
+        private DirtyValue<string> _equifaxName;
         public string EquifaxName { get { return _equifaxName; } set { _equifaxName = value; } }
-        private Value<string> _equifaxPhone;
+        private DirtyValue<string> _equifaxPhone;
         public string EquifaxPhone { get { return _equifaxPhone; } set { _equifaxPhone = value; } }
-        private Value<string> _equifaxPostalCode;
+        private DirtyValue<string> _equifaxPostalCode;
         public string EquifaxPostalCode { get { return _equifaxPostalCode; } set { _equifaxPostalCode = value; } }
-        private Value<string> _equifaxScoreRangeFrom;
+        private DirtyValue<string> _equifaxScoreRangeFrom;
         public string EquifaxScoreRangeFrom { get { return _equifaxScoreRangeFrom; } set { _equifaxScoreRangeFrom = value; } }
-        private Value<string> _equifaxScoreRangeTo;
+        private DirtyValue<string> _equifaxScoreRangeTo;
         public string EquifaxScoreRangeTo { get { return _equifaxScoreRangeTo; } set { _equifaxScoreRangeTo = value; } }
-        private Value<string> _equifaxState;
+        private DirtyValue<string> _equifaxState;
         public string EquifaxState { get { return _equifaxState; } set { _equifaxState = value; } }
-        private Value<string> _equifaxWebsite;
+        private DirtyValue<string> _equifaxWebsite;
         public string EquifaxWebsite { get { return _equifaxWebsite; } set { _equifaxWebsite = value; } }
-        private Value<string> _experianAddress;
+        private DirtyValue<string> _experianAddress;
         public string ExperianAddress { get { return _experianAddress; } set { _experianAddress = value; } }
-        private Value<string> _experianCity;
+        private DirtyValue<string> _experianCity;
         public string ExperianCity { get { return _experianCity; } set { _experianCity = value; } }
-        private Value<string> _experianFax;
+        private DirtyValue<string> _experianFax;
         public string ExperianFax { get { return _experianFax; } set { _experianFax = value; } }
-        private Value<string> _experianModel;
+        private DirtyValue<string> _experianModel;
         public string ExperianModel { get { return _experianModel; } set { _experianModel = value; } }
-        private Value<string> _experianName;
+        private DirtyValue<string> _experianName;
         public string ExperianName { get { return _experianName; } set { _experianName = value; } }
-        private Value<string> _experianPhone;
+        private DirtyValue<string> _experianPhone;
         public string ExperianPhone { get { return _experianPhone; } set { _experianPhone = value; } }
-        private Value<string> _experianPostalCode;
+        private DirtyValue<string> _experianPostalCode;
         public string ExperianPostalCode { get { return _experianPostalCode; } set { _experianPostalCode = value; } }
-        private Value<string> _experianScoreRangeFrom;
+        private DirtyValue<string> _experianScoreRangeFrom;
         public string ExperianScoreRangeFrom { get { return _experianScoreRangeFrom; } set { _experianScoreRangeFrom = value; } }
-        private Value<string> _experianScoreRangeTo;
+        private DirtyValue<string> _experianScoreRangeTo;
         public string ExperianScoreRangeTo { get { return _experianScoreRangeTo; } set { _experianScoreRangeTo = value; } }
-        private Value<string> _experianState;
+        private DirtyValue<string> _experianState;
         public string ExperianState { get { return _experianState; } set { _experianState = value; } }
-        private Value<string> _experianWebsite;
+        private DirtyValue<string> _experianWebsite;
         public string ExperianWebsite { get { return _experianWebsite; } set { _experianWebsite = value; } }
-        private Value<decimal?> _fhaVaDebtIncomeRatio;
+        private DirtyValue<decimal?> _fhaVaDebtIncomeRatio;
         public decimal? FhaVaDebtIncomeRatio { get { return _fhaVaDebtIncomeRatio; } set { _fhaVaDebtIncomeRatio = value; } }
-        private Value<decimal?> _fhaVaFamilySupportAmount;
+        private DirtyValue<decimal?> _fhaVaFamilySupportAmount;
         public decimal? FhaVaFamilySupportAmount { get { return _fhaVaFamilySupportAmount; } set { _fhaVaFamilySupportAmount = value; } }
-        private Value<decimal?> _fhaVaTotalEstimatedMonthlyShelterExpenseAmount;
+        private DirtyValue<decimal?> _fhaVaTotalEstimatedMonthlyShelterExpenseAmount;
         public decimal? FhaVaTotalEstimatedMonthlyShelterExpenseAmount { get { return _fhaVaTotalEstimatedMonthlyShelterExpenseAmount; } set { _fhaVaTotalEstimatedMonthlyShelterExpenseAmount = value; } }
-        private Value<decimal?> _fhaVaTotalNetEffectiveIncomeAmount;
+        private DirtyValue<decimal?> _fhaVaTotalNetEffectiveIncomeAmount;
         public decimal? FhaVaTotalNetEffectiveIncomeAmount { get { return _fhaVaTotalNetEffectiveIncomeAmount; } set { _fhaVaTotalNetEffectiveIncomeAmount = value; } }
-        private Value<decimal?> _fhaVaTotalNetIncomeAmount;
+        private DirtyValue<decimal?> _fhaVaTotalNetIncomeAmount;
         public decimal? FhaVaTotalNetIncomeAmount { get { return _fhaVaTotalNetIncomeAmount; } set { _fhaVaTotalNetIncomeAmount = value; } }
-        private Value<decimal?> _fhaVaTotalNetTakeHomePayAmount;
+        private DirtyValue<decimal?> _fhaVaTotalNetTakeHomePayAmount;
         public decimal? FhaVaTotalNetTakeHomePayAmount { get { return _fhaVaTotalNetTakeHomePayAmount; } set { _fhaVaTotalNetTakeHomePayAmount = value; } }
-        private Value<decimal?> _fhaVaTotalOtherNetIncome;
+        private DirtyValue<decimal?> _fhaVaTotalOtherNetIncome;
         public decimal? FhaVaTotalOtherNetIncome { get { return _fhaVaTotalOtherNetIncome; } set { _fhaVaTotalOtherNetIncome = value; } }
-        private Value<decimal?> _firstMortgagePrincipalAndInterestAmount;
+        private DirtyValue<decimal?> _firstMortgagePrincipalAndInterestAmount;
         public decimal? FirstMortgagePrincipalAndInterestAmount { get { return _firstMortgagePrincipalAndInterestAmount; } set { _firstMortgagePrincipalAndInterestAmount = value; } }
-        private Value<string> _freddieMacCreditReportReferenceIdentifier;
+        private DirtyValue<string> _freddieMacCreditReportReferenceIdentifier;
         public string FreddieMacCreditReportReferenceIdentifier { get { return _freddieMacCreditReportReferenceIdentifier; } set { _freddieMacCreditReportReferenceIdentifier = value; } }
-        private Value<decimal?> _freddieMacOccupantDebtRatio;
+        private DirtyValue<decimal?> _freddieMacOccupantDebtRatio;
         public decimal? FreddieMacOccupantDebtRatio { get { return _freddieMacOccupantDebtRatio; } set { _freddieMacOccupantDebtRatio = value; } }
-        private Value<decimal?> _freddieMacOccupantHousingRatio;
+        private DirtyValue<decimal?> _freddieMacOccupantHousingRatio;
         public decimal? FreddieMacOccupantHousingRatio { get { return _freddieMacOccupantHousingRatio; } set { _freddieMacOccupantHousingRatio = value; } }
-        private Value<decimal?> _freDebtToHousingGapRatio;
+        private DirtyValue<decimal?> _freDebtToHousingGapRatio;
         public decimal? FreDebtToHousingGapRatio { get { return _freDebtToHousingGapRatio; } set { _freDebtToHousingGapRatio = value; } }
-        private Value<decimal?> _grossBaseIncomeAmount;
+        private DirtyValue<decimal?> _grossBaseIncomeAmount;
         public decimal? GrossBaseIncomeAmount { get { return _grossBaseIncomeAmount; } set { _grossBaseIncomeAmount = value; } }
-        private Value<decimal?> _grossIncomeForComortSet;
+        private DirtyValue<decimal?> _grossIncomeForComortSet;
         public decimal? GrossIncomeForComortSet { get { return _grossIncomeForComortSet; } set { _grossIncomeForComortSet = value; } }
-        private Value<decimal?> _grossNegativeCashFlow;
+        private DirtyValue<decimal?> _grossNegativeCashFlow;
         public decimal? GrossNegativeCashFlow { get { return _grossNegativeCashFlow; } set { _grossNegativeCashFlow = value; } }
-        private Value<decimal?> _grossOtherIncomeAmount;
+        private DirtyValue<decimal?> _grossOtherIncomeAmount;
         public decimal? GrossOtherIncomeAmount { get { return _grossOtherIncomeAmount; } set { _grossOtherIncomeAmount = value; } }
-        private Value<decimal?> _grossPositiveCashFlow;
+        private DirtyValue<decimal?> _grossPositiveCashFlow;
         public decimal? GrossPositiveCashFlow { get { return _grossPositiveCashFlow; } set { _grossPositiveCashFlow = value; } }
-        private Value<string> _hazardInsuranceAmount;
+        private DirtyValue<string> _hazardInsuranceAmount;
         public string HazardInsuranceAmount { get { return _hazardInsuranceAmount; } set { _hazardInsuranceAmount = value; } }
-        private Value<string> _homeownersAssociationDuesAndCondoFeesAmount;
+        private DirtyValue<string> _homeownersAssociationDuesAndCondoFeesAmount;
         public string HomeownersAssociationDuesAndCondoFeesAmount { get { return _homeownersAssociationDuesAndCondoFeesAmount; } set { _homeownersAssociationDuesAndCondoFeesAmount = value; } }
-        private Value<string> _hudAutoLienHolderName1;
+        private DirtyValue<string> _hudAutoLienHolderName1;
         public string HudAutoLienHolderName1 { get { return _hudAutoLienHolderName1; } set { _hudAutoLienHolderName1 = value; } }
-        private Value<string> _hudAutoLienHolderName2;
+        private DirtyValue<string> _hudAutoLienHolderName2;
         public string HudAutoLienHolderName2 { get { return _hudAutoLienHolderName2; } set { _hudAutoLienHolderName2 = value; } }
-        private Value<decimal?> _hudAutoLoanAmount1;
+        private DirtyValue<decimal?> _hudAutoLoanAmount1;
         public decimal? HudAutoLoanAmount1 { get { return _hudAutoLoanAmount1; } set { _hudAutoLoanAmount1 = value; } }
-        private Value<decimal?> _hudAutoLoanAmount2;
+        private DirtyValue<decimal?> _hudAutoLoanAmount2;
         public decimal? HudAutoLoanAmount2 { get { return _hudAutoLoanAmount2; } set { _hudAutoLoanAmount2 = value; } }
-        private Value<decimal?> _hudAutoMonthlyPayment1;
+        private DirtyValue<decimal?> _hudAutoMonthlyPayment1;
         public decimal? HudAutoMonthlyPayment1 { get { return _hudAutoMonthlyPayment1; } set { _hudAutoMonthlyPayment1 = value; } }
-        private Value<decimal?> _hudAutoMonthlyPayment2;
+        private DirtyValue<decimal?> _hudAutoMonthlyPayment2;
         public decimal? HudAutoMonthlyPayment2 { get { return _hudAutoMonthlyPayment2; } set { _hudAutoMonthlyPayment2 = value; } }
-        private Value<decimal?> _hudAutoPresentBalance1;
+        private DirtyValue<decimal?> _hudAutoPresentBalance1;
         public decimal? HudAutoPresentBalance1 { get { return _hudAutoPresentBalance1; } set { _hudAutoPresentBalance1 = value; } }
-        private Value<decimal?> _hudAutoPresentBalance2;
+        private DirtyValue<decimal?> _hudAutoPresentBalance2;
         public decimal? HudAutoPresentBalance2 { get { return _hudAutoPresentBalance2; } set { _hudAutoPresentBalance2 = value; } }
-        private Value<string> _hudAutoYearAndMake1;
+        private DirtyValue<string> _hudAutoYearAndMake1;
         public string HudAutoYearAndMake1 { get { return _hudAutoYearAndMake1; } set { _hudAutoYearAndMake1 = value; } }
-        private Value<string> _hudAutoYearAndMake2;
+        private DirtyValue<string> _hudAutoYearAndMake2;
         public string HudAutoYearAndMake2 { get { return _hudAutoYearAndMake2; } set { _hudAutoYearAndMake2 = value; } }
-        private Value<decimal?> _hudLoanAmount1;
+        private DirtyValue<decimal?> _hudLoanAmount1;
         public decimal? HudLoanAmount1 { get { return _hudLoanAmount1; } set { _hudLoanAmount1 = value; } }
-        private Value<decimal?> _hudLoanAmount10;
+        private DirtyValue<decimal?> _hudLoanAmount10;
         public decimal? HudLoanAmount10 { get { return _hudLoanAmount10; } set { _hudLoanAmount10 = value; } }
-        private Value<decimal?> _hudLoanAmount11;
+        private DirtyValue<decimal?> _hudLoanAmount11;
         public decimal? HudLoanAmount11 { get { return _hudLoanAmount11; } set { _hudLoanAmount11 = value; } }
-        private Value<decimal?> _hudLoanAmount2;
+        private DirtyValue<decimal?> _hudLoanAmount2;
         public decimal? HudLoanAmount2 { get { return _hudLoanAmount2; } set { _hudLoanAmount2 = value; } }
-        private Value<decimal?> _hudLoanAmount3;
+        private DirtyValue<decimal?> _hudLoanAmount3;
         public decimal? HudLoanAmount3 { get { return _hudLoanAmount3; } set { _hudLoanAmount3 = value; } }
-        private Value<decimal?> _hudLoanAmount4;
+        private DirtyValue<decimal?> _hudLoanAmount4;
         public decimal? HudLoanAmount4 { get { return _hudLoanAmount4; } set { _hudLoanAmount4 = value; } }
-        private Value<decimal?> _hudLoanAmount5;
+        private DirtyValue<decimal?> _hudLoanAmount5;
         public decimal? HudLoanAmount5 { get { return _hudLoanAmount5; } set { _hudLoanAmount5 = value; } }
-        private Value<decimal?> _hudLoanAmount6;
+        private DirtyValue<decimal?> _hudLoanAmount6;
         public decimal? HudLoanAmount6 { get { return _hudLoanAmount6; } set { _hudLoanAmount6 = value; } }
-        private Value<decimal?> _hudLoanAmount7;
+        private DirtyValue<decimal?> _hudLoanAmount7;
         public decimal? HudLoanAmount7 { get { return _hudLoanAmount7; } set { _hudLoanAmount7 = value; } }
-        private Value<decimal?> _hudLoanAmount8;
+        private DirtyValue<decimal?> _hudLoanAmount8;
         public decimal? HudLoanAmount8 { get { return _hudLoanAmount8; } set { _hudLoanAmount8 = value; } }
-        private Value<decimal?> _hudLoanAmount9;
+        private DirtyValue<decimal?> _hudLoanAmount9;
         public decimal? HudLoanAmount9 { get { return _hudLoanAmount9; } set { _hudLoanAmount9 = value; } }
-        private Value<bool?> _hudRealEstateFhaInsured1;
+        private DirtyValue<bool?> _hudRealEstateFhaInsured1;
         public bool? HudRealEstateFhaInsured1 { get { return _hudRealEstateFhaInsured1; } set { _hudRealEstateFhaInsured1 = value; } }
-        private Value<bool?> _hudRealEstateFhaInsured2;
+        private DirtyValue<bool?> _hudRealEstateFhaInsured2;
         public bool? HudRealEstateFhaInsured2 { get { return _hudRealEstateFhaInsured2; } set { _hudRealEstateFhaInsured2 = value; } }
-        private Value<string> _hudRealEstateLienHolder1;
+        private DirtyValue<string> _hudRealEstateLienHolder1;
         public string HudRealEstateLienHolder1 { get { return _hudRealEstateLienHolder1; } set { _hudRealEstateLienHolder1 = value; } }
-        private Value<string> _hudRealEstateLienHolder2;
+        private DirtyValue<string> _hudRealEstateLienHolder2;
         public string HudRealEstateLienHolder2 { get { return _hudRealEstateLienHolder2; } set { _hudRealEstateLienHolder2 = value; } }
-        private Value<decimal?> _hudRealEstateLoanAmount1;
+        private DirtyValue<decimal?> _hudRealEstateLoanAmount1;
         public decimal? HudRealEstateLoanAmount1 { get { return _hudRealEstateLoanAmount1; } set { _hudRealEstateLoanAmount1 = value; } }
-        private Value<decimal?> _hudRealEstateLoanAmount2;
+        private DirtyValue<decimal?> _hudRealEstateLoanAmount2;
         public decimal? HudRealEstateLoanAmount2 { get { return _hudRealEstateLoanAmount2; } set { _hudRealEstateLoanAmount2 = value; } }
-        private Value<decimal?> _hudRealEstateMonthlyPayment1;
+        private DirtyValue<decimal?> _hudRealEstateMonthlyPayment1;
         public decimal? HudRealEstateMonthlyPayment1 { get { return _hudRealEstateMonthlyPayment1; } set { _hudRealEstateMonthlyPayment1 = value; } }
-        private Value<decimal?> _hudRealEstateMonthlyPayment2;
+        private DirtyValue<decimal?> _hudRealEstateMonthlyPayment2;
         public decimal? HudRealEstateMonthlyPayment2 { get { return _hudRealEstateMonthlyPayment2; } set { _hudRealEstateMonthlyPayment2 = value; } }
-        private Value<decimal?> _hudRealEstatePresentBalance1;
+        private DirtyValue<decimal?> _hudRealEstatePresentBalance1;
         public decimal? HudRealEstatePresentBalance1 { get { return _hudRealEstatePresentBalance1; } set { _hudRealEstatePresentBalance1 = value; } }
-        private Value<decimal?> _hudRealEstatePresentBalance2;
+        private DirtyValue<decimal?> _hudRealEstatePresentBalance2;
         public decimal? HudRealEstatePresentBalance2 { get { return _hudRealEstatePresentBalance2; } set { _hudRealEstatePresentBalance2 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private DirtyList<Income> _income;
         public IList<Income> Income { get { var v = _income; return v ?? Interlocked.CompareExchange(ref _income, (v = new DirtyList<Income>()), null) ?? v; } set { _income = new DirtyList<Income>(value); } }
-        private Value<bool?> _incomeOfBorrowersSpouseUsedIndicator;
+        private DirtyValue<bool?> _incomeOfBorrowersSpouseUsedIndicator;
         public bool? IncomeOfBorrowersSpouseUsedIndicator { get { return _incomeOfBorrowersSpouseUsedIndicator; } set { _incomeOfBorrowersSpouseUsedIndicator = value; } }
-        private Value<bool?> _incomeOtherThanBorrowerUsedIndicator;
+        private DirtyValue<bool?> _incomeOtherThanBorrowerUsedIndicator;
         public bool? IncomeOtherThanBorrowerUsedIndicator { get { return _incomeOtherThanBorrowerUsedIndicator; } set { _incomeOtherThanBorrowerUsedIndicator = value; } }
-        private Value<bool?> _jointAssetLiabilityReportingIndicator;
+        private DirtyValue<bool?> _jointAssetLiabilityReportingIndicator;
         public bool? JointAssetLiabilityReportingIndicator { get { return _jointAssetLiabilityReportingIndicator; } set { _jointAssetLiabilityReportingIndicator = value; } }
         private DirtyList<Liability> _liabilities;
         public IList<Liability> Liabilities { get { var v = _liabilities; return v ?? Interlocked.CompareExchange(ref _liabilities, (v = new DirtyList<Liability>()), null) ?? v; } set { _liabilities = new DirtyList<Liability>(value); } }
-        private Value<decimal?> _liquidAssetsComortSet;
+        private DirtyValue<decimal?> _liquidAssetsComortSet;
         public decimal? LiquidAssetsComortSet { get { return _liquidAssetsComortSet; } set { _liquidAssetsComortSet = value; } }
-        private Value<decimal?> _mcawBorrowerOtherMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _mcawBorrowerOtherMonthlyIncomeAmount;
         public decimal? McawBorrowerOtherMonthlyIncomeAmount { get { return _mcawBorrowerOtherMonthlyIncomeAmount; } set { _mcawBorrowerOtherMonthlyIncomeAmount = value; } }
-        private Value<decimal?> _mcawCoborrowerOtherMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _mcawCoborrowerOtherMonthlyIncomeAmount;
         public decimal? McawCoborrowerOtherMonthlyIncomeAmount { get { return _mcawCoborrowerOtherMonthlyIncomeAmount; } set { _mcawCoborrowerOtherMonthlyIncomeAmount = value; } }
-        private Value<decimal?> _mcawGrossMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _mcawGrossMonthlyIncomeAmount;
         public decimal? McawGrossMonthlyIncomeAmount { get { return _mcawGrossMonthlyIncomeAmount; } set { _mcawGrossMonthlyIncomeAmount = value; } }
-        private Value<decimal?> _mcawMortgagePaymentToIncome1Amount;
+        private DirtyValue<decimal?> _mcawMortgagePaymentToIncome1Amount;
         public decimal? McawMortgagePaymentToIncome1Amount { get { return _mcawMortgagePaymentToIncome1Amount; } set { _mcawMortgagePaymentToIncome1Amount = value; } }
-        private Value<decimal?> _mcawMortgagePaymentToIncome2Amount;
+        private DirtyValue<decimal?> _mcawMortgagePaymentToIncome2Amount;
         public decimal? McawMortgagePaymentToIncome2Amount { get { return _mcawMortgagePaymentToIncome2Amount; } set { _mcawMortgagePaymentToIncome2Amount = value; } }
-        private Value<decimal?> _mcawOtherAmount;
+        private DirtyValue<decimal?> _mcawOtherAmount;
         public decimal? McawOtherAmount { get { return _mcawOtherAmount; } set { _mcawOtherAmount = value; } }
-        private Value<decimal?> _mcawOtherDebtsAndObligationsAmount;
+        private DirtyValue<decimal?> _mcawOtherDebtsAndObligationsAmount;
         public decimal? McawOtherDebtsAndObligationsAmount { get { return _mcawOtherDebtsAndObligationsAmount; } set { _mcawOtherDebtsAndObligationsAmount = value; } }
-        private Value<decimal?> _mcawTotalFixedPaymentForPurchaseAmount;
+        private DirtyValue<decimal?> _mcawTotalFixedPaymentForPurchaseAmount;
         public decimal? McawTotalFixedPaymentForPurchaseAmount { get { return _mcawTotalFixedPaymentForPurchaseAmount; } set { _mcawTotalFixedPaymentForPurchaseAmount = value; } }
-        private Value<decimal?> _mcawTotalFixedPaymentForRefinanceAmount;
+        private DirtyValue<decimal?> _mcawTotalFixedPaymentForRefinanceAmount;
         public decimal? McawTotalFixedPaymentForRefinanceAmount { get { return _mcawTotalFixedPaymentForRefinanceAmount; } set { _mcawTotalFixedPaymentForRefinanceAmount = value; } }
-        private Value<decimal?> _mcawTotalFixedPaymentToIncome1Amount;
+        private DirtyValue<decimal?> _mcawTotalFixedPaymentToIncome1Amount;
         public decimal? McawTotalFixedPaymentToIncome1Amount { get { return _mcawTotalFixedPaymentToIncome1Amount; } set { _mcawTotalFixedPaymentToIncome1Amount = value; } }
-        private Value<decimal?> _mcawTotalFixedPaymentToIncome2Amount;
+        private DirtyValue<decimal?> _mcawTotalFixedPaymentToIncome2Amount;
         public decimal? McawTotalFixedPaymentToIncome2Amount { get { return _mcawTotalFixedPaymentToIncome2Amount; } set { _mcawTotalFixedPaymentToIncome2Amount = value; } }
-        private Value<decimal?> _mcawTotalMonthlyPaymentsAmount;
+        private DirtyValue<decimal?> _mcawTotalMonthlyPaymentsAmount;
         public decimal? McawTotalMonthlyPaymentsAmount { get { return _mcawTotalMonthlyPaymentsAmount; } set { _mcawTotalMonthlyPaymentsAmount = value; } }
-        private Value<decimal?> _mcawTotalMortgagePaymentAmount;
+        private DirtyValue<decimal?> _mcawTotalMortgagePaymentAmount;
         public decimal? McawTotalMortgagePaymentAmount { get { return _mcawTotalMortgagePaymentAmount; } set { _mcawTotalMortgagePaymentAmount = value; } }
-        private Value<decimal?> _monthlyExpenseComortSet;
+        private DirtyValue<decimal?> _monthlyExpenseComortSet;
         public decimal? MonthlyExpenseComortSet { get { return _monthlyExpenseComortSet; } set { _monthlyExpenseComortSet = value; } }
-        private Value<decimal?> _monthlyHousingExpenseAmount;
+        private DirtyValue<decimal?> _monthlyHousingExpenseAmount;
         public decimal? MonthlyHousingExpenseAmount { get { return _monthlyHousingExpenseAmount; } set { _monthlyHousingExpenseAmount = value; } }
-        private Value<decimal?> _monthlyInstallmentExpenseAmount;
+        private DirtyValue<decimal?> _monthlyInstallmentExpenseAmount;
         public decimal? MonthlyInstallmentExpenseAmount { get { return _monthlyInstallmentExpenseAmount; } set { _monthlyInstallmentExpenseAmount = value; } }
-        private Value<decimal?> _monthlyNegativeRealEstateAmount;
+        private DirtyValue<decimal?> _monthlyNegativeRealEstateAmount;
         public decimal? MonthlyNegativeRealEstateAmount { get { return _monthlyNegativeRealEstateAmount; } set { _monthlyNegativeRealEstateAmount = value; } }
-        private Value<decimal?> _monthlySecondHomeAmount;
+        private DirtyValue<decimal?> _monthlySecondHomeAmount;
         public decimal? MonthlySecondHomeAmount { get { return _monthlySecondHomeAmount; } set { _monthlySecondHomeAmount = value; } }
-        private Value<string> _mortgageInsuranceAmount;
+        private DirtyValue<string> _mortgageInsuranceAmount;
         public string MortgageInsuranceAmount { get { return _mortgageInsuranceAmount; } set { _mortgageInsuranceAmount = value; } }
-        private Value<decimal?> _netWorthAmount;
+        private DirtyValue<decimal?> _netWorthAmount;
         public decimal? NetWorthAmount { get { return _netWorthAmount; } set { _netWorthAmount = value; } }
-        private Value<decimal?> _otherHousingExpenseAmount;
+        private DirtyValue<decimal?> _otherHousingExpenseAmount;
         public decimal? OtherHousingExpenseAmount { get { return _otherHousingExpenseAmount; } set { _otherHousingExpenseAmount = value; } }
-        private Value<decimal?> _otherItemsDeducted;
+        private DirtyValue<decimal?> _otherItemsDeducted;
         public decimal? OtherItemsDeducted { get { return _otherItemsDeducted; } set { _otherItemsDeducted = value; } }
-        private Value<decimal?> _otherMortgagePrincipalAndInterestAmount;
+        private DirtyValue<decimal?> _otherMortgagePrincipalAndInterestAmount;
         public decimal? OtherMortgagePrincipalAndInterestAmount { get { return _otherMortgagePrincipalAndInterestAmount; } set { _otherMortgagePrincipalAndInterestAmount = value; } }
-        private Value<string> _pastCreditRecord;
+        private DirtyValue<string> _pastCreditRecord;
         public string PastCreditRecord { get { return _pastCreditRecord; } set { _pastCreditRecord = value; } }
-        private Value<decimal?> _presentHousingExpComortSet;
+        private DirtyValue<decimal?> _presentHousingExpComortSet;
         public decimal? PresentHousingExpComortSet { get { return _presentHousingExpComortSet; } set { _presentHousingExpComortSet = value; } }
-        private Value<decimal?> _primaryResidenceComortSet;
+        private DirtyValue<decimal?> _primaryResidenceComortSet;
         public decimal? PrimaryResidenceComortSet { get { return _primaryResidenceComortSet; } set { _primaryResidenceComortSet = value; } }
-        private Value<string> _propertyUsageType;
+        private DirtyValue<string> _propertyUsageType;
         public string PropertyUsageType { get { return _propertyUsageType; } set { _propertyUsageType = value; } }
-        private Value<string> _proposedDuesAmount;
+        private DirtyValue<string> _proposedDuesAmount;
         public string ProposedDuesAmount { get { return _proposedDuesAmount; } set { _proposedDuesAmount = value; } }
-        private Value<decimal?> _proposedFirstMortgageAmount;
+        private DirtyValue<decimal?> _proposedFirstMortgageAmount;
         public decimal? ProposedFirstMortgageAmount { get { return _proposedFirstMortgageAmount; } set { _proposedFirstMortgageAmount = value; } }
-        private Value<decimal?> _proposedGroundRentAmount;
+        private DirtyValue<decimal?> _proposedGroundRentAmount;
         public decimal? ProposedGroundRentAmount { get { return _proposedGroundRentAmount; } set { _proposedGroundRentAmount = value; } }
-        private Value<string> _proposedHazardInsuranceAmount;
+        private DirtyValue<string> _proposedHazardInsuranceAmount;
         public string ProposedHazardInsuranceAmount { get { return _proposedHazardInsuranceAmount; } set { _proposedHazardInsuranceAmount = value; } }
-        private Value<string> _proposedMortgageInsuranceAmount;
+        private DirtyValue<string> _proposedMortgageInsuranceAmount;
         public string ProposedMortgageInsuranceAmount { get { return _proposedMortgageInsuranceAmount; } set { _proposedMortgageInsuranceAmount = value; } }
-        private Value<decimal?> _proposedOtherAmount;
+        private DirtyValue<decimal?> _proposedOtherAmount;
         public decimal? ProposedOtherAmount { get { return _proposedOtherAmount; } set { _proposedOtherAmount = value; } }
-        private Value<decimal?> _proposedOtherMortgagesAmount;
+        private DirtyValue<decimal?> _proposedOtherMortgagesAmount;
         public decimal? ProposedOtherMortgagesAmount { get { return _proposedOtherMortgagesAmount; } set { _proposedOtherMortgagesAmount = value; } }
-        private Value<string> _proposedRealEstateTaxesAmount;
+        private DirtyValue<string> _proposedRealEstateTaxesAmount;
         public string ProposedRealEstateTaxesAmount { get { return _proposedRealEstateTaxesAmount; } set { _proposedRealEstateTaxesAmount = value; } }
-        private Value<string> _realEstateTaxAmount;
+        private DirtyValue<string> _realEstateTaxAmount;
         public string RealEstateTaxAmount { get { return _realEstateTaxAmount; } set { _realEstateTaxAmount = value; } }
-        private Value<decimal?> _rentAmount;
+        private DirtyValue<decimal?> _rentAmount;
         public decimal? RentAmount { get { return _rentAmount; } set { _rentAmount = value; } }
         private DirtyList<ReoProperty> _reoProperties;
         public IList<ReoProperty> ReoProperties { get { var v = _reoProperties; return v ?? Interlocked.CompareExchange(ref _reoProperties, (v = new DirtyList<ReoProperty>()), null) ?? v; } set { _reoProperties = new DirtyList<ReoProperty>(value); } }
-        private Value<decimal?> _reoTotalGrossRentalIncomeAmount;
+        private DirtyValue<decimal?> _reoTotalGrossRentalIncomeAmount;
         public decimal? ReoTotalGrossRentalIncomeAmount { get { return _reoTotalGrossRentalIncomeAmount; } set { _reoTotalGrossRentalIncomeAmount = value; } }
-        private Value<decimal?> _reoTotalMaintenanceAmount;
+        private DirtyValue<decimal?> _reoTotalMaintenanceAmount;
         public decimal? ReoTotalMaintenanceAmount { get { return _reoTotalMaintenanceAmount; } set { _reoTotalMaintenanceAmount = value; } }
-        private Value<decimal?> _reoTotalMarketValueAmount;
+        private DirtyValue<decimal?> _reoTotalMarketValueAmount;
         public decimal? ReoTotalMarketValueAmount { get { return _reoTotalMarketValueAmount; } set { _reoTotalMarketValueAmount = value; } }
-        private Value<decimal?> _reoTotalMortgagePaymentsAmount;
+        private DirtyValue<decimal?> _reoTotalMortgagePaymentsAmount;
         public decimal? ReoTotalMortgagePaymentsAmount { get { return _reoTotalMortgagePaymentsAmount; } set { _reoTotalMortgagePaymentsAmount = value; } }
-        private Value<decimal?> _reoTotalMortgagesAndLiensAmount;
+        private DirtyValue<decimal?> _reoTotalMortgagesAndLiensAmount;
         public decimal? ReoTotalMortgagesAndLiensAmount { get { return _reoTotalMortgagesAndLiensAmount; } set { _reoTotalMortgagesAndLiensAmount = value; } }
-        private Value<int?> _reoTotalNetRentalIncomeAmount;
+        private DirtyValue<int?> _reoTotalNetRentalIncomeAmount;
         public int? ReoTotalNetRentalIncomeAmount { get { return _reoTotalNetRentalIncomeAmount; } set { _reoTotalNetRentalIncomeAmount = value; } }
         private DirtyList<Residence> _residences;
         public IList<Residence> Residences { get { var v = _residences; return v ?? Interlocked.CompareExchange(ref _residences, (v = new DirtyList<Residence>()), null) ?? v; } set { _residences = new DirtyList<Residence>(value); } }
         private DirtyList<SelfEmployedIncome> _selfEmployedIncomes;
         public IList<SelfEmployedIncome> SelfEmployedIncomes { get { var v = _selfEmployedIncomes; return v ?? Interlocked.CompareExchange(ref _selfEmployedIncomes, (v = new DirtyList<SelfEmployedIncome>()), null) ?? v; } set { _selfEmployedIncomes = new DirtyList<SelfEmployedIncome>(value); } }
-        private Value<string> _sofDBorrowerAddress;
+        private DirtyValue<string> _sofDBorrowerAddress;
         public string SofDBorrowerAddress { get { return _sofDBorrowerAddress; } set { _sofDBorrowerAddress = value; } }
-        private Value<string> _sofDBorrowerAddressCity;
+        private DirtyValue<string> _sofDBorrowerAddressCity;
         public string SofDBorrowerAddressCity { get { return _sofDBorrowerAddressCity; } set { _sofDBorrowerAddressCity = value; } }
-        private Value<string> _sofDBorrowerAddressState;
+        private DirtyValue<string> _sofDBorrowerAddressState;
         public string SofDBorrowerAddressState { get { return _sofDBorrowerAddressState; } set { _sofDBorrowerAddressState = value; } }
-        private Value<string> _sofDBorrowerAddressType;
+        private DirtyValue<string> _sofDBorrowerAddressType;
         public string SofDBorrowerAddressType { get { return _sofDBorrowerAddressType; } set { _sofDBorrowerAddressType = value; } }
-        private Value<string> _sofDBorrowerAddressZipcode;
+        private DirtyValue<string> _sofDBorrowerAddressZipcode;
         public string SofDBorrowerAddressZipcode { get { return _sofDBorrowerAddressZipcode; } set { _sofDBorrowerAddressZipcode = value; } }
-        private Value<string> _sofDCoBorrowerAddress;
+        private DirtyValue<string> _sofDCoBorrowerAddress;
         public string SofDCoBorrowerAddress { get { return _sofDCoBorrowerAddress; } set { _sofDCoBorrowerAddress = value; } }
-        private Value<string> _sofDCoBorrowerAddressCity;
+        private DirtyValue<string> _sofDCoBorrowerAddressCity;
         public string SofDCoBorrowerAddressCity { get { return _sofDCoBorrowerAddressCity; } set { _sofDCoBorrowerAddressCity = value; } }
-        private Value<string> _sofDCoBorrowerAddressState;
+        private DirtyValue<string> _sofDCoBorrowerAddressState;
         public string SofDCoBorrowerAddressState { get { return _sofDCoBorrowerAddressState; } set { _sofDCoBorrowerAddressState = value; } }
-        private Value<string> _sofDCoBorrowerAddressType;
+        private DirtyValue<string> _sofDCoBorrowerAddressType;
         public string SofDCoBorrowerAddressType { get { return _sofDCoBorrowerAddressType; } set { _sofDCoBorrowerAddressType = value; } }
-        private Value<string> _sofDCoBorrowerAddressZipcode;
+        private DirtyValue<string> _sofDCoBorrowerAddressZipcode;
         public string SofDCoBorrowerAddressZipcode { get { return _sofDCoBorrowerAddressZipcode; } set { _sofDCoBorrowerAddressZipcode = value; } }
-        private Value<bool?> _spouseIncomeConsider;
+        private DirtyValue<bool?> _spouseIncomeConsider;
         public bool? SpouseIncomeConsider { get { return _spouseIncomeConsider; } set { _spouseIncomeConsider = value; } }
         private DirtyList<Tax4506> _tax4506s;
         public IList<Tax4506> Tax4506s { get { var v = _tax4506s; return v ?? Interlocked.CompareExchange(ref _tax4506s, (v = new DirtyList<Tax4506>()), null) ?? v; } set { _tax4506s = new DirtyList<Tax4506>(value); } }
-        private Value<decimal?> _topRatioPercent;
+        private DirtyValue<decimal?> _topRatioPercent;
         public decimal? TopRatioPercent { get { return _topRatioPercent; } set { _topRatioPercent = value; } }
-        private Value<decimal?> _totalAssetsAmount;
+        private DirtyValue<decimal?> _totalAssetsAmount;
         public decimal? TotalAssetsAmount { get { return _totalAssetsAmount; } set { _totalAssetsAmount = value; } }
-        private Value<decimal?> _totalBaseIncomeAmount;
+        private DirtyValue<decimal?> _totalBaseIncomeAmount;
         public decimal? TotalBaseIncomeAmount { get { return _totalBaseIncomeAmount; } set { _totalBaseIncomeAmount = value; } }
-        private Value<decimal?> _totalBonusAmount;
+        private DirtyValue<decimal?> _totalBonusAmount;
         public decimal? TotalBonusAmount { get { return _totalBonusAmount; } set { _totalBonusAmount = value; } }
-        private Value<decimal?> _totalCommissionsAmount;
+        private DirtyValue<decimal?> _totalCommissionsAmount;
         public decimal? TotalCommissionsAmount { get { return _totalCommissionsAmount; } set { _totalCommissionsAmount = value; } }
-        private Value<decimal?> _totalDeposit;
+        private DirtyValue<decimal?> _totalDeposit;
         public decimal? TotalDeposit { get { return _totalDeposit; } set { _totalDeposit = value; } }
-        private Value<decimal?> _totalDividendsInterestAmount;
+        private DirtyValue<decimal?> _totalDividendsInterestAmount;
         public decimal? TotalDividendsInterestAmount { get { return _totalDividendsInterestAmount; } set { _totalDividendsInterestAmount = value; } }
-        private Value<decimal?> _totalEmploymentAmount;
+        private DirtyValue<decimal?> _totalEmploymentAmount;
         public decimal? TotalEmploymentAmount { get { return _totalEmploymentAmount; } set { _totalEmploymentAmount = value; } }
-        private Value<decimal?> _totalFixedPaymentAmount;
+        private DirtyValue<decimal?> _totalFixedPaymentAmount;
         public decimal? TotalFixedPaymentAmount { get { return _totalFixedPaymentAmount; } set { _totalFixedPaymentAmount = value; } }
-        private Value<decimal?> _totalGrossMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _totalGrossMonthlyIncomeAmount;
         public decimal? TotalGrossMonthlyIncomeAmount { get { return _totalGrossMonthlyIncomeAmount; } set { _totalGrossMonthlyIncomeAmount = value; } }
-        private Value<decimal?> _totalIncomeAmount;
+        private DirtyValue<decimal?> _totalIncomeAmount;
         public decimal? TotalIncomeAmount { get { return _totalIncomeAmount; } set { _totalIncomeAmount = value; } }
-        private Value<decimal?> _totalMonthlyPaymentAmount;
+        private DirtyValue<decimal?> _totalMonthlyPaymentAmount;
         public decimal? TotalMonthlyPaymentAmount { get { return _totalMonthlyPaymentAmount; } set { _totalMonthlyPaymentAmount = value; } }
-        private Value<decimal?> _totalMortgagesBalanceAmount;
+        private DirtyValue<decimal?> _totalMortgagesBalanceAmount;
         public decimal? TotalMortgagesBalanceAmount { get { return _totalMortgagesBalanceAmount; } set { _totalMortgagesBalanceAmount = value; } }
-        private Value<decimal?> _totalMortgagesMonthlyPaymentAmount;
+        private DirtyValue<decimal?> _totalMortgagesMonthlyPaymentAmount;
         public decimal? TotalMortgagesMonthlyPaymentAmount { get { return _totalMortgagesMonthlyPaymentAmount; } set { _totalMortgagesMonthlyPaymentAmount = value; } }
-        private Value<decimal?> _totalNetRentalIncomeAmount;
+        private DirtyValue<decimal?> _totalNetRentalIncomeAmount;
         public decimal? TotalNetRentalIncomeAmount { get { return _totalNetRentalIncomeAmount; } set { _totalNetRentalIncomeAmount = value; } }
-        private Value<decimal?> _totalOther1Amount;
+        private DirtyValue<decimal?> _totalOther1Amount;
         public decimal? TotalOther1Amount { get { return _totalOther1Amount; } set { _totalOther1Amount = value; } }
-        private Value<decimal?> _totalOther2Amount;
+        private DirtyValue<decimal?> _totalOther2Amount;
         public decimal? TotalOther2Amount { get { return _totalOther2Amount; } set { _totalOther2Amount = value; } }
-        private Value<decimal?> _totalOvertimeAmount;
+        private DirtyValue<decimal?> _totalOvertimeAmount;
         public decimal? TotalOvertimeAmount { get { return _totalOvertimeAmount; } set { _totalOvertimeAmount = value; } }
-        private Value<decimal?> _totalPaymentsAmount;
+        private DirtyValue<decimal?> _totalPaymentsAmount;
         public decimal? TotalPaymentsAmount { get { return _totalPaymentsAmount; } set { _totalPaymentsAmount = value; } }
-        private Value<decimal?> _totalPrimaryHousingExpenseAmount;
+        private DirtyValue<decimal?> _totalPrimaryHousingExpenseAmount;
         public decimal? TotalPrimaryHousingExpenseAmount { get { return _totalPrimaryHousingExpenseAmount; } set { _totalPrimaryHousingExpenseAmount = value; } }
-        private Value<decimal?> _totalReoMarketValueAmount;
+        private DirtyValue<decimal?> _totalReoMarketValueAmount;
         public decimal? TotalReoMarketValueAmount { get { return _totalReoMarketValueAmount; } set { _totalReoMarketValueAmount = value; } }
-        private Value<decimal?> _totalUserDefinedIncome;
+        private DirtyValue<decimal?> _totalUserDefinedIncome;
         public decimal? TotalUserDefinedIncome { get { return _totalUserDefinedIncome; } set { _totalUserDefinedIncome = value; } }
         private DirtyList<TQLReportInformation> _tQLReports;
         public IList<TQLReportInformation> TQLReports { get { var v = _tQLReports; return v ?? Interlocked.CompareExchange(ref _tQLReports, (v = new DirtyList<TQLReportInformation>()), null) ?? v; } set { _tQLReports = new DirtyList<TQLReportInformation>(value); } }
-        private Value<string> _transUnionAddress;
+        private DirtyValue<string> _transUnionAddress;
         public string TransUnionAddress { get { return _transUnionAddress; } set { _transUnionAddress = value; } }
-        private Value<string> _transUnionCity;
+        private DirtyValue<string> _transUnionCity;
         public string TransUnionCity { get { return _transUnionCity; } set { _transUnionCity = value; } }
-        private Value<string> _transUnionFax;
+        private DirtyValue<string> _transUnionFax;
         public string TransUnionFax { get { return _transUnionFax; } set { _transUnionFax = value; } }
-        private Value<string> _transUnionModel;
+        private DirtyValue<string> _transUnionModel;
         public string TransUnionModel { get { return _transUnionModel; } set { _transUnionModel = value; } }
-        private Value<string> _transUnionName;
+        private DirtyValue<string> _transUnionName;
         public string TransUnionName { get { return _transUnionName; } set { _transUnionName = value; } }
-        private Value<string> _transUnionPhone;
+        private DirtyValue<string> _transUnionPhone;
         public string TransUnionPhone { get { return _transUnionPhone; } set { _transUnionPhone = value; } }
-        private Value<string> _transUnionPostalCode;
+        private DirtyValue<string> _transUnionPostalCode;
         public string TransUnionPostalCode { get { return _transUnionPostalCode; } set { _transUnionPostalCode = value; } }
-        private Value<string> _transUnionScoreRangeFrom;
+        private DirtyValue<string> _transUnionScoreRangeFrom;
         public string TransUnionScoreRangeFrom { get { return _transUnionScoreRangeFrom; } set { _transUnionScoreRangeFrom = value; } }
-        private Value<string> _transUnionScoreRangeTo;
+        private DirtyValue<string> _transUnionScoreRangeTo;
         public string TransUnionScoreRangeTo { get { return _transUnionScoreRangeTo; } set { _transUnionScoreRangeTo = value; } }
-        private Value<string> _transUnionState;
+        private DirtyValue<string> _transUnionState;
         public string TransUnionState { get { return _transUnionState; } set { _transUnionState = value; } }
-        private Value<string> _transUnionWebsite;
+        private DirtyValue<string> _transUnionWebsite;
         public string TransUnionWebsite { get { return _transUnionWebsite; } set { _transUnionWebsite = value; } }
-        private Value<decimal?> _userDefinedIncome;
+        private DirtyValue<decimal?> _userDefinedIncome;
         public decimal? UserDefinedIncome { get { return _userDefinedIncome; } set { _userDefinedIncome = value; } }
-        private Value<string> _userDefinedIncomeDescription;
+        private DirtyValue<string> _userDefinedIncomeDescription;
         public string UserDefinedIncomeDescription { get { return _userDefinedIncomeDescription; } set { _userDefinedIncomeDescription = value; } }
-        private Value<string> _vACreditStandards;
+        private DirtyValue<string> _vACreditStandards;
         public string VACreditStandards { get { return _vACreditStandards; } set { _vACreditStandards = value; } }
-        private Value<decimal?> _vaSummarySpouseIncomeAmount;
+        private DirtyValue<decimal?> _vaSummarySpouseIncomeAmount;
         public decimal? VaSummarySpouseIncomeAmount { get { return _vaSummarySpouseIncomeAmount; } set { _vaSummarySpouseIncomeAmount = value; } }
-        private Value<decimal?> _vaSummaryTotalMonthlyGrossIncomeAmount;
+        private DirtyValue<decimal?> _vaSummaryTotalMonthlyGrossIncomeAmount;
         public decimal? VaSummaryTotalMonthlyGrossIncomeAmount { get { return _vaSummaryTotalMonthlyGrossIncomeAmount; } set { _vaSummaryTotalMonthlyGrossIncomeAmount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Asset.cs
+++ b/src/EncompassRest/Loans/Asset.cs
@@ -8,73 +8,73 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Asset : IDirty
     {
-        private Value<string> _accountIdentifier;
+        private DirtyValue<string> _accountIdentifier;
         public string AccountIdentifier { get { return _accountIdentifier; } set { _accountIdentifier = value; } }
-        private Value<string> _altId;
+        private DirtyValue<string> _altId;
         public string AltId { get { return _altId; } set { _altId = value; } }
-        private Value<int?> _assetIndex;
+        private DirtyValue<int?> _assetIndex;
         public int? AssetIndex { get { return _assetIndex; } set { _assetIndex = value; } }
-        private Value<string> _assetType;
+        private DirtyValue<string> _assetType;
         public string AssetType { get { return _assetType; } set { _assetType = value; } }
-        private Value<string> _attention;
+        private DirtyValue<string> _attention;
         public string Attention { get { return _attention; } set { _attention = value; } }
-        private Value<string> _borrowerId;
+        private DirtyValue<string> _borrowerId;
         public string BorrowerId { get { return _borrowerId; } set { _borrowerId = value; } }
-        private Value<decimal?> _cashOrMarketValueAmount;
+        private DirtyValue<decimal?> _cashOrMarketValueAmount;
         public decimal? CashOrMarketValueAmount { get { return _cashOrMarketValueAmount; } set { _cashOrMarketValueAmount = value; } }
-        private Value<string> _depositoryAccountName;
+        private DirtyValue<string> _depositoryAccountName;
         public string DepositoryAccountName { get { return _depositoryAccountName; } set { _depositoryAccountName = value; } }
-        private Value<DateTime?> _depositoryRequestDate;
+        private DirtyValue<DateTime?> _depositoryRequestDate;
         public DateTime? DepositoryRequestDate { get { return _depositoryRequestDate; } set { _depositoryRequestDate = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<bool?> _entityDeleted;
+        private DirtyValue<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
-        private Value<string> _holderAddressCity;
+        private DirtyValue<string> _holderAddressCity;
         public string HolderAddressCity { get { return _holderAddressCity; } set { _holderAddressCity = value; } }
-        private Value<string> _holderAddressPostalCode;
+        private DirtyValue<string> _holderAddressPostalCode;
         public string HolderAddressPostalCode { get { return _holderAddressPostalCode; } set { _holderAddressPostalCode = value; } }
-        private Value<string> _holderAddressState;
+        private DirtyValue<string> _holderAddressState;
         public string HolderAddressState { get { return _holderAddressState; } set { _holderAddressState = value; } }
-        private Value<string> _holderAddressStreetLine1;
+        private DirtyValue<string> _holderAddressStreetLine1;
         public string HolderAddressStreetLine1 { get { return _holderAddressStreetLine1; } set { _holderAddressStreetLine1 = value; } }
-        private Value<string> _holderComments;
+        private DirtyValue<string> _holderComments;
         public string HolderComments { get { return _holderComments; } set { _holderComments = value; } }
-        private Value<string> _holderEmail;
+        private DirtyValue<string> _holderEmail;
         public string HolderEmail { get { return _holderEmail; } set { _holderEmail = value; } }
-        private Value<string> _holderFax;
+        private DirtyValue<string> _holderFax;
         public string HolderFax { get { return _holderFax; } set { _holderFax = value; } }
-        private Value<string> _holderName;
+        private DirtyValue<string> _holderName;
         public string HolderName { get { return _holderName; } set { _holderName = value; } }
-        private Value<string> _holderPhone;
+        private DirtyValue<string> _holderPhone;
         public string HolderPhone { get { return _holderPhone; } set { _holderPhone = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEmpty;
+        private DirtyValue<bool?> _isEmpty;
         public bool? IsEmpty { get { return _isEmpty; } set { _isEmpty = value; } }
-        private Value<bool?> _isVod;
+        private DirtyValue<bool?> _isVod;
         public bool? IsVod { get { return _isVod; } set { _isVod = value; } }
-        private Value<decimal?> _lifeInsuranceFaceValueAmount;
+        private DirtyValue<decimal?> _lifeInsuranceFaceValueAmount;
         public decimal? LifeInsuranceFaceValueAmount { get { return _lifeInsuranceFaceValueAmount; } set { _lifeInsuranceFaceValueAmount = value; } }
-        private Value<string> _nameInAccount;
+        private DirtyValue<string> _nameInAccount;
         public string NameInAccount { get { return _nameInAccount; } set { _nameInAccount = value; } }
-        private Value<bool?> _noLinkToDocTrackIndicator;
+        private DirtyValue<bool?> _noLinkToDocTrackIndicator;
         public bool? NoLinkToDocTrackIndicator { get { return _noLinkToDocTrackIndicator; } set { _noLinkToDocTrackIndicator = value; } }
-        private Value<string> _owner;
+        private DirtyValue<string> _owner;
         public string Owner { get { return _owner; } set { _owner = value; } }
-        private Value<bool?> _printAttachmentIndicator;
+        private DirtyValue<bool?> _printAttachmentIndicator;
         public bool? PrintAttachmentIndicator { get { return _printAttachmentIndicator; } set { _printAttachmentIndicator = value; } }
-        private Value<bool?> _printUserNameIndicator;
+        private DirtyValue<bool?> _printUserNameIndicator;
         public bool? PrintUserNameIndicator { get { return _printUserNameIndicator; } set { _printUserNameIndicator = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _titleFax;
+        private DirtyValue<string> _titleFax;
         public string TitleFax { get { return _titleFax; } set { _titleFax = value; } }
-        private Value<string> _titlePhone;
+        private DirtyValue<string> _titlePhone;
         public string TitlePhone { get { return _titlePhone; } set { _titlePhone = value; } }
-        private Value<decimal?> _total;
+        private DirtyValue<decimal?> _total;
         public decimal? Total { get { return _total; } set { _total = value; } }
-        private Value<int?> _vodIndex;
+        private DirtyValue<int?> _vodIndex;
         public int? VodIndex { get { return _vodIndex; } set { _vodIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Attachments/Image.cs
+++ b/src/EncompassRest/Loans/Attachments/Image.cs
@@ -4,17 +4,17 @@ namespace EncompassRest.Loans.Attachments
 {
     public abstract class Image : IDirty
     {
-        private Value<string> _imageKey;
+        private DirtyValue<string> _imageKey;
         public string ImageKey { get { return _imageKey; } set { _imageKey = value; } }
-        private Value<string> _zipKey;
+        private DirtyValue<string> _zipKey;
         public string ZipKey { get { return _zipKey; } set { _zipKey = value; } }
-        private Value<int?> _width;
+        private DirtyValue<int?> _width;
         public int? Width { get { return _width; } set { _width = value; } }
-        private Value<int?> _height;
+        private DirtyValue<int?> _height;
         public int? Height { get { return _height; } set { _height = value; } }
-        private Value<float?> _horizontalResolution;
+        private DirtyValue<float?> _horizontalResolution;
         public float? HorizontalResolution { get { return _horizontalResolution; } set { _horizontalResolution = value; } }
-        private Value<float?> _verticalResolution;
+        private DirtyValue<float?> _verticalResolution;
         public float? VeriticalResolution { get { return _verticalResolution; } set { _verticalResolution = value; } }
         private int _gettingDirty;
         private int _settingDirty;

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -8,29 +8,29 @@ namespace EncompassRest.Loans.Attachments
 {
     public sealed class LoanAttachment : IDirty
     {
-        private Value<string> _attachmentId;
+        private DirtyValue<string> _attachmentId;
         public string AttachmentId { get { return _attachmentId; } set { _attachmentId = value; } }
-        private Value<DateTime?> _dateCreated;
+        private DirtyValue<DateTime?> _dateCreated;
         public DateTime? DateCreated { get { return _dateCreated; } set { _dateCreated = value; } }
-        private Value<string> _createdBy;
+        private DirtyValue<string> _createdBy;
         public string CreatedBy { get { return _createdBy; } set { _createdBy = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<AttachmentCreateReason?> _createReason;
+        private DirtyValue<AttachmentCreateReason?> _createReason;
         [EnumOutput(EnumOutput.Integer)]
         public AttachmentCreateReason? CreateReason { get { return _createReason; } set { _createReason = value; } }
-        private Value<AttachmentType?> _attachmentType;
+        private DirtyValue<AttachmentType?> _attachmentType;
         [EnumOutput(EnumOutput.Integer)]
         public AttachmentType? AttachmentType { get { return _attachmentType; } set { _attachmentType = value; } }
-        private Value<long?> _fileSize;
+        private DirtyValue<long?> _fileSize;
         public long? FileSize { get { return _fileSize; } set { _fileSize = value; } }
-        private Value<bool?> _isActive;
+        private DirtyValue<bool?> _isActive;
         public bool? IsActive { get { return _isActive; } set { _isActive = value; } }
-        private Value<List<PageImage>> _pages;
+        private DirtyValue<List<PageImage>> _pages;
         public List<PageImage> Pages { get { return _pages; } set { _pages = value; } }
-        private Value<int?> _rotation;
+        private DirtyValue<int?> _rotation;
         public int? Rotation { get { return _rotation; } set { _rotation = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public EntityReference Document { get; set; }

--- a/src/EncompassRest/Loans/Attachments/PageAnnotation.cs
+++ b/src/EncompassRest/Loans/Attachments/PageAnnotation.cs
@@ -5,21 +5,21 @@ namespace EncompassRest.Loans.Attachments
 {
     public sealed class PageAnnotation : IDirty
     {
-        private Value<DateTime?> _dateCreated;
+        private DirtyValue<DateTime?> _dateCreated;
         public DateTime? DateCreated { get { return _dateCreated; } set { _dateCreated = value; } }
-        private Value<string> _createdBy;
+        private DirtyValue<string> _createdBy;
         public string CreatedBy { get { return _createdBy; } set { _createdBy = value; } }
-        private Value<string> _text;
+        private DirtyValue<string> _text;
         public string Text { get { return _text; } set { _text = value; } }
-        private Value<int?> _left;
+        private DirtyValue<int?> _left;
         public int? Left { get { return _left; } set { _left = value; } }
-        private Value<int?> _top;
+        private DirtyValue<int?> _top;
         public int? Top { get { return _top; } set { _top = value; } }
-        private Value<int?> _width;
+        private DirtyValue<int?> _width;
         public int? Width { get { return _width; } set { _width = value; } }
-        private Value<int?> _height;
+        private DirtyValue<int?> _height;
         public int? Height { get { return _height; } set { _height = value; } }
-        private Value<AnnotationVisibilityType?> _visibilityType;
+        private DirtyValue<AnnotationVisibilityType?> _visibilityType;
         public AnnotationVisibilityType? VisibilityType { get { return _visibilityType; } set { _visibilityType = value; } }
         private int _gettingDirty;
         private int _settingDirty;

--- a/src/EncompassRest/Loans/Attachments/PageImage.cs
+++ b/src/EncompassRest/Loans/Attachments/PageImage.cs
@@ -5,14 +5,14 @@ namespace EncompassRest.Loans.Attachments
 {
     public sealed class PageImage : Image
     {
-        private Value<string> _nativeKey;
+        private DirtyValue<string> _nativeKey;
         public string NativeKey { get { return _nativeKey; } set { _nativeKey = value; } }
-        private Value<int?> _rotation;
+        private DirtyValue<int?> _rotation;
         public int? Rotation { get { return _rotation; } set { _rotation = value; } }
-        private Value<long?> _fileSize;
+        private DirtyValue<long?> _fileSize;
         public long? FileSize { get { return _fileSize; } set { _fileSize = value; } }
         public PageThumbnail Thumbnail { get; set; }
-        private Value<List<PageAnnotation>> _annotations;
+        private DirtyValue<List<PageAnnotation>> _annotations;
         public List<PageAnnotation> Annotations { get { return _annotations; } set { _annotations = value; } }
         private int _gettingDirty;
         private int _settingDirty;

--- a/src/EncompassRest/Loans/Borrower.cs
+++ b/src/EncompassRest/Loans/Borrower.cs
@@ -8,639 +8,639 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Borrower : IDirty
     {
-        private Value<string> _acountChekAssetId;
+        private DirtyValue<string> _acountChekAssetId;
         public string AcountChekAssetId { get { return _acountChekAssetId; } set { _acountChekAssetId = value; } }
-        private Value<int?> _ageAtApplicationYearsCount;
+        private DirtyValue<int?> _ageAtApplicationYearsCount;
         public int? AgeAtApplicationYearsCount { get { return _ageAtApplicationYearsCount; } set { _ageAtApplicationYearsCount = value; } }
-        private Value<string> _aliasName;
+        private DirtyValue<string> _aliasName;
         public string AliasName { get { return _aliasName; } set { _aliasName = value; } }
-        private Value<bool?> _alimonyChildSupportObligationIndicator;
+        private DirtyValue<bool?> _alimonyChildSupportObligationIndicator;
         public bool? AlimonyChildSupportObligationIndicator { get { return _alimonyChildSupportObligationIndicator; } set { _alimonyChildSupportObligationIndicator = value; } }
-        private Value<string> _altId;
+        private DirtyValue<string> _altId;
         public string AltId { get { return _altId; } set { _altId = value; } }
-        private Value<string> _applicantType;
+        private DirtyValue<string> _applicantType;
         public string ApplicantType { get { return _applicantType; } set { _applicantType = value; } }
         private Application _application;
         public Application Application { get { var v = _application; return v ?? Interlocked.CompareExchange(ref _application, (v = new Application()), null) ?? v; } set { _application = value; } }
-        private Value<string> _applicationTakenMethodType;
+        private DirtyValue<string> _applicationTakenMethodType;
         public string ApplicationTakenMethodType { get { return _applicationTakenMethodType; } set { _applicationTakenMethodType = value; } }
-        private Value<string> _assetRepAndWarrantyMessage;
+        private DirtyValue<string> _assetRepAndWarrantyMessage;
         public string AssetRepAndWarrantyMessage { get { return _assetRepAndWarrantyMessage; } set { _assetRepAndWarrantyMessage = value; } }
-        private Value<bool?> _assetRepAndWarrantyReliefAvailable;
+        private DirtyValue<bool?> _assetRepAndWarrantyReliefAvailable;
         public bool? AssetRepAndWarrantyReliefAvailable { get { return _assetRepAndWarrantyReliefAvailable; } set { _assetRepAndWarrantyReliefAvailable = value; } }
-        private Value<bool?> _authorizedCreditReportIndicator;
+        private DirtyValue<bool?> _authorizedCreditReportIndicator;
         public bool? AuthorizedCreditReportIndicator { get { return _authorizedCreditReportIndicator; } set { _authorizedCreditReportIndicator = value; } }
-        private Value<bool?> _authorizedToSignIndicator;
+        private DirtyValue<bool?> _authorizedToSignIndicator;
         public bool? AuthorizedToSignIndicator { get { return _authorizedToSignIndicator; } set { _authorizedToSignIndicator = value; } }
-        private Value<string> _bankAccountNumber;
+        private DirtyValue<string> _bankAccountNumber;
         public string BankAccountNumber { get { return _bankAccountNumber; } set { _bankAccountNumber = value; } }
-        private Value<string> _bankAccountType;
+        private DirtyValue<string> _bankAccountType;
         public string BankAccountType { get { return _bankAccountType; } set { _bankAccountType = value; } }
-        private Value<string> _bankContactAddress;
+        private DirtyValue<string> _bankContactAddress;
         public string BankContactAddress { get { return _bankContactAddress; } set { _bankContactAddress = value; } }
-        private Value<string> _bankContactCity;
+        private DirtyValue<string> _bankContactCity;
         public string BankContactCity { get { return _bankContactCity; } set { _bankContactCity = value; } }
-        private Value<string> _bankContactName;
+        private DirtyValue<string> _bankContactName;
         public string BankContactName { get { return _bankContactName; } set { _bankContactName = value; } }
-        private Value<string> _bankContactPostalCode;
+        private DirtyValue<string> _bankContactPostalCode;
         public string BankContactPostalCode { get { return _bankContactPostalCode; } set { _bankContactPostalCode = value; } }
-        private Value<string> _bankContactState;
+        private DirtyValue<string> _bankContactState;
         public string BankContactState { get { return _bankContactState; } set { _bankContactState = value; } }
-        private Value<bool?> _bankruptcyIndicator;
+        private DirtyValue<bool?> _bankruptcyIndicator;
         public bool? BankruptcyIndicator { get { return _bankruptcyIndicator; } set { _bankruptcyIndicator = value; } }
-        private Value<string> _bankruptcyStatus;
+        private DirtyValue<string> _bankruptcyStatus;
         public string BankruptcyStatus { get { return _bankruptcyStatus; } set { _bankruptcyStatus = value; } }
-        private Value<decimal?> _baseMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _baseMonthlyIncomeAmount;
         public decimal? BaseMonthlyIncomeAmount { get { return _baseMonthlyIncomeAmount; } set { _baseMonthlyIncomeAmount = value; } }
-        private Value<DateTime?> _birthDate;
+        private DirtyValue<DateTime?> _birthDate;
         public DateTime? BirthDate { get { return _birthDate; } set { _birthDate = value; } }
-        private Value<bool?> _borrowedDownPaymentIndicator;
+        private DirtyValue<bool?> _borrowedDownPaymentIndicator;
         public bool? BorrowedDownPaymentIndicator { get { return _borrowedDownPaymentIndicator; } set { _borrowedDownPaymentIndicator = value; } }
-        private Value<DateTime?> _borrowerConsentRequestDate;
+        private DirtyValue<DateTime?> _borrowerConsentRequestDate;
         public DateTime? BorrowerConsentRequestDate { get { return _borrowerConsentRequestDate; } set { _borrowerConsentRequestDate = value; } }
-        private Value<int?> _borrowerIndex;
+        private DirtyValue<int?> _borrowerIndex;
         public int? BorrowerIndex { get { return _borrowerIndex; } set { _borrowerIndex = value; } }
-        private Value<string> _borrowerType;
+        private DirtyValue<string> _borrowerType;
         public string BorrowerType { get { return _borrowerType; } set { _borrowerType = value; } }
-        private Value<string> _borrowerTypeInSummary;
+        private DirtyValue<string> _borrowerTypeInSummary;
         public string BorrowerTypeInSummary { get { return _borrowerTypeInSummary; } set { _borrowerTypeInSummary = value; } }
-        private Value<string> _caivrsIdentifier;
+        private DirtyValue<string> _caivrsIdentifier;
         public string CaivrsIdentifier { get { return _caivrsIdentifier; } set { _caivrsIdentifier = value; } }
-        private Value<string> _citizenshipResidencyType;
+        private DirtyValue<string> _citizenshipResidencyType;
         public string CitizenshipResidencyType { get { return _citizenshipResidencyType; } set { _citizenshipResidencyType = value; } }
-        private Value<bool?> _coMakerEndorserOfNoteIndicator;
+        private DirtyValue<bool?> _coMakerEndorserOfNoteIndicator;
         public bool? CoMakerEndorserOfNoteIndicator { get { return _coMakerEndorserOfNoteIndicator; } set { _coMakerEndorserOfNoteIndicator = value; } }
-        private Value<string> _commentOfCreditReport;
+        private DirtyValue<string> _commentOfCreditReport;
         public string CommentOfCreditReport { get { return _commentOfCreditReport; } set { _commentOfCreditReport = value; } }
-        private Value<bool?> _confirmedCRDIL;
+        private DirtyValue<bool?> _confirmedCRDIL;
         public bool? ConfirmedCRDIL { get { return _confirmedCRDIL; } set { _confirmedCRDIL = value; } }
-        private Value<bool?> _confirmedCRFCEC;
+        private DirtyValue<bool?> _confirmedCRFCEC;
         public bool? ConfirmedCRFCEC { get { return _confirmedCRFCEC; } set { _confirmedCRFCEC = value; } }
-        private Value<bool?> _confirmedCRFCIncorrect;
+        private DirtyValue<bool?> _confirmedCRFCIncorrect;
         public bool? ConfirmedCRFCIncorrect { get { return _confirmedCRFCIncorrect; } set { _confirmedCRFCIncorrect = value; } }
-        private Value<bool?> _confirmedCRPFS;
+        private DirtyValue<bool?> _confirmedCRPFS;
         public bool? ConfirmedCRPFS { get { return _confirmedCRPFS; } set { _confirmedCRPFS = value; } }
-        private Value<bool?> _confirmedOther;
+        private DirtyValue<bool?> _confirmedOther;
         public bool? ConfirmedOther { get { return _confirmedOther; } set { _confirmedOther = value; } }
-        private Value<string> _confirmedOtherDescription;
+        private DirtyValue<string> _confirmedOtherDescription;
         public string ConfirmedOtherDescription { get { return _confirmedOtherDescription; } set { _confirmedOtherDescription = value; } }
-        private Value<bool?> _creditCounseling;
+        private DirtyValue<bool?> _creditCounseling;
         public bool? CreditCounseling { get { return _creditCounseling; } set { _creditCounseling = value; } }
-        private Value<DateTime?> _creditReceivedDate;
+        private DirtyValue<DateTime?> _creditReceivedDate;
         public DateTime? CreditReceivedDate { get { return _creditReceivedDate; } set { _creditReceivedDate = value; } }
-        private Value<string> _creditReportAuthorizationMethod;
+        private DirtyValue<string> _creditReportAuthorizationMethod;
         public string CreditReportAuthorizationMethod { get { return _creditReportAuthorizationMethod; } set { _creditReportAuthorizationMethod = value; } }
-        private Value<bool?> _creditScoreIndicator;
+        private DirtyValue<bool?> _creditScoreIndicator;
         public bool? CreditScoreIndicator { get { return _creditScoreIndicator; } set { _creditScoreIndicator = value; } }
-        private Value<DateTime?> _dateAuthorizedCreditReport;
+        private DirtyValue<DateTime?> _dateAuthorizedCreditReport;
         public DateTime? DateAuthorizedCreditReport { get { return _dateAuthorizedCreditReport; } set { _dateAuthorizedCreditReport = value; } }
-        private Value<DateTime?> _dateOfBankruptcy;
+        private DirtyValue<DateTime?> _dateOfBankruptcy;
         public DateTime? DateOfBankruptcy { get { return _dateOfBankruptcy; } set { _dateOfBankruptcy = value; } }
-        private Value<DateTime?> _dateOfForeclosure;
+        private DirtyValue<DateTime?> _dateOfForeclosure;
         public DateTime? DateOfForeclosure { get { return _dateOfForeclosure; } set { _dateOfForeclosure = value; } }
-        private Value<bool?> _declarationsJIndicator;
+        private DirtyValue<bool?> _declarationsJIndicator;
         public bool? DeclarationsJIndicator { get { return _declarationsJIndicator; } set { _declarationsJIndicator = value; } }
-        private Value<bool?> _declarationsKIndicator;
+        private DirtyValue<bool?> _declarationsKIndicator;
         public bool? DeclarationsKIndicator { get { return _declarationsKIndicator; } set { _declarationsKIndicator = value; } }
-        private Value<int?> _dependentCount;
+        private DirtyValue<int?> _dependentCount;
         public int? DependentCount { get { return _dependentCount; } set { _dependentCount = value; } }
-        private Value<string> _dependentsAgesDescription;
+        private DirtyValue<string> _dependentsAgesDescription;
         public string DependentsAgesDescription { get { return _dependentsAgesDescription; } set { _dependentsAgesDescription = value; } }
-        private Value<bool?> _disabledIndicator;
+        private DirtyValue<bool?> _disabledIndicator;
         public bool? DisabledIndicator { get { return _disabledIndicator; } set { _disabledIndicator = value; } }
-        private Value<string> _emailAddressText;
+        private DirtyValue<string> _emailAddressText;
         public string EmailAddressText { get { return _emailAddressText; } set { _emailAddressText = value; } }
-        private Value<int?> _equifax120Days;
+        private DirtyValue<int?> _equifax120Days;
         public int? Equifax120Days { get { return _equifax120Days; } set { _equifax120Days = value; } }
-        private Value<int?> _equifax150Days;
+        private DirtyValue<int?> _equifax150Days;
         public int? Equifax150Days { get { return _equifax150Days; } set { _equifax150Days = value; } }
-        private Value<int?> _equifax30Days;
+        private DirtyValue<int?> _equifax30Days;
         public int? Equifax30Days { get { return _equifax30Days; } set { _equifax30Days = value; } }
-        private Value<int?> _equifax60Days;
+        private DirtyValue<int?> _equifax60Days;
         public int? Equifax60Days { get { return _equifax60Days; } set { _equifax60Days = value; } }
-        private Value<int?> _equifax90Days;
+        private DirtyValue<int?> _equifax90Days;
         public int? Equifax90Days { get { return _equifax90Days; } set { _equifax90Days = value; } }
-        private Value<bool?> _equifaxCreditScoreForDisclosure;
+        private DirtyValue<bool?> _equifaxCreditScoreForDisclosure;
         public bool? EquifaxCreditScoreForDisclosure { get { return _equifaxCreditScoreForDisclosure; } set { _equifaxCreditScoreForDisclosure = value; } }
-        private Value<int?> _equifaxCreditScoreRanksPercent;
+        private DirtyValue<int?> _equifaxCreditScoreRanksPercent;
         public int? EquifaxCreditScoreRanksPercent { get { return _equifaxCreditScoreRanksPercent; } set { _equifaxCreditScoreRanksPercent = value; } }
-        private Value<DateTime?> _equifaxDatePulled;
+        private DirtyValue<DateTime?> _equifaxDatePulled;
         public DateTime? EquifaxDatePulled { get { return _equifaxDatePulled; } set { _equifaxDatePulled = value; } }
-        private Value<string> _equifaxFactorCode1;
+        private DirtyValue<string> _equifaxFactorCode1;
         public string EquifaxFactorCode1 { get { return _equifaxFactorCode1; } set { _equifaxFactorCode1 = value; } }
-        private Value<string> _equifaxFactorCode2;
+        private DirtyValue<string> _equifaxFactorCode2;
         public string EquifaxFactorCode2 { get { return _equifaxFactorCode2; } set { _equifaxFactorCode2 = value; } }
-        private Value<string> _equifaxFactorCode3;
+        private DirtyValue<string> _equifaxFactorCode3;
         public string EquifaxFactorCode3 { get { return _equifaxFactorCode3; } set { _equifaxFactorCode3 = value; } }
-        private Value<string> _equifaxFactorCode4;
+        private DirtyValue<string> _equifaxFactorCode4;
         public string EquifaxFactorCode4 { get { return _equifaxFactorCode4; } set { _equifaxFactorCode4 = value; } }
-        private Value<string> _equifaxFactorCode5;
+        private DirtyValue<string> _equifaxFactorCode5;
         public string EquifaxFactorCode5 { get { return _equifaxFactorCode5; } set { _equifaxFactorCode5 = value; } }
-        private Value<string> _equifaxKeyFactor1;
+        private DirtyValue<string> _equifaxKeyFactor1;
         public string EquifaxKeyFactor1 { get { return _equifaxKeyFactor1; } set { _equifaxKeyFactor1 = value; } }
-        private Value<string> _equifaxKeyFactor2;
+        private DirtyValue<string> _equifaxKeyFactor2;
         public string EquifaxKeyFactor2 { get { return _equifaxKeyFactor2; } set { _equifaxKeyFactor2 = value; } }
-        private Value<string> _equifaxKeyFactor3;
+        private DirtyValue<string> _equifaxKeyFactor3;
         public string EquifaxKeyFactor3 { get { return _equifaxKeyFactor3; } set { _equifaxKeyFactor3 = value; } }
-        private Value<string> _equifaxKeyFactor4;
+        private DirtyValue<string> _equifaxKeyFactor4;
         public string EquifaxKeyFactor4 { get { return _equifaxKeyFactor4; } set { _equifaxKeyFactor4 = value; } }
-        private Value<string> _equifaxKeyFactor5;
+        private DirtyValue<string> _equifaxKeyFactor5;
         public string EquifaxKeyFactor5 { get { return _equifaxKeyFactor5; } set { _equifaxKeyFactor5 = value; } }
-        private Value<bool?> _equifaxMaterialTermsCreditByScore;
+        private DirtyValue<bool?> _equifaxMaterialTermsCreditByScore;
         public bool? EquifaxMaterialTermsCreditByScore { get { return _equifaxMaterialTermsCreditByScore; } set { _equifaxMaterialTermsCreditByScore = value; } }
-        private Value<string> _equifaxScore;
+        private DirtyValue<string> _equifaxScore;
         public string EquifaxScore { get { return _equifaxScore; } set { _equifaxScore = value; } }
-        private Value<int?> _experian120Days;
+        private DirtyValue<int?> _experian120Days;
         public int? Experian120Days { get { return _experian120Days; } set { _experian120Days = value; } }
-        private Value<int?> _experian150Days;
+        private DirtyValue<int?> _experian150Days;
         public int? Experian150Days { get { return _experian150Days; } set { _experian150Days = value; } }
-        private Value<int?> _experian30Days;
+        private DirtyValue<int?> _experian30Days;
         public int? Experian30Days { get { return _experian30Days; } set { _experian30Days = value; } }
-        private Value<int?> _experian60Days;
+        private DirtyValue<int?> _experian60Days;
         public int? Experian60Days { get { return _experian60Days; } set { _experian60Days = value; } }
-        private Value<int?> _experian90Days;
+        private DirtyValue<int?> _experian90Days;
         public int? Experian90Days { get { return _experian90Days; } set { _experian90Days = value; } }
-        private Value<string> _experianCreditScore;
+        private DirtyValue<string> _experianCreditScore;
         public string ExperianCreditScore { get { return _experianCreditScore; } set { _experianCreditScore = value; } }
-        private Value<bool?> _experianCreditScoreForDisclosure;
+        private DirtyValue<bool?> _experianCreditScoreForDisclosure;
         public bool? ExperianCreditScoreForDisclosure { get { return _experianCreditScoreForDisclosure; } set { _experianCreditScoreForDisclosure = value; } }
-        private Value<int?> _experianCreditScoreRanksPercent;
+        private DirtyValue<int?> _experianCreditScoreRanksPercent;
         public int? ExperianCreditScoreRanksPercent { get { return _experianCreditScoreRanksPercent; } set { _experianCreditScoreRanksPercent = value; } }
-        private Value<DateTime?> _experianDatePulled;
+        private DirtyValue<DateTime?> _experianDatePulled;
         public DateTime? ExperianDatePulled { get { return _experianDatePulled; } set { _experianDatePulled = value; } }
-        private Value<string> _experianFactorCode1;
+        private DirtyValue<string> _experianFactorCode1;
         public string ExperianFactorCode1 { get { return _experianFactorCode1; } set { _experianFactorCode1 = value; } }
-        private Value<string> _experianFactorCode2;
+        private DirtyValue<string> _experianFactorCode2;
         public string ExperianFactorCode2 { get { return _experianFactorCode2; } set { _experianFactorCode2 = value; } }
-        private Value<string> _experianFactorCode3;
+        private DirtyValue<string> _experianFactorCode3;
         public string ExperianFactorCode3 { get { return _experianFactorCode3; } set { _experianFactorCode3 = value; } }
-        private Value<string> _experianFactorCode4;
+        private DirtyValue<string> _experianFactorCode4;
         public string ExperianFactorCode4 { get { return _experianFactorCode4; } set { _experianFactorCode4 = value; } }
-        private Value<string> _experianFactorCode5;
+        private DirtyValue<string> _experianFactorCode5;
         public string ExperianFactorCode5 { get { return _experianFactorCode5; } set { _experianFactorCode5 = value; } }
-        private Value<string> _experianKeyFactor1;
+        private DirtyValue<string> _experianKeyFactor1;
         public string ExperianKeyFactor1 { get { return _experianKeyFactor1; } set { _experianKeyFactor1 = value; } }
-        private Value<string> _experianKeyFactor2;
+        private DirtyValue<string> _experianKeyFactor2;
         public string ExperianKeyFactor2 { get { return _experianKeyFactor2; } set { _experianKeyFactor2 = value; } }
-        private Value<string> _experianKeyFactor3;
+        private DirtyValue<string> _experianKeyFactor3;
         public string ExperianKeyFactor3 { get { return _experianKeyFactor3; } set { _experianKeyFactor3 = value; } }
-        private Value<string> _experianKeyFactor4;
+        private DirtyValue<string> _experianKeyFactor4;
         public string ExperianKeyFactor4 { get { return _experianKeyFactor4; } set { _experianKeyFactor4 = value; } }
-        private Value<string> _experianKeyFactor5;
+        private DirtyValue<string> _experianKeyFactor5;
         public string ExperianKeyFactor5 { get { return _experianKeyFactor5; } set { _experianKeyFactor5 = value; } }
-        private Value<bool?> _experianMaterialTermsCreditByScore;
+        private DirtyValue<bool?> _experianMaterialTermsCreditByScore;
         public bool? ExperianMaterialTermsCreditByScore { get { return _experianMaterialTermsCreditByScore; } set { _experianMaterialTermsCreditByScore = value; } }
-        private Value<string> _firstName;
+        private DirtyValue<string> _firstName;
         public string FirstName { get { return _firstName; } set { _firstName = value; } }
-        private Value<string> _firstNameWithMiddleName;
+        private DirtyValue<string> _firstNameWithMiddleName;
         public string FirstNameWithMiddleName { get { return _firstNameWithMiddleName; } set { _firstNameWithMiddleName = value; } }
-        private Value<bool?> _firstTimeHomeBuyer;
+        private DirtyValue<bool?> _firstTimeHomeBuyer;
         public bool? FirstTimeHomeBuyer { get { return _firstTimeHomeBuyer; } set { _firstTimeHomeBuyer = value; } }
-        private Value<DateTime?> _foreclosureSatisfied;
+        private DirtyValue<DateTime?> _foreclosureSatisfied;
         public DateTime? ForeclosureSatisfied { get { return _foreclosureSatisfied; } set { _foreclosureSatisfied = value; } }
-        private Value<string> _foreclosureStatus;
+        private DirtyValue<string> _foreclosureStatus;
         public string ForeclosureStatus { get { return _foreclosureStatus; } set { _foreclosureStatus = value; } }
-        private Value<string> _freddieMacPerson1;
+        private DirtyValue<string> _freddieMacPerson1;
         public string FreddieMacPerson1 { get { return _freddieMacPerson1; } set { _freddieMacPerson1 = value; } }
-        private Value<string> _freddieMacPerson2;
+        private DirtyValue<string> _freddieMacPerson2;
         public string FreddieMacPerson2 { get { return _freddieMacPerson2; } set { _freddieMacPerson2 = value; } }
-        private Value<string> _fullName;
+        private DirtyValue<string> _fullName;
         public string FullName { get { return _fullName; } set { _fullName = value; } }
-        private Value<string> _fullNameWithSuffix;
+        private DirtyValue<string> _fullNameWithSuffix;
         public string FullNameWithSuffix { get { return _fullNameWithSuffix; } set { _fullNameWithSuffix = value; } }
-        private Value<decimal?> _highestCreditLimit;
+        private DirtyValue<decimal?> _highestCreditLimit;
         public decimal? HighestCreditLimit { get { return _highestCreditLimit; } set { _highestCreditLimit = value; } }
-        private Value<string> _hmda2003OtherRaceNationalOriginDescription;
+        private DirtyValue<string> _hmda2003OtherRaceNationalOriginDescription;
         public string Hmda2003OtherRaceNationalOriginDescription { get { return _hmda2003OtherRaceNationalOriginDescription; } set { _hmda2003OtherRaceNationalOriginDescription = value; } }
-        private Value<string> _hmda2003RaceNationalOriginType;
+        private DirtyValue<string> _hmda2003RaceNationalOriginType;
         public string Hmda2003RaceNationalOriginType { get { return _hmda2003RaceNationalOriginType; } set { _hmda2003RaceNationalOriginType = value; } }
-        private Value<bool?> _hmdaAfricanAmericanIndicator;
+        private DirtyValue<bool?> _hmdaAfricanAmericanIndicator;
         public bool? HmdaAfricanAmericanIndicator { get { return _hmdaAfricanAmericanIndicator; } set { _hmdaAfricanAmericanIndicator = value; } }
-        private Value<string> _hmdaAge;
+        private DirtyValue<string> _hmdaAge;
         public string HmdaAge { get { return _hmdaAge; } set { _hmdaAge = value; } }
-        private Value<bool?> _hmdaAmericanIndianIndicator;
+        private DirtyValue<bool?> _hmdaAmericanIndianIndicator;
         public bool? HmdaAmericanIndianIndicator { get { return _hmdaAmericanIndianIndicator; } set { _hmdaAmericanIndianIndicator = value; } }
-        private Value<string> _hmdaAmericanIndianTribe;
+        private DirtyValue<string> _hmdaAmericanIndianTribe;
         public string HmdaAmericanIndianTribe { get { return _hmdaAmericanIndianTribe; } set { _hmdaAmericanIndianTribe = value; } }
-        private Value<bool?> _hmdaAsianIndianIndicator;
+        private DirtyValue<bool?> _hmdaAsianIndianIndicator;
         public bool? HmdaAsianIndianIndicator { get { return _hmdaAsianIndianIndicator; } set { _hmdaAsianIndianIndicator = value; } }
-        private Value<bool?> _hmdaAsianIndicator;
+        private DirtyValue<bool?> _hmdaAsianIndicator;
         public bool? HmdaAsianIndicator { get { return _hmdaAsianIndicator; } set { _hmdaAsianIndicator = value; } }
-        private Value<bool?> _hmdaAsianOtherRaceIndicator;
+        private DirtyValue<bool?> _hmdaAsianOtherRaceIndicator;
         public bool? HmdaAsianOtherRaceIndicator { get { return _hmdaAsianOtherRaceIndicator; } set { _hmdaAsianOtherRaceIndicator = value; } }
-        private Value<bool?> _hmdaChineseIndicator;
+        private DirtyValue<bool?> _hmdaChineseIndicator;
         public bool? HmdaChineseIndicator { get { return _hmdaChineseIndicator; } set { _hmdaChineseIndicator = value; } }
-        private Value<string> _hmdaCreditScoreForDecisionMaking;
+        private DirtyValue<string> _hmdaCreditScoreForDecisionMaking;
         public string HmdaCreditScoreForDecisionMaking { get { return _hmdaCreditScoreForDecisionMaking; } set { _hmdaCreditScoreForDecisionMaking = value; } }
-        private Value<string> _hmdaCreditScoringModel;
+        private DirtyValue<string> _hmdaCreditScoringModel;
         public string HmdaCreditScoringModel { get { return _hmdaCreditScoringModel; } set { _hmdaCreditScoringModel = value; } }
-        private Value<bool?> _hmdaCubanIndicator;
+        private DirtyValue<bool?> _hmdaCubanIndicator;
         public bool? HmdaCubanIndicator { get { return _hmdaCubanIndicator; } set { _hmdaCubanIndicator = value; } }
-        private Value<bool?> _hmdaEthnicityDoNotWishIndicator;
+        private DirtyValue<bool?> _hmdaEthnicityDoNotWishIndicator;
         public bool? HmdaEthnicityDoNotWishIndicator { get { return _hmdaEthnicityDoNotWishIndicator; } set { _hmdaEthnicityDoNotWishIndicator = value; } }
-        private Value<bool?> _hmdaEthnicityHispanicLatinoIndicator;
+        private DirtyValue<bool?> _hmdaEthnicityHispanicLatinoIndicator;
         public bool? HmdaEthnicityHispanicLatinoIndicator { get { return _hmdaEthnicityHispanicLatinoIndicator; } set { _hmdaEthnicityHispanicLatinoIndicator = value; } }
-        private Value<bool?> _hmdaEthnicityNotApplicableIndicator;
+        private DirtyValue<bool?> _hmdaEthnicityNotApplicableIndicator;
         public bool? HmdaEthnicityNotApplicableIndicator { get { return _hmdaEthnicityNotApplicableIndicator; } set { _hmdaEthnicityNotApplicableIndicator = value; } }
-        private Value<bool?> _hmdaEthnicityNotHispanicLatinoIndicator;
+        private DirtyValue<bool?> _hmdaEthnicityNotHispanicLatinoIndicator;
         public bool? HmdaEthnicityNotHispanicLatinoIndicator { get { return _hmdaEthnicityNotHispanicLatinoIndicator; } set { _hmdaEthnicityNotHispanicLatinoIndicator = value; } }
-        private Value<string> _hmdaEthnicityReportedField1;
+        private DirtyValue<string> _hmdaEthnicityReportedField1;
         public string HmdaEthnicityReportedField1 { get { return _hmdaEthnicityReportedField1; } set { _hmdaEthnicityReportedField1 = value; } }
-        private Value<string> _hmdaEthnicityReportedField2;
+        private DirtyValue<string> _hmdaEthnicityReportedField2;
         public string HmdaEthnicityReportedField2 { get { return _hmdaEthnicityReportedField2; } set { _hmdaEthnicityReportedField2 = value; } }
-        private Value<string> _hmdaEthnicityReportedField3;
+        private DirtyValue<string> _hmdaEthnicityReportedField3;
         public string HmdaEthnicityReportedField3 { get { return _hmdaEthnicityReportedField3; } set { _hmdaEthnicityReportedField3 = value; } }
-        private Value<string> _hmdaEthnicityReportedField4;
+        private DirtyValue<string> _hmdaEthnicityReportedField4;
         public string HmdaEthnicityReportedField4 { get { return _hmdaEthnicityReportedField4; } set { _hmdaEthnicityReportedField4 = value; } }
-        private Value<string> _hmdaEthnicityReportedField5;
+        private DirtyValue<string> _hmdaEthnicityReportedField5;
         public string HmdaEthnicityReportedField5 { get { return _hmdaEthnicityReportedField5; } set { _hmdaEthnicityReportedField5 = value; } }
-        private Value<string> _hmdaEthnicityType;
+        private DirtyValue<string> _hmdaEthnicityType;
         public string HmdaEthnicityType { get { return _hmdaEthnicityType; } set { _hmdaEthnicityType = value; } }
-        private Value<bool?> _hmdaFilipinoIndicator;
+        private DirtyValue<bool?> _hmdaFilipinoIndicator;
         public bool? HmdaFilipinoIndicator { get { return _hmdaFilipinoIndicator; } set { _hmdaFilipinoIndicator = value; } }
-        private Value<string> _hmdaGenderType;
+        private DirtyValue<string> _hmdaGenderType;
         public string HmdaGenderType { get { return _hmdaGenderType; } set { _hmdaGenderType = value; } }
-        private Value<bool?> _hmdaGendertypeDoNotWishIndicator;
+        private DirtyValue<bool?> _hmdaGendertypeDoNotWishIndicator;
         public bool? HmdaGendertypeDoNotWishIndicator { get { return _hmdaGendertypeDoNotWishIndicator; } set { _hmdaGendertypeDoNotWishIndicator = value; } }
-        private Value<bool?> _hmdaGendertypeFemaleIndicator;
+        private DirtyValue<bool?> _hmdaGendertypeFemaleIndicator;
         public bool? HmdaGendertypeFemaleIndicator { get { return _hmdaGendertypeFemaleIndicator; } set { _hmdaGendertypeFemaleIndicator = value; } }
-        private Value<bool?> _hmdaGendertypeMaleIndicator;
+        private DirtyValue<bool?> _hmdaGendertypeMaleIndicator;
         public bool? HmdaGendertypeMaleIndicator { get { return _hmdaGendertypeMaleIndicator; } set { _hmdaGendertypeMaleIndicator = value; } }
-        private Value<bool?> _hmdaGendertypeNotApplicableIndicator;
+        private DirtyValue<bool?> _hmdaGendertypeNotApplicableIndicator;
         public bool? HmdaGendertypeNotApplicableIndicator { get { return _hmdaGendertypeNotApplicableIndicator; } set { _hmdaGendertypeNotApplicableIndicator = value; } }
-        private Value<bool?> _hmdaGuamanianOrChamorroIndicator;
+        private DirtyValue<bool?> _hmdaGuamanianOrChamorroIndicator;
         public bool? HmdaGuamanianOrChamorroIndicator { get { return _hmdaGuamanianOrChamorroIndicator; } set { _hmdaGuamanianOrChamorroIndicator = value; } }
-        private Value<bool?> _hmdaHispanicLatinoOtherOriginIndicator;
+        private DirtyValue<bool?> _hmdaHispanicLatinoOtherOriginIndicator;
         public bool? HmdaHispanicLatinoOtherOriginIndicator { get { return _hmdaHispanicLatinoOtherOriginIndicator; } set { _hmdaHispanicLatinoOtherOriginIndicator = value; } }
-        private Value<bool?> _hmdaJapaneseIndicator;
+        private DirtyValue<bool?> _hmdaJapaneseIndicator;
         public bool? HmdaJapaneseIndicator { get { return _hmdaJapaneseIndicator; } set { _hmdaJapaneseIndicator = value; } }
-        private Value<bool?> _hmdaKoreanIndicator;
+        private DirtyValue<bool?> _hmdaKoreanIndicator;
         public bool? HmdaKoreanIndicator { get { return _hmdaKoreanIndicator; } set { _hmdaKoreanIndicator = value; } }
-        private Value<bool?> _hmdaMexicanIndicator;
+        private DirtyValue<bool?> _hmdaMexicanIndicator;
         public bool? HmdaMexicanIndicator { get { return _hmdaMexicanIndicator; } set { _hmdaMexicanIndicator = value; } }
-        private Value<bool?> _hmdaNativeHawaiianIndicator;
+        private DirtyValue<bool?> _hmdaNativeHawaiianIndicator;
         public bool? HmdaNativeHawaiianIndicator { get { return _hmdaNativeHawaiianIndicator; } set { _hmdaNativeHawaiianIndicator = value; } }
-        private Value<bool?> _hmdaNoCoApplicantIndicator;
+        private DirtyValue<bool?> _hmdaNoCoApplicantIndicator;
         public bool? HmdaNoCoApplicantIndicator { get { return _hmdaNoCoApplicantIndicator; } set { _hmdaNoCoApplicantIndicator = value; } }
-        private Value<bool?> _hmdaNotApplicableIndicator;
+        private DirtyValue<bool?> _hmdaNotApplicableIndicator;
         public bool? HmdaNotApplicableIndicator { get { return _hmdaNotApplicableIndicator; } set { _hmdaNotApplicableIndicator = value; } }
-        private Value<bool?> _hmdaNotProvidedIndicator;
+        private DirtyValue<bool?> _hmdaNotProvidedIndicator;
         public bool? HmdaNotProvidedIndicator { get { return _hmdaNotProvidedIndicator; } set { _hmdaNotProvidedIndicator = value; } }
-        private Value<string> _hmdaOtherAsianRace;
+        private DirtyValue<string> _hmdaOtherAsianRace;
         public string HmdaOtherAsianRace { get { return _hmdaOtherAsianRace; } set { _hmdaOtherAsianRace = value; } }
-        private Value<string> _hmdaOtherHispanicLatinoOrigin;
+        private DirtyValue<string> _hmdaOtherHispanicLatinoOrigin;
         public string HmdaOtherHispanicLatinoOrigin { get { return _hmdaOtherHispanicLatinoOrigin; } set { _hmdaOtherHispanicLatinoOrigin = value; } }
-        private Value<string> _hmdaOtherPacificIslanderRace;
+        private DirtyValue<string> _hmdaOtherPacificIslanderRace;
         public string HmdaOtherPacificIslanderRace { get { return _hmdaOtherPacificIslanderRace; } set { _hmdaOtherPacificIslanderRace = value; } }
-        private Value<string> _hmdaOtherScoringModel;
+        private DirtyValue<string> _hmdaOtherScoringModel;
         public string HmdaOtherScoringModel { get { return _hmdaOtherScoringModel; } set { _hmdaOtherScoringModel = value; } }
-        private Value<bool?> _hmdaPacificIslanderIndicator;
+        private DirtyValue<bool?> _hmdaPacificIslanderIndicator;
         public bool? HmdaPacificIslanderIndicator { get { return _hmdaPacificIslanderIndicator; } set { _hmdaPacificIslanderIndicator = value; } }
-        private Value<bool?> _hmdaPacificIslanderOtherIndicator;
+        private DirtyValue<bool?> _hmdaPacificIslanderOtherIndicator;
         public bool? HmdaPacificIslanderOtherIndicator { get { return _hmdaPacificIslanderOtherIndicator; } set { _hmdaPacificIslanderOtherIndicator = value; } }
-        private Value<bool?> _hmdaPuertoRicanIndicator;
+        private DirtyValue<bool?> _hmdaPuertoRicanIndicator;
         public bool? HmdaPuertoRicanIndicator { get { return _hmdaPuertoRicanIndicator; } set { _hmdaPuertoRicanIndicator = value; } }
-        private Value<string> _hmdaRaceReportedField1;
+        private DirtyValue<string> _hmdaRaceReportedField1;
         public string HmdaRaceReportedField1 { get { return _hmdaRaceReportedField1; } set { _hmdaRaceReportedField1 = value; } }
-        private Value<string> _hmdaRaceReportedField2;
+        private DirtyValue<string> _hmdaRaceReportedField2;
         public string HmdaRaceReportedField2 { get { return _hmdaRaceReportedField2; } set { _hmdaRaceReportedField2 = value; } }
-        private Value<string> _hmdaRaceReportedField3;
+        private DirtyValue<string> _hmdaRaceReportedField3;
         public string HmdaRaceReportedField3 { get { return _hmdaRaceReportedField3; } set { _hmdaRaceReportedField3 = value; } }
-        private Value<string> _hmdaRaceReportedField4;
+        private DirtyValue<string> _hmdaRaceReportedField4;
         public string HmdaRaceReportedField4 { get { return _hmdaRaceReportedField4; } set { _hmdaRaceReportedField4 = value; } }
-        private Value<string> _hmdaRaceReportedField5;
+        private DirtyValue<string> _hmdaRaceReportedField5;
         public string HmdaRaceReportedField5 { get { return _hmdaRaceReportedField5; } set { _hmdaRaceReportedField5 = value; } }
-        private Value<bool?> _hmdaRefusalIndicator;
+        private DirtyValue<bool?> _hmdaRefusalIndicator;
         public bool? HmdaRefusalIndicator { get { return _hmdaRefusalIndicator; } set { _hmdaRefusalIndicator = value; } }
-        private Value<bool?> _hmdaSamoanIndicator;
+        private DirtyValue<bool?> _hmdaSamoanIndicator;
         public bool? HmdaSamoanIndicator { get { return _hmdaSamoanIndicator; } set { _hmdaSamoanIndicator = value; } }
-        private Value<bool?> _hmdaVietnameseIndicator;
+        private DirtyValue<bool?> _hmdaVietnameseIndicator;
         public bool? HmdaVietnameseIndicator { get { return _hmdaVietnameseIndicator; } set { _hmdaVietnameseIndicator = value; } }
-        private Value<bool?> _hmdaWhiteIndicator;
+        private DirtyValue<bool?> _hmdaWhiteIndicator;
         public bool? HmdaWhiteIndicator { get { return _hmdaWhiteIndicator; } set { _hmdaWhiteIndicator = value; } }
-        private Value<bool?> _homeownerPastThreeYearsIndicator;
+        private DirtyValue<bool?> _homeownerPastThreeYearsIndicator;
         public bool? HomeownerPastThreeYearsIndicator { get { return _homeownerPastThreeYearsIndicator; } set { _homeownerPastThreeYearsIndicator = value; } }
-        private Value<string> _homePhoneNumber;
+        private DirtyValue<string> _homePhoneNumber;
         public string HomePhoneNumber { get { return _homePhoneNumber; } set { _homePhoneNumber = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _incomeRepAndWarrantyMessage;
+        private DirtyValue<string> _incomeRepAndWarrantyMessage;
         public string IncomeRepAndWarrantyMessage { get { return _incomeRepAndWarrantyMessage; } set { _incomeRepAndWarrantyMessage = value; } }
-        private Value<bool?> _incomeRepAndWarrantyReliefAvailable;
+        private DirtyValue<bool?> _incomeRepAndWarrantyReliefAvailable;
         public bool? IncomeRepAndWarrantyReliefAvailable { get { return _incomeRepAndWarrantyReliefAvailable; } set { _incomeRepAndWarrantyReliefAvailable = value; } }
-        private Value<bool?> _intentToOccupyIndicator;
+        private DirtyValue<bool?> _intentToOccupyIndicator;
         public bool? IntentToOccupyIndicator { get { return _intentToOccupyIndicator; } set { _intentToOccupyIndicator = value; } }
-        private Value<string> _intuitReportId;
+        private DirtyValue<string> _intuitReportId;
         public string IntuitReportId { get { return _intuitReportId; } set { _intuitReportId = value; } }
-        private Value<bool?> _isBaseIncomeAvailable;
+        private DirtyValue<bool?> _isBaseIncomeAvailable;
         public bool? IsBaseIncomeAvailable { get { return _isBaseIncomeAvailable; } set { _isBaseIncomeAvailable = value; } }
-        private Value<bool?> _isBonusAvailable;
+        private DirtyValue<bool?> _isBonusAvailable;
         public bool? IsBonusAvailable { get { return _isBonusAvailable; } set { _isBonusAvailable = value; } }
-        private Value<bool?> _isBorrower;
+        private DirtyValue<bool?> _isBorrower;
         public bool? IsBorrower { get { return _isBorrower; } set { _isBorrower = value; } }
-        private Value<bool?> _isCommissionAvailable;
+        private DirtyValue<bool?> _isCommissionAvailable;
         public bool? IsCommissionAvailable { get { return _isCommissionAvailable; } set { _isCommissionAvailable = value; } }
-        private Value<string> _isEthnicityBasedOnVisual;
+        private DirtyValue<string> _isEthnicityBasedOnVisual;
         public string IsEthnicityBasedOnVisual { get { return _isEthnicityBasedOnVisual; } set { _isEthnicityBasedOnVisual = value; } }
-        private Value<bool?> _isOvertimeAvailable;
+        private DirtyValue<bool?> _isOvertimeAvailable;
         public bool? IsOvertimeAvailable { get { return _isOvertimeAvailable; } set { _isOvertimeAvailable = value; } }
-        private Value<string> _isRaceBasedOnVisual;
+        private DirtyValue<string> _isRaceBasedOnVisual;
         public string IsRaceBasedOnVisual { get { return _isRaceBasedOnVisual; } set { _isRaceBasedOnVisual = value; } }
-        private Value<bool?> _isSelfEmployed;
+        private DirtyValue<bool?> _isSelfEmployed;
         public bool? IsSelfEmployed { get { return _isSelfEmployed; } set { _isSelfEmployed = value; } }
-        private Value<string> _isSexBasedOnVisual;
+        private DirtyValue<string> _isSexBasedOnVisual;
         public string IsSexBasedOnVisual { get { return _isSexBasedOnVisual; } set { _isSexBasedOnVisual = value; } }
-        private Value<bool?> _isSocialSecurityAvailable;
+        private DirtyValue<bool?> _isSocialSecurityAvailable;
         public bool? IsSocialSecurityAvailable { get { return _isSocialSecurityAvailable; } set { _isSocialSecurityAvailable = value; } }
-        private Value<string> _lastName;
+        private DirtyValue<string> _lastName;
         public string LastName { get { return _lastName; } set { _lastName = value; } }
-        private Value<string> _lastNameWithSuffix;
+        private DirtyValue<string> _lastNameWithSuffix;
         public string LastNameWithSuffix { get { return _lastNameWithSuffix; } set { _lastNameWithSuffix = value; } }
-        private Value<bool?> _loanForeclosureOrJudgementIndicator;
+        private DirtyValue<bool?> _loanForeclosureOrJudgementIndicator;
         public bool? LoanForeclosureOrJudgementIndicator { get { return _loanForeclosureOrJudgementIndicator; } set { _loanForeclosureOrJudgementIndicator = value; } }
-        private Value<string> _lpdGsa;
+        private DirtyValue<string> _lpdGsa;
         public string LpdGsa { get { return _lpdGsa; } set { _lpdGsa = value; } }
-        private Value<bool?> _mailingAddressSameAsPresentIndicator;
+        private DirtyValue<bool?> _mailingAddressSameAsPresentIndicator;
         public bool? MailingAddressSameAsPresentIndicator { get { return _mailingAddressSameAsPresentIndicator; } set { _mailingAddressSameAsPresentIndicator = value; } }
-        private Value<string> _maritalStatusType;
+        private DirtyValue<string> _maritalStatusType;
         public string MaritalStatusType { get { return _maritalStatusType; } set { _maritalStatusType = value; } }
-        private Value<int?> _middleCreditScore;
+        private DirtyValue<int?> _middleCreditScore;
         public int? MiddleCreditScore { get { return _middleCreditScore; } set { _middleCreditScore = value; } }
-        private Value<string> _middleFicoScore;
+        private DirtyValue<string> _middleFicoScore;
         public string MiddleFicoScore { get { return _middleFicoScore; } set { _middleFicoScore = value; } }
-        private Value<string> _middleName;
+        private DirtyValue<string> _middleName;
         public string MiddleName { get { return _middleName; } set { _middleName = value; } }
-        private Value<string> _minFicoScore;
+        private DirtyValue<string> _minFicoScore;
         public string MinFicoScore { get { return _minFicoScore; } set { _minFicoScore = value; } }
-        private Value<string> _mobilePhone;
+        private DirtyValue<string> _mobilePhone;
         public string MobilePhone { get { return _mobilePhone; } set { _mobilePhone = value; } }
-        private Value<bool?> _mortgageOnCredit;
+        private DirtyValue<bool?> _mortgageOnCredit;
         public bool? MortgageOnCredit { get { return _mortgageOnCredit; } set { _mortgageOnCredit = value; } }
-        private Value<string> _nameToObtainLoanFromRHS;
+        private DirtyValue<string> _nameToObtainLoanFromRHS;
         public string NameToObtainLoanFromRHS { get { return _nameToObtainLoanFromRHS; } set { _nameToObtainLoanFromRHS = value; } }
-        private Value<string> _nearestRelativeAddress;
+        private DirtyValue<string> _nearestRelativeAddress;
         public string NearestRelativeAddress { get { return _nearestRelativeAddress; } set { _nearestRelativeAddress = value; } }
-        private Value<string> _nearestRelativeCity;
+        private DirtyValue<string> _nearestRelativeCity;
         public string NearestRelativeCity { get { return _nearestRelativeCity; } set { _nearestRelativeCity = value; } }
-        private Value<string> _nearestRelativeName;
+        private DirtyValue<string> _nearestRelativeName;
         public string NearestRelativeName { get { return _nearestRelativeName; } set { _nearestRelativeName = value; } }
-        private Value<string> _nearestRelativePhone;
+        private DirtyValue<string> _nearestRelativePhone;
         public string NearestRelativePhone { get { return _nearestRelativePhone; } set { _nearestRelativePhone = value; } }
-        private Value<string> _nearestRelativePostalCode;
+        private DirtyValue<string> _nearestRelativePostalCode;
         public string NearestRelativePostalCode { get { return _nearestRelativePostalCode; } set { _nearestRelativePostalCode = value; } }
-        private Value<string> _nearestRelativeRelationship;
+        private DirtyValue<string> _nearestRelativeRelationship;
         public string NearestRelativeRelationship { get { return _nearestRelativeRelationship; } set { _nearestRelativeRelationship = value; } }
-        private Value<string> _nearestRelativeState;
+        private DirtyValue<string> _nearestRelativeState;
         public string NearestRelativeState { get { return _nearestRelativeState; } set { _nearestRelativeState = value; } }
-        private Value<bool?> _no3rdPartyEmailIndicator;
+        private DirtyValue<bool?> _no3rdPartyEmailIndicator;
         public bool? No3rdPartyEmailIndicator { get { return _no3rdPartyEmailIndicator; } set { _no3rdPartyEmailIndicator = value; } }
-        private Value<bool?> _noCoApplicantEthnicityIndicator;
+        private DirtyValue<bool?> _noCoApplicantEthnicityIndicator;
         public bool? NoCoApplicantEthnicityIndicator { get { return _noCoApplicantEthnicityIndicator; } set { _noCoApplicantEthnicityIndicator = value; } }
-        private Value<bool?> _noCoApplicantIndicator;
+        private DirtyValue<bool?> _noCoApplicantIndicator;
         public bool? NoCoApplicantIndicator { get { return _noCoApplicantIndicator; } set { _noCoApplicantIndicator = value; } }
-        private Value<bool?> _noCoApplicantSexIndicator;
+        private DirtyValue<bool?> _noCoApplicantSexIndicator;
         public bool? NoCoApplicantSexIndicator { get { return _noCoApplicantSexIndicator; } set { _noCoApplicantSexIndicator = value; } }
-        private Value<int?> _numberofTradelines;
+        private DirtyValue<int?> _numberofTradelines;
         public int? NumberofTradelines { get { return _numberofTradelines; } set { _numberofTradelines = value; } }
-        private Value<bool?> _obtainLoanFromRHSIndicator;
+        private DirtyValue<bool?> _obtainLoanFromRHSIndicator;
         public bool? ObtainLoanFromRHSIndicator { get { return _obtainLoanFromRHSIndicator; } set { _obtainLoanFromRHSIndicator = value; } }
-        private Value<string> _openBankruptcy2;
+        private DirtyValue<string> _openBankruptcy2;
         public string OpenBankruptcy2 { get { return _openBankruptcy2; } set { _openBankruptcy2 = value; } }
-        private Value<decimal?> _otherMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _otherMonthlyIncomeAmount;
         public decimal? OtherMonthlyIncomeAmount { get { return _otherMonthlyIncomeAmount; } set { _otherMonthlyIncomeAmount = value; } }
-        private Value<decimal?> _otherSumAmount;
+        private DirtyValue<decimal?> _otherSumAmount;
         public decimal? OtherSumAmount { get { return _otherSumAmount; } set { _otherSumAmount = value; } }
-        private Value<bool?> _outstandingJudgementsIndicator;
+        private DirtyValue<bool?> _outstandingJudgementsIndicator;
         public bool? OutstandingJudgementsIndicator { get { return _outstandingJudgementsIndicator; } set { _outstandingJudgementsIndicator = value; } }
-        private Value<bool?> _partyToLawsuitIndicator;
+        private DirtyValue<bool?> _partyToLawsuitIndicator;
         public bool? PartyToLawsuitIndicator { get { return _partyToLawsuitIndicator; } set { _partyToLawsuitIndicator = value; } }
-        private Value<int?> _pass120Days;
+        private DirtyValue<int?> _pass120Days;
         public int? Pass120Days { get { return _pass120Days; } set { _pass120Days = value; } }
-        private Value<int?> _pass150Days;
+        private DirtyValue<int?> _pass150Days;
         public int? Pass150Days { get { return _pass150Days; } set { _pass150Days = value; } }
-        private Value<int?> _pass30Days;
+        private DirtyValue<int?> _pass30Days;
         public int? Pass30Days { get { return _pass30Days; } set { _pass30Days = value; } }
-        private Value<int?> _pass60Days;
+        private DirtyValue<int?> _pass60Days;
         public int? Pass60Days { get { return _pass60Days; } set { _pass60Days = value; } }
-        private Value<int?> _pass90Days;
+        private DirtyValue<int?> _pass90Days;
         public int? Pass90Days { get { return _pass90Days; } set { _pass90Days = value; } }
-        private Value<string> _personFaxNumber;
+        private DirtyValue<string> _personFaxNumber;
         public string PersonFaxNumber { get { return _personFaxNumber; } set { _personFaxNumber = value; } }
-        private Value<decimal?> _personHoursPerWeek;
+        private DirtyValue<decimal?> _personHoursPerWeek;
         public decimal? PersonHoursPerWeek { get { return _personHoursPerWeek; } set { _personHoursPerWeek = value; } }
-        private Value<decimal?> _personIncomeAmount;
+        private DirtyValue<decimal?> _personIncomeAmount;
         public decimal? PersonIncomeAmount { get { return _personIncomeAmount; } set { _personIncomeAmount = value; } }
-        private Value<string> _personIncomeFrequencyType;
+        private DirtyValue<string> _personIncomeFrequencyType;
         public string PersonIncomeFrequencyType { get { return _personIncomeFrequencyType; } set { _personIncomeFrequencyType = value; } }
-        private Value<decimal?> _personMonthlyIncome;
+        private DirtyValue<decimal?> _personMonthlyIncome;
         public decimal? PersonMonthlyIncome { get { return _personMonthlyIncome; } set { _personMonthlyIncome = value; } }
-        private Value<bool?> _pIWAccepted;
+        private DirtyValue<bool?> _pIWAccepted;
         public bool? PIWAccepted { get { return _pIWAccepted; } set { _pIWAccepted = value; } }
-        private Value<string> _pIWMessage;
+        private DirtyValue<string> _pIWMessage;
         public string PIWMessage { get { return _pIWMessage; } set { _pIWMessage = value; } }
-        private Value<string> _poaOccupancyIntent;
+        private DirtyValue<string> _poaOccupancyIntent;
         public string PoaOccupancyIntent { get { return _poaOccupancyIntent; } set { _poaOccupancyIntent = value; } }
-        private Value<string> _poaSignatureText;
+        private DirtyValue<string> _poaSignatureText;
         public string PoaSignatureText { get { return _poaSignatureText; } set { _poaSignatureText = value; } }
-        private Value<decimal?> _positiveCashFlow;
+        private DirtyValue<decimal?> _positiveCashFlow;
         public decimal? PositiveCashFlow { get { return _positiveCashFlow; } set { _positiveCashFlow = value; } }
-        private Value<string> _powerOfAttorneyName;
+        private DirtyValue<string> _powerOfAttorneyName;
         public string PowerOfAttorneyName { get { return _powerOfAttorneyName; } set { _powerOfAttorneyName = value; } }
-        private Value<string> _powerOfAttorneyTitleDescription;
+        private DirtyValue<string> _powerOfAttorneyTitleDescription;
         public string PowerOfAttorneyTitleDescription { get { return _powerOfAttorneyTitleDescription; } set { _powerOfAttorneyTitleDescription = value; } }
-        private Value<bool?> _presentlyDelinquentIndicator;
+        private DirtyValue<bool?> _presentlyDelinquentIndicator;
         public bool? PresentlyDelinquentIndicator { get { return _presentlyDelinquentIndicator; } set { _presentlyDelinquentIndicator = value; } }
-        private Value<DateTime?> _priorBankruptcy2;
+        private DirtyValue<DateTime?> _priorBankruptcy2;
         public DateTime? PriorBankruptcy2 { get { return _priorBankruptcy2; } set { _priorBankruptcy2 = value; } }
-        private Value<bool?> _priorForeclosure;
+        private DirtyValue<bool?> _priorForeclosure;
         public bool? PriorForeclosure { get { return _priorForeclosure; } set { _priorForeclosure = value; } }
-        private Value<string> _priorPropertyTitleType;
+        private DirtyValue<string> _priorPropertyTitleType;
         public string PriorPropertyTitleType { get { return _priorPropertyTitleType; } set { _priorPropertyTitleType = value; } }
-        private Value<string> _priorPropertyUsageType;
+        private DirtyValue<string> _priorPropertyUsageType;
         public string PriorPropertyUsageType { get { return _priorPropertyUsageType; } set { _priorPropertyUsageType = value; } }
-        private Value<bool?> _propertyForeclosedPastSevenYearsIndicator;
+        private DirtyValue<bool?> _propertyForeclosedPastSevenYearsIndicator;
         public bool? PropertyForeclosedPastSevenYearsIndicator { get { return _propertyForeclosedPastSevenYearsIndicator; } set { _propertyForeclosedPastSevenYearsIndicator = value; } }
-        private Value<string> _relationshipDescription;
+        private DirtyValue<string> _relationshipDescription;
         public string RelationshipDescription { get { return _relationshipDescription; } set { _relationshipDescription = value; } }
-        private Value<bool?> _relationshipWithRDEmployeeIndicator;
+        private DirtyValue<bool?> _relationshipWithRDEmployeeIndicator;
         public bool? RelationshipWithRDEmployeeIndicator { get { return _relationshipWithRDEmployeeIndicator; } set { _relationshipWithRDEmployeeIndicator = value; } }
-        private Value<int?> _schoolingTermYears;
+        private DirtyValue<int?> _schoolingTermYears;
         public int? SchoolingTermYears { get { return _schoolingTermYears; } set { _schoolingTermYears = value; } }
-        private Value<bool?> _sSA89BackgroundCheckIndicator;
+        private DirtyValue<bool?> _sSA89BackgroundCheckIndicator;
         public bool? SSA89BackgroundCheckIndicator { get { return _sSA89BackgroundCheckIndicator; } set { _sSA89BackgroundCheckIndicator = value; } }
-        private Value<bool?> _sSA89BankingServiceIndicator;
+        private DirtyValue<bool?> _sSA89BankingServiceIndicator;
         public bool? SSA89BankingServiceIndicator { get { return _sSA89BankingServiceIndicator; } set { _sSA89BankingServiceIndicator = value; } }
-        private Value<bool?> _sSA89CreditCheckIndicator;
+        private DirtyValue<bool?> _sSA89CreditCheckIndicator;
         public bool? SSA89CreditCheckIndicator { get { return _sSA89CreditCheckIndicator; } set { _sSA89CreditCheckIndicator = value; } }
-        private Value<bool?> _sSA89LicenseRequirementIndicator;
+        private DirtyValue<bool?> _sSA89LicenseRequirementIndicator;
         public bool? SSA89LicenseRequirementIndicator { get { return _sSA89LicenseRequirementIndicator; } set { _sSA89LicenseRequirementIndicator = value; } }
-        private Value<bool?> _sSA89MortgageServiceIndicator;
+        private DirtyValue<bool?> _sSA89MortgageServiceIndicator;
         public bool? SSA89MortgageServiceIndicator { get { return _sSA89MortgageServiceIndicator; } set { _sSA89MortgageServiceIndicator = value; } }
-        private Value<bool?> _sSA89OtherIndicator;
+        private DirtyValue<bool?> _sSA89OtherIndicator;
         public bool? SSA89OtherIndicator { get { return _sSA89OtherIndicator; } set { _sSA89OtherIndicator = value; } }
-        private Value<decimal?> _subtotalLiquidAssetsMinusGiftAmount;
+        private DirtyValue<decimal?> _subtotalLiquidAssetsMinusGiftAmount;
         public decimal? SubtotalLiquidAssetsMinusGiftAmount { get { return _subtotalLiquidAssetsMinusGiftAmount; } set { _subtotalLiquidAssetsMinusGiftAmount = value; } }
-        private Value<string> _suffixToName;
+        private DirtyValue<string> _suffixToName;
         public string SuffixToName { get { return _suffixToName; } set { _suffixToName = value; } }
-        private Value<string> _tax4506LastInvestor;
+        private DirtyValue<string> _tax4506LastInvestor;
         public string Tax4506LastInvestor { get { return _tax4506LastInvestor; } set { _tax4506LastInvestor = value; } }
-        private Value<string> _tax4506LastOrderNumber;
+        private DirtyValue<string> _tax4506LastOrderNumber;
         public string Tax4506LastOrderNumber { get { return _tax4506LastOrderNumber; } set { _tax4506LastOrderNumber = value; } }
-        private Value<int?> _tax4506LastOrderYear1;
+        private DirtyValue<int?> _tax4506LastOrderYear1;
         public int? Tax4506LastOrderYear1 { get { return _tax4506LastOrderYear1; } set { _tax4506LastOrderYear1 = value; } }
-        private Value<int?> _tax4506LastOrderYear2;
+        private DirtyValue<int?> _tax4506LastOrderYear2;
         public int? Tax4506LastOrderYear2 { get { return _tax4506LastOrderYear2; } set { _tax4506LastOrderYear2 = value; } }
-        private Value<int?> _tax4506LastOrderYear3;
+        private DirtyValue<int?> _tax4506LastOrderYear3;
         public int? Tax4506LastOrderYear3 { get { return _tax4506LastOrderYear3; } set { _tax4506LastOrderYear3 = value; } }
-        private Value<int?> _tax4506LastOrderYear4;
+        private DirtyValue<int?> _tax4506LastOrderYear4;
         public int? Tax4506LastOrderYear4 { get { return _tax4506LastOrderYear4; } set { _tax4506LastOrderYear4 = value; } }
-        private Value<string> _tax4506LastProductsOrdered;
+        private DirtyValue<string> _tax4506LastProductsOrdered;
         public string Tax4506LastProductsOrdered { get { return _tax4506LastProductsOrdered; } set { _tax4506LastProductsOrdered = value; } }
-        private Value<string> _tax4506LastStatus;
+        private DirtyValue<string> _tax4506LastStatus;
         public string Tax4506LastStatus { get { return _tax4506LastStatus; } set { _tax4506LastStatus = value; } }
-        private Value<string> _tax4506LastTranscriptType;
+        private DirtyValue<string> _tax4506LastTranscriptType;
         public string Tax4506LastTranscriptType { get { return _tax4506LastTranscriptType; } set { _tax4506LastTranscriptType = value; } }
-        private Value<string> _tax4506LastUserIDWhoOrdered;
+        private DirtyValue<string> _tax4506LastUserIDWhoOrdered;
         public string Tax4506LastUserIDWhoOrdered { get { return _tax4506LastUserIDWhoOrdered; } set { _tax4506LastUserIDWhoOrdered = value; } }
-        private Value<decimal?> _tax4506TotalYearlyIncome1;
+        private DirtyValue<decimal?> _tax4506TotalYearlyIncome1;
         public decimal? Tax4506TotalYearlyIncome1 { get { return _tax4506TotalYearlyIncome1; } set { _tax4506TotalYearlyIncome1 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyIncome2;
+        private DirtyValue<decimal?> _tax4506TotalYearlyIncome2;
         public decimal? Tax4506TotalYearlyIncome2 { get { return _tax4506TotalYearlyIncome2; } set { _tax4506TotalYearlyIncome2 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyIncome3;
+        private DirtyValue<decimal?> _tax4506TotalYearlyIncome3;
         public decimal? Tax4506TotalYearlyIncome3 { get { return _tax4506TotalYearlyIncome3; } set { _tax4506TotalYearlyIncome3 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyIncome4;
+        private DirtyValue<decimal?> _tax4506TotalYearlyIncome4;
         public decimal? Tax4506TotalYearlyIncome4 { get { return _tax4506TotalYearlyIncome4; } set { _tax4506TotalYearlyIncome4 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyJointIncome1;
+        private DirtyValue<decimal?> _tax4506TotalYearlyJointIncome1;
         public decimal? Tax4506TotalYearlyJointIncome1 { get { return _tax4506TotalYearlyJointIncome1; } set { _tax4506TotalYearlyJointIncome1 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyJointIncome2;
+        private DirtyValue<decimal?> _tax4506TotalYearlyJointIncome2;
         public decimal? Tax4506TotalYearlyJointIncome2 { get { return _tax4506TotalYearlyJointIncome2; } set { _tax4506TotalYearlyJointIncome2 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyJointIncome3;
+        private DirtyValue<decimal?> _tax4506TotalYearlyJointIncome3;
         public decimal? Tax4506TotalYearlyJointIncome3 { get { return _tax4506TotalYearlyJointIncome3; } set { _tax4506TotalYearlyJointIncome3 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyJointIncome4;
+        private DirtyValue<decimal?> _tax4506TotalYearlyJointIncome4;
         public decimal? Tax4506TotalYearlyJointIncome4 { get { return _tax4506TotalYearlyJointIncome4; } set { _tax4506TotalYearlyJointIncome4 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceIncome1;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceIncome1;
         public decimal? Tax4506TotalYearlyVarianceIncome1 { get { return _tax4506TotalYearlyVarianceIncome1; } set { _tax4506TotalYearlyVarianceIncome1 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceIncome2;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceIncome2;
         public decimal? Tax4506TotalYearlyVarianceIncome2 { get { return _tax4506TotalYearlyVarianceIncome2; } set { _tax4506TotalYearlyVarianceIncome2 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceIncome3;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceIncome3;
         public decimal? Tax4506TotalYearlyVarianceIncome3 { get { return _tax4506TotalYearlyVarianceIncome3; } set { _tax4506TotalYearlyVarianceIncome3 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceIncome4;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceIncome4;
         public decimal? Tax4506TotalYearlyVarianceIncome4 { get { return _tax4506TotalYearlyVarianceIncome4; } set { _tax4506TotalYearlyVarianceIncome4 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceJointIncome1;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceJointIncome1;
         public decimal? Tax4506TotalYearlyVarianceJointIncome1 { get { return _tax4506TotalYearlyVarianceJointIncome1; } set { _tax4506TotalYearlyVarianceJointIncome1 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceJointIncome2;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceJointIncome2;
         public decimal? Tax4506TotalYearlyVarianceJointIncome2 { get { return _tax4506TotalYearlyVarianceJointIncome2; } set { _tax4506TotalYearlyVarianceJointIncome2 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceJointIncome3;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceJointIncome3;
         public decimal? Tax4506TotalYearlyVarianceJointIncome3 { get { return _tax4506TotalYearlyVarianceJointIncome3; } set { _tax4506TotalYearlyVarianceJointIncome3 = value; } }
-        private Value<decimal?> _tax4506TotalYearlyVarianceJointIncome4;
+        private DirtyValue<decimal?> _tax4506TotalYearlyVarianceJointIncome4;
         public decimal? Tax4506TotalYearlyVarianceJointIncome4 { get { return _tax4506TotalYearlyVarianceJointIncome4; } set { _tax4506TotalYearlyVarianceJointIncome4 = value; } }
-        private Value<string> _taxIdentificationIdentifier;
+        private DirtyValue<string> _taxIdentificationIdentifier;
         public string TaxIdentificationIdentifier { get { return _taxIdentificationIdentifier; } set { _taxIdentificationIdentifier = value; } }
-        private Value<decimal?> _totalLiabilitiesBalanceAmount;
+        private DirtyValue<decimal?> _totalLiabilitiesBalanceAmount;
         public decimal? TotalLiabilitiesBalanceAmount { get { return _totalLiabilitiesBalanceAmount; } set { _totalLiabilitiesBalanceAmount = value; } }
-        private Value<decimal?> _totalMonthlyIncomeAmount;
+        private DirtyValue<decimal?> _totalMonthlyIncomeAmount;
         public decimal? TotalMonthlyIncomeAmount { get { return _totalMonthlyIncomeAmount; } set { _totalMonthlyIncomeAmount = value; } }
-        private Value<decimal?> _totalMonthlyIncomeMinusNetRentalAmount;
+        private DirtyValue<decimal?> _totalMonthlyIncomeMinusNetRentalAmount;
         public decimal? TotalMonthlyIncomeMinusNetRentalAmount { get { return _totalMonthlyIncomeMinusNetRentalAmount; } set { _totalMonthlyIncomeMinusNetRentalAmount = value; } }
-        private Value<decimal?> _totalPresentHousingExpenseAmount;
+        private DirtyValue<decimal?> _totalPresentHousingExpenseAmount;
         public decimal? TotalPresentHousingExpenseAmount { get { return _totalPresentHousingExpenseAmount; } set { _totalPresentHousingExpenseAmount = value; } }
-        private Value<string> _transactionPurposeDescription;
+        private DirtyValue<string> _transactionPurposeDescription;
         public string TransactionPurposeDescription { get { return _transactionPurposeDescription; } set { _transactionPurposeDescription = value; } }
-        private Value<int?> _transUnion120Days;
+        private DirtyValue<int?> _transUnion120Days;
         public int? TransUnion120Days { get { return _transUnion120Days; } set { _transUnion120Days = value; } }
-        private Value<int?> _transUnion150Days;
+        private DirtyValue<int?> _transUnion150Days;
         public int? TransUnion150Days { get { return _transUnion150Days; } set { _transUnion150Days = value; } }
-        private Value<int?> _transUnion30Days;
+        private DirtyValue<int?> _transUnion30Days;
         public int? TransUnion30Days { get { return _transUnion30Days; } set { _transUnion30Days = value; } }
-        private Value<int?> _transUnion60Days;
+        private DirtyValue<int?> _transUnion60Days;
         public int? TransUnion60Days { get { return _transUnion60Days; } set { _transUnion60Days = value; } }
-        private Value<int?> _transUnion90Days;
+        private DirtyValue<int?> _transUnion90Days;
         public int? TransUnion90Days { get { return _transUnion90Days; } set { _transUnion90Days = value; } }
-        private Value<bool?> _transUnionCreditScoreForDisclosure;
+        private DirtyValue<bool?> _transUnionCreditScoreForDisclosure;
         public bool? TransUnionCreditScoreForDisclosure { get { return _transUnionCreditScoreForDisclosure; } set { _transUnionCreditScoreForDisclosure = value; } }
-        private Value<int?> _transUnionCreditScoreRanksPercent;
+        private DirtyValue<int?> _transUnionCreditScoreRanksPercent;
         public int? TransUnionCreditScoreRanksPercent { get { return _transUnionCreditScoreRanksPercent; } set { _transUnionCreditScoreRanksPercent = value; } }
-        private Value<DateTime?> _transUnionDatePulled;
+        private DirtyValue<DateTime?> _transUnionDatePulled;
         public DateTime? TransUnionDatePulled { get { return _transUnionDatePulled; } set { _transUnionDatePulled = value; } }
-        private Value<string> _transUnionFactorCode1;
+        private DirtyValue<string> _transUnionFactorCode1;
         public string TransUnionFactorCode1 { get { return _transUnionFactorCode1; } set { _transUnionFactorCode1 = value; } }
-        private Value<string> _transUnionFactorCode2;
+        private DirtyValue<string> _transUnionFactorCode2;
         public string TransUnionFactorCode2 { get { return _transUnionFactorCode2; } set { _transUnionFactorCode2 = value; } }
-        private Value<string> _transUnionFactorCode3;
+        private DirtyValue<string> _transUnionFactorCode3;
         public string TransUnionFactorCode3 { get { return _transUnionFactorCode3; } set { _transUnionFactorCode3 = value; } }
-        private Value<string> _transUnionFactorCode4;
+        private DirtyValue<string> _transUnionFactorCode4;
         public string TransUnionFactorCode4 { get { return _transUnionFactorCode4; } set { _transUnionFactorCode4 = value; } }
-        private Value<string> _transUnionFactorCode5;
+        private DirtyValue<string> _transUnionFactorCode5;
         public string TransUnionFactorCode5 { get { return _transUnionFactorCode5; } set { _transUnionFactorCode5 = value; } }
-        private Value<string> _transUnionKeyFactor1;
+        private DirtyValue<string> _transUnionKeyFactor1;
         public string TransUnionKeyFactor1 { get { return _transUnionKeyFactor1; } set { _transUnionKeyFactor1 = value; } }
-        private Value<string> _transUnionKeyFactor2;
+        private DirtyValue<string> _transUnionKeyFactor2;
         public string TransUnionKeyFactor2 { get { return _transUnionKeyFactor2; } set { _transUnionKeyFactor2 = value; } }
-        private Value<string> _transUnionKeyFactor3;
+        private DirtyValue<string> _transUnionKeyFactor3;
         public string TransUnionKeyFactor3 { get { return _transUnionKeyFactor3; } set { _transUnionKeyFactor3 = value; } }
-        private Value<string> _transUnionKeyFactor4;
+        private DirtyValue<string> _transUnionKeyFactor4;
         public string TransUnionKeyFactor4 { get { return _transUnionKeyFactor4; } set { _transUnionKeyFactor4 = value; } }
-        private Value<string> _transUnionKeyFactor5;
+        private DirtyValue<string> _transUnionKeyFactor5;
         public string TransUnionKeyFactor5 { get { return _transUnionKeyFactor5; } set { _transUnionKeyFactor5 = value; } }
-        private Value<bool?> _transUnionMaterialTermsCreditByScore;
+        private DirtyValue<bool?> _transUnionMaterialTermsCreditByScore;
         public bool? TransUnionMaterialTermsCreditByScore { get { return _transUnionMaterialTermsCreditByScore; } set { _transUnionMaterialTermsCreditByScore = value; } }
-        private Value<string> _transUnionScore;
+        private DirtyValue<string> _transUnionScore;
         public string TransUnionScore { get { return _transUnionScore; } set { _transUnionScore = value; } }
-        private Value<decimal?> _userDefinedIncome;
+        private DirtyValue<decimal?> _userDefinedIncome;
         public decimal? UserDefinedIncome { get { return _userDefinedIncome; } set { _userDefinedIncome = value; } }
-        private Value<decimal?> _vaFederalTaxAmount;
+        private DirtyValue<decimal?> _vaFederalTaxAmount;
         public decimal? VaFederalTaxAmount { get { return _vaFederalTaxAmount; } set { _vaFederalTaxAmount = value; } }
-        private Value<int?> _validDaysForConsentCount;
+        private DirtyValue<int?> _validDaysForConsentCount;
         public int? ValidDaysForConsentCount { get { return _validDaysForConsentCount; } set { _validDaysForConsentCount = value; } }
-        private Value<bool?> _valueRepAndWarrantyAvailable;
+        private DirtyValue<bool?> _valueRepAndWarrantyAvailable;
         public bool? ValueRepAndWarrantyAvailable { get { return _valueRepAndWarrantyAvailable; } set { _valueRepAndWarrantyAvailable = value; } }
-        private Value<string> _valueRepAndWarrantyMessage;
+        private DirtyValue<string> _valueRepAndWarrantyMessage;
         public string ValueRepAndWarrantyMessage { get { return _valueRepAndWarrantyMessage; } set { _valueRepAndWarrantyMessage = value; } }
-        private Value<decimal?> _vaNetTakeHomePayAmount;
+        private DirtyValue<decimal?> _vaNetTakeHomePayAmount;
         public decimal? VaNetTakeHomePayAmount { get { return _vaNetTakeHomePayAmount; } set { _vaNetTakeHomePayAmount = value; } }
-        private Value<decimal?> _vaOtherAmount;
+        private DirtyValue<decimal?> _vaOtherAmount;
         public decimal? VaOtherAmount { get { return _vaOtherAmount; } set { _vaOtherAmount = value; } }
-        private Value<decimal?> _vaOtherNetIncomeAmount;
+        private DirtyValue<decimal?> _vaOtherNetIncomeAmount;
         public decimal? VaOtherNetIncomeAmount { get { return _vaOtherNetIncomeAmount; } set { _vaOtherNetIncomeAmount = value; } }
-        private Value<decimal?> _vaRetirementAmount;
+        private DirtyValue<decimal?> _vaRetirementAmount;
         public decimal? VaRetirementAmount { get { return _vaRetirementAmount; } set { _vaRetirementAmount = value; } }
-        private Value<decimal?> _vaStateTaxAmount;
+        private DirtyValue<decimal?> _vaStateTaxAmount;
         public decimal? VaStateTaxAmount { get { return _vaStateTaxAmount; } set { _vaStateTaxAmount = value; } }
-        private Value<decimal?> _vaTotalIncomeDeductionsAmount;
+        private DirtyValue<decimal?> _vaTotalIncomeDeductionsAmount;
         public decimal? VaTotalIncomeDeductionsAmount { get { return _vaTotalIncomeDeductionsAmount; } set { _vaTotalIncomeDeductionsAmount = value; } }
-        private Value<decimal?> _vaTotalNetIncomeAmount;
+        private DirtyValue<decimal?> _vaTotalNetIncomeAmount;
         public decimal? VaTotalNetIncomeAmount { get { return _vaTotalNetIncomeAmount; } set { _vaTotalNetIncomeAmount = value; } }
-        private Value<string> _vendor1;
+        private DirtyValue<string> _vendor1;
         public string Vendor1 { get { return _vendor1; } set { _vendor1 = value; } }
-        private Value<string> _vendor10;
+        private DirtyValue<string> _vendor10;
         public string Vendor10 { get { return _vendor10; } set { _vendor10 = value; } }
-        private Value<string> _vendor11;
+        private DirtyValue<string> _vendor11;
         public string Vendor11 { get { return _vendor11; } set { _vendor11 = value; } }
-        private Value<string> _vendor12;
+        private DirtyValue<string> _vendor12;
         public string Vendor12 { get { return _vendor12; } set { _vendor12 = value; } }
-        private Value<string> _vendor2;
+        private DirtyValue<string> _vendor2;
         public string Vendor2 { get { return _vendor2; } set { _vendor2 = value; } }
-        private Value<string> _vendor3;
+        private DirtyValue<string> _vendor3;
         public string Vendor3 { get { return _vendor3; } set { _vendor3 = value; } }
-        private Value<string> _vendor4;
+        private DirtyValue<string> _vendor4;
         public string Vendor4 { get { return _vendor4; } set { _vendor4 = value; } }
-        private Value<string> _vendor5;
+        private DirtyValue<string> _vendor5;
         public string Vendor5 { get { return _vendor5; } set { _vendor5 = value; } }
-        private Value<string> _vendor6;
+        private DirtyValue<string> _vendor6;
         public string Vendor6 { get { return _vendor6; } set { _vendor6 = value; } }
-        private Value<string> _vendor7;
+        private DirtyValue<string> _vendor7;
         public string Vendor7 { get { return _vendor7; } set { _vendor7 = value; } }
-        private Value<string> _vendor8;
+        private DirtyValue<string> _vendor8;
         public string Vendor8 { get { return _vendor8; } set { _vendor8 = value; } }
-        private Value<string> _vendor9;
+        private DirtyValue<string> _vendor9;
         public string Vendor9 { get { return _vendor9; } set { _vendor9 = value; } }
-        private Value<string> _vestingTrusteeOfType;
+        private DirtyValue<string> _vestingTrusteeOfType;
         public string VestingTrusteeOfType { get { return _vestingTrusteeOfType; } set { _vestingTrusteeOfType = value; } }
-        private Value<bool?> _veteranIndicator;
+        private DirtyValue<bool?> _veteranIndicator;
         public bool? VeteranIndicator { get { return _veteranIndicator; } set { _veteranIndicator = value; } }
-        private Value<string> _workEmailAddress;
+        private DirtyValue<string> _workEmailAddress;
         public string WorkEmailAddress { get { return _workEmailAddress; } set { _workEmailAddress = value; } }
-        private Value<int?> _yearsofCreditOnFile;
+        private DirtyValue<int?> _yearsofCreditOnFile;
         public int? YearsofCreditOnFile { get { return _yearsofCreditOnFile; } set { _yearsofCreditOnFile = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Borrower.cs
+++ b/src/EncompassRest/Loans/Borrower.cs
@@ -20,7 +20,8 @@ namespace EncompassRest.Loans
         public string AltId { get { return _altId; } set { _altId = value; } }
         private Value<string> _applicantType;
         public string ApplicantType { get { return _applicantType; } set { _applicantType = value; } }
-        public Application Application { get; set; }
+        private Application _application;
+        public Application Application { get { var v = _application; return v ?? Interlocked.CompareExchange(ref _application, (v = new Application()), null) ?? v; } set { _application = value; } }
         private Value<string> _applicationTakenMethodType;
         public string ApplicationTakenMethodType { get { return _applicationTakenMethodType; } set { _applicationTakenMethodType = value; } }
         private Value<string> _assetRepAndWarrantyMessage;
@@ -235,6 +236,24 @@ namespace EncompassRest.Loans
         public string HmdaCreditScoringModel { get { return _hmdaCreditScoringModel; } set { _hmdaCreditScoringModel = value; } }
         private Value<bool?> _hmdaCubanIndicator;
         public bool? HmdaCubanIndicator { get { return _hmdaCubanIndicator; } set { _hmdaCubanIndicator = value; } }
+        private Value<bool?> _hmdaEthnicityDoNotWishIndicator;
+        public bool? HmdaEthnicityDoNotWishIndicator { get { return _hmdaEthnicityDoNotWishIndicator; } set { _hmdaEthnicityDoNotWishIndicator = value; } }
+        private Value<bool?> _hmdaEthnicityHispanicLatinoIndicator;
+        public bool? HmdaEthnicityHispanicLatinoIndicator { get { return _hmdaEthnicityHispanicLatinoIndicator; } set { _hmdaEthnicityHispanicLatinoIndicator = value; } }
+        private Value<bool?> _hmdaEthnicityNotApplicableIndicator;
+        public bool? HmdaEthnicityNotApplicableIndicator { get { return _hmdaEthnicityNotApplicableIndicator; } set { _hmdaEthnicityNotApplicableIndicator = value; } }
+        private Value<bool?> _hmdaEthnicityNotHispanicLatinoIndicator;
+        public bool? HmdaEthnicityNotHispanicLatinoIndicator { get { return _hmdaEthnicityNotHispanicLatinoIndicator; } set { _hmdaEthnicityNotHispanicLatinoIndicator = value; } }
+        private Value<string> _hmdaEthnicityReportedField1;
+        public string HmdaEthnicityReportedField1 { get { return _hmdaEthnicityReportedField1; } set { _hmdaEthnicityReportedField1 = value; } }
+        private Value<string> _hmdaEthnicityReportedField2;
+        public string HmdaEthnicityReportedField2 { get { return _hmdaEthnicityReportedField2; } set { _hmdaEthnicityReportedField2 = value; } }
+        private Value<string> _hmdaEthnicityReportedField3;
+        public string HmdaEthnicityReportedField3 { get { return _hmdaEthnicityReportedField3; } set { _hmdaEthnicityReportedField3 = value; } }
+        private Value<string> _hmdaEthnicityReportedField4;
+        public string HmdaEthnicityReportedField4 { get { return _hmdaEthnicityReportedField4; } set { _hmdaEthnicityReportedField4 = value; } }
+        private Value<string> _hmdaEthnicityReportedField5;
+        public string HmdaEthnicityReportedField5 { get { return _hmdaEthnicityReportedField5; } set { _hmdaEthnicityReportedField5 = value; } }
         private Value<string> _hmdaEthnicityType;
         public string HmdaEthnicityType { get { return _hmdaEthnicityType; } set { _hmdaEthnicityType = value; } }
         private Value<bool?> _hmdaFilipinoIndicator;
@@ -281,6 +300,16 @@ namespace EncompassRest.Loans
         public bool? HmdaPacificIslanderOtherIndicator { get { return _hmdaPacificIslanderOtherIndicator; } set { _hmdaPacificIslanderOtherIndicator = value; } }
         private Value<bool?> _hmdaPuertoRicanIndicator;
         public bool? HmdaPuertoRicanIndicator { get { return _hmdaPuertoRicanIndicator; } set { _hmdaPuertoRicanIndicator = value; } }
+        private Value<string> _hmdaRaceReportedField1;
+        public string HmdaRaceReportedField1 { get { return _hmdaRaceReportedField1; } set { _hmdaRaceReportedField1 = value; } }
+        private Value<string> _hmdaRaceReportedField2;
+        public string HmdaRaceReportedField2 { get { return _hmdaRaceReportedField2; } set { _hmdaRaceReportedField2 = value; } }
+        private Value<string> _hmdaRaceReportedField3;
+        public string HmdaRaceReportedField3 { get { return _hmdaRaceReportedField3; } set { _hmdaRaceReportedField3 = value; } }
+        private Value<string> _hmdaRaceReportedField4;
+        public string HmdaRaceReportedField4 { get { return _hmdaRaceReportedField4; } set { _hmdaRaceReportedField4 = value; } }
+        private Value<string> _hmdaRaceReportedField5;
+        public string HmdaRaceReportedField5 { get { return _hmdaRaceReportedField5; } set { _hmdaRaceReportedField5 = value; } }
         private Value<bool?> _hmdaRefusalIndicator;
         public bool? HmdaRefusalIndicator { get { return _hmdaRefusalIndicator; } set { _hmdaRefusalIndicator = value; } }
         private Value<bool?> _hmdaSamoanIndicator;
@@ -733,6 +762,15 @@ namespace EncompassRest.Loans
                     || _hmdaCreditScoreForDecisionMaking.Dirty
                     || _hmdaCreditScoringModel.Dirty
                     || _hmdaCubanIndicator.Dirty
+                    || _hmdaEthnicityDoNotWishIndicator.Dirty
+                    || _hmdaEthnicityHispanicLatinoIndicator.Dirty
+                    || _hmdaEthnicityNotApplicableIndicator.Dirty
+                    || _hmdaEthnicityNotHispanicLatinoIndicator.Dirty
+                    || _hmdaEthnicityReportedField1.Dirty
+                    || _hmdaEthnicityReportedField2.Dirty
+                    || _hmdaEthnicityReportedField3.Dirty
+                    || _hmdaEthnicityReportedField4.Dirty
+                    || _hmdaEthnicityReportedField5.Dirty
                     || _hmdaEthnicityType.Dirty
                     || _hmdaFilipinoIndicator.Dirty
                     || _hmdaGenderType.Dirty
@@ -756,6 +794,11 @@ namespace EncompassRest.Loans
                     || _hmdaPacificIslanderIndicator.Dirty
                     || _hmdaPacificIslanderOtherIndicator.Dirty
                     || _hmdaPuertoRicanIndicator.Dirty
+                    || _hmdaRaceReportedField1.Dirty
+                    || _hmdaRaceReportedField2.Dirty
+                    || _hmdaRaceReportedField3.Dirty
+                    || _hmdaRaceReportedField4.Dirty
+                    || _hmdaRaceReportedField5.Dirty
                     || _hmdaRefusalIndicator.Dirty
                     || _hmdaSamoanIndicator.Dirty
                     || _hmdaVietnameseIndicator.Dirty
@@ -922,7 +965,7 @@ namespace EncompassRest.Loans
                     || _veteranIndicator.Dirty
                     || _workEmailAddress.Dirty
                     || _yearsofCreditOnFile.Dirty
-                    || Application?.Dirty == true;
+                    || _application?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -1042,6 +1085,15 @@ namespace EncompassRest.Loans
                 _hmdaCreditScoreForDecisionMaking.Dirty = value;
                 _hmdaCreditScoringModel.Dirty = value;
                 _hmdaCubanIndicator.Dirty = value;
+                _hmdaEthnicityDoNotWishIndicator.Dirty = value;
+                _hmdaEthnicityHispanicLatinoIndicator.Dirty = value;
+                _hmdaEthnicityNotApplicableIndicator.Dirty = value;
+                _hmdaEthnicityNotHispanicLatinoIndicator.Dirty = value;
+                _hmdaEthnicityReportedField1.Dirty = value;
+                _hmdaEthnicityReportedField2.Dirty = value;
+                _hmdaEthnicityReportedField3.Dirty = value;
+                _hmdaEthnicityReportedField4.Dirty = value;
+                _hmdaEthnicityReportedField5.Dirty = value;
                 _hmdaEthnicityType.Dirty = value;
                 _hmdaFilipinoIndicator.Dirty = value;
                 _hmdaGenderType.Dirty = value;
@@ -1065,6 +1117,11 @@ namespace EncompassRest.Loans
                 _hmdaPacificIslanderIndicator.Dirty = value;
                 _hmdaPacificIslanderOtherIndicator.Dirty = value;
                 _hmdaPuertoRicanIndicator.Dirty = value;
+                _hmdaRaceReportedField1.Dirty = value;
+                _hmdaRaceReportedField2.Dirty = value;
+                _hmdaRaceReportedField3.Dirty = value;
+                _hmdaRaceReportedField4.Dirty = value;
+                _hmdaRaceReportedField5.Dirty = value;
                 _hmdaRefusalIndicator.Dirty = value;
                 _hmdaSamoanIndicator.Dirty = value;
                 _hmdaVietnameseIndicator.Dirty = value;
@@ -1231,7 +1288,7 @@ namespace EncompassRest.Loans
                 _veteranIndicator.Dirty = value;
                 _workEmailAddress.Dirty = value;
                 _yearsofCreditOnFile.Dirty = value;
-                if (Application != null) Application.Dirty = value;
+                if (_application != null) _application.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Buydown.cs
+++ b/src/EncompassRest/Loans/Buydown.cs
@@ -8,25 +8,25 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Buydown : IDirty
     {
-        private Value<int?> _buydownIndex;
+        private DirtyValue<int?> _buydownIndex;
         public int? BuydownIndex { get { return _buydownIndex; } set { _buydownIndex = value; } }
-        private Value<decimal?> _buydownRatePercent;
+        private DirtyValue<decimal?> _buydownRatePercent;
         public decimal? BuydownRatePercent { get { return _buydownRatePercent; } set { _buydownRatePercent = value; } }
-        private Value<int?> _changeFrequencyMonthsCount;
+        private DirtyValue<int?> _changeFrequencyMonthsCount;
         public int? ChangeFrequencyMonthsCount { get { return _changeFrequencyMonthsCount; } set { _changeFrequencyMonthsCount = value; } }
-        private Value<int?> _durationMonthsCount;
+        private DirtyValue<int?> _durationMonthsCount;
         public int? DurationMonthsCount { get { return _durationMonthsCount; } set { _durationMonthsCount = value; } }
-        private Value<decimal?> _fundBalanceAmount;
+        private DirtyValue<decimal?> _fundBalanceAmount;
         public decimal? FundBalanceAmount { get { return _fundBalanceAmount; } set { _fundBalanceAmount = value; } }
-        private Value<decimal?> _fundTotalAmount;
+        private DirtyValue<decimal?> _fundTotalAmount;
         public decimal? FundTotalAmount { get { return _fundTotalAmount; } set { _fundTotalAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _increaseRatePercent;
+        private DirtyValue<decimal?> _increaseRatePercent;
         public decimal? IncreaseRatePercent { get { return _increaseRatePercent; } set { _increaseRatePercent = value; } }
-        private Value<int?> _remainingMonthsCount;
+        private DirtyValue<int?> _remainingMonthsCount;
         public int? RemainingMonthsCount { get { return _remainingMonthsCount; } set { _remainingMonthsCount = value; } }
-        private Value<decimal?> _subsidyAmount;
+        private DirtyValue<decimal?> _subsidyAmount;
         public decimal? SubsidyAmount { get { return _subsidyAmount; } set { _subsidyAmount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingCost.cs
+++ b/src/EncompassRest/Loans/ClosingCost.cs
@@ -24,11 +24,16 @@ namespace EncompassRest.Loans
         public string ClosingCostProgram { get { return _closingCostProgram; } set { _closingCostProgram = value; } }
         private Value<string> _closingCostScenarioXml;
         public string ClosingCostScenarioXml { get { return _closingCostScenarioXml; } set { _closingCostScenarioXml = value; } }
-        public ClosingDisclosure1 ClosingDisclosure1 { get; set; }
-        public ClosingDisclosure2 ClosingDisclosure2 { get; set; }
-        public ClosingDisclosure3 ClosingDisclosure3 { get; set; }
-        public ClosingDisclosure4 ClosingDisclosure4 { get; set; }
-        public ClosingDisclosure5 ClosingDisclosure5 { get; set; }
+        private ClosingDisclosure1 _closingDisclosure1;
+        public ClosingDisclosure1 ClosingDisclosure1 { get { var v = _closingDisclosure1; return v ?? Interlocked.CompareExchange(ref _closingDisclosure1, (v = new ClosingDisclosure1()), null) ?? v; } set { _closingDisclosure1 = value; } }
+        private ClosingDisclosure2 _closingDisclosure2;
+        public ClosingDisclosure2 ClosingDisclosure2 { get { var v = _closingDisclosure2; return v ?? Interlocked.CompareExchange(ref _closingDisclosure2, (v = new ClosingDisclosure2()), null) ?? v; } set { _closingDisclosure2 = value; } }
+        private ClosingDisclosure3 _closingDisclosure3;
+        public ClosingDisclosure3 ClosingDisclosure3 { get { var v = _closingDisclosure3; return v ?? Interlocked.CompareExchange(ref _closingDisclosure3, (v = new ClosingDisclosure3()), null) ?? v; } set { _closingDisclosure3 = value; } }
+        private ClosingDisclosure4 _closingDisclosure4;
+        public ClosingDisclosure4 ClosingDisclosure4 { get { var v = _closingDisclosure4; return v ?? Interlocked.CompareExchange(ref _closingDisclosure4, (v = new ClosingDisclosure4()), null) ?? v; } set { _closingDisclosure4 = value; } }
+        private ClosingDisclosure5 _closingDisclosure5;
+        public ClosingDisclosure5 ClosingDisclosure5 { get { var v = _closingDisclosure5; return v ?? Interlocked.CompareExchange(ref _closingDisclosure5, (v = new ClosingDisclosure5()), null) ?? v; } set { _closingDisclosure5 = value; } }
         private Value<decimal?> _disclosedSalesPrice;
         public decimal? DisclosedSalesPrice { get { return _disclosedSalesPrice; } set { _disclosedSalesPrice = value; } }
         private Value<string> _escrowCompanyName;
@@ -57,12 +62,16 @@ namespace EncompassRest.Loans
         public decimal? EscrowTableFee5 { get { return _escrowTableFee5; } set { _escrowTableFee5 = value; } }
         private Value<string> _escrowTableName;
         public string EscrowTableName { get { return _escrowTableName; } set { _escrowTableName = value; } }
-        public FeeVarianceOther FeeVarianceOther { get; set; }
-        private Value<List<FeeVariance>> _feeVariances;
-        public List<FeeVariance> FeeVariances { get { return _feeVariances; } set { _feeVariances = value; } }
-        public Gfe2010 Gfe2010 { get; set; }
-        public Gfe2010Page Gfe2010Page { get; set; }
-        public Gfe2010Section Gfe2010Section { get; set; }
+        private FeeVarianceOther _feeVarianceOther;
+        public FeeVarianceOther FeeVarianceOther { get { var v = _feeVarianceOther; return v ?? Interlocked.CompareExchange(ref _feeVarianceOther, (v = new FeeVarianceOther()), null) ?? v; } set { _feeVarianceOther = value; } }
+        private DirtyList<FeeVariance> _feeVariances;
+        public IList<FeeVariance> FeeVariances { get { var v = _feeVariances; return v ?? Interlocked.CompareExchange(ref _feeVariances, (v = new DirtyList<FeeVariance>()), null) ?? v; } set { _feeVariances = new DirtyList<FeeVariance>(value); } }
+        private Gfe2010 _gfe2010;
+        public Gfe2010 Gfe2010 { get { var v = _gfe2010; return v ?? Interlocked.CompareExchange(ref _gfe2010, (v = new Gfe2010()), null) ?? v; } set { _gfe2010 = value; } }
+        private Gfe2010Page _gfe2010Page;
+        public Gfe2010Page Gfe2010Page { get { var v = _gfe2010Page; return v ?? Interlocked.CompareExchange(ref _gfe2010Page, (v = new Gfe2010Page()), null) ?? v; } set { _gfe2010Page = value; } }
+        private Gfe2010Section _gfe2010Section;
+        public Gfe2010Section Gfe2010Section { get { var v = _gfe2010Section; return v ?? Interlocked.CompareExchange(ref _gfe2010Section, (v = new Gfe2010Section()), null) ?? v; } set { _gfe2010Section = value; } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private Value<decimal?> _impoundHazInsRate;
@@ -81,9 +90,12 @@ namespace EncompassRest.Loans
         public string ImpoundType3 { get { return _impoundType3; } set { _impoundType3 = value; } }
         private Value<string> _impoundType4;
         public string ImpoundType4 { get { return _impoundType4; } set { _impoundType4 = value; } }
-        public LoanEstimate1 LoanEstimate1 { get; set; }
-        public LoanEstimate2 LoanEstimate2 { get; set; }
-        public LoanEstimate3 LoanEstimate3 { get; set; }
+        private LoanEstimate1 _loanEstimate1;
+        public LoanEstimate1 LoanEstimate1 { get { var v = _loanEstimate1; return v ?? Interlocked.CompareExchange(ref _loanEstimate1, (v = new LoanEstimate1()), null) ?? v; } set { _loanEstimate1 = value; } }
+        private LoanEstimate2 _loanEstimate2;
+        public LoanEstimate2 LoanEstimate2 { get { var v = _loanEstimate2; return v ?? Interlocked.CompareExchange(ref _loanEstimate2, (v = new LoanEstimate2()), null) ?? v; } set { _loanEstimate2 = value; } }
+        private LoanEstimate3 _loanEstimate3;
+        public LoanEstimate3 LoanEstimate3 { get { var v = _loanEstimate3; return v ?? Interlocked.CompareExchange(ref _loanEstimate3, (v = new LoanEstimate3()), null) ?? v; } set { _loanEstimate3 = value; } }
         private Value<decimal?> _proposedMonthlyHazardInsurance;
         public decimal? ProposedMonthlyHazardInsurance { get { return _proposedMonthlyHazardInsurance; } set { _proposedMonthlyHazardInsurance = value; } }
         private Value<decimal?> _proposedMonthlyMortgageInsurance;
@@ -157,7 +169,6 @@ namespace EncompassRest.Loans
                     || _escrowTableFee4.Dirty
                     || _escrowTableFee5.Dirty
                     || _escrowTableName.Dirty
-                    || _feeVariances.Dirty
                     || _id.Dirty
                     || _impoundHazInsRate.Dirty
                     || _impoundMortgInsPremRate.Dirty
@@ -189,18 +200,19 @@ namespace EncompassRest.Loans
                     || _totalForSellerPaid4.Dirty
                     || _totalForSellerPaid5.Dirty
                     || _totalForSellerPaid6.Dirty
-                    || ClosingDisclosure1?.Dirty == true
-                    || ClosingDisclosure2?.Dirty == true
-                    || ClosingDisclosure3?.Dirty == true
-                    || ClosingDisclosure4?.Dirty == true
-                    || ClosingDisclosure5?.Dirty == true
-                    || FeeVarianceOther?.Dirty == true
-                    || Gfe2010?.Dirty == true
-                    || Gfe2010Page?.Dirty == true
-                    || Gfe2010Section?.Dirty == true
-                    || LoanEstimate1?.Dirty == true
-                    || LoanEstimate2?.Dirty == true
-                    || LoanEstimate3?.Dirty == true;
+                    || _closingDisclosure1?.Dirty == true
+                    || _closingDisclosure2?.Dirty == true
+                    || _closingDisclosure3?.Dirty == true
+                    || _closingDisclosure4?.Dirty == true
+                    || _closingDisclosure5?.Dirty == true
+                    || _feeVarianceOther?.Dirty == true
+                    || _feeVariances?.Dirty == true
+                    || _gfe2010?.Dirty == true
+                    || _gfe2010Page?.Dirty == true
+                    || _gfe2010Section?.Dirty == true
+                    || _loanEstimate1?.Dirty == true
+                    || _loanEstimate2?.Dirty == true
+                    || _loanEstimate3?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -229,7 +241,6 @@ namespace EncompassRest.Loans
                 _escrowTableFee4.Dirty = value;
                 _escrowTableFee5.Dirty = value;
                 _escrowTableName.Dirty = value;
-                _feeVariances.Dirty = value;
                 _id.Dirty = value;
                 _impoundHazInsRate.Dirty = value;
                 _impoundMortgInsPremRate.Dirty = value;
@@ -261,18 +272,19 @@ namespace EncompassRest.Loans
                 _totalForSellerPaid4.Dirty = value;
                 _totalForSellerPaid5.Dirty = value;
                 _totalForSellerPaid6.Dirty = value;
-                if (ClosingDisclosure1 != null) ClosingDisclosure1.Dirty = value;
-                if (ClosingDisclosure2 != null) ClosingDisclosure2.Dirty = value;
-                if (ClosingDisclosure3 != null) ClosingDisclosure3.Dirty = value;
-                if (ClosingDisclosure4 != null) ClosingDisclosure4.Dirty = value;
-                if (ClosingDisclosure5 != null) ClosingDisclosure5.Dirty = value;
-                if (FeeVarianceOther != null) FeeVarianceOther.Dirty = value;
-                if (Gfe2010 != null) Gfe2010.Dirty = value;
-                if (Gfe2010Page != null) Gfe2010Page.Dirty = value;
-                if (Gfe2010Section != null) Gfe2010Section.Dirty = value;
-                if (LoanEstimate1 != null) LoanEstimate1.Dirty = value;
-                if (LoanEstimate2 != null) LoanEstimate2.Dirty = value;
-                if (LoanEstimate3 != null) LoanEstimate3.Dirty = value;
+                if (_closingDisclosure1 != null) _closingDisclosure1.Dirty = value;
+                if (_closingDisclosure2 != null) _closingDisclosure2.Dirty = value;
+                if (_closingDisclosure3 != null) _closingDisclosure3.Dirty = value;
+                if (_closingDisclosure4 != null) _closingDisclosure4.Dirty = value;
+                if (_closingDisclosure5 != null) _closingDisclosure5.Dirty = value;
+                if (_feeVarianceOther != null) _feeVarianceOther.Dirty = value;
+                if (_feeVariances != null) _feeVariances.Dirty = value;
+                if (_gfe2010 != null) _gfe2010.Dirty = value;
+                if (_gfe2010Page != null) _gfe2010Page.Dirty = value;
+                if (_gfe2010Section != null) _gfe2010Section.Dirty = value;
+                if (_loanEstimate1 != null) _loanEstimate1.Dirty = value;
+                if (_loanEstimate2 != null) _loanEstimate2.Dirty = value;
+                if (_loanEstimate3 != null) _loanEstimate3.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/ClosingCost.cs
+++ b/src/EncompassRest/Loans/ClosingCost.cs
@@ -8,21 +8,21 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingCost : IDirty
     {
-        private Value<decimal?> _adjustmentFactor;
+        private DirtyValue<decimal?> _adjustmentFactor;
         public decimal? AdjustmentFactor { get { return _adjustmentFactor; } set { _adjustmentFactor = value; } }
-        private Value<string> _aggregateAdjustmentFwbc;
+        private DirtyValue<string> _aggregateAdjustmentFwbc;
         public string AggregateAdjustmentFwbc { get { return _aggregateAdjustmentFwbc; } set { _aggregateAdjustmentFwbc = value; } }
-        private Value<decimal?> _borrowerPaidDiscountPointsTotalAmount;
+        private DirtyValue<decimal?> _borrowerPaidDiscountPointsTotalAmount;
         public decimal? BorrowerPaidDiscountPointsTotalAmount { get { return _borrowerPaidDiscountPointsTotalAmount; } set { _borrowerPaidDiscountPointsTotalAmount = value; } }
-        private Value<decimal?> _brokerCommissionBasedPrice;
+        private DirtyValue<decimal?> _brokerCommissionBasedPrice;
         public decimal? BrokerCommissionBasedPrice { get { return _brokerCommissionBasedPrice; } set { _brokerCommissionBasedPrice = value; } }
-        private Value<decimal?> _brokerCommissionBasedUnitPercentage;
+        private DirtyValue<decimal?> _brokerCommissionBasedUnitPercentage;
         public decimal? BrokerCommissionBasedUnitPercentage { get { return _brokerCommissionBasedUnitPercentage; } set { _brokerCommissionBasedUnitPercentage = value; } }
-        private Value<decimal?> _brokerCommissionBasedUnitPrice;
+        private DirtyValue<decimal?> _brokerCommissionBasedUnitPrice;
         public decimal? BrokerCommissionBasedUnitPrice { get { return _brokerCommissionBasedUnitPrice; } set { _brokerCommissionBasedUnitPrice = value; } }
-        private Value<string> _closingCostProgram;
+        private DirtyValue<string> _closingCostProgram;
         public string ClosingCostProgram { get { return _closingCostProgram; } set { _closingCostProgram = value; } }
-        private Value<string> _closingCostScenarioXml;
+        private DirtyValue<string> _closingCostScenarioXml;
         public string ClosingCostScenarioXml { get { return _closingCostScenarioXml; } set { _closingCostScenarioXml = value; } }
         private ClosingDisclosure1 _closingDisclosure1;
         public ClosingDisclosure1 ClosingDisclosure1 { get { var v = _closingDisclosure1; return v ?? Interlocked.CompareExchange(ref _closingDisclosure1, (v = new ClosingDisclosure1()), null) ?? v; } set { _closingDisclosure1 = value; } }
@@ -34,33 +34,33 @@ namespace EncompassRest.Loans
         public ClosingDisclosure4 ClosingDisclosure4 { get { var v = _closingDisclosure4; return v ?? Interlocked.CompareExchange(ref _closingDisclosure4, (v = new ClosingDisclosure4()), null) ?? v; } set { _closingDisclosure4 = value; } }
         private ClosingDisclosure5 _closingDisclosure5;
         public ClosingDisclosure5 ClosingDisclosure5 { get { var v = _closingDisclosure5; return v ?? Interlocked.CompareExchange(ref _closingDisclosure5, (v = new ClosingDisclosure5()), null) ?? v; } set { _closingDisclosure5 = value; } }
-        private Value<decimal?> _disclosedSalesPrice;
+        private DirtyValue<decimal?> _disclosedSalesPrice;
         public decimal? DisclosedSalesPrice { get { return _disclosedSalesPrice; } set { _disclosedSalesPrice = value; } }
-        private Value<string> _escrowCompanyName;
+        private DirtyValue<string> _escrowCompanyName;
         public string EscrowCompanyName { get { return _escrowCompanyName; } set { _escrowCompanyName = value; } }
-        private Value<string> _escrowTableDesc1;
+        private DirtyValue<string> _escrowTableDesc1;
         public string EscrowTableDesc1 { get { return _escrowTableDesc1; } set { _escrowTableDesc1 = value; } }
-        private Value<string> _escrowTableDesc2;
+        private DirtyValue<string> _escrowTableDesc2;
         public string EscrowTableDesc2 { get { return _escrowTableDesc2; } set { _escrowTableDesc2 = value; } }
-        private Value<string> _escrowTableDesc3;
+        private DirtyValue<string> _escrowTableDesc3;
         public string EscrowTableDesc3 { get { return _escrowTableDesc3; } set { _escrowTableDesc3 = value; } }
-        private Value<string> _escrowTableDesc4;
+        private DirtyValue<string> _escrowTableDesc4;
         public string EscrowTableDesc4 { get { return _escrowTableDesc4; } set { _escrowTableDesc4 = value; } }
-        private Value<string> _escrowTableDesc5;
+        private DirtyValue<string> _escrowTableDesc5;
         public string EscrowTableDesc5 { get { return _escrowTableDesc5; } set { _escrowTableDesc5 = value; } }
-        private Value<decimal?> _escrowTableFee;
+        private DirtyValue<decimal?> _escrowTableFee;
         public decimal? EscrowTableFee { get { return _escrowTableFee; } set { _escrowTableFee = value; } }
-        private Value<decimal?> _escrowTableFee1;
+        private DirtyValue<decimal?> _escrowTableFee1;
         public decimal? EscrowTableFee1 { get { return _escrowTableFee1; } set { _escrowTableFee1 = value; } }
-        private Value<decimal?> _escrowTableFee2;
+        private DirtyValue<decimal?> _escrowTableFee2;
         public decimal? EscrowTableFee2 { get { return _escrowTableFee2; } set { _escrowTableFee2 = value; } }
-        private Value<decimal?> _escrowTableFee3;
+        private DirtyValue<decimal?> _escrowTableFee3;
         public decimal? EscrowTableFee3 { get { return _escrowTableFee3; } set { _escrowTableFee3 = value; } }
-        private Value<decimal?> _escrowTableFee4;
+        private DirtyValue<decimal?> _escrowTableFee4;
         public decimal? EscrowTableFee4 { get { return _escrowTableFee4; } set { _escrowTableFee4 = value; } }
-        private Value<decimal?> _escrowTableFee5;
+        private DirtyValue<decimal?> _escrowTableFee5;
         public decimal? EscrowTableFee5 { get { return _escrowTableFee5; } set { _escrowTableFee5 = value; } }
-        private Value<string> _escrowTableName;
+        private DirtyValue<string> _escrowTableName;
         public string EscrowTableName { get { return _escrowTableName; } set { _escrowTableName = value; } }
         private FeeVarianceOther _feeVarianceOther;
         public FeeVarianceOther FeeVarianceOther { get { var v = _feeVarianceOther; return v ?? Interlocked.CompareExchange(ref _feeVarianceOther, (v = new FeeVarianceOther()), null) ?? v; } set { _feeVarianceOther = value; } }
@@ -72,23 +72,23 @@ namespace EncompassRest.Loans
         public Gfe2010Page Gfe2010Page { get { var v = _gfe2010Page; return v ?? Interlocked.CompareExchange(ref _gfe2010Page, (v = new Gfe2010Page()), null) ?? v; } set { _gfe2010Page = value; } }
         private Gfe2010Section _gfe2010Section;
         public Gfe2010Section Gfe2010Section { get { var v = _gfe2010Section; return v ?? Interlocked.CompareExchange(ref _gfe2010Section, (v = new Gfe2010Section()), null) ?? v; } set { _gfe2010Section = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _impoundHazInsRate;
+        private DirtyValue<decimal?> _impoundHazInsRate;
         public decimal? ImpoundHazInsRate { get { return _impoundHazInsRate; } set { _impoundHazInsRate = value; } }
-        private Value<decimal?> _impoundMortgInsPremRate;
+        private DirtyValue<decimal?> _impoundMortgInsPremRate;
         public decimal? ImpoundMortgInsPremRate { get { return _impoundMortgInsPremRate; } set { _impoundMortgInsPremRate = value; } }
-        private Value<string> _impoundMortgInsPremYearlyBasis;
+        private DirtyValue<string> _impoundMortgInsPremYearlyBasis;
         public string ImpoundMortgInsPremYearlyBasis { get { return _impoundMortgInsPremYearlyBasis; } set { _impoundMortgInsPremYearlyBasis = value; } }
-        private Value<decimal?> _impoundTaxesRate;
+        private DirtyValue<decimal?> _impoundTaxesRate;
         public decimal? ImpoundTaxesRate { get { return _impoundTaxesRate; } set { _impoundTaxesRate = value; } }
-        private Value<string> _impoundType1;
+        private DirtyValue<string> _impoundType1;
         public string ImpoundType1 { get { return _impoundType1; } set { _impoundType1 = value; } }
-        private Value<string> _impoundType2;
+        private DirtyValue<string> _impoundType2;
         public string ImpoundType2 { get { return _impoundType2; } set { _impoundType2 = value; } }
-        private Value<string> _impoundType3;
+        private DirtyValue<string> _impoundType3;
         public string ImpoundType3 { get { return _impoundType3; } set { _impoundType3 = value; } }
-        private Value<string> _impoundType4;
+        private DirtyValue<string> _impoundType4;
         public string ImpoundType4 { get { return _impoundType4; } set { _impoundType4 = value; } }
         private LoanEstimate1 _loanEstimate1;
         public LoanEstimate1 LoanEstimate1 { get { var v = _loanEstimate1; return v ?? Interlocked.CompareExchange(ref _loanEstimate1, (v = new LoanEstimate1()), null) ?? v; } set { _loanEstimate1 = value; } }
@@ -96,49 +96,49 @@ namespace EncompassRest.Loans
         public LoanEstimate2 LoanEstimate2 { get { var v = _loanEstimate2; return v ?? Interlocked.CompareExchange(ref _loanEstimate2, (v = new LoanEstimate2()), null) ?? v; } set { _loanEstimate2 = value; } }
         private LoanEstimate3 _loanEstimate3;
         public LoanEstimate3 LoanEstimate3 { get { var v = _loanEstimate3; return v ?? Interlocked.CompareExchange(ref _loanEstimate3, (v = new LoanEstimate3()), null) ?? v; } set { _loanEstimate3 = value; } }
-        private Value<decimal?> _proposedMonthlyHazardInsurance;
+        private DirtyValue<decimal?> _proposedMonthlyHazardInsurance;
         public decimal? ProposedMonthlyHazardInsurance { get { return _proposedMonthlyHazardInsurance; } set { _proposedMonthlyHazardInsurance = value; } }
-        private Value<decimal?> _proposedMonthlyMortgageInsurance;
+        private DirtyValue<decimal?> _proposedMonthlyMortgageInsurance;
         public decimal? ProposedMonthlyMortgageInsurance { get { return _proposedMonthlyMortgageInsurance; } set { _proposedMonthlyMortgageInsurance = value; } }
-        private Value<decimal?> _section1000BorrowerPaidTotalAmount;
+        private DirtyValue<decimal?> _section1000BorrowerPaidTotalAmount;
         public decimal? Section1000BorrowerPaidTotalAmount { get { return _section1000BorrowerPaidTotalAmount; } set { _section1000BorrowerPaidTotalAmount = value; } }
-        private Value<decimal?> _section1000SellerPaidTotalAmount;
+        private DirtyValue<decimal?> _section1000SellerPaidTotalAmount;
         public decimal? Section1000SellerPaidTotalAmount { get { return _section1000SellerPaidTotalAmount; } set { _section1000SellerPaidTotalAmount = value; } }
-        private Value<decimal?> _settlementClosingFeeNewHudBorPaidAmount;
+        private DirtyValue<decimal?> _settlementClosingFeeNewHudBorPaidAmount;
         public decimal? SettlementClosingFeeNewHudBorPaidAmount { get { return _settlementClosingFeeNewHudBorPaidAmount; } set { _settlementClosingFeeNewHudBorPaidAmount = value; } }
-        private Value<decimal?> _settlementClosingFeeNewHudSelPaidAmount;
+        private DirtyValue<decimal?> _settlementClosingFeeNewHudSelPaidAmount;
         public decimal? SettlementClosingFeeNewHudSelPaidAmount { get { return _settlementClosingFeeNewHudSelPaidAmount; } set { _settlementClosingFeeNewHudSelPaidAmount = value; } }
-        private Value<string> _titleCompanyName;
+        private DirtyValue<string> _titleCompanyName;
         public string TitleCompanyName { get { return _titleCompanyName; } set { _titleCompanyName = value; } }
-        private Value<decimal?> _titleExaminationNewHudSelPaidAmount;
+        private DirtyValue<decimal?> _titleExaminationNewHudSelPaidAmount;
         public decimal? TitleExaminationNewHudSelPaidAmount { get { return _titleExaminationNewHudSelPaidAmount; } set { _titleExaminationNewHudSelPaidAmount = value; } }
-        private Value<string> _titleTable2010Name;
+        private DirtyValue<string> _titleTable2010Name;
         public string TitleTable2010Name { get { return _titleTable2010Name; } set { _titleTable2010Name = value; } }
-        private Value<string> _titleTableName;
+        private DirtyValue<string> _titleTableName;
         public string TitleTableName { get { return _titleTableName; } set { _titleTableName = value; } }
-        private Value<decimal?> _totalForBorPaid1;
+        private DirtyValue<decimal?> _totalForBorPaid1;
         public decimal? TotalForBorPaid1 { get { return _totalForBorPaid1; } set { _totalForBorPaid1 = value; } }
-        private Value<decimal?> _totalForBorPaid2;
+        private DirtyValue<decimal?> _totalForBorPaid2;
         public decimal? TotalForBorPaid2 { get { return _totalForBorPaid2; } set { _totalForBorPaid2 = value; } }
-        private Value<decimal?> _totalForBorPaid3;
+        private DirtyValue<decimal?> _totalForBorPaid3;
         public decimal? TotalForBorPaid3 { get { return _totalForBorPaid3; } set { _totalForBorPaid3 = value; } }
-        private Value<decimal?> _totalForBorPaid4;
+        private DirtyValue<decimal?> _totalForBorPaid4;
         public decimal? TotalForBorPaid4 { get { return _totalForBorPaid4; } set { _totalForBorPaid4 = value; } }
-        private Value<decimal?> _totalForBorPaid5;
+        private DirtyValue<decimal?> _totalForBorPaid5;
         public decimal? TotalForBorPaid5 { get { return _totalForBorPaid5; } set { _totalForBorPaid5 = value; } }
-        private Value<decimal?> _totalForBorPaid6;
+        private DirtyValue<decimal?> _totalForBorPaid6;
         public decimal? TotalForBorPaid6 { get { return _totalForBorPaid6; } set { _totalForBorPaid6 = value; } }
-        private Value<decimal?> _totalForSellerPaid1;
+        private DirtyValue<decimal?> _totalForSellerPaid1;
         public decimal? TotalForSellerPaid1 { get { return _totalForSellerPaid1; } set { _totalForSellerPaid1 = value; } }
-        private Value<decimal?> _totalForSellerPaid2;
+        private DirtyValue<decimal?> _totalForSellerPaid2;
         public decimal? TotalForSellerPaid2 { get { return _totalForSellerPaid2; } set { _totalForSellerPaid2 = value; } }
-        private Value<decimal?> _totalForSellerPaid3;
+        private DirtyValue<decimal?> _totalForSellerPaid3;
         public decimal? TotalForSellerPaid3 { get { return _totalForSellerPaid3; } set { _totalForSellerPaid3 = value; } }
-        private Value<decimal?> _totalForSellerPaid4;
+        private DirtyValue<decimal?> _totalForSellerPaid4;
         public decimal? TotalForSellerPaid4 { get { return _totalForSellerPaid4; } set { _totalForSellerPaid4 = value; } }
-        private Value<decimal?> _totalForSellerPaid5;
+        private DirtyValue<decimal?> _totalForSellerPaid5;
         public decimal? TotalForSellerPaid5 { get { return _totalForSellerPaid5; } set { _totalForSellerPaid5 = value; } }
-        private Value<decimal?> _totalForSellerPaid6;
+        private DirtyValue<decimal?> _totalForSellerPaid6;
         public decimal? TotalForSellerPaid6 { get { return _totalForSellerPaid6; } set { _totalForSellerPaid6 = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingDisclosure1.cs
+++ b/src/EncompassRest/Loans/ClosingDisclosure1.cs
@@ -8,217 +8,217 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingDisclosure1 : IDirty
     {
-        private Value<DateTime?> _cDDateIssued;
+        private DirtyValue<DateTime?> _cDDateIssued;
         public DateTime? CDDateIssued { get { return _cDDateIssued; } set { _cDDateIssued = value; } }
-        private Value<string> _changedCircumstance;
+        private DirtyValue<string> _changedCircumstance;
         public string ChangedCircumstance { get { return _changedCircumstance; } set { _changedCircumstance = value; } }
-        private Value<bool?> _changedCircumstanceFlag;
+        private DirtyValue<bool?> _changedCircumstanceFlag;
         public bool? ChangedCircumstanceFlag { get { return _changedCircumstanceFlag; } set { _changedCircumstanceFlag = value; } }
-        private Value<DateTime?> _changesReceivedDate;
+        private DirtyValue<DateTime?> _changesReceivedDate;
         public DateTime? ChangesReceivedDate { get { return _changesReceivedDate; } set { _changesReceivedDate = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _disclosureBy;
+        private DirtyValue<string> _disclosureBy;
         public string DisclosureBy { get { return _disclosureBy; } set { _disclosureBy = value; } }
-        private Value<string> _disclosureComments;
+        private DirtyValue<string> _disclosureComments;
         public string DisclosureComments { get { return _disclosureComments; } set { _disclosureComments = value; } }
-        private Value<DateTime?> _disclosureLastSentDate;
+        private DirtyValue<DateTime?> _disclosureLastSentDate;
         public DateTime? DisclosureLastSentDate { get { return _disclosureLastSentDate; } set { _disclosureLastSentDate = value; } }
-        private Value<DateTime?> _disclosureReceivedDate;
+        private DirtyValue<DateTime?> _disclosureReceivedDate;
         public DateTime? DisclosureReceivedDate { get { return _disclosureReceivedDate; } set { _disclosureReceivedDate = value; } }
-        private Value<string> _disclosureSentMethod;
+        private DirtyValue<string> _disclosureSentMethod;
         public string DisclosureSentMethod { get { return _disclosureSentMethod; } set { _disclosureSentMethod = value; } }
-        private Value<string> _documentGUIDFinalExecutedCopyofAlternateCD;
+        private DirtyValue<string> _documentGUIDFinalExecutedCopyofAlternateCD;
         public string DocumentGUIDFinalExecutedCopyofAlternateCD { get { return _documentGUIDFinalExecutedCopyofAlternateCD; } set { _documentGUIDFinalExecutedCopyofAlternateCD = value; } }
-        private Value<string> _documentGUIDFinalExecutedCopyofSellerCD;
+        private DirtyValue<string> _documentGUIDFinalExecutedCopyofSellerCD;
         public string DocumentGUIDFinalExecutedCopyofSellerCD { get { return _documentGUIDFinalExecutedCopyofSellerCD; } set { _documentGUIDFinalExecutedCopyofSellerCD = value; } }
-        private Value<string> _documentGUIDFinalExecutedCopyofStandardCD;
+        private DirtyValue<string> _documentGUIDFinalExecutedCopyofStandardCD;
         public string DocumentGUIDFinalExecutedCopyofStandardCD { get { return _documentGUIDFinalExecutedCopyofStandardCD; } set { _documentGUIDFinalExecutedCopyofStandardCD = value; } }
-        private Value<decimal?> _estimatedTaxesInsuranceAssessments;
+        private DirtyValue<decimal?> _estimatedTaxesInsuranceAssessments;
         public decimal? EstimatedTaxesInsuranceAssessments { get { return _estimatedTaxesInsuranceAssessments; } set { _estimatedTaxesInsuranceAssessments = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _inEscrowHomeownerInsurance;
+        private DirtyValue<string> _inEscrowHomeownerInsurance;
         public string InEscrowHomeownerInsurance { get { return _inEscrowHomeownerInsurance; } set { _inEscrowHomeownerInsurance = value; } }
-        private Value<string> _inEscrowOther;
+        private DirtyValue<string> _inEscrowOther;
         public string InEscrowOther { get { return _inEscrowOther; } set { _inEscrowOther = value; } }
-        private Value<string> _inEscrowPropertyTaxes;
+        private DirtyValue<string> _inEscrowPropertyTaxes;
         public string InEscrowPropertyTaxes { get { return _inEscrowPropertyTaxes; } set { _inEscrowPropertyTaxes = value; } }
-        private Value<DateTime?> _initialCDReceivedDate;
+        private DirtyValue<DateTime?> _initialCDReceivedDate;
         public DateTime? InitialCDReceivedDate { get { return _initialCDReceivedDate; } set { _initialCDReceivedDate = value; } }
-        private Value<string> _mICReference;
+        private DirtyValue<string> _mICReference;
         public string MICReference { get { return _mICReference; } set { _mICReference = value; } }
-        private Value<bool?> _notNaturalPersonFlag;
+        private DirtyValue<bool?> _notNaturalPersonFlag;
         public bool? NotNaturalPersonFlag { get { return _notNaturalPersonFlag; } set { _notNaturalPersonFlag = value; } }
-        private Value<decimal?> _pPC1EstimatedEscrowAmount;
+        private DirtyValue<decimal?> _pPC1EstimatedEscrowAmount;
         public decimal? PPC1EstimatedEscrowAmount { get { return _pPC1EstimatedEscrowAmount; } set { _pPC1EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC1EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC1EstimatedEscrowAmountUI;
         public string PPC1EstimatedEscrowAmountUI { get { return _pPC1EstimatedEscrowAmountUI; } set { _pPC1EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC1InterestOnly;
+        private DirtyValue<bool?> _pPC1InterestOnly;
         public bool? PPC1InterestOnly { get { return _pPC1InterestOnly; } set { _pPC1InterestOnly = value; } }
-        private Value<decimal?> _pPC1MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC1MaximumMonthlyPayment;
         public decimal? PPC1MaximumMonthlyPayment { get { return _pPC1MaximumMonthlyPayment; } set { _pPC1MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC1MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC1MaximumMonthlyPaymentUI;
         public string PPC1MaximumMonthlyPaymentUI { get { return _pPC1MaximumMonthlyPaymentUI; } set { _pPC1MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC1MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC1MaximumPIPayment;
         public decimal? PPC1MaximumPIPayment { get { return _pPC1MaximumPIPayment; } set { _pPC1MaximumPIPayment = value; } }
-        private Value<string> _pPC1MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC1MaximumPIPaymentUI;
         public string PPC1MaximumPIPaymentUI { get { return _pPC1MaximumPIPaymentUI; } set { _pPC1MaximumPIPaymentUI = value; } }
-        private Value<decimal?> _pPC1MIAmount;
+        private DirtyValue<decimal?> _pPC1MIAmount;
         public decimal? PPC1MIAmount { get { return _pPC1MIAmount; } set { _pPC1MIAmount = value; } }
-        private Value<string> _pPC1MIAmountUI;
+        private DirtyValue<string> _pPC1MIAmountUI;
         public string PPC1MIAmountUI { get { return _pPC1MIAmountUI; } set { _pPC1MIAmountUI = value; } }
-        private Value<decimal?> _pPC1MinimumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC1MinimumMonthlyPayment;
         public decimal? PPC1MinimumMonthlyPayment { get { return _pPC1MinimumMonthlyPayment; } set { _pPC1MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC1MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC1MinimumMonthlyPaymentUI;
         public string PPC1MinimumMonthlyPaymentUI { get { return _pPC1MinimumMonthlyPaymentUI; } set { _pPC1MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC1MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC1MinimumPIPayment;
         public decimal? PPC1MinimumPIPayment { get { return _pPC1MinimumPIPayment; } set { _pPC1MinimumPIPayment = value; } }
-        private Value<string> _pPC1MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC1MinimumPIPaymentUI;
         public string PPC1MinimumPIPaymentUI { get { return _pPC1MinimumPIPaymentUI; } set { _pPC1MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC1Year;
+        private DirtyValue<int?> _pPC1Year;
         public int? PPC1Year { get { return _pPC1Year; } set { _pPC1Year = value; } }
-        private Value<decimal?> _pPC2EstimatedEscrowAmount;
+        private DirtyValue<decimal?> _pPC2EstimatedEscrowAmount;
         public decimal? PPC2EstimatedEscrowAmount { get { return _pPC2EstimatedEscrowAmount; } set { _pPC2EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC2EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC2EstimatedEscrowAmountUI;
         public string PPC2EstimatedEscrowAmountUI { get { return _pPC2EstimatedEscrowAmountUI; } set { _pPC2EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC2InterestOnly;
+        private DirtyValue<bool?> _pPC2InterestOnly;
         public bool? PPC2InterestOnly { get { return _pPC2InterestOnly; } set { _pPC2InterestOnly = value; } }
-        private Value<decimal?> _pPC2MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC2MaximumMonthlyPayment;
         public decimal? PPC2MaximumMonthlyPayment { get { return _pPC2MaximumMonthlyPayment; } set { _pPC2MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC2MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC2MaximumMonthlyPaymentUI;
         public string PPC2MaximumMonthlyPaymentUI { get { return _pPC2MaximumMonthlyPaymentUI; } set { _pPC2MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC2MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC2MaximumPIPayment;
         public decimal? PPC2MaximumPIPayment { get { return _pPC2MaximumPIPayment; } set { _pPC2MaximumPIPayment = value; } }
-        private Value<string> _pPC2MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC2MaximumPIPaymentUI;
         public string PPC2MaximumPIPaymentUI { get { return _pPC2MaximumPIPaymentUI; } set { _pPC2MaximumPIPaymentUI = value; } }
-        private Value<decimal?> _pPC2MIAmount;
+        private DirtyValue<decimal?> _pPC2MIAmount;
         public decimal? PPC2MIAmount { get { return _pPC2MIAmount; } set { _pPC2MIAmount = value; } }
-        private Value<string> _pPC2MIAmountUI;
+        private DirtyValue<string> _pPC2MIAmountUI;
         public string PPC2MIAmountUI { get { return _pPC2MIAmountUI; } set { _pPC2MIAmountUI = value; } }
-        private Value<decimal?> _pPC2MinimumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC2MinimumMonthlyPayment;
         public decimal? PPC2MinimumMonthlyPayment { get { return _pPC2MinimumMonthlyPayment; } set { _pPC2MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC2MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC2MinimumMonthlyPaymentUI;
         public string PPC2MinimumMonthlyPaymentUI { get { return _pPC2MinimumMonthlyPaymentUI; } set { _pPC2MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC2MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC2MinimumPIPayment;
         public decimal? PPC2MinimumPIPayment { get { return _pPC2MinimumPIPayment; } set { _pPC2MinimumPIPayment = value; } }
-        private Value<string> _pPC2MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC2MinimumPIPaymentUI;
         public string PPC2MinimumPIPaymentUI { get { return _pPC2MinimumPIPaymentUI; } set { _pPC2MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC2YearFrom;
+        private DirtyValue<int?> _pPC2YearFrom;
         public int? PPC2YearFrom { get { return _pPC2YearFrom; } set { _pPC2YearFrom = value; } }
-        private Value<int?> _pPC2YearTo;
+        private DirtyValue<int?> _pPC2YearTo;
         public int? PPC2YearTo { get { return _pPC2YearTo; } set { _pPC2YearTo = value; } }
-        private Value<decimal?> _pPC3EstimatedEscrowAmount;
+        private DirtyValue<decimal?> _pPC3EstimatedEscrowAmount;
         public decimal? PPC3EstimatedEscrowAmount { get { return _pPC3EstimatedEscrowAmount; } set { _pPC3EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC3EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC3EstimatedEscrowAmountUI;
         public string PPC3EstimatedEscrowAmountUI { get { return _pPC3EstimatedEscrowAmountUI; } set { _pPC3EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC3InterestOnly;
+        private DirtyValue<bool?> _pPC3InterestOnly;
         public bool? PPC3InterestOnly { get { return _pPC3InterestOnly; } set { _pPC3InterestOnly = value; } }
-        private Value<decimal?> _pPC3MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC3MaximumMonthlyPayment;
         public decimal? PPC3MaximumMonthlyPayment { get { return _pPC3MaximumMonthlyPayment; } set { _pPC3MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC3MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC3MaximumMonthlyPaymentUI;
         public string PPC3MaximumMonthlyPaymentUI { get { return _pPC3MaximumMonthlyPaymentUI; } set { _pPC3MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC3MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC3MaximumPIPayment;
         public decimal? PPC3MaximumPIPayment { get { return _pPC3MaximumPIPayment; } set { _pPC3MaximumPIPayment = value; } }
-        private Value<string> _pPC3MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC3MaximumPIPaymentUI;
         public string PPC3MaximumPIPaymentUI { get { return _pPC3MaximumPIPaymentUI; } set { _pPC3MaximumPIPaymentUI = value; } }
-        private Value<decimal?> _pPC3MIAmount;
+        private DirtyValue<decimal?> _pPC3MIAmount;
         public decimal? PPC3MIAmount { get { return _pPC3MIAmount; } set { _pPC3MIAmount = value; } }
-        private Value<string> _pPC3MIAmountUI;
+        private DirtyValue<string> _pPC3MIAmountUI;
         public string PPC3MIAmountUI { get { return _pPC3MIAmountUI; } set { _pPC3MIAmountUI = value; } }
-        private Value<decimal?> _pPC3MinimumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC3MinimumMonthlyPayment;
         public decimal? PPC3MinimumMonthlyPayment { get { return _pPC3MinimumMonthlyPayment; } set { _pPC3MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC3MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC3MinimumMonthlyPaymentUI;
         public string PPC3MinimumMonthlyPaymentUI { get { return _pPC3MinimumMonthlyPaymentUI; } set { _pPC3MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC3MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC3MinimumPIPayment;
         public decimal? PPC3MinimumPIPayment { get { return _pPC3MinimumPIPayment; } set { _pPC3MinimumPIPayment = value; } }
-        private Value<string> _pPC3MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC3MinimumPIPaymentUI;
         public string PPC3MinimumPIPaymentUI { get { return _pPC3MinimumPIPaymentUI; } set { _pPC3MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC3YearFrom;
+        private DirtyValue<int?> _pPC3YearFrom;
         public int? PPC3YearFrom { get { return _pPC3YearFrom; } set { _pPC3YearFrom = value; } }
-        private Value<int?> _pPC3YearTo;
+        private DirtyValue<int?> _pPC3YearTo;
         public int? PPC3YearTo { get { return _pPC3YearTo; } set { _pPC3YearTo = value; } }
-        private Value<decimal?> _pPC4EstimatedEscrowAmount;
+        private DirtyValue<decimal?> _pPC4EstimatedEscrowAmount;
         public decimal? PPC4EstimatedEscrowAmount { get { return _pPC4EstimatedEscrowAmount; } set { _pPC4EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC4EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC4EstimatedEscrowAmountUI;
         public string PPC4EstimatedEscrowAmountUI { get { return _pPC4EstimatedEscrowAmountUI; } set { _pPC4EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC4InterestOnly;
+        private DirtyValue<bool?> _pPC4InterestOnly;
         public bool? PPC4InterestOnly { get { return _pPC4InterestOnly; } set { _pPC4InterestOnly = value; } }
-        private Value<decimal?> _pPC4MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC4MaximumMonthlyPayment;
         public decimal? PPC4MaximumMonthlyPayment { get { return _pPC4MaximumMonthlyPayment; } set { _pPC4MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC4MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC4MaximumMonthlyPaymentUI;
         public string PPC4MaximumMonthlyPaymentUI { get { return _pPC4MaximumMonthlyPaymentUI; } set { _pPC4MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC4MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC4MaximumPIPayment;
         public decimal? PPC4MaximumPIPayment { get { return _pPC4MaximumPIPayment; } set { _pPC4MaximumPIPayment = value; } }
-        private Value<string> _pPC4MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC4MaximumPIPaymentUI;
         public string PPC4MaximumPIPaymentUI { get { return _pPC4MaximumPIPaymentUI; } set { _pPC4MaximumPIPaymentUI = value; } }
-        private Value<decimal?> _pPC4MIAmount;
+        private DirtyValue<decimal?> _pPC4MIAmount;
         public decimal? PPC4MIAmount { get { return _pPC4MIAmount; } set { _pPC4MIAmount = value; } }
-        private Value<string> _pPC4MIAmountUI;
+        private DirtyValue<string> _pPC4MIAmountUI;
         public string PPC4MIAmountUI { get { return _pPC4MIAmountUI; } set { _pPC4MIAmountUI = value; } }
-        private Value<decimal?> _pPC4MinimumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC4MinimumMonthlyPayment;
         public decimal? PPC4MinimumMonthlyPayment { get { return _pPC4MinimumMonthlyPayment; } set { _pPC4MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC4MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC4MinimumMonthlyPaymentUI;
         public string PPC4MinimumMonthlyPaymentUI { get { return _pPC4MinimumMonthlyPaymentUI; } set { _pPC4MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC4MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC4MinimumPIPayment;
         public decimal? PPC4MinimumPIPayment { get { return _pPC4MinimumPIPayment; } set { _pPC4MinimumPIPayment = value; } }
-        private Value<string> _pPC4MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC4MinimumPIPaymentUI;
         public string PPC4MinimumPIPaymentUI { get { return _pPC4MinimumPIPaymentUI; } set { _pPC4MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC4YearFrom;
+        private DirtyValue<int?> _pPC4YearFrom;
         public int? PPC4YearFrom { get { return _pPC4YearFrom; } set { _pPC4YearFrom = value; } }
-        private Value<int?> _pPC4YearTo;
+        private DirtyValue<int?> _pPC4YearTo;
         public int? PPC4YearTo { get { return _pPC4YearTo; } set { _pPC4YearTo = value; } }
-        private Value<bool?> _pPCEstimatedEscrowIndicator;
+        private DirtyValue<bool?> _pPCEstimatedEscrowIndicator;
         public bool? PPCEstimatedEscrowIndicator { get { return _pPCEstimatedEscrowIndicator; } set { _pPCEstimatedEscrowIndicator = value; } }
-        private Value<bool?> _pPCMortgageInsuranceIndicator;
+        private DirtyValue<bool?> _pPCMortgageInsuranceIndicator;
         public bool? PPCMortgageInsuranceIndicator { get { return _pPCMortgageInsuranceIndicator; } set { _pPCMortgageInsuranceIndicator = value; } }
-        private Value<bool?> _rangePaymentIndicatorC1;
+        private DirtyValue<bool?> _rangePaymentIndicatorC1;
         public bool? RangePaymentIndicatorC1 { get { return _rangePaymentIndicatorC1; } set { _rangePaymentIndicatorC1 = value; } }
-        private Value<bool?> _rangePaymentIndicatorC2;
+        private DirtyValue<bool?> _rangePaymentIndicatorC2;
         public bool? RangePaymentIndicatorC2 { get { return _rangePaymentIndicatorC2; } set { _rangePaymentIndicatorC2 = value; } }
-        private Value<bool?> _rangePaymentIndicatorC3;
+        private DirtyValue<bool?> _rangePaymentIndicatorC3;
         public bool? RangePaymentIndicatorC3 { get { return _rangePaymentIndicatorC3; } set { _rangePaymentIndicatorC3 = value; } }
-        private Value<bool?> _rangePaymentIndicatorC4;
+        private DirtyValue<bool?> _rangePaymentIndicatorC4;
         public bool? RangePaymentIndicatorC4 { get { return _rangePaymentIndicatorC4; } set { _rangePaymentIndicatorC4 = value; } }
-        private Value<bool?> _reasonAdvancedReview;
+        private DirtyValue<bool?> _reasonAdvancedReview;
         public bool? ReasonAdvancedReview { get { return _reasonAdvancedReview; } set { _reasonAdvancedReview = value; } }
-        private Value<bool?> _reasonChangedCircumstanceElg;
+        private DirtyValue<bool?> _reasonChangedCircumstanceElg;
         public bool? ReasonChangedCircumstanceElg { get { return _reasonChangedCircumstanceElg; } set { _reasonChangedCircumstanceElg = value; } }
-        private Value<string> _reasonChangedCircumstanceFlags;
+        private DirtyValue<string> _reasonChangedCircumstanceFlags;
         public string ReasonChangedCircumstanceFlags { get { return _reasonChangedCircumstanceFlags; } set { _reasonChangedCircumstanceFlags = value; } }
-        private Value<bool?> _reasonChangeInAPR;
+        private DirtyValue<bool?> _reasonChangeInAPR;
         public bool? ReasonChangeInAPR { get { return _reasonChangeInAPR; } set { _reasonChangeInAPR = value; } }
-        private Value<bool?> _reasonChangeInLoanProduct;
+        private DirtyValue<bool?> _reasonChangeInLoanProduct;
         public bool? ReasonChangeInLoanProduct { get { return _reasonChangeInLoanProduct; } set { _reasonChangeInLoanProduct = value; } }
-        private Value<bool?> _reasonChangeSettlementCharges;
+        private DirtyValue<bool?> _reasonChangeSettlementCharges;
         public bool? ReasonChangeSettlementCharges { get { return _reasonChangeSettlementCharges; } set { _reasonChangeSettlementCharges = value; } }
-        private Value<bool?> _reasonClericalErrorCorrection;
+        private DirtyValue<bool?> _reasonClericalErrorCorrection;
         public bool? ReasonClericalErrorCorrection { get { return _reasonClericalErrorCorrection; } set { _reasonClericalErrorCorrection = value; } }
-        private Value<bool?> _reasonInterestRatecharges;
+        private DirtyValue<bool?> _reasonInterestRatecharges;
         public bool? ReasonInterestRatecharges { get { return _reasonInterestRatecharges; } set { _reasonInterestRatecharges = value; } }
-        private Value<bool?> _reasonOther;
+        private DirtyValue<bool?> _reasonOther;
         public bool? ReasonOther { get { return _reasonOther; } set { _reasonOther = value; } }
-        private Value<string> _reasonOtherDescription;
+        private DirtyValue<string> _reasonOtherDescription;
         public string ReasonOtherDescription { get { return _reasonOtherDescription; } set { _reasonOtherDescription = value; } }
-        private Value<bool?> _reasonPrepaymentPenalty;
+        private DirtyValue<bool?> _reasonPrepaymentPenalty;
         public bool? ReasonPrepaymentPenalty { get { return _reasonPrepaymentPenalty; } set { _reasonPrepaymentPenalty = value; } }
-        private Value<bool?> _reasonRevisionsReqConsumer;
+        private DirtyValue<bool?> _reasonRevisionsReqConsumer;
         public bool? ReasonRevisionsReqConsumer { get { return _reasonRevisionsReqConsumer; } set { _reasonRevisionsReqConsumer = value; } }
-        private Value<bool?> _reasonToleranceCure;
+        private DirtyValue<bool?> _reasonToleranceCure;
         public bool? ReasonToleranceCure { get { return _reasonToleranceCure; } set { _reasonToleranceCure = value; } }
-        private Value<DateTime?> _revisedCDDueDate;
+        private DirtyValue<DateTime?> _revisedCDDueDate;
         public DateTime? RevisedCDDueDate { get { return _revisedCDDueDate; } set { _revisedCDDueDate = value; } }
-        private Value<DateTime?> _revisedCDReceivedDate;
+        private DirtyValue<DateTime?> _revisedCDReceivedDate;
         public DateTime? RevisedCDReceivedDate { get { return _revisedCDReceivedDate; } set { _revisedCDReceivedDate = value; } }
-        private Value<string> _sellerNames;
+        private DirtyValue<string> _sellerNames;
         public string SellerNames { get { return _sellerNames; } set { _sellerNames = value; } }
-        private Value<string> _signatureTypeFinalExecutedCopyofAlternateCD;
+        private DirtyValue<string> _signatureTypeFinalExecutedCopyofAlternateCD;
         public string SignatureTypeFinalExecutedCopyofAlternateCD { get { return _signatureTypeFinalExecutedCopyofAlternateCD; } set { _signatureTypeFinalExecutedCopyofAlternateCD = value; } }
-        private Value<string> _signatureTypeFinalExecutedCopyofSellerCD;
+        private DirtyValue<string> _signatureTypeFinalExecutedCopyofSellerCD;
         public string SignatureTypeFinalExecutedCopyofSellerCD { get { return _signatureTypeFinalExecutedCopyofSellerCD; } set { _signatureTypeFinalExecutedCopyofSellerCD = value; } }
-        private Value<string> _signatureTypeFinalExecutedCopyofStandardCD;
+        private DirtyValue<string> _signatureTypeFinalExecutedCopyofStandardCD;
         public string SignatureTypeFinalExecutedCopyofStandardCD { get { return _signatureTypeFinalExecutedCopyofStandardCD; } set { _signatureTypeFinalExecutedCopyofStandardCD = value; } }
-        private Value<decimal?> _totalCashToClose;
+        private DirtyValue<decimal?> _totalCashToClose;
         public decimal? TotalCashToClose { get { return _totalCashToClose; } set { _totalCashToClose = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingDisclosure2.cs
+++ b/src/EncompassRest/Loans/ClosingDisclosure2.cs
@@ -8,55 +8,55 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingDisclosure2 : IDirty
     {
-        private Value<decimal?> _borrowerClosingCostAtClosing;
+        private DirtyValue<decimal?> _borrowerClosingCostAtClosing;
         public decimal? BorrowerClosingCostAtClosing { get { return _borrowerClosingCostAtClosing; } set { _borrowerClosingCostAtClosing = value; } }
-        private Value<decimal?> _borrowerClosingCostBeforeClosing;
+        private DirtyValue<decimal?> _borrowerClosingCostBeforeClosing;
         public decimal? BorrowerClosingCostBeforeClosing { get { return _borrowerClosingCostBeforeClosing; } set { _borrowerClosingCostBeforeClosing = value; } }
-        private Value<decimal?> _closingCostLenderCredits;
+        private DirtyValue<decimal?> _closingCostLenderCredits;
         public decimal? ClosingCostLenderCredits { get { return _closingCostLenderCredits; } set { _closingCostLenderCredits = value; } }
-        private Value<decimal?> _closingCostPaidByOthers;
+        private DirtyValue<decimal?> _closingCostPaidByOthers;
         public decimal? ClosingCostPaidByOthers { get { return _closingCostPaidByOthers; } set { _closingCostPaidByOthers = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _initialEscrowSubTotal;
+        private DirtyValue<decimal?> _initialEscrowSubTotal;
         public decimal? InitialEscrowSubTotal { get { return _initialEscrowSubTotal; } set { _initialEscrowSubTotal = value; } }
-        private Value<decimal?> _lastDisclosedLenderCredits;
+        private DirtyValue<decimal?> _lastDisclosedLenderCredits;
         public decimal? LastDisclosedLenderCredits { get { return _lastDisclosedLenderCredits; } set { _lastDisclosedLenderCredits = value; } }
-        private Value<decimal?> _lastDisclosedLoanCosts;
+        private DirtyValue<decimal?> _lastDisclosedLoanCosts;
         public decimal? LastDisclosedLoanCosts { get { return _lastDisclosedLoanCosts; } set { _lastDisclosedLoanCosts = value; } }
-        private Value<decimal?> _lastDisclosedOtherCosts;
+        private DirtyValue<decimal?> _lastDisclosedOtherCosts;
         public decimal? LastDisclosedOtherCosts { get { return _lastDisclosedOtherCosts; } set { _lastDisclosedOtherCosts = value; } }
-        private Value<decimal?> _lCAtClosing;
+        private DirtyValue<decimal?> _lCAtClosing;
         public decimal? LCAtClosing { get { return _lCAtClosing; } set { _lCAtClosing = value; } }
-        private Value<decimal?> _originationChargesSubTotal;
+        private DirtyValue<decimal?> _originationChargesSubTotal;
         public decimal? OriginationChargesSubTotal { get { return _originationChargesSubTotal; } set { _originationChargesSubTotal = value; } }
-        private Value<decimal?> _otherSubTotal;
+        private DirtyValue<decimal?> _otherSubTotal;
         public decimal? OtherSubTotal { get { return _otherSubTotal; } set { _otherSubTotal = value; } }
-        private Value<decimal?> _prepaidsSubTotal;
+        private DirtyValue<decimal?> _prepaidsSubTotal;
         public decimal? PrepaidsSubTotal { get { return _prepaidsSubTotal; } set { _prepaidsSubTotal = value; } }
-        private Value<decimal?> _sellerClosingCostAtClosing;
+        private DirtyValue<decimal?> _sellerClosingCostAtClosing;
         public decimal? SellerClosingCostAtClosing { get { return _sellerClosingCostAtClosing; } set { _sellerClosingCostAtClosing = value; } }
-        private Value<decimal?> _sellerClosingCostBeforeClosing;
+        private DirtyValue<decimal?> _sellerClosingCostBeforeClosing;
         public decimal? SellerClosingCostBeforeClosing { get { return _sellerClosingCostBeforeClosing; } set { _sellerClosingCostBeforeClosing = value; } }
-        private Value<decimal?> _servicesDidNotShopSubTotal;
+        private DirtyValue<decimal?> _servicesDidNotShopSubTotal;
         public decimal? ServicesDidNotShopSubTotal { get { return _servicesDidNotShopSubTotal; } set { _servicesDidNotShopSubTotal = value; } }
-        private Value<decimal?> _servicesDidShopSubTotal;
+        private DirtyValue<decimal?> _servicesDidShopSubTotal;
         public decimal? ServicesDidShopSubTotal { get { return _servicesDidShopSubTotal; } set { _servicesDidShopSubTotal = value; } }
-        private Value<decimal?> _taxesGovermentFeesSubTotal;
+        private DirtyValue<decimal?> _taxesGovermentFeesSubTotal;
         public decimal? TaxesGovermentFeesSubTotal { get { return _taxesGovermentFeesSubTotal; } set { _taxesGovermentFeesSubTotal = value; } }
-        private Value<decimal?> _totalBorrowerPaidAtClosing;
+        private DirtyValue<decimal?> _totalBorrowerPaidAtClosing;
         public decimal? TotalBorrowerPaidAtClosing { get { return _totalBorrowerPaidAtClosing; } set { _totalBorrowerPaidAtClosing = value; } }
-        private Value<decimal?> _totalBorrowerPaidBeforeClosing;
+        private DirtyValue<decimal?> _totalBorrowerPaidBeforeClosing;
         public decimal? TotalBorrowerPaidBeforeClosing { get { return _totalBorrowerPaidBeforeClosing; } set { _totalBorrowerPaidBeforeClosing = value; } }
-        private Value<decimal?> _totalClosingCost;
+        private DirtyValue<decimal?> _totalClosingCost;
         public decimal? TotalClosingCost { get { return _totalClosingCost; } set { _totalClosingCost = value; } }
-        private Value<decimal?> _totalLoanCost;
+        private DirtyValue<decimal?> _totalLoanCost;
         public decimal? TotalLoanCost { get { return _totalLoanCost; } set { _totalLoanCost = value; } }
-        private Value<decimal?> _totalOtherCost;
+        private DirtyValue<decimal?> _totalOtherCost;
         public decimal? TotalOtherCost { get { return _totalOtherCost; } set { _totalOtherCost = value; } }
-        private Value<decimal?> _totalOtherCostAtClosing;
+        private DirtyValue<decimal?> _totalOtherCostAtClosing;
         public decimal? TotalOtherCostAtClosing { get { return _totalOtherCostAtClosing; } set { _totalOtherCostAtClosing = value; } }
-        private Value<decimal?> _totalOtherCostBeforeClosing;
+        private DirtyValue<decimal?> _totalOtherCostBeforeClosing;
         public decimal? TotalOtherCostBeforeClosing { get { return _totalOtherCostBeforeClosing; } set { _totalOtherCostBeforeClosing = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingDisclosure3.cs
+++ b/src/EncompassRest/Loans/ClosingDisclosure3.cs
@@ -8,317 +8,317 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingDisclosure3 : IDirty
     {
-        private Value<decimal?> _actualLECD3TotalClosingCostJFromLatestRec;
+        private DirtyValue<decimal?> _actualLECD3TotalClosingCostJFromLatestRec;
         public decimal? ActualLECD3TotalClosingCostJFromLatestRec { get { return _actualLECD3TotalClosingCostJFromLatestRec; } set { _actualLECD3TotalClosingCostJFromLatestRec = value; } }
-        private Value<decimal?> _actualLECD3TotalPayoffsAndPaymentsKFromLatestRec;
+        private DirtyValue<decimal?> _actualLECD3TotalPayoffsAndPaymentsKFromLatestRec;
         public decimal? ActualLECD3TotalPayoffsAndPaymentsKFromLatestRec { get { return _actualLECD3TotalPayoffsAndPaymentsKFromLatestRec; } set { _actualLECD3TotalPayoffsAndPaymentsKFromLatestRec = value; } }
-        private Value<decimal?> _actualLELoanAmountFromLatestRec;
+        private DirtyValue<decimal?> _actualLELoanAmountFromLatestRec;
         public decimal? ActualLELoanAmountFromLatestRec { get { return _actualLELoanAmountFromLatestRec; } set { _actualLELoanAmountFromLatestRec = value; } }
-        private Value<decimal?> _actualLenderCredits;
+        private DirtyValue<decimal?> _actualLenderCredits;
         public decimal? ActualLenderCredits { get { return _actualLenderCredits; } set { _actualLenderCredits = value; } }
-        private Value<decimal?> _actualSTDLEAdjustmentAndOtherCreditsFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLEAdjustmentAndOtherCreditsFromLatestRec;
         public decimal? ActualSTDLEAdjustmentAndOtherCreditsFromLatestRec { get { return _actualSTDLEAdjustmentAndOtherCreditsFromLatestRec; } set { _actualSTDLEAdjustmentAndOtherCreditsFromLatestRec = value; } }
-        private Value<decimal?> _actualSTDLEClosingCostFinancedFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLEClosingCostFinancedFromLatestRec;
         public decimal? ActualSTDLEClosingCostFinancedFromLatestRec { get { return _actualSTDLEClosingCostFinancedFromLatestRec; } set { _actualSTDLEClosingCostFinancedFromLatestRec = value; } }
-        private Value<decimal?> _actualSTDLEDepositFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLEDepositFromLatestRec;
         public decimal? ActualSTDLEDepositFromLatestRec { get { return _actualSTDLEDepositFromLatestRec; } set { _actualSTDLEDepositFromLatestRec = value; } }
-        private Value<decimal?> _actualSTDLEDownPaymentFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLEDownPaymentFromLatestRec;
         public decimal? ActualSTDLEDownPaymentFromLatestRec { get { return _actualSTDLEDownPaymentFromLatestRec; } set { _actualSTDLEDownPaymentFromLatestRec = value; } }
-        private Value<decimal?> _actualSTDLEFundForBorrowerFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLEFundForBorrowerFromLatestRec;
         public decimal? ActualSTDLEFundForBorrowerFromLatestRec { get { return _actualSTDLEFundForBorrowerFromLatestRec; } set { _actualSTDLEFundForBorrowerFromLatestRec = value; } }
-        private Value<decimal?> _actualSTDLESellerCredits;
+        private DirtyValue<decimal?> _actualSTDLESellerCredits;
         public decimal? ActualSTDLESellerCredits { get { return _actualSTDLESellerCredits; } set { _actualSTDLESellerCredits = value; } }
-        private Value<decimal?> _actualSTDLESellerCreditsFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLESellerCreditsFromLatestRec;
         public decimal? ActualSTDLESellerCreditsFromLatestRec { get { return _actualSTDLESellerCreditsFromLatestRec; } set { _actualSTDLESellerCreditsFromLatestRec = value; } }
-        private Value<decimal?> _actualSTDLETotalClosingCostJ;
+        private DirtyValue<decimal?> _actualSTDLETotalClosingCostJ;
         public decimal? ActualSTDLETotalClosingCostJ { get { return _actualSTDLETotalClosingCostJ; } set { _actualSTDLETotalClosingCostJ = value; } }
-        private Value<decimal?> _actualSTDLETotalClosingCostJFromLatestRec;
+        private DirtyValue<decimal?> _actualSTDLETotalClosingCostJFromLatestRec;
         public decimal? ActualSTDLETotalClosingCostJFromLatestRec { get { return _actualSTDLETotalClosingCostJFromLatestRec; } set { _actualSTDLETotalClosingCostJFromLatestRec = value; } }
-        private Value<string> _adjustments06_1;
+        private DirtyValue<string> _adjustments06_1;
         public string Adjustments06_1 { get { return _adjustments06_1; } set { _adjustments06_1 = value; } }
-        private Value<decimal?> _adjustments06_2;
+        private DirtyValue<decimal?> _adjustments06_2;
         public decimal? Adjustments06_2 { get { return _adjustments06_2; } set { _adjustments06_2 = value; } }
-        private Value<string> _adjustments07_1;
+        private DirtyValue<string> _adjustments07_1;
         public string Adjustments07_1 { get { return _adjustments07_1; } set { _adjustments07_1 = value; } }
-        private Value<decimal?> _adjustments07_2;
+        private DirtyValue<decimal?> _adjustments07_2;
         public decimal? Adjustments07_2 { get { return _adjustments07_2; } set { _adjustments07_2 = value; } }
-        private Value<string> _adjustments10_1;
+        private DirtyValue<string> _adjustments10_1;
         public string Adjustments10_1 { get { return _adjustments10_1; } set { _adjustments10_1 = value; } }
-        private Value<decimal?> _adjustments10_2;
+        private DirtyValue<decimal?> _adjustments10_2;
         public decimal? Adjustments10_2 { get { return _adjustments10_2; } set { _adjustments10_2 = value; } }
-        private Value<string> _adjustments11_1;
+        private DirtyValue<string> _adjustments11_1;
         public string Adjustments11_1 { get { return _adjustments11_1; } set { _adjustments11_1 = value; } }
-        private Value<decimal?> _adjustments11_2;
+        private DirtyValue<decimal?> _adjustments11_2;
         public decimal? Adjustments11_2 { get { return _adjustments11_2; } set { _adjustments11_2 = value; } }
-        private Value<string> _adjustments15_1;
+        private DirtyValue<string> _adjustments15_1;
         public string Adjustments15_1 { get { return _adjustments15_1; } set { _adjustments15_1 = value; } }
-        private Value<decimal?> _adjustments15_2;
+        private DirtyValue<decimal?> _adjustments15_2;
         public decimal? Adjustments15_2 { get { return _adjustments15_2; } set { _adjustments15_2 = value; } }
-        private Value<string> _adjustments8_1;
+        private DirtyValue<string> _adjustments8_1;
         public string Adjustments8_1 { get { return _adjustments8_1; } set { _adjustments8_1 = value; } }
-        private Value<decimal?> _adjustments8_2;
+        private DirtyValue<decimal?> _adjustments8_2;
         public decimal? Adjustments8_2 { get { return _adjustments8_2; } set { _adjustments8_2 = value; } }
-        private Value<string> _adjustments9_1;
+        private DirtyValue<string> _adjustments9_1;
         public string Adjustments9_1 { get { return _adjustments9_1; } set { _adjustments9_1 = value; } }
-        private Value<decimal?> _adjustments9_2;
+        private DirtyValue<decimal?> _adjustments9_2;
         public decimal? Adjustments9_2 { get { return _adjustments9_2; } set { _adjustments9_2 = value; } }
-        private Value<string> _adjustmentsforItemsPaidbySellerinAdvance16_1;
+        private DirtyValue<string> _adjustmentsforItemsPaidbySellerinAdvance16_1;
         public string AdjustmentsforItemsPaidbySellerinAdvance16_1 { get { return _adjustmentsforItemsPaidbySellerinAdvance16_1; } set { _adjustmentsforItemsPaidbySellerinAdvance16_1 = value; } }
-        private Value<decimal?> _adjustmentsforItemsPaidbySellerinAdvance16_2;
+        private DirtyValue<decimal?> _adjustmentsforItemsPaidbySellerinAdvance16_2;
         public decimal? AdjustmentsforItemsPaidbySellerinAdvance16_2 { get { return _adjustmentsforItemsPaidbySellerinAdvance16_2; } set { _adjustmentsforItemsPaidbySellerinAdvance16_2 = value; } }
-        private Value<string> _aLTCashToCloseDidChangeCol;
+        private DirtyValue<string> _aLTCashToCloseDidChangeCol;
         public string ALTCashToCloseDidChangeCol { get { return _aLTCashToCloseDidChangeCol; } set { _aLTCashToCloseDidChangeCol = value; } }
-        private Value<decimal?> _aLTCashToCloseRemark;
+        private DirtyValue<decimal?> _aLTCashToCloseRemark;
         public decimal? ALTCashToCloseRemark { get { return _aLTCashToCloseRemark; } set { _aLTCashToCloseRemark = value; } }
-        private Value<string> _aLTClosingCostBeforeClosingDidChangeCol;
+        private DirtyValue<string> _aLTClosingCostBeforeClosingDidChangeCol;
         public string ALTClosingCostBeforeClosingDidChangeCol { get { return _aLTClosingCostBeforeClosingDidChangeCol; } set { _aLTClosingCostBeforeClosingDidChangeCol = value; } }
-        private Value<decimal?> _aLTLegalLimit;
+        private DirtyValue<decimal?> _aLTLegalLimit;
         public decimal? ALTLegalLimit { get { return _aLTLegalLimit; } set { _aLTLegalLimit = value; } }
-        private Value<string> _aLTLoanAmountDidChangeCol;
+        private DirtyValue<string> _aLTLoanAmountDidChangeCol;
         public string ALTLoanAmountDidChangeCol { get { return _aLTLoanAmountDidChangeCol; } set { _aLTLoanAmountDidChangeCol = value; } }
-        private Value<string> _aLTLoanAmountIncDecRemark;
+        private DirtyValue<string> _aLTLoanAmountIncDecRemark;
         public string ALTLoanAmountIncDecRemark { get { return _aLTLoanAmountIncDecRemark; } set { _aLTLoanAmountIncDecRemark = value; } }
-        private Value<string> _aLTTotalClosingCostDidChangeCol;
+        private DirtyValue<string> _aLTTotalClosingCostDidChangeCol;
         public string ALTTotalClosingCostDidChangeCol { get { return _aLTTotalClosingCostDidChangeCol; } set { _aLTTotalClosingCostDidChangeCol = value; } }
-        private Value<string> _aLTTotalClosingCostRemark;
+        private DirtyValue<string> _aLTTotalClosingCostRemark;
         public string ALTTotalClosingCostRemark { get { return _aLTTotalClosingCostRemark; } set { _aLTTotalClosingCostRemark = value; } }
-        private Value<string> _aLTTotalPayoffsDidChangeCol;
+        private DirtyValue<string> _aLTTotalPayoffsDidChangeCol;
         public string ALTTotalPayoffsDidChangeCol { get { return _aLTTotalPayoffsDidChangeCol; } set { _aLTTotalPayoffsDidChangeCol = value; } }
-        private Value<decimal?> _cash;
+        private DirtyValue<decimal?> _cash;
         public decimal? Cash { get { return _cash; } set { _cash = value; } }
-        private Value<decimal?> _cashToClose;
+        private DirtyValue<decimal?> _cashToClose;
         public decimal? CashToClose { get { return _cashToClose; } set { _cashToClose = value; } }
-        private Value<decimal?> _cD3CashToClose;
+        private DirtyValue<decimal?> _cD3CashToClose;
         public decimal? CD3CashToClose { get { return _cD3CashToClose; } set { _cD3CashToClose = value; } }
-        private Value<string> _cD3CashToCloseFromToBorrower;
+        private DirtyValue<string> _cD3CashToCloseFromToBorrower;
         public string CD3CashToCloseFromToBorrower { get { return _cD3CashToCloseFromToBorrower; } set { _cD3CashToCloseFromToBorrower = value; } }
-        private Value<decimal?> _cD3ClosingCostsPaidBeforeClosing;
+        private DirtyValue<decimal?> _cD3ClosingCostsPaidBeforeClosing;
         public decimal? CD3ClosingCostsPaidBeforeClosing { get { return _cD3ClosingCostsPaidBeforeClosing; } set { _cD3ClosingCostsPaidBeforeClosing = value; } }
-        private Value<decimal?> _cD3TotalClosingCost_J;
+        private DirtyValue<decimal?> _cD3TotalClosingCost_J;
         public decimal? CD3TotalClosingCost_J { get { return _cD3TotalClosingCost_J; } set { _cD3TotalClosingCost_J = value; } }
-        private Value<decimal?> _cD3TotalPayoffsAndPayments_K;
+        private DirtyValue<decimal?> _cD3TotalPayoffsAndPayments_K;
         public decimal? CD3TotalPayoffsAndPayments_K { get { return _cD3TotalPayoffsAndPayments_K; } set { _cD3TotalPayoffsAndPayments_K = value; } }
-        private Value<decimal?> _closingCostsPaidAtClosing;
+        private DirtyValue<decimal?> _closingCostsPaidAtClosing;
         public decimal? ClosingCostsPaidAtClosing { get { return _closingCostsPaidAtClosing; } set { _closingCostsPaidAtClosing = value; } }
-        private Value<decimal?> _closingCostsPaidatClosing_J;
+        private DirtyValue<decimal?> _closingCostsPaidatClosing_J;
         public decimal? ClosingCostsPaidatClosing_J { get { return _closingCostsPaidatClosing_J; } set { _closingCostsPaidatClosing_J = value; } }
-        private Value<string> _duefromSelleratClosing11_1;
+        private DirtyValue<string> _duefromSelleratClosing11_1;
         public string DuefromSelleratClosing11_1 { get { return _duefromSelleratClosing11_1; } set { _duefromSelleratClosing11_1 = value; } }
-        private Value<decimal?> _duefromSelleratClosing11_2;
+        private DirtyValue<decimal?> _duefromSelleratClosing11_2;
         public decimal? DuefromSelleratClosing11_2 { get { return _duefromSelleratClosing11_2; } set { _duefromSelleratClosing11_2 = value; } }
-        private Value<string> _duefromSelleratClosing12_1;
+        private DirtyValue<string> _duefromSelleratClosing12_1;
         public string DuefromSelleratClosing12_1 { get { return _duefromSelleratClosing12_1; } set { _duefromSelleratClosing12_1 = value; } }
-        private Value<decimal?> _duefromSelleratClosing12_2;
+        private DirtyValue<decimal?> _duefromSelleratClosing12_2;
         public decimal? DuefromSelleratClosing12_2 { get { return _duefromSelleratClosing12_2; } set { _duefromSelleratClosing12_2 = value; } }
-        private Value<string> _duefromSelleratClosing13_1;
+        private DirtyValue<string> _duefromSelleratClosing13_1;
         public string DuefromSelleratClosing13_1 { get { return _duefromSelleratClosing13_1; } set { _duefromSelleratClosing13_1 = value; } }
-        private Value<decimal?> _duefromSelleratClosing13_2;
+        private DirtyValue<decimal?> _duefromSelleratClosing13_2;
         public decimal? DuefromSelleratClosing13_2 { get { return _duefromSelleratClosing13_2; } set { _duefromSelleratClosing13_2 = value; } }
-        private Value<string> _dueToSellerAtClosing6_1;
+        private DirtyValue<string> _dueToSellerAtClosing6_1;
         public string DueToSellerAtClosing6_1 { get { return _dueToSellerAtClosing6_1; } set { _dueToSellerAtClosing6_1 = value; } }
-        private Value<decimal?> _dueToSellerAtClosing6_2;
+        private DirtyValue<decimal?> _dueToSellerAtClosing6_2;
         public decimal? DueToSellerAtClosing6_2 { get { return _dueToSellerAtClosing6_2; } set { _dueToSellerAtClosing6_2 = value; } }
-        private Value<string> _dueToSellerAtClosing7_1;
+        private DirtyValue<string> _dueToSellerAtClosing7_1;
         public string DueToSellerAtClosing7_1 { get { return _dueToSellerAtClosing7_1; } set { _dueToSellerAtClosing7_1 = value; } }
-        private Value<decimal?> _dueToSellerAtClosing7_2;
+        private DirtyValue<decimal?> _dueToSellerAtClosing7_2;
         public decimal? DueToSellerAtClosing7_2 { get { return _dueToSellerAtClosing7_2; } set { _dueToSellerAtClosing7_2 = value; } }
-        private Value<string> _dueToSellerAtClosing8_1;
+        private DirtyValue<string> _dueToSellerAtClosing8_1;
         public string DueToSellerAtClosing8_1 { get { return _dueToSellerAtClosing8_1; } set { _dueToSellerAtClosing8_1 = value; } }
-        private Value<decimal?> _dueToSellerAtClosing8_2;
+        private DirtyValue<decimal?> _dueToSellerAtClosing8_2;
         public decimal? DueToSellerAtClosing8_2 { get { return _dueToSellerAtClosing8_2; } set { _dueToSellerAtClosing8_2 = value; } }
-        private Value<bool?> _excludeBorrowerClosingCosts;
+        private DirtyValue<bool?> _excludeBorrowerClosingCosts;
         public bool? ExcludeBorrowerClosingCosts { get { return _excludeBorrowerClosingCosts; } set { _excludeBorrowerClosingCosts = value; } }
-        private Value<decimal?> _finalCashToClose;
+        private DirtyValue<decimal?> _finalCashToClose;
         public decimal? FinalCashToClose { get { return _finalCashToClose; } set { _finalCashToClose = value; } }
-        private Value<string> _fromToBorrower;
+        private DirtyValue<string> _fromToBorrower;
         public string FromToBorrower { get { return _fromToBorrower; } set { _fromToBorrower = value; } }
-        private Value<string> _fromToSeller;
+        private DirtyValue<string> _fromToSeller;
         public string FromToSeller { get { return _fromToSeller; } set { _fromToSeller = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _lECD3CashToClose;
+        private DirtyValue<decimal?> _lECD3CashToClose;
         public decimal? LECD3CashToClose { get { return _lECD3CashToClose; } set { _lECD3CashToClose = value; } }
-        private Value<string> _lECD3CashToCloseFromToBorrower;
+        private DirtyValue<string> _lECD3CashToCloseFromToBorrower;
         public string LECD3CashToCloseFromToBorrower { get { return _lECD3CashToCloseFromToBorrower; } set { _lECD3CashToCloseFromToBorrower = value; } }
-        private Value<decimal?> _lECD3ClosingCostsPaidBeforeClosing;
+        private DirtyValue<decimal?> _lECD3ClosingCostsPaidBeforeClosing;
         public decimal? LECD3ClosingCostsPaidBeforeClosing { get { return _lECD3ClosingCostsPaidBeforeClosing; } set { _lECD3ClosingCostsPaidBeforeClosing = value; } }
-        private Value<decimal?> _lECD3TotalClosingCost_J;
+        private DirtyValue<decimal?> _lECD3TotalClosingCost_J;
         public decimal? LECD3TotalClosingCost_J { get { return _lECD3TotalClosingCost_J; } set { _lECD3TotalClosingCost_J = value; } }
-        private Value<decimal?> _lECD3TotalPayoffsAndPayments_K;
+        private DirtyValue<decimal?> _lECD3TotalPayoffsAndPayments_K;
         public decimal? LECD3TotalPayoffsAndPayments_K { get { return _lECD3TotalPayoffsAndPayments_K; } set { _lECD3TotalPayoffsAndPayments_K = value; } }
-        private Value<decimal?> _lELoanAmount;
+        private DirtyValue<decimal?> _lELoanAmount;
         public decimal? LELoanAmount { get { return _lELoanAmount; } set { _lELoanAmount = value; } }
-        private Value<decimal?> _liabilityAmount1;
+        private DirtyValue<decimal?> _liabilityAmount1;
         public decimal? LiabilityAmount1 { get { return _liabilityAmount1; } set { _liabilityAmount1 = value; } }
-        private Value<decimal?> _liabilityAmount10;
+        private DirtyValue<decimal?> _liabilityAmount10;
         public decimal? LiabilityAmount10 { get { return _liabilityAmount10; } set { _liabilityAmount10 = value; } }
-        private Value<decimal?> _liabilityAmount11;
+        private DirtyValue<decimal?> _liabilityAmount11;
         public decimal? LiabilityAmount11 { get { return _liabilityAmount11; } set { _liabilityAmount11 = value; } }
-        private Value<decimal?> _liabilityAmount12;
+        private DirtyValue<decimal?> _liabilityAmount12;
         public decimal? LiabilityAmount12 { get { return _liabilityAmount12; } set { _liabilityAmount12 = value; } }
-        private Value<decimal?> _liabilityAmount13;
+        private DirtyValue<decimal?> _liabilityAmount13;
         public decimal? LiabilityAmount13 { get { return _liabilityAmount13; } set { _liabilityAmount13 = value; } }
-        private Value<decimal?> _liabilityAmount14;
+        private DirtyValue<decimal?> _liabilityAmount14;
         public decimal? LiabilityAmount14 { get { return _liabilityAmount14; } set { _liabilityAmount14 = value; } }
-        private Value<decimal?> _liabilityAmount15;
+        private DirtyValue<decimal?> _liabilityAmount15;
         public decimal? LiabilityAmount15 { get { return _liabilityAmount15; } set { _liabilityAmount15 = value; } }
-        private Value<decimal?> _liabilityAmount2;
+        private DirtyValue<decimal?> _liabilityAmount2;
         public decimal? LiabilityAmount2 { get { return _liabilityAmount2; } set { _liabilityAmount2 = value; } }
-        private Value<decimal?> _liabilityAmount3;
+        private DirtyValue<decimal?> _liabilityAmount3;
         public decimal? LiabilityAmount3 { get { return _liabilityAmount3; } set { _liabilityAmount3 = value; } }
-        private Value<decimal?> _liabilityAmount4;
+        private DirtyValue<decimal?> _liabilityAmount4;
         public decimal? LiabilityAmount4 { get { return _liabilityAmount4; } set { _liabilityAmount4 = value; } }
-        private Value<decimal?> _liabilityAmount5;
+        private DirtyValue<decimal?> _liabilityAmount5;
         public decimal? LiabilityAmount5 { get { return _liabilityAmount5; } set { _liabilityAmount5 = value; } }
-        private Value<decimal?> _liabilityAmount6;
+        private DirtyValue<decimal?> _liabilityAmount6;
         public decimal? LiabilityAmount6 { get { return _liabilityAmount6; } set { _liabilityAmount6 = value; } }
-        private Value<decimal?> _liabilityAmount7;
+        private DirtyValue<decimal?> _liabilityAmount7;
         public decimal? LiabilityAmount7 { get { return _liabilityAmount7; } set { _liabilityAmount7 = value; } }
-        private Value<decimal?> _liabilityAmount8;
+        private DirtyValue<decimal?> _liabilityAmount8;
         public decimal? LiabilityAmount8 { get { return _liabilityAmount8; } set { _liabilityAmount8 = value; } }
-        private Value<decimal?> _liabilityAmount9;
+        private DirtyValue<decimal?> _liabilityAmount9;
         public decimal? LiabilityAmount9 { get { return _liabilityAmount9; } set { _liabilityAmount9 = value; } }
-        private Value<string> _liabilityTo1;
+        private DirtyValue<string> _liabilityTo1;
         public string LiabilityTo1 { get { return _liabilityTo1; } set { _liabilityTo1 = value; } }
-        private Value<string> _liabilityTo10;
+        private DirtyValue<string> _liabilityTo10;
         public string LiabilityTo10 { get { return _liabilityTo10; } set { _liabilityTo10 = value; } }
-        private Value<string> _liabilityTo11;
+        private DirtyValue<string> _liabilityTo11;
         public string LiabilityTo11 { get { return _liabilityTo11; } set { _liabilityTo11 = value; } }
-        private Value<string> _liabilityTo12;
+        private DirtyValue<string> _liabilityTo12;
         public string LiabilityTo12 { get { return _liabilityTo12; } set { _liabilityTo12 = value; } }
-        private Value<string> _liabilityTo13;
+        private DirtyValue<string> _liabilityTo13;
         public string LiabilityTo13 { get { return _liabilityTo13; } set { _liabilityTo13 = value; } }
-        private Value<string> _liabilityTo14;
+        private DirtyValue<string> _liabilityTo14;
         public string LiabilityTo14 { get { return _liabilityTo14; } set { _liabilityTo14 = value; } }
-        private Value<string> _liabilityTo15;
+        private DirtyValue<string> _liabilityTo15;
         public string LiabilityTo15 { get { return _liabilityTo15; } set { _liabilityTo15 = value; } }
-        private Value<string> _liabilityTo2;
+        private DirtyValue<string> _liabilityTo2;
         public string LiabilityTo2 { get { return _liabilityTo2; } set { _liabilityTo2 = value; } }
-        private Value<string> _liabilityTo3;
+        private DirtyValue<string> _liabilityTo3;
         public string LiabilityTo3 { get { return _liabilityTo3; } set { _liabilityTo3 = value; } }
-        private Value<string> _liabilityTo4;
+        private DirtyValue<string> _liabilityTo4;
         public string LiabilityTo4 { get { return _liabilityTo4; } set { _liabilityTo4 = value; } }
-        private Value<string> _liabilityTo5;
+        private DirtyValue<string> _liabilityTo5;
         public string LiabilityTo5 { get { return _liabilityTo5; } set { _liabilityTo5 = value; } }
-        private Value<string> _liabilityTo6;
+        private DirtyValue<string> _liabilityTo6;
         public string LiabilityTo6 { get { return _liabilityTo6; } set { _liabilityTo6 = value; } }
-        private Value<string> _liabilityTo7;
+        private DirtyValue<string> _liabilityTo7;
         public string LiabilityTo7 { get { return _liabilityTo7; } set { _liabilityTo7 = value; } }
-        private Value<string> _liabilityTo8;
+        private DirtyValue<string> _liabilityTo8;
         public string LiabilityTo8 { get { return _liabilityTo8; } set { _liabilityTo8 = value; } }
-        private Value<string> _liabilityTo9;
+        private DirtyValue<string> _liabilityTo9;
         public string LiabilityTo9 { get { return _liabilityTo9; } set { _liabilityTo9 = value; } }
-        private Value<decimal?> _liabilityTotal;
+        private DirtyValue<decimal?> _liabilityTotal;
         public decimal? LiabilityTotal { get { return _liabilityTotal; } set { _liabilityTotal = value; } }
-        private Value<decimal?> _loanAmount;
+        private DirtyValue<decimal?> _loanAmount;
         public decimal? LoanAmount { get { return _loanAmount; } set { _loanAmount = value; } }
-        private Value<decimal?> _nonUCDTotalAdjustmentsAndOtherCredits;
+        private DirtyValue<decimal?> _nonUCDTotalAdjustmentsAndOtherCredits;
         public decimal? NonUCDTotalAdjustmentsAndOtherCredits { get { return _nonUCDTotalAdjustmentsAndOtherCredits; } set { _nonUCDTotalAdjustmentsAndOtherCredits = value; } }
-        private Value<bool?> _omitFromPrintSellersTransaction;
+        private DirtyValue<bool?> _omitFromPrintSellersTransaction;
         public bool? OmitFromPrintSellersTransaction { get { return _omitFromPrintSellersTransaction; } set { _omitFromPrintSellersTransaction = value; } }
-        private Value<string> _otherCredits6_1;
+        private DirtyValue<string> _otherCredits6_1;
         public string OtherCredits6_1 { get { return _otherCredits6_1; } set { _otherCredits6_1 = value; } }
-        private Value<decimal?> _otherCredits6_2;
+        private DirtyValue<decimal?> _otherCredits6_2;
         public decimal? OtherCredits6_2 { get { return _otherCredits6_2; } set { _otherCredits6_2 = value; } }
-        private Value<string> _otherCredits7_1;
+        private DirtyValue<string> _otherCredits7_1;
         public string OtherCredits7_1 { get { return _otherCredits7_1; } set { _otherCredits7_1 = value; } }
-        private Value<decimal?> _otherCredits7_2;
+        private DirtyValue<decimal?> _otherCredits7_2;
         public decimal? OtherCredits7_2 { get { return _otherCredits7_2; } set { _otherCredits7_2 = value; } }
-        private Value<decimal?> _priorToleranceCureAmount;
+        private DirtyValue<decimal?> _priorToleranceCureAmount;
         public decimal? PriorToleranceCureAmount { get { return _priorToleranceCureAmount; } set { _priorToleranceCureAmount = value; } }
-        private Value<string> _sTDAdjustmentAndOtherCreditsRemark;
+        private DirtyValue<string> _sTDAdjustmentAndOtherCreditsRemark;
         public string STDAdjustmentAndOtherCreditsRemark { get { return _sTDAdjustmentAndOtherCreditsRemark; } set { _sTDAdjustmentAndOtherCreditsRemark = value; } }
-        private Value<string> _sTDAdjustmentsDidChangeCol;
+        private DirtyValue<string> _sTDAdjustmentsDidChangeCol;
         public string STDAdjustmentsDidChangeCol { get { return _sTDAdjustmentsDidChangeCol; } set { _sTDAdjustmentsDidChangeCol = value; } }
-        private Value<string> _sTDClosingCostFinancedDidChangeCol;
+        private DirtyValue<string> _sTDClosingCostFinancedDidChangeCol;
         public string STDClosingCostFinancedDidChangeCol { get { return _sTDClosingCostFinancedDidChangeCol; } set { _sTDClosingCostFinancedDidChangeCol = value; } }
-        private Value<string> _sTDDepositDidChangeCol;
+        private DirtyValue<string> _sTDDepositDidChangeCol;
         public string STDDepositDidChangeCol { get { return _sTDDepositDidChangeCol; } set { _sTDDepositDidChangeCol = value; } }
-        private Value<string> _sTDDepositIncDecRemark;
+        private DirtyValue<string> _sTDDepositIncDecRemark;
         public string STDDepositIncDecRemark { get { return _sTDDepositIncDecRemark; } set { _sTDDepositIncDecRemark = value; } }
-        private Value<string> _sTDDownPaymentDidChangeCol;
+        private DirtyValue<string> _sTDDownPaymentDidChangeCol;
         public string STDDownPaymentDidChangeCol { get { return _sTDDownPaymentDidChangeCol; } set { _sTDDownPaymentDidChangeCol = value; } }
-        private Value<string> _sTDDownPaymentIncDecRemark;
+        private DirtyValue<string> _sTDDownPaymentIncDecRemark;
         public string STDDownPaymentIncDecRemark { get { return _sTDDownPaymentIncDecRemark; } set { _sTDDownPaymentIncDecRemark = value; } }
-        private Value<string> _sTDDownPaymentSectionRemark;
+        private DirtyValue<string> _sTDDownPaymentSectionRemark;
         public string STDDownPaymentSectionRemark { get { return _sTDDownPaymentSectionRemark; } set { _sTDDownPaymentSectionRemark = value; } }
-        private Value<decimal?> _sTDFinalAdjustmentAndOtherCredits;
+        private DirtyValue<decimal?> _sTDFinalAdjustmentAndOtherCredits;
         public decimal? STDFinalAdjustmentAndOtherCredits { get { return _sTDFinalAdjustmentAndOtherCredits; } set { _sTDFinalAdjustmentAndOtherCredits = value; } }
-        private Value<decimal?> _sTDFinalCashToClose;
+        private DirtyValue<decimal?> _sTDFinalCashToClose;
         public decimal? STDFinalCashToClose { get { return _sTDFinalCashToClose; } set { _sTDFinalCashToClose = value; } }
-        private Value<decimal?> _sTDFinalCD3ClosingCostsPaidBeforeClosing;
+        private DirtyValue<decimal?> _sTDFinalCD3ClosingCostsPaidBeforeClosing;
         public decimal? STDFinalCD3ClosingCostsPaidBeforeClosing { get { return _sTDFinalCD3ClosingCostsPaidBeforeClosing; } set { _sTDFinalCD3ClosingCostsPaidBeforeClosing = value; } }
-        private Value<decimal?> _sTDFinalClosingCostFinanced;
+        private DirtyValue<decimal?> _sTDFinalClosingCostFinanced;
         public decimal? STDFinalClosingCostFinanced { get { return _sTDFinalClosingCostFinanced; } set { _sTDFinalClosingCostFinanced = value; } }
-        private Value<decimal?> _sTDFinalDeposit;
+        private DirtyValue<decimal?> _sTDFinalDeposit;
         public decimal? STDFinalDeposit { get { return _sTDFinalDeposit; } set { _sTDFinalDeposit = value; } }
-        private Value<decimal?> _sTDFinalDownPayment;
+        private DirtyValue<decimal?> _sTDFinalDownPayment;
         public decimal? STDFinalDownPayment { get { return _sTDFinalDownPayment; } set { _sTDFinalDownPayment = value; } }
-        private Value<decimal?> _sTDFinalFundForBorrower;
+        private DirtyValue<decimal?> _sTDFinalFundForBorrower;
         public decimal? STDFinalFundForBorrower { get { return _sTDFinalFundForBorrower; } set { _sTDFinalFundForBorrower = value; } }
-        private Value<decimal?> _sTDFinalSellerCredits;
+        private DirtyValue<decimal?> _sTDFinalSellerCredits;
         public decimal? STDFinalSellerCredits { get { return _sTDFinalSellerCredits; } set { _sTDFinalSellerCredits = value; } }
-        private Value<decimal?> _sTDFinalTotalClosingCostJ;
+        private DirtyValue<decimal?> _sTDFinalTotalClosingCostJ;
         public decimal? STDFinalTotalClosingCostJ { get { return _sTDFinalTotalClosingCostJ; } set { _sTDFinalTotalClosingCostJ = value; } }
-        private Value<string> _sTDFundsForBorrowerDidChangeCol;
+        private DirtyValue<string> _sTDFundsForBorrowerDidChangeCol;
         public string STDFundsForBorrowerDidChangeCol { get { return _sTDFundsForBorrowerDidChangeCol; } set { _sTDFundsForBorrowerDidChangeCol = value; } }
-        private Value<string> _sTDFundsForBorrowerIncDecRemark;
+        private DirtyValue<string> _sTDFundsForBorrowerIncDecRemark;
         public string STDFundsForBorrowerIncDecRemark { get { return _sTDFundsForBorrowerIncDecRemark; } set { _sTDFundsForBorrowerIncDecRemark = value; } }
-        private Value<decimal?> _sTDLEAdjustmentAndOtherCredits;
+        private DirtyValue<decimal?> _sTDLEAdjustmentAndOtherCredits;
         public decimal? STDLEAdjustmentAndOtherCredits { get { return _sTDLEAdjustmentAndOtherCredits; } set { _sTDLEAdjustmentAndOtherCredits = value; } }
-        private Value<decimal?> _sTDLECashToClose;
+        private DirtyValue<decimal?> _sTDLECashToClose;
         public decimal? STDLECashToClose { get { return _sTDLECashToClose; } set { _sTDLECashToClose = value; } }
-        private Value<decimal?> _sTDLECD3ClosingCostsPaidBeforeClosing;
+        private DirtyValue<decimal?> _sTDLECD3ClosingCostsPaidBeforeClosing;
         public decimal? STDLECD3ClosingCostsPaidBeforeClosing { get { return _sTDLECD3ClosingCostsPaidBeforeClosing; } set { _sTDLECD3ClosingCostsPaidBeforeClosing = value; } }
-        private Value<decimal?> _sTDLEClosingCostFinanced;
+        private DirtyValue<decimal?> _sTDLEClosingCostFinanced;
         public decimal? STDLEClosingCostFinanced { get { return _sTDLEClosingCostFinanced; } set { _sTDLEClosingCostFinanced = value; } }
-        private Value<decimal?> _sTDLEDeposit;
+        private DirtyValue<decimal?> _sTDLEDeposit;
         public decimal? STDLEDeposit { get { return _sTDLEDeposit; } set { _sTDLEDeposit = value; } }
-        private Value<decimal?> _sTDLEDownPayment;
+        private DirtyValue<decimal?> _sTDLEDownPayment;
         public decimal? STDLEDownPayment { get { return _sTDLEDownPayment; } set { _sTDLEDownPayment = value; } }
-        private Value<decimal?> _sTDLEFundForBorrower;
+        private DirtyValue<decimal?> _sTDLEFundForBorrower;
         public decimal? STDLEFundForBorrower { get { return _sTDLEFundForBorrower; } set { _sTDLEFundForBorrower = value; } }
-        private Value<decimal?> _sTDLegalLimit;
+        private DirtyValue<decimal?> _sTDLegalLimit;
         public decimal? STDLegalLimit { get { return _sTDLegalLimit; } set { _sTDLegalLimit = value; } }
-        private Value<decimal?> _sTDLESellerCredits;
+        private DirtyValue<decimal?> _sTDLESellerCredits;
         public decimal? STDLESellerCredits { get { return _sTDLESellerCredits; } set { _sTDLESellerCredits = value; } }
-        private Value<decimal?> _sTDLETotalClosingCostJ;
+        private DirtyValue<decimal?> _sTDLETotalClosingCostJ;
         public decimal? STDLETotalClosingCostJ { get { return _sTDLETotalClosingCostJ; } set { _sTDLETotalClosingCostJ = value; } }
-        private Value<string> _sTDSellerCreditsDidChangeCol;
+        private DirtyValue<string> _sTDSellerCreditsDidChangeCol;
         public string STDSellerCreditsDidChangeCol { get { return _sTDSellerCreditsDidChangeCol; } set { _sTDSellerCreditsDidChangeCol = value; } }
-        private Value<string> _sTDSellerCreditsIncDecRemark;
+        private DirtyValue<string> _sTDSellerCreditsIncDecRemark;
         public string STDSellerCreditsIncDecRemark { get { return _sTDSellerCreditsIncDecRemark; } set { _sTDSellerCreditsIncDecRemark = value; } }
-        private Value<string> _sTDTotalClosingCostBeforeClosingDidChangeCol;
+        private DirtyValue<string> _sTDTotalClosingCostBeforeClosingDidChangeCol;
         public string STDTotalClosingCostBeforeClosingDidChangeCol { get { return _sTDTotalClosingCostBeforeClosingDidChangeCol; } set { _sTDTotalClosingCostBeforeClosingDidChangeCol = value; } }
-        private Value<string> _sTDTotalClosingCostDidChangeCol;
+        private DirtyValue<string> _sTDTotalClosingCostDidChangeCol;
         public string STDTotalClosingCostDidChangeCol { get { return _sTDTotalClosingCostDidChangeCol; } set { _sTDTotalClosingCostDidChangeCol = value; } }
-        private Value<string> _sTDTotalClosingCostRemark;
+        private DirtyValue<string> _sTDTotalClosingCostRemark;
         public string STDTotalClosingCostRemark { get { return _sTDTotalClosingCostRemark; } set { _sTDTotalClosingCostRemark = value; } }
-        private Value<decimal?> _totalAdjustmentsAndOtherCredits;
+        private DirtyValue<decimal?> _totalAdjustmentsAndOtherCredits;
         public decimal? TotalAdjustmentsAndOtherCredits { get { return _totalAdjustmentsAndOtherCredits; } set { _totalAdjustmentsAndOtherCredits = value; } }
-        private Value<decimal?> _totalDuefromBorrowerAtClosing;
+        private DirtyValue<decimal?> _totalDuefromBorrowerAtClosing;
         public decimal? TotalDuefromBorrowerAtClosing { get { return _totalDuefromBorrowerAtClosing; } set { _totalDuefromBorrowerAtClosing = value; } }
-        private Value<decimal?> _totalDuefromSelleratClosing_N;
+        private DirtyValue<decimal?> _totalDuefromSelleratClosing_N;
         public decimal? TotalDuefromSelleratClosing_N { get { return _totalDuefromSelleratClosing_N; } set { _totalDuefromSelleratClosing_N = value; } }
-        private Value<decimal?> _totalDuetoSelleratClosing_M;
+        private DirtyValue<decimal?> _totalDuetoSelleratClosing_M;
         public decimal? TotalDuetoSelleratClosing_M { get { return _totalDuetoSelleratClosing_M; } set { _totalDuetoSelleratClosing_M = value; } }
-        private Value<decimal?> _totalFromK;
+        private DirtyValue<decimal?> _totalFromK;
         public decimal? TotalFromK { get { return _totalFromK; } set { _totalFromK = value; } }
-        private Value<decimal?> _totalFromL;
+        private DirtyValue<decimal?> _totalFromL;
         public decimal? TotalFromL { get { return _totalFromL; } set { _totalFromL = value; } }
-        private Value<decimal?> _totalFromM;
+        private DirtyValue<decimal?> _totalFromM;
         public decimal? TotalFromM { get { return _totalFromM; } set { _totalFromM = value; } }
-        private Value<decimal?> _totalFromN;
+        private DirtyValue<decimal?> _totalFromN;
         public decimal? TotalFromN { get { return _totalFromN; } set { _totalFromN = value; } }
-        private Value<decimal?> _totalPaidAlreadybyoronBehalfofBoroweratClosing;
+        private DirtyValue<decimal?> _totalPaidAlreadybyoronBehalfofBoroweratClosing;
         public decimal? TotalPaidAlreadybyoronBehalfofBoroweratClosing { get { return _totalPaidAlreadybyoronBehalfofBoroweratClosing; } set { _totalPaidAlreadybyoronBehalfofBoroweratClosing = value; } }
         private DirtyList<UCDDetail> _uCDDetails;
         public IList<UCDDetail> UCDDetails { get { var v = _uCDDetails; return v ?? Interlocked.CompareExchange(ref _uCDDetails, (v = new DirtyList<UCDDetail>()), null) ?? v; } set { _uCDDetails = new DirtyList<UCDDetail>(value); } }
-        private Value<decimal?> _uCDKSubTotal;
+        private DirtyValue<decimal?> _uCDKSubTotal;
         public decimal? UCDKSubTotal { get { return _uCDKSubTotal; } set { _uCDKSubTotal = value; } }
-        private Value<decimal?> _uCDLSubTotal;
+        private DirtyValue<decimal?> _uCDLSubTotal;
         public decimal? UCDLSubTotal { get { return _uCDLSubTotal; } set { _uCDLSubTotal = value; } }
-        private Value<decimal?> _uCDTotalAdjustmentsAndOtherCredits;
+        private DirtyValue<decimal?> _uCDTotalAdjustmentsAndOtherCredits;
         public decimal? UCDTotalAdjustmentsAndOtherCredits { get { return _uCDTotalAdjustmentsAndOtherCredits; } set { _uCDTotalAdjustmentsAndOtherCredits = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingDisclosure3.cs
+++ b/src/EncompassRest/Loans/ClosingDisclosure3.cs
@@ -312,8 +312,8 @@ namespace EncompassRest.Loans
         public decimal? TotalFromN { get { return _totalFromN; } set { _totalFromN = value; } }
         private Value<decimal?> _totalPaidAlreadybyoronBehalfofBoroweratClosing;
         public decimal? TotalPaidAlreadybyoronBehalfofBoroweratClosing { get { return _totalPaidAlreadybyoronBehalfofBoroweratClosing; } set { _totalPaidAlreadybyoronBehalfofBoroweratClosing = value; } }
-        private Value<List<UCDDetail>> _uCDDetails;
-        public List<UCDDetail> UCDDetails { get { return _uCDDetails; } set { _uCDDetails = value; } }
+        private DirtyList<UCDDetail> _uCDDetails;
+        public IList<UCDDetail> UCDDetails { get { var v = _uCDDetails; return v ?? Interlocked.CompareExchange(ref _uCDDetails, (v = new DirtyList<UCDDetail>()), null) ?? v; } set { _uCDDetails = new DirtyList<UCDDetail>(value); } }
         private Value<decimal?> _uCDKSubTotal;
         public decimal? UCDKSubTotal { get { return _uCDKSubTotal; } set { _uCDKSubTotal = value; } }
         private Value<decimal?> _uCDLSubTotal;
@@ -479,10 +479,10 @@ namespace EncompassRest.Loans
                     || _totalFromM.Dirty
                     || _totalFromN.Dirty
                     || _totalPaidAlreadybyoronBehalfofBoroweratClosing.Dirty
-                    || _uCDDetails.Dirty
                     || _uCDKSubTotal.Dirty
                     || _uCDLSubTotal.Dirty
-                    || _uCDTotalAdjustmentsAndOtherCredits.Dirty;
+                    || _uCDTotalAdjustmentsAndOtherCredits.Dirty
+                    || _uCDDetails?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -641,10 +641,10 @@ namespace EncompassRest.Loans
                 _totalFromM.Dirty = value;
                 _totalFromN.Dirty = value;
                 _totalPaidAlreadybyoronBehalfofBoroweratClosing.Dirty = value;
-                _uCDDetails.Dirty = value;
                 _uCDKSubTotal.Dirty = value;
                 _uCDLSubTotal.Dirty = value;
                 _uCDTotalAdjustmentsAndOtherCredits.Dirty = value;
+                if (_uCDDetails != null) _uCDDetails.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/ClosingDisclosure4.cs
+++ b/src/EncompassRest/Loans/ClosingDisclosure4.cs
@@ -8,73 +8,73 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingDisclosure4 : IDirty
     {
-        private Value<string> _demandFeature;
+        private DirtyValue<string> _demandFeature;
         public string DemandFeature { get { return _demandFeature; } set { _demandFeature = value; } }
-        private Value<bool?> _escrowIndicator;
+        private DirtyValue<bool?> _escrowIndicator;
         public bool? EscrowIndicator { get { return _escrowIndicator; } set { _escrowIndicator = value; } }
-        private Value<decimal?> _estimatedPropertyCosts;
+        private DirtyValue<decimal?> _estimatedPropertyCosts;
         public decimal? EstimatedPropertyCosts { get { return _estimatedPropertyCosts; } set { _estimatedPropertyCosts = value; } }
-        private Value<string> _firstChangeAmt;
+        private DirtyValue<string> _firstChangeAmt;
         public string FirstChangeAmt { get { return _firstChangeAmt; } set { _firstChangeAmt = value; } }
-        private Value<decimal?> _firstChangeMaxAmt;
+        private DirtyValue<decimal?> _firstChangeMaxAmt;
         public decimal? FirstChangeMaxAmt { get { return _firstChangeMaxAmt; } set { _firstChangeMaxAmt = value; } }
-        private Value<decimal?> _firstChangeMinAmt;
+        private DirtyValue<decimal?> _firstChangeMinAmt;
         public decimal? FirstChangeMinAmt { get { return _firstChangeMinAmt; } set { _firstChangeMinAmt = value; } }
-        private Value<string> _firstChangePayment;
+        private DirtyValue<string> _firstChangePayment;
         public string FirstChangePayment { get { return _firstChangePayment; } set { _firstChangePayment = value; } }
-        private Value<bool?> _hOADuesIsEscrow;
+        private DirtyValue<bool?> _hOADuesIsEscrow;
         public bool? HOADuesIsEscrow { get { return _hOADuesIsEscrow; } set { _hOADuesIsEscrow = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _ignoreARMAdj;
+        private DirtyValue<bool?> _ignoreARMAdj;
         public bool? IgnoreARMAdj { get { return _ignoreARMAdj; } set { _ignoreARMAdj = value; } }
-        private Value<decimal?> _initialEscrowPayment;
+        private DirtyValue<decimal?> _initialEscrowPayment;
         public decimal? InitialEscrowPayment { get { return _initialEscrowPayment; } set { _initialEscrowPayment = value; } }
-        private Value<int?> _interestOnlyPaymentMonths;
+        private DirtyValue<int?> _interestOnlyPaymentMonths;
         public int? InterestOnlyPaymentMonths { get { return _interestOnlyPaymentMonths; } set { _interestOnlyPaymentMonths = value; } }
-        private Value<bool?> _interestOnlyPayments;
+        private DirtyValue<bool?> _interestOnlyPayments;
         public bool? InterestOnlyPayments { get { return _interestOnlyPayments; } set { _interestOnlyPayments = value; } }
-        private Value<int?> _interestRateAdjustments;
+        private DirtyValue<int?> _interestRateAdjustments;
         public int? InterestRateAdjustments { get { return _interestRateAdjustments; } set { _interestRateAdjustments = value; } }
-        private Value<bool?> _lender;
+        private DirtyValue<bool?> _lender;
         public bool? Lender { get { return _lender; } set { _lender = value; } }
-        private Value<string> _maximumPaymentAmt;
+        private DirtyValue<string> _maximumPaymentAmt;
         public string MaximumPaymentAmt { get { return _maximumPaymentAmt; } set { _maximumPaymentAmt = value; } }
-        private Value<string> _maxPayment;
+        private DirtyValue<string> _maxPayment;
         public string MaxPayment { get { return _maxPayment; } set { _maxPayment = value; } }
-        private Value<decimal?> _maxPaymentAmt;
+        private DirtyValue<decimal?> _maxPaymentAmt;
         public decimal? MaxPaymentAmt { get { return _maxPaymentAmt; } set { _maxPaymentAmt = value; } }
-        private Value<decimal?> _monthlyEscrowPayment;
+        private DirtyValue<decimal?> _monthlyEscrowPayment;
         public decimal? MonthlyEscrowPayment { get { return _monthlyEscrowPayment; } set { _monthlyEscrowPayment = value; } }
-        private Value<string> _negativeAmortization;
+        private DirtyValue<string> _negativeAmortization;
         public string NegativeAmortization { get { return _negativeAmortization; } set { _negativeAmortization = value; } }
-        private Value<decimal?> _nonEscrowedPropertyCosts1YearConsummation;
+        private DirtyValue<decimal?> _nonEscrowedPropertyCosts1YearConsummation;
         public decimal? NonEscrowedPropertyCosts1YearConsummation { get { return _nonEscrowedPropertyCosts1YearConsummation; } set { _nonEscrowedPropertyCosts1YearConsummation = value; } }
-        private Value<bool?> _other1;
+        private DirtyValue<bool?> _other1;
         public bool? Other1 { get { return _other1; } set { _other1 = value; } }
-        private Value<bool?> _other2;
+        private DirtyValue<bool?> _other2;
         public bool? Other2 { get { return _other2; } set { _other2 = value; } }
-        private Value<bool?> _other3;
+        private DirtyValue<bool?> _other3;
         public bool? Other3 { get { return _other3; } set { _other3 = value; } }
-        private Value<string> _partialPayment;
+        private DirtyValue<string> _partialPayment;
         public string PartialPayment { get { return _partialPayment; } set { _partialPayment = value; } }
-        private Value<string> _partialPaymentHoldUntilComplete;
+        private DirtyValue<string> _partialPaymentHoldUntilComplete;
         public string PartialPaymentHoldUntilComplete { get { return _partialPaymentHoldUntilComplete; } set { _partialPaymentHoldUntilComplete = value; } }
-        private Value<string> _partialPaymentNone;
+        private DirtyValue<string> _partialPaymentNone;
         public string PartialPaymentNone { get { return _partialPaymentNone; } set { _partialPaymentNone = value; } }
-        private Value<string> _seasonalPaymentFromYr;
+        private DirtyValue<string> _seasonalPaymentFromYr;
         public string SeasonalPaymentFromYr { get { return _seasonalPaymentFromYr; } set { _seasonalPaymentFromYr = value; } }
-        private Value<bool?> _seasonalPayments;
+        private DirtyValue<bool?> _seasonalPayments;
         public bool? SeasonalPayments { get { return _seasonalPayments; } set { _seasonalPayments = value; } }
-        private Value<int?> _stepPayment;
+        private DirtyValue<int?> _stepPayment;
         public int? StepPayment { get { return _stepPayment; } set { _stepPayment = value; } }
-        private Value<bool?> _stepPayments;
+        private DirtyValue<bool?> _stepPayments;
         public bool? StepPayments { get { return _stepPayments; } set { _stepPayments = value; } }
-        private Value<decimal?> _stepRateFirstChange;
+        private DirtyValue<decimal?> _stepRateFirstChange;
         public decimal? StepRateFirstChange { get { return _stepRateFirstChange; } set { _stepRateFirstChange = value; } }
-        private Value<string> _subsequentChanges;
+        private DirtyValue<string> _subsequentChanges;
         public string SubsequentChanges { get { return _subsequentChanges; } set { _subsequentChanges = value; } }
-        private Value<decimal?> _totalDisbursed1YearConsummation;
+        private DirtyValue<decimal?> _totalDisbursed1YearConsummation;
         public decimal? TotalDisbursed1YearConsummation { get { return _totalDisbursed1YearConsummation; } set { _totalDisbursed1YearConsummation = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingDisclosure5.cs
+++ b/src/EncompassRest/Loans/ClosingDisclosure5.cs
@@ -8,133 +8,133 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingDisclosure5 : IDirty
     {
-        private Value<string> _cDLiabilityAfterForeclosure;
+        private DirtyValue<string> _cDLiabilityAfterForeclosure;
         public string CDLiabilityAfterForeclosure { get { return _cDLiabilityAfterForeclosure; } set { _cDLiabilityAfterForeclosure = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lenderAddress;
+        private DirtyValue<string> _lenderAddress;
         public string LenderAddress { get { return _lenderAddress; } set { _lenderAddress = value; } }
-        private Value<string> _lenderCity;
+        private DirtyValue<string> _lenderCity;
         public string LenderCity { get { return _lenderCity; } set { _lenderCity = value; } }
-        private Value<string> _lenderContact;
+        private DirtyValue<string> _lenderContact;
         public string LenderContact { get { return _lenderContact; } set { _lenderContact = value; } }
-        private Value<string> _lenderContactATLicenseID;
+        private DirtyValue<string> _lenderContactATLicenseID;
         public string LenderContactATLicenseID { get { return _lenderContactATLicenseID; } set { _lenderContactATLicenseID = value; } }
-        private Value<string> _lenderContactNMLSID;
+        private DirtyValue<string> _lenderContactNMLSID;
         public string LenderContactNMLSID { get { return _lenderContactNMLSID; } set { _lenderContactNMLSID = value; } }
-        private Value<string> _lenderEmail;
+        private DirtyValue<string> _lenderEmail;
         public string LenderEmail { get { return _lenderEmail; } set { _lenderEmail = value; } }
-        private Value<string> _lenderName;
+        private DirtyValue<string> _lenderName;
         public string LenderName { get { return _lenderName; } set { _lenderName = value; } }
-        private Value<string> _lenderNMLSID;
+        private DirtyValue<string> _lenderNMLSID;
         public string LenderNMLSID { get { return _lenderNMLSID; } set { _lenderNMLSID = value; } }
-        private Value<string> _lenderPhone;
+        private DirtyValue<string> _lenderPhone;
         public string LenderPhone { get { return _lenderPhone; } set { _lenderPhone = value; } }
-        private Value<string> _lenderState;
+        private DirtyValue<string> _lenderState;
         public string LenderState { get { return _lenderState; } set { _lenderState = value; } }
-        private Value<string> _lenderSTLicenseID;
+        private DirtyValue<string> _lenderSTLicenseID;
         public string LenderSTLicenseID { get { return _lenderSTLicenseID; } set { _lenderSTLicenseID = value; } }
-        private Value<string> _lenderZip;
+        private DirtyValue<string> _lenderZip;
         public string LenderZip { get { return _lenderZip; } set { _lenderZip = value; } }
-        private Value<string> _mortgageBrokerAddress;
+        private DirtyValue<string> _mortgageBrokerAddress;
         public string MortgageBrokerAddress { get { return _mortgageBrokerAddress; } set { _mortgageBrokerAddress = value; } }
-        private Value<string> _mortgageBrokerCity;
+        private DirtyValue<string> _mortgageBrokerCity;
         public string MortgageBrokerCity { get { return _mortgageBrokerCity; } set { _mortgageBrokerCity = value; } }
-        private Value<string> _mortgageBrokerContact;
+        private DirtyValue<string> _mortgageBrokerContact;
         public string MortgageBrokerContact { get { return _mortgageBrokerContact; } set { _mortgageBrokerContact = value; } }
-        private Value<string> _mortgageBrokerContactATLicenseID;
+        private DirtyValue<string> _mortgageBrokerContactATLicenseID;
         public string MortgageBrokerContactATLicenseID { get { return _mortgageBrokerContactATLicenseID; } set { _mortgageBrokerContactATLicenseID = value; } }
-        private Value<string> _mortgageBrokerContactNMLSID;
+        private DirtyValue<string> _mortgageBrokerContactNMLSID;
         public string MortgageBrokerContactNMLSID { get { return _mortgageBrokerContactNMLSID; } set { _mortgageBrokerContactNMLSID = value; } }
-        private Value<string> _mortgageBrokerEmail;
+        private DirtyValue<string> _mortgageBrokerEmail;
         public string MortgageBrokerEmail { get { return _mortgageBrokerEmail; } set { _mortgageBrokerEmail = value; } }
-        private Value<string> _mortgageBrokerName;
+        private DirtyValue<string> _mortgageBrokerName;
         public string MortgageBrokerName { get { return _mortgageBrokerName; } set { _mortgageBrokerName = value; } }
-        private Value<string> _mortgageBrokerNMLSID;
+        private DirtyValue<string> _mortgageBrokerNMLSID;
         public string MortgageBrokerNMLSID { get { return _mortgageBrokerNMLSID; } set { _mortgageBrokerNMLSID = value; } }
-        private Value<string> _mortgageBrokerPhone;
+        private DirtyValue<string> _mortgageBrokerPhone;
         public string MortgageBrokerPhone { get { return _mortgageBrokerPhone; } set { _mortgageBrokerPhone = value; } }
-        private Value<string> _mortgageBrokerState;
+        private DirtyValue<string> _mortgageBrokerState;
         public string MortgageBrokerState { get { return _mortgageBrokerState; } set { _mortgageBrokerState = value; } }
-        private Value<string> _mortgageBrokerSTLicenseID;
+        private DirtyValue<string> _mortgageBrokerSTLicenseID;
         public string MortgageBrokerSTLicenseID { get { return _mortgageBrokerSTLicenseID; } set { _mortgageBrokerSTLicenseID = value; } }
-        private Value<string> _mortgageBrokerZip;
+        private DirtyValue<string> _mortgageBrokerZip;
         public string MortgageBrokerZip { get { return _mortgageBrokerZip; } set { _mortgageBrokerZip = value; } }
-        private Value<string> _realEstateBrokerBAddress;
+        private DirtyValue<string> _realEstateBrokerBAddress;
         public string RealEstateBrokerBAddress { get { return _realEstateBrokerBAddress; } set { _realEstateBrokerBAddress = value; } }
-        private Value<string> _realEstateBrokerBCity;
+        private DirtyValue<string> _realEstateBrokerBCity;
         public string RealEstateBrokerBCity { get { return _realEstateBrokerBCity; } set { _realEstateBrokerBCity = value; } }
-        private Value<string> _realEstateBrokerBContact;
+        private DirtyValue<string> _realEstateBrokerBContact;
         public string RealEstateBrokerBContact { get { return _realEstateBrokerBContact; } set { _realEstateBrokerBContact = value; } }
-        private Value<string> _realEstateBrokerBContactATLicenseID;
+        private DirtyValue<string> _realEstateBrokerBContactATLicenseID;
         public string RealEstateBrokerBContactATLicenseID { get { return _realEstateBrokerBContactATLicenseID; } set { _realEstateBrokerBContactATLicenseID = value; } }
-        private Value<string> _realEstateBrokerBContactNMLSID;
+        private DirtyValue<string> _realEstateBrokerBContactNMLSID;
         public string RealEstateBrokerBContactNMLSID { get { return _realEstateBrokerBContactNMLSID; } set { _realEstateBrokerBContactNMLSID = value; } }
-        private Value<string> _realEstateBrokerBEmail;
+        private DirtyValue<string> _realEstateBrokerBEmail;
         public string RealEstateBrokerBEmail { get { return _realEstateBrokerBEmail; } set { _realEstateBrokerBEmail = value; } }
-        private Value<string> _realEstateBrokerBName;
+        private DirtyValue<string> _realEstateBrokerBName;
         public string RealEstateBrokerBName { get { return _realEstateBrokerBName; } set { _realEstateBrokerBName = value; } }
-        private Value<string> _realEstateBrokerBNMLSID;
+        private DirtyValue<string> _realEstateBrokerBNMLSID;
         public string RealEstateBrokerBNMLSID { get { return _realEstateBrokerBNMLSID; } set { _realEstateBrokerBNMLSID = value; } }
-        private Value<string> _realEstateBrokerBPhone;
+        private DirtyValue<string> _realEstateBrokerBPhone;
         public string RealEstateBrokerBPhone { get { return _realEstateBrokerBPhone; } set { _realEstateBrokerBPhone = value; } }
-        private Value<string> _realEstateBrokerBState;
+        private DirtyValue<string> _realEstateBrokerBState;
         public string RealEstateBrokerBState { get { return _realEstateBrokerBState; } set { _realEstateBrokerBState = value; } }
-        private Value<string> _realEstateBrokerBSTLicenseID;
+        private DirtyValue<string> _realEstateBrokerBSTLicenseID;
         public string RealEstateBrokerBSTLicenseID { get { return _realEstateBrokerBSTLicenseID; } set { _realEstateBrokerBSTLicenseID = value; } }
-        private Value<string> _realEstateBrokerBZip;
+        private DirtyValue<string> _realEstateBrokerBZip;
         public string RealEstateBrokerBZip { get { return _realEstateBrokerBZip; } set { _realEstateBrokerBZip = value; } }
-        private Value<string> _realEstateBrokerSAddress;
+        private DirtyValue<string> _realEstateBrokerSAddress;
         public string RealEstateBrokerSAddress { get { return _realEstateBrokerSAddress; } set { _realEstateBrokerSAddress = value; } }
-        private Value<string> _realEstateBrokerSCity;
+        private DirtyValue<string> _realEstateBrokerSCity;
         public string RealEstateBrokerSCity { get { return _realEstateBrokerSCity; } set { _realEstateBrokerSCity = value; } }
-        private Value<string> _realEstateBrokerSContact;
+        private DirtyValue<string> _realEstateBrokerSContact;
         public string RealEstateBrokerSContact { get { return _realEstateBrokerSContact; } set { _realEstateBrokerSContact = value; } }
-        private Value<string> _realEstateBrokerSContactATLicenseID;
+        private DirtyValue<string> _realEstateBrokerSContactATLicenseID;
         public string RealEstateBrokerSContactATLicenseID { get { return _realEstateBrokerSContactATLicenseID; } set { _realEstateBrokerSContactATLicenseID = value; } }
-        private Value<string> _realEstateBrokerSContactNMLSID;
+        private DirtyValue<string> _realEstateBrokerSContactNMLSID;
         public string RealEstateBrokerSContactNMLSID { get { return _realEstateBrokerSContactNMLSID; } set { _realEstateBrokerSContactNMLSID = value; } }
-        private Value<string> _realEstateBrokerSEmail;
+        private DirtyValue<string> _realEstateBrokerSEmail;
         public string RealEstateBrokerSEmail { get { return _realEstateBrokerSEmail; } set { _realEstateBrokerSEmail = value; } }
-        private Value<string> _realEstateBrokerSName;
+        private DirtyValue<string> _realEstateBrokerSName;
         public string RealEstateBrokerSName { get { return _realEstateBrokerSName; } set { _realEstateBrokerSName = value; } }
-        private Value<string> _realEstateBrokerSNMLSID;
+        private DirtyValue<string> _realEstateBrokerSNMLSID;
         public string RealEstateBrokerSNMLSID { get { return _realEstateBrokerSNMLSID; } set { _realEstateBrokerSNMLSID = value; } }
-        private Value<string> _realEstateBrokerSPhone;
+        private DirtyValue<string> _realEstateBrokerSPhone;
         public string RealEstateBrokerSPhone { get { return _realEstateBrokerSPhone; } set { _realEstateBrokerSPhone = value; } }
-        private Value<string> _realEstateBrokerSState;
+        private DirtyValue<string> _realEstateBrokerSState;
         public string RealEstateBrokerSState { get { return _realEstateBrokerSState; } set { _realEstateBrokerSState = value; } }
-        private Value<string> _realEstateBrokerSSTLicenseID;
+        private DirtyValue<string> _realEstateBrokerSSTLicenseID;
         public string RealEstateBrokerSSTLicenseID { get { return _realEstateBrokerSSTLicenseID; } set { _realEstateBrokerSSTLicenseID = value; } }
-        private Value<string> _realEstateBrokerSZip;
+        private DirtyValue<string> _realEstateBrokerSZip;
         public string RealEstateBrokerSZip { get { return _realEstateBrokerSZip; } set { _realEstateBrokerSZip = value; } }
-        private Value<string> _settlementAgentAddress;
+        private DirtyValue<string> _settlementAgentAddress;
         public string SettlementAgentAddress { get { return _settlementAgentAddress; } set { _settlementAgentAddress = value; } }
-        private Value<string> _settlementAgentCity;
+        private DirtyValue<string> _settlementAgentCity;
         public string SettlementAgentCity { get { return _settlementAgentCity; } set { _settlementAgentCity = value; } }
-        private Value<string> _settlementAgentContact;
+        private DirtyValue<string> _settlementAgentContact;
         public string SettlementAgentContact { get { return _settlementAgentContact; } set { _settlementAgentContact = value; } }
-        private Value<string> _settlementAgentContactATLicenseID;
+        private DirtyValue<string> _settlementAgentContactATLicenseID;
         public string SettlementAgentContactATLicenseID { get { return _settlementAgentContactATLicenseID; } set { _settlementAgentContactATLicenseID = value; } }
-        private Value<string> _settlementAgentContactNMLSID;
+        private DirtyValue<string> _settlementAgentContactNMLSID;
         public string SettlementAgentContactNMLSID { get { return _settlementAgentContactNMLSID; } set { _settlementAgentContactNMLSID = value; } }
-        private Value<string> _settlementAgentEmail;
+        private DirtyValue<string> _settlementAgentEmail;
         public string SettlementAgentEmail { get { return _settlementAgentEmail; } set { _settlementAgentEmail = value; } }
-        private Value<string> _settlementAgentName;
+        private DirtyValue<string> _settlementAgentName;
         public string SettlementAgentName { get { return _settlementAgentName; } set { _settlementAgentName = value; } }
-        private Value<string> _settlementAgentNMLSID;
+        private DirtyValue<string> _settlementAgentNMLSID;
         public string SettlementAgentNMLSID { get { return _settlementAgentNMLSID; } set { _settlementAgentNMLSID = value; } }
-        private Value<string> _settlementAgentPhone;
+        private DirtyValue<string> _settlementAgentPhone;
         public string SettlementAgentPhone { get { return _settlementAgentPhone; } set { _settlementAgentPhone = value; } }
-        private Value<string> _settlementAgentState;
+        private DirtyValue<string> _settlementAgentState;
         public string SettlementAgentState { get { return _settlementAgentState; } set { _settlementAgentState = value; } }
-        private Value<string> _settlementAgentSTLicenseID;
+        private DirtyValue<string> _settlementAgentSTLicenseID;
         public string SettlementAgentSTLicenseID { get { return _settlementAgentSTLicenseID; } set { _settlementAgentSTLicenseID = value; } }
-        private Value<string> _settlementAgentZip;
+        private DirtyValue<string> _settlementAgentZip;
         public string SettlementAgentZip { get { return _settlementAgentZip; } set { _settlementAgentZip = value; } }
-        private Value<string> _signatureType;
+        private DirtyValue<string> _signatureType;
         public string SignatureType { get { return _signatureType; } set { _signatureType = value; } }
-        private Value<decimal?> _totalPayments;
+        private DirtyValue<decimal?> _totalPayments;
         public decimal? TotalPayments { get { return _totalPayments; } set { _totalPayments = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingDocument.cs
+++ b/src/EncompassRest/Loans/ClosingDocument.cs
@@ -22,16 +22,16 @@ namespace EncompassRest.Loans
         public decimal? AdditionalOriginalPincipalAmountSecured { get { return _additionalOriginalPincipalAmountSecured; } set { _additionalOriginalPincipalAmountSecured = value; } }
         private Value<string> _additionalSigVerbiageType;
         public string AdditionalSigVerbiageType { get { return _additionalSigVerbiageType; } set { _additionalSigVerbiageType = value; } }
-        private Value<List<AdditionalStateDisclosure>> _additionalStateDisclosures;
-        public List<AdditionalStateDisclosure> AdditionalStateDisclosures { get { return _additionalStateDisclosures; } set { _additionalStateDisclosures = value; } }
+        private DirtyList<AdditionalStateDisclosure> _additionalStateDisclosures;
+        public IList<AdditionalStateDisclosure> AdditionalStateDisclosures { get { var v = _additionalStateDisclosures; return v ?? Interlocked.CompareExchange(ref _additionalStateDisclosures, (v = new DirtyList<AdditionalStateDisclosure>()), null) ?? v; } set { _additionalStateDisclosures = new DirtyList<AdditionalStateDisclosure>(value); } }
         private Value<bool?> _affectedByInterest;
         public bool? AffectedByInterest { get { return _affectedByInterest; } set { _affectedByInterest = value; } }
         private Value<string> _alternateLender;
         public string AlternateLender { get { return _alternateLender; } set { _alternateLender = value; } }
         private Value<string> _altLenderId;
         public string AltLenderId { get { return _altLenderId; } set { _altLenderId = value; } }
-        private Value<List<AntiSteeringLoanOption>> _antiSteeringLoanOptions;
-        public List<AntiSteeringLoanOption> AntiSteeringLoanOptions { get { return _antiSteeringLoanOptions; } set { _antiSteeringLoanOptions = value; } }
+        private DirtyList<AntiSteeringLoanOption> _antiSteeringLoanOptions;
+        public IList<AntiSteeringLoanOption> AntiSteeringLoanOptions { get { var v = _antiSteeringLoanOptions; return v ?? Interlocked.CompareExchange(ref _antiSteeringLoanOptions, (v = new DirtyList<AntiSteeringLoanOption>()), null) ?? v; } set { _antiSteeringLoanOptions = new DirtyList<AntiSteeringLoanOption>(value); } }
         private Value<string> _areAbleToServiceIndicator;
         public string AreAbleToServiceIndicator { get { return _areAbleToServiceIndicator; } set { _areAbleToServiceIndicator = value; } }
         private Value<string> _associatedDocumentNumber;
@@ -92,14 +92,40 @@ namespace EncompassRest.Loans
         public string BrokerWithLenders { get { return _brokerWithLenders; } set { _brokerWithLenders = value; } }
         private Value<decimal?> _cashCheckFromBorrower;
         public decimal? CashCheckFromBorrower { get { return _cashCheckFromBorrower; } set { _cashCheckFromBorrower = value; } }
+        private Value<DateTime?> _cLClearCloseStatusReceivedByLenderDateTime;
+        public DateTime? CLClearCloseStatusReceivedByLenderDateTime { get { return _cLClearCloseStatusReceivedByLenderDateTime; } set { _cLClearCloseStatusReceivedByLenderDateTime = value; } }
+        private Value<DateTime?> _cLClosingEscrowOrderAcceptedDateTime;
+        public DateTime? CLClosingEscrowOrderAcceptedDateTime { get { return _cLClosingEscrowOrderAcceptedDateTime; } set { _cLClosingEscrowOrderAcceptedDateTime = value; } }
+        private Value<DateTime?> _cLClosingEscrowOrderSentDateTime;
+        public DateTime? CLClosingEscrowOrderSentDateTime { get { return _cLClosingEscrowOrderSentDateTime; } set { _cLClosingEscrowOrderSentDateTime = value; } }
+        private Value<DateTime?> _cLDraftClosingDisclosureReceivedByLenderDateTime;
+        public DateTime? CLDraftClosingDisclosureReceivedByLenderDateTime { get { return _cLDraftClosingDisclosureReceivedByLenderDateTime; } set { _cLDraftClosingDisclosureReceivedByLenderDateTime = value; } }
+        private Value<DateTime?> _cLFinalCDSentDateTime;
+        public DateTime? CLFinalCDSentDateTime { get { return _cLFinalCDSentDateTime; } set { _cLFinalCDSentDateTime = value; } }
+        private Value<DateTime?> _cLFinalTitlePolicyDateTime;
+        public DateTime? CLFinalTitlePolicyDateTime { get { return _cLFinalTitlePolicyDateTime; } set { _cLFinalTitlePolicyDateTime = value; } }
+        private Value<DateTime?> _cLLastFeeQuoteReceivedDateTime;
+        public DateTime? CLLastFeeQuoteReceivedDateTime { get { return _cLLastFeeQuoteReceivedDateTime; } set { _cLLastFeeQuoteReceivedDateTime = value; } }
+        private Value<DateTime?> _cLLastFeeQuoteRequestedDateTime;
+        public DateTime? CLLastFeeQuoteRequestedDateTime { get { return _cLLastFeeQuoteRequestedDateTime; } set { _cLLastFeeQuoteRequestedDateTime = value; } }
         private Value<string> _closingDocsLoanProgramType;
         public string ClosingDocsLoanProgramType { get { return _closingDocsLoanProgramType; } set { _closingDocsLoanProgramType = value; } }
-        private Value<List<ClosingEntity>> _closingEntities;
-        public List<ClosingEntity> ClosingEntities { get { return _closingEntities; } set { _closingEntities = value; } }
+        private DirtyList<ClosingEntity> _closingEntities;
+        public IList<ClosingEntity> ClosingEntities { get { var v = _closingEntities; return v ?? Interlocked.CompareExchange(ref _closingEntities, (v = new DirtyList<ClosingEntity>()), null) ?? v; } set { _closingEntities = new DirtyList<ClosingEntity>(value); } }
         private Value<string> _closingProvider;
         public string ClosingProvider { get { return _closingProvider; } set { _closingProvider = value; } }
         private Value<string> _closingState;
         public string ClosingState { get { return _closingState; } set { _closingState = value; } }
+        private Value<DateTime?> _cLPayoffsRequestedDateTime;
+        public DateTime? CLPayoffsRequestedDateTime { get { return _cLPayoffsRequestedDateTime; } set { _cLPayoffsRequestedDateTime = value; } }
+        private Value<DateTime?> _cLPrelimCommitmentReceivedByLenderDateTime;
+        public DateTime? CLPrelimCommitmentReceivedByLenderDateTime { get { return _cLPrelimCommitmentReceivedByLenderDateTime; } set { _cLPrelimCommitmentReceivedByLenderDateTime = value; } }
+        private Value<DateTime?> _cLProviderDisburseFundsDateTime;
+        public DateTime? CLProviderDisburseFundsDateTime { get { return _cLProviderDisburseFundsDateTime; } set { _cLProviderDisburseFundsDateTime = value; } }
+        private Value<DateTime?> _cLTitleOrderAcceptedDateTime;
+        public DateTime? CLTitleOrderAcceptedDateTime { get { return _cLTitleOrderAcceptedDateTime; } set { _cLTitleOrderAcceptedDateTime = value; } }
+        private Value<DateTime?> _cLTitleOrderSentDateTime;
+        public DateTime? CLTitleOrderSentDateTime { get { return _cLTitleOrderSentDateTime; } set { _cLTitleOrderSentDateTime = value; } }
         private Value<string> _complianceJurisdictionCounty;
         public string ComplianceJurisdictionCounty { get { return _complianceJurisdictionCounty; } set { _complianceJurisdictionCounty = value; } }
         private Value<DateTime?> _compliancePropertyIdentifiedDate;
@@ -318,8 +344,8 @@ namespace EncompassRest.Loans
         public string RenewalExtensionDescription { get { return _renewalExtensionDescription; } set { _renewalExtensionDescription = value; } }
         private Value<DateTime?> _rescissionDate;
         public DateTime? RescissionDate { get { return _rescissionDate; } set { _rescissionDate = value; } }
-        private Value<List<RespaHudDetail>> _respaHudDetails;
-        public List<RespaHudDetail> RespaHudDetails { get { return _respaHudDetails; } set { _respaHudDetails = value; } }
+        private DirtyList<RespaHudDetail> _respaHudDetails;
+        public IList<RespaHudDetail> RespaHudDetails { get { var v = _respaHudDetails; return v ?? Interlocked.CompareExchange(ref _respaHudDetails, (v = new DirtyList<RespaHudDetail>()), null) ?? v; } set { _respaHudDetails = new DirtyList<RespaHudDetail>(value); } }
         private Value<string> _rMLANamePreceding10Years;
         public string RMLANamePreceding10Years { get { return _rMLANamePreceding10Years; } set { _rMLANamePreceding10Years = value; } }
         private Value<string> _rmlLenderBrokerRepresents;
@@ -332,8 +358,8 @@ namespace EncompassRest.Loans
         public DateTime? SignatureDateFor1003 { get { return _signatureDateFor1003; } set { _signatureDateFor1003 = value; } }
         private Value<string> _specialFloodHazardAreaIndictor;
         public string SpecialFloodHazardAreaIndictor { get { return _specialFloodHazardAreaIndictor; } set { _specialFloodHazardAreaIndictor = value; } }
-        private Value<List<StateLicense>> _stateLicenses;
-        public List<StateLicense> StateLicenses { get { return _stateLicenses; } set { _stateLicenses = value; } }
+        private DirtyList<StateLicense> _stateLicenses;
+        public IList<StateLicense> StateLicenses { get { var v = _stateLicenses; return v ?? Interlocked.CompareExchange(ref _stateLicenses, (v = new DirtyList<StateLicense>()), null) ?? v; } set { _stateLicenses = new DirtyList<StateLicense>(value); } }
         private Value<string> _suretyCompanyName;
         public string SuretyCompanyName { get { return _suretyCompanyName; } set { _suretyCompanyName = value; } }
         private Value<bool?> _syncInterestDateDisbursementDate;
@@ -370,11 +396,9 @@ namespace EncompassRest.Loans
                     || _additionalLienHolderName.Dirty
                     || _additionalOriginalPincipalAmountSecured.Dirty
                     || _additionalSigVerbiageType.Dirty
-                    || _additionalStateDisclosures.Dirty
                     || _affectedByInterest.Dirty
                     || _alternateLender.Dirty
                     || _altLenderId.Dirty
-                    || _antiSteeringLoanOptions.Dirty
                     || _areAbleToServiceIndicator.Dirty
                     || _associatedDocumentNumber.Dirty
                     || _beneficiaries.Dirty
@@ -405,10 +429,22 @@ namespace EncompassRest.Loans
                     || _brokerTaxIdentificationNumberIdentifier.Dirty
                     || _brokerWithLenders.Dirty
                     || _cashCheckFromBorrower.Dirty
+                    || _cLClearCloseStatusReceivedByLenderDateTime.Dirty
+                    || _cLClosingEscrowOrderAcceptedDateTime.Dirty
+                    || _cLClosingEscrowOrderSentDateTime.Dirty
+                    || _cLDraftClosingDisclosureReceivedByLenderDateTime.Dirty
+                    || _cLFinalCDSentDateTime.Dirty
+                    || _cLFinalTitlePolicyDateTime.Dirty
+                    || _cLLastFeeQuoteReceivedDateTime.Dirty
+                    || _cLLastFeeQuoteRequestedDateTime.Dirty
                     || _closingDocsLoanProgramType.Dirty
-                    || _closingEntities.Dirty
                     || _closingProvider.Dirty
                     || _closingState.Dirty
+                    || _cLPayoffsRequestedDateTime.Dirty
+                    || _cLPrelimCommitmentReceivedByLenderDateTime.Dirty
+                    || _cLProviderDisburseFundsDateTime.Dirty
+                    || _cLTitleOrderAcceptedDateTime.Dirty
+                    || _cLTitleOrderSentDateTime.Dirty
                     || _complianceJurisdictionCounty.Dirty
                     || _compliancePropertyIdentifiedDate.Dirty
                     || _conditionDescription.Dirty
@@ -518,14 +554,12 @@ namespace EncompassRest.Loans
                     || _refinanceRightOfRescissionExemptFlag.Dirty
                     || _renewalExtensionDescription.Dirty
                     || _rescissionDate.Dirty
-                    || _respaHudDetails.Dirty
                     || _rMLANamePreceding10Years.Dirty
                     || _rmlLenderBrokerRepresents.Dirty
                     || _secondTransferYear.Dirty
                     || _secondTransferYearValue.Dirty
                     || _signatureDateFor1003.Dirty
                     || _specialFloodHazardAreaIndictor.Dirty
-                    || _stateLicenses.Dirty
                     || _suretyCompanyName.Dirty
                     || _syncInterestDateDisbursementDate.Dirty
                     || _termiteReportRequiredIndicator.Dirty
@@ -536,7 +570,12 @@ namespace EncompassRest.Loans
                     || _titleReportRequiredEndorsementsDescription.Dirty
                     || _totalDisbursed.Dirty
                     || _trust2Beneficiaries.Dirty
-                    || _weConductBusiness.Dirty;
+                    || _weConductBusiness.Dirty
+                    || _additionalStateDisclosures?.Dirty == true
+                    || _antiSteeringLoanOptions?.Dirty == true
+                    || _closingEntities?.Dirty == true
+                    || _respaHudDetails?.Dirty == true
+                    || _stateLicenses?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -550,11 +589,9 @@ namespace EncompassRest.Loans
                 _additionalLienHolderName.Dirty = value;
                 _additionalOriginalPincipalAmountSecured.Dirty = value;
                 _additionalSigVerbiageType.Dirty = value;
-                _additionalStateDisclosures.Dirty = value;
                 _affectedByInterest.Dirty = value;
                 _alternateLender.Dirty = value;
                 _altLenderId.Dirty = value;
-                _antiSteeringLoanOptions.Dirty = value;
                 _areAbleToServiceIndicator.Dirty = value;
                 _associatedDocumentNumber.Dirty = value;
                 _beneficiaries.Dirty = value;
@@ -585,10 +622,22 @@ namespace EncompassRest.Loans
                 _brokerTaxIdentificationNumberIdentifier.Dirty = value;
                 _brokerWithLenders.Dirty = value;
                 _cashCheckFromBorrower.Dirty = value;
+                _cLClearCloseStatusReceivedByLenderDateTime.Dirty = value;
+                _cLClosingEscrowOrderAcceptedDateTime.Dirty = value;
+                _cLClosingEscrowOrderSentDateTime.Dirty = value;
+                _cLDraftClosingDisclosureReceivedByLenderDateTime.Dirty = value;
+                _cLFinalCDSentDateTime.Dirty = value;
+                _cLFinalTitlePolicyDateTime.Dirty = value;
+                _cLLastFeeQuoteReceivedDateTime.Dirty = value;
+                _cLLastFeeQuoteRequestedDateTime.Dirty = value;
                 _closingDocsLoanProgramType.Dirty = value;
-                _closingEntities.Dirty = value;
                 _closingProvider.Dirty = value;
                 _closingState.Dirty = value;
+                _cLPayoffsRequestedDateTime.Dirty = value;
+                _cLPrelimCommitmentReceivedByLenderDateTime.Dirty = value;
+                _cLProviderDisburseFundsDateTime.Dirty = value;
+                _cLTitleOrderAcceptedDateTime.Dirty = value;
+                _cLTitleOrderSentDateTime.Dirty = value;
                 _complianceJurisdictionCounty.Dirty = value;
                 _compliancePropertyIdentifiedDate.Dirty = value;
                 _conditionDescription.Dirty = value;
@@ -698,14 +747,12 @@ namespace EncompassRest.Loans
                 _refinanceRightOfRescissionExemptFlag.Dirty = value;
                 _renewalExtensionDescription.Dirty = value;
                 _rescissionDate.Dirty = value;
-                _respaHudDetails.Dirty = value;
                 _rMLANamePreceding10Years.Dirty = value;
                 _rmlLenderBrokerRepresents.Dirty = value;
                 _secondTransferYear.Dirty = value;
                 _secondTransferYearValue.Dirty = value;
                 _signatureDateFor1003.Dirty = value;
                 _specialFloodHazardAreaIndictor.Dirty = value;
-                _stateLicenses.Dirty = value;
                 _suretyCompanyName.Dirty = value;
                 _syncInterestDateDisbursementDate.Dirty = value;
                 _termiteReportRequiredIndicator.Dirty = value;
@@ -717,6 +764,11 @@ namespace EncompassRest.Loans
                 _totalDisbursed.Dirty = value;
                 _trust2Beneficiaries.Dirty = value;
                 _weConductBusiness.Dirty = value;
+                if (_additionalStateDisclosures != null) _additionalStateDisclosures.Dirty = value;
+                if (_antiSteeringLoanOptions != null) _antiSteeringLoanOptions.Dirty = value;
+                if (_closingEntities != null) _closingEntities.Dirty = value;
+                if (_respaHudDetails != null) _respaHudDetails.Dirty = value;
+                if (_stateLicenses != null) _stateLicenses.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/ClosingDocument.cs
+++ b/src/EncompassRest/Loans/ClosingDocument.cs
@@ -8,379 +8,379 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingDocument : IDirty
     {
-        private Value<string> _additionalLienHolderAddress;
+        private DirtyValue<string> _additionalLienHolderAddress;
         public string AdditionalLienHolderAddress { get { return _additionalLienHolderAddress; } set { _additionalLienHolderAddress = value; } }
-        private Value<string> _additionalLienHolderAddressCity;
+        private DirtyValue<string> _additionalLienHolderAddressCity;
         public string AdditionalLienHolderAddressCity { get { return _additionalLienHolderAddressCity; } set { _additionalLienHolderAddressCity = value; } }
-        private Value<string> _additionalLienHolderAddressPostalCode;
+        private DirtyValue<string> _additionalLienHolderAddressPostalCode;
         public string AdditionalLienHolderAddressPostalCode { get { return _additionalLienHolderAddressPostalCode; } set { _additionalLienHolderAddressPostalCode = value; } }
-        private Value<string> _additionalLienHolderAddressState;
+        private DirtyValue<string> _additionalLienHolderAddressState;
         public string AdditionalLienHolderAddressState { get { return _additionalLienHolderAddressState; } set { _additionalLienHolderAddressState = value; } }
-        private Value<string> _additionalLienHolderName;
+        private DirtyValue<string> _additionalLienHolderName;
         public string AdditionalLienHolderName { get { return _additionalLienHolderName; } set { _additionalLienHolderName = value; } }
-        private Value<decimal?> _additionalOriginalPincipalAmountSecured;
+        private DirtyValue<decimal?> _additionalOriginalPincipalAmountSecured;
         public decimal? AdditionalOriginalPincipalAmountSecured { get { return _additionalOriginalPincipalAmountSecured; } set { _additionalOriginalPincipalAmountSecured = value; } }
-        private Value<string> _additionalSigVerbiageType;
+        private DirtyValue<string> _additionalSigVerbiageType;
         public string AdditionalSigVerbiageType { get { return _additionalSigVerbiageType; } set { _additionalSigVerbiageType = value; } }
         private DirtyList<AdditionalStateDisclosure> _additionalStateDisclosures;
         public IList<AdditionalStateDisclosure> AdditionalStateDisclosures { get { var v = _additionalStateDisclosures; return v ?? Interlocked.CompareExchange(ref _additionalStateDisclosures, (v = new DirtyList<AdditionalStateDisclosure>()), null) ?? v; } set { _additionalStateDisclosures = new DirtyList<AdditionalStateDisclosure>(value); } }
-        private Value<bool?> _affectedByInterest;
+        private DirtyValue<bool?> _affectedByInterest;
         public bool? AffectedByInterest { get { return _affectedByInterest; } set { _affectedByInterest = value; } }
-        private Value<string> _alternateLender;
+        private DirtyValue<string> _alternateLender;
         public string AlternateLender { get { return _alternateLender; } set { _alternateLender = value; } }
-        private Value<string> _altLenderId;
+        private DirtyValue<string> _altLenderId;
         public string AltLenderId { get { return _altLenderId; } set { _altLenderId = value; } }
         private DirtyList<AntiSteeringLoanOption> _antiSteeringLoanOptions;
         public IList<AntiSteeringLoanOption> AntiSteeringLoanOptions { get { var v = _antiSteeringLoanOptions; return v ?? Interlocked.CompareExchange(ref _antiSteeringLoanOptions, (v = new DirtyList<AntiSteeringLoanOption>()), null) ?? v; } set { _antiSteeringLoanOptions = new DirtyList<AntiSteeringLoanOption>(value); } }
-        private Value<string> _areAbleToServiceIndicator;
+        private DirtyValue<string> _areAbleToServiceIndicator;
         public string AreAbleToServiceIndicator { get { return _areAbleToServiceIndicator; } set { _areAbleToServiceIndicator = value; } }
-        private Value<string> _associatedDocumentNumber;
+        private DirtyValue<string> _associatedDocumentNumber;
         public string AssociatedDocumentNumber { get { return _associatedDocumentNumber; } set { _associatedDocumentNumber = value; } }
-        private Value<string> _beneficiaries;
+        private DirtyValue<string> _beneficiaries;
         public string Beneficiaries { get { return _beneficiaries; } set { _beneficiaries = value; } }
-        private Value<bool?> _borrowerConsentType1;
+        private DirtyValue<bool?> _borrowerConsentType1;
         public bool? BorrowerConsentType1 { get { return _borrowerConsentType1; } set { _borrowerConsentType1 = value; } }
-        private Value<bool?> _borrowerConsentType2;
+        private DirtyValue<bool?> _borrowerConsentType2;
         public bool? BorrowerConsentType2 { get { return _borrowerConsentType2; } set { _borrowerConsentType2 = value; } }
-        private Value<string> _borrowerOrganizationType1;
+        private DirtyValue<string> _borrowerOrganizationType1;
         public string BorrowerOrganizationType1 { get { return _borrowerOrganizationType1; } set { _borrowerOrganizationType1 = value; } }
-        private Value<string> _borrowerOrganizationType2;
+        private DirtyValue<string> _borrowerOrganizationType2;
         public string BorrowerOrganizationType2 { get { return _borrowerOrganizationType2; } set { _borrowerOrganizationType2 = value; } }
-        private Value<string> _borrowerOrganizedUnderTheLawsOfJurisdictionName1;
+        private DirtyValue<string> _borrowerOrganizedUnderTheLawsOfJurisdictionName1;
         public string BorrowerOrganizedUnderTheLawsOfJurisdictionName1 { get { return _borrowerOrganizedUnderTheLawsOfJurisdictionName1; } set { _borrowerOrganizedUnderTheLawsOfJurisdictionName1 = value; } }
-        private Value<string> _borrowerOrganizedUnderTheLawsOfJurisdictionName2;
+        private DirtyValue<string> _borrowerOrganizedUnderTheLawsOfJurisdictionName2;
         public string BorrowerOrganizedUnderTheLawsOfJurisdictionName2 { get { return _borrowerOrganizedUnderTheLawsOfJurisdictionName2; } set { _borrowerOrganizedUnderTheLawsOfJurisdictionName2 = value; } }
-        private Value<string> _borrowerTaxIdentificationNumberIdentifier1;
+        private DirtyValue<string> _borrowerTaxIdentificationNumberIdentifier1;
         public string BorrowerTaxIdentificationNumberIdentifier1 { get { return _borrowerTaxIdentificationNumberIdentifier1; } set { _borrowerTaxIdentificationNumberIdentifier1 = value; } }
-        private Value<string> _borrowerTaxIdentificationNumberIdentifier2;
+        private DirtyValue<string> _borrowerTaxIdentificationNumberIdentifier2;
         public string BorrowerTaxIdentificationNumberIdentifier2 { get { return _borrowerTaxIdentificationNumberIdentifier2; } set { _borrowerTaxIdentificationNumberIdentifier2 = value; } }
-        private Value<string> _borrowerTrustAmendedDateOrYear1;
+        private DirtyValue<string> _borrowerTrustAmendedDateOrYear1;
         public string BorrowerTrustAmendedDateOrYear1 { get { return _borrowerTrustAmendedDateOrYear1; } set { _borrowerTrustAmendedDateOrYear1 = value; } }
-        private Value<string> _borrowerTrustAmendedDateOrYear2;
+        private DirtyValue<string> _borrowerTrustAmendedDateOrYear2;
         public string BorrowerTrustAmendedDateOrYear2 { get { return _borrowerTrustAmendedDateOrYear2; } set { _borrowerTrustAmendedDateOrYear2 = value; } }
-        private Value<string> _borrowerTrustDateOrYear1;
+        private DirtyValue<string> _borrowerTrustDateOrYear1;
         public string BorrowerTrustDateOrYear1 { get { return _borrowerTrustDateOrYear1; } set { _borrowerTrustDateOrYear1 = value; } }
-        private Value<string> _borrowerTrustDateOrYear2;
+        private DirtyValue<string> _borrowerTrustDateOrYear2;
         public string BorrowerTrustDateOrYear2 { get { return _borrowerTrustDateOrYear2; } set { _borrowerTrustDateOrYear2 = value; } }
-        private Value<string> _borrowerUnparsedName1;
+        private DirtyValue<string> _borrowerUnparsedName1;
         public string BorrowerUnparsedName1 { get { return _borrowerUnparsedName1; } set { _borrowerUnparsedName1 = value; } }
-        private Value<string> _borrowerUnparsedName2;
+        private DirtyValue<string> _borrowerUnparsedName2;
         public string BorrowerUnparsedName2 { get { return _borrowerUnparsedName2; } set { _borrowerUnparsedName2 = value; } }
-        private Value<string> _brokerAuthorizedRepresentativeTitle;
+        private DirtyValue<string> _brokerAuthorizedRepresentativeTitle;
         public string BrokerAuthorizedRepresentativeTitle { get { return _brokerAuthorizedRepresentativeTitle; } set { _brokerAuthorizedRepresentativeTitle = value; } }
-        private Value<string> _brokerCompensationMethod;
+        private DirtyValue<string> _brokerCompensationMethod;
         public string BrokerCompensationMethod { get { return _brokerCompensationMethod; } set { _brokerCompensationMethod = value; } }
-        private Value<string> _brokerFeeRefundConditions1;
+        private DirtyValue<string> _brokerFeeRefundConditions1;
         public string BrokerFeeRefundConditions1 { get { return _brokerFeeRefundConditions1; } set { _brokerFeeRefundConditions1 = value; } }
-        private Value<string> _brokerFeeRefundConditions2;
+        private DirtyValue<string> _brokerFeeRefundConditions2;
         public string BrokerFeeRefundConditions2 { get { return _brokerFeeRefundConditions2; } set { _brokerFeeRefundConditions2 = value; } }
-        private Value<string> _brokerFeeRefundConditions3;
+        private DirtyValue<string> _brokerFeeRefundConditions3;
         public string BrokerFeeRefundConditions3 { get { return _brokerFeeRefundConditions3; } set { _brokerFeeRefundConditions3 = value; } }
-        private Value<string> _brokerForPlacingLoan;
+        private DirtyValue<string> _brokerForPlacingLoan;
         public string BrokerForPlacingLoan { get { return _brokerForPlacingLoan; } set { _brokerForPlacingLoan = value; } }
-        private Value<string> _brokerInterestRateEffect;
+        private DirtyValue<string> _brokerInterestRateEffect;
         public string BrokerInterestRateEffect { get { return _brokerInterestRateEffect; } set { _brokerInterestRateEffect = value; } }
-        private Value<string> _brokerLenderRelationship;
+        private DirtyValue<string> _brokerLenderRelationship;
         public string BrokerLenderRelationship { get { return _brokerLenderRelationship; } set { _brokerLenderRelationship = value; } }
-        private Value<string> _brokerLicenseNumberIdentifier;
+        private DirtyValue<string> _brokerLicenseNumberIdentifier;
         public string BrokerLicenseNumberIdentifier { get { return _brokerLicenseNumberIdentifier; } set { _brokerLicenseNumberIdentifier = value; } }
-        private Value<string> _brokerNameAsLicensed;
+        private DirtyValue<string> _brokerNameAsLicensed;
         public string BrokerNameAsLicensed { get { return _brokerNameAsLicensed; } set { _brokerNameAsLicensed = value; } }
-        private Value<string> _brokerTaxIdentificationNumberIdentifier;
+        private DirtyValue<string> _brokerTaxIdentificationNumberIdentifier;
         public string BrokerTaxIdentificationNumberIdentifier { get { return _brokerTaxIdentificationNumberIdentifier; } set { _brokerTaxIdentificationNumberIdentifier = value; } }
-        private Value<string> _brokerWithLenders;
+        private DirtyValue<string> _brokerWithLenders;
         public string BrokerWithLenders { get { return _brokerWithLenders; } set { _brokerWithLenders = value; } }
-        private Value<decimal?> _cashCheckFromBorrower;
+        private DirtyValue<decimal?> _cashCheckFromBorrower;
         public decimal? CashCheckFromBorrower { get { return _cashCheckFromBorrower; } set { _cashCheckFromBorrower = value; } }
-        private Value<DateTime?> _cLClearCloseStatusReceivedByLenderDateTime;
+        private DirtyValue<DateTime?> _cLClearCloseStatusReceivedByLenderDateTime;
         public DateTime? CLClearCloseStatusReceivedByLenderDateTime { get { return _cLClearCloseStatusReceivedByLenderDateTime; } set { _cLClearCloseStatusReceivedByLenderDateTime = value; } }
-        private Value<DateTime?> _cLClosingEscrowOrderAcceptedDateTime;
+        private DirtyValue<DateTime?> _cLClosingEscrowOrderAcceptedDateTime;
         public DateTime? CLClosingEscrowOrderAcceptedDateTime { get { return _cLClosingEscrowOrderAcceptedDateTime; } set { _cLClosingEscrowOrderAcceptedDateTime = value; } }
-        private Value<DateTime?> _cLClosingEscrowOrderSentDateTime;
+        private DirtyValue<DateTime?> _cLClosingEscrowOrderSentDateTime;
         public DateTime? CLClosingEscrowOrderSentDateTime { get { return _cLClosingEscrowOrderSentDateTime; } set { _cLClosingEscrowOrderSentDateTime = value; } }
-        private Value<DateTime?> _cLDraftClosingDisclosureReceivedByLenderDateTime;
+        private DirtyValue<DateTime?> _cLDraftClosingDisclosureReceivedByLenderDateTime;
         public DateTime? CLDraftClosingDisclosureReceivedByLenderDateTime { get { return _cLDraftClosingDisclosureReceivedByLenderDateTime; } set { _cLDraftClosingDisclosureReceivedByLenderDateTime = value; } }
-        private Value<DateTime?> _cLFinalCDSentDateTime;
+        private DirtyValue<DateTime?> _cLFinalCDSentDateTime;
         public DateTime? CLFinalCDSentDateTime { get { return _cLFinalCDSentDateTime; } set { _cLFinalCDSentDateTime = value; } }
-        private Value<DateTime?> _cLFinalTitlePolicyDateTime;
+        private DirtyValue<DateTime?> _cLFinalTitlePolicyDateTime;
         public DateTime? CLFinalTitlePolicyDateTime { get { return _cLFinalTitlePolicyDateTime; } set { _cLFinalTitlePolicyDateTime = value; } }
-        private Value<DateTime?> _cLLastFeeQuoteReceivedDateTime;
+        private DirtyValue<DateTime?> _cLLastFeeQuoteReceivedDateTime;
         public DateTime? CLLastFeeQuoteReceivedDateTime { get { return _cLLastFeeQuoteReceivedDateTime; } set { _cLLastFeeQuoteReceivedDateTime = value; } }
-        private Value<DateTime?> _cLLastFeeQuoteRequestedDateTime;
+        private DirtyValue<DateTime?> _cLLastFeeQuoteRequestedDateTime;
         public DateTime? CLLastFeeQuoteRequestedDateTime { get { return _cLLastFeeQuoteRequestedDateTime; } set { _cLLastFeeQuoteRequestedDateTime = value; } }
-        private Value<string> _closingDocsLoanProgramType;
+        private DirtyValue<string> _closingDocsLoanProgramType;
         public string ClosingDocsLoanProgramType { get { return _closingDocsLoanProgramType; } set { _closingDocsLoanProgramType = value; } }
         private DirtyList<ClosingEntity> _closingEntities;
         public IList<ClosingEntity> ClosingEntities { get { var v = _closingEntities; return v ?? Interlocked.CompareExchange(ref _closingEntities, (v = new DirtyList<ClosingEntity>()), null) ?? v; } set { _closingEntities = new DirtyList<ClosingEntity>(value); } }
-        private Value<string> _closingProvider;
+        private DirtyValue<string> _closingProvider;
         public string ClosingProvider { get { return _closingProvider; } set { _closingProvider = value; } }
-        private Value<string> _closingState;
+        private DirtyValue<string> _closingState;
         public string ClosingState { get { return _closingState; } set { _closingState = value; } }
-        private Value<DateTime?> _cLPayoffsRequestedDateTime;
+        private DirtyValue<DateTime?> _cLPayoffsRequestedDateTime;
         public DateTime? CLPayoffsRequestedDateTime { get { return _cLPayoffsRequestedDateTime; } set { _cLPayoffsRequestedDateTime = value; } }
-        private Value<DateTime?> _cLPrelimCommitmentReceivedByLenderDateTime;
+        private DirtyValue<DateTime?> _cLPrelimCommitmentReceivedByLenderDateTime;
         public DateTime? CLPrelimCommitmentReceivedByLenderDateTime { get { return _cLPrelimCommitmentReceivedByLenderDateTime; } set { _cLPrelimCommitmentReceivedByLenderDateTime = value; } }
-        private Value<DateTime?> _cLProviderDisburseFundsDateTime;
+        private DirtyValue<DateTime?> _cLProviderDisburseFundsDateTime;
         public DateTime? CLProviderDisburseFundsDateTime { get { return _cLProviderDisburseFundsDateTime; } set { _cLProviderDisburseFundsDateTime = value; } }
-        private Value<DateTime?> _cLTitleOrderAcceptedDateTime;
+        private DirtyValue<DateTime?> _cLTitleOrderAcceptedDateTime;
         public DateTime? CLTitleOrderAcceptedDateTime { get { return _cLTitleOrderAcceptedDateTime; } set { _cLTitleOrderAcceptedDateTime = value; } }
-        private Value<DateTime?> _cLTitleOrderSentDateTime;
+        private DirtyValue<DateTime?> _cLTitleOrderSentDateTime;
         public DateTime? CLTitleOrderSentDateTime { get { return _cLTitleOrderSentDateTime; } set { _cLTitleOrderSentDateTime = value; } }
-        private Value<string> _complianceJurisdictionCounty;
+        private DirtyValue<string> _complianceJurisdictionCounty;
         public string ComplianceJurisdictionCounty { get { return _complianceJurisdictionCounty; } set { _complianceJurisdictionCounty = value; } }
-        private Value<DateTime?> _compliancePropertyIdentifiedDate;
+        private DirtyValue<DateTime?> _compliancePropertyIdentifiedDate;
         public DateTime? CompliancePropertyIdentifiedDate { get { return _compliancePropertyIdentifiedDate; } set { _compliancePropertyIdentifiedDate = value; } }
-        private Value<string> _conditionDescription;
+        private DirtyValue<string> _conditionDescription;
         public string ConditionDescription { get { return _conditionDescription; } set { _conditionDescription = value; } }
-        private Value<bool?> _conflictofInterestCheck1;
+        private DirtyValue<bool?> _conflictofInterestCheck1;
         public bool? ConflictofInterestCheck1 { get { return _conflictofInterestCheck1; } set { _conflictofInterestCheck1 = value; } }
-        private Value<bool?> _conflictofInterestCheck2;
+        private DirtyValue<bool?> _conflictofInterestCheck2;
         public bool? ConflictofInterestCheck2 { get { return _conflictofInterestCheck2; } set { _conflictofInterestCheck2 = value; } }
-        private Value<bool?> _conflictofInterestCheck3;
+        private DirtyValue<bool?> _conflictofInterestCheck3;
         public bool? ConflictofInterestCheck3 { get { return _conflictofInterestCheck3; } set { _conflictofInterestCheck3 = value; } }
-        private Value<bool?> _conflictofInterestCheck4;
+        private DirtyValue<bool?> _conflictofInterestCheck4;
         public bool? ConflictofInterestCheck4 { get { return _conflictofInterestCheck4; } set { _conflictofInterestCheck4 = value; } }
-        private Value<bool?> _conflictofInterestCheck5;
+        private DirtyValue<bool?> _conflictofInterestCheck5;
         public bool? ConflictofInterestCheck5 { get { return _conflictofInterestCheck5; } set { _conflictofInterestCheck5 = value; } }
-        private Value<bool?> _conflictofInterestCheck6;
+        private DirtyValue<bool?> _conflictofInterestCheck6;
         public bool? ConflictofInterestCheck6 { get { return _conflictofInterestCheck6; } set { _conflictofInterestCheck6 = value; } }
-        private Value<string> _coopApartmentNumber;
+        private DirtyValue<string> _coopApartmentNumber;
         public string CoopApartmentNumber { get { return _coopApartmentNumber; } set { _coopApartmentNumber = value; } }
-        private Value<DateTime?> _coopAssignmentLeaseDate;
+        private DirtyValue<DateTime?> _coopAssignmentLeaseDate;
         public DateTime? CoopAssignmentLeaseDate { get { return _coopAssignmentLeaseDate; } set { _coopAssignmentLeaseDate = value; } }
-        private Value<string> _coopAttorneyInFact;
+        private DirtyValue<string> _coopAttorneyInFact;
         public string CoopAttorneyInFact { get { return _coopAttorneyInFact; } set { _coopAttorneyInFact = value; } }
-        private Value<string> _coopBuildingName;
+        private DirtyValue<string> _coopBuildingName;
         public string CoopBuildingName { get { return _coopBuildingName; } set { _coopBuildingName = value; } }
-        private Value<string> _coopCompanyExistsUnderTHeLawsOf;
+        private DirtyValue<string> _coopCompanyExistsUnderTHeLawsOf;
         public string CoopCompanyExistsUnderTHeLawsOf { get { return _coopCompanyExistsUnderTHeLawsOf; } set { _coopCompanyExistsUnderTHeLawsOf = value; } }
-        private Value<string> _coopCompanyName;
+        private DirtyValue<string> _coopCompanyName;
         public string CoopCompanyName { get { return _coopCompanyName; } set { _coopCompanyName = value; } }
-        private Value<DateTime?> _coopProprietaryLeaseDate;
+        private DirtyValue<DateTime?> _coopProprietaryLeaseDate;
         public DateTime? CoopProprietaryLeaseDate { get { return _coopProprietaryLeaseDate; } set { _coopProprietaryLeaseDate = value; } }
-        private Value<decimal?> _coopSharesOwned;
+        private DirtyValue<decimal?> _coopSharesOwned;
         public decimal? CoopSharesOwned { get { return _coopSharesOwned; } set { _coopSharesOwned = value; } }
-        private Value<string> _coopStockCertificationNumber;
+        private DirtyValue<string> _coopStockCertificationNumber;
         public string CoopStockCertificationNumber { get { return _coopStockCertificationNumber; } set { _coopStockCertificationNumber = value; } }
-        private Value<decimal?> _coopVacancyPercentNotification;
+        private DirtyValue<decimal?> _coopVacancyPercentNotification;
         public decimal? CoopVacancyPercentNotification { get { return _coopVacancyPercentNotification; } set { _coopVacancyPercentNotification = value; } }
-        private Value<string> _customOtherRiderDescription;
+        private DirtyValue<string> _customOtherRiderDescription;
         public string CustomOtherRiderDescription { get { return _customOtherRiderDescription; } set { _customOtherRiderDescription = value; } }
-        private Value<DateTime?> _disbursementDate;
+        private DirtyValue<DateTime?> _disbursementDate;
         public DateTime? DisbursementDate { get { return _disbursementDate; } set { _disbursementDate = value; } }
-        private Value<decimal?> _disbursementsToBorrower;
+        private DirtyValue<decimal?> _disbursementsToBorrower;
         public decimal? DisbursementsToBorrower { get { return _disbursementsToBorrower; } set { _disbursementsToBorrower = value; } }
-        private Value<string> _disclosureAlternateLender;
+        private DirtyValue<string> _disclosureAlternateLender;
         public string DisclosureAlternateLender { get { return _disclosureAlternateLender; } set { _disclosureAlternateLender = value; } }
-        private Value<string> _disclosureCompanyFunction;
+        private DirtyValue<string> _disclosureCompanyFunction;
         public string DisclosureCompanyFunction { get { return _disclosureCompanyFunction; } set { _disclosureCompanyFunction = value; } }
-        private Value<string> _disclosurePlanCode;
+        private DirtyValue<string> _disclosurePlanCode;
         public string DisclosurePlanCode { get { return _disclosurePlanCode; } set { _disclosurePlanCode = value; } }
-        private Value<string> _docReportGUID;
+        private DirtyValue<string> _docReportGUID;
         public string DocReportGUID { get { return _docReportGUID; } set { _docReportGUID = value; } }
-        private Value<DateTime?> _documentPreparationDate;
+        private DirtyValue<DateTime?> _documentPreparationDate;
         public DateTime? DocumentPreparationDate { get { return _documentPreparationDate; } set { _documentPreparationDate = value; } }
-        private Value<DateTime?> _documentSigningDate;
+        private DirtyValue<DateTime?> _documentSigningDate;
         public DateTime? DocumentSigningDate { get { return _documentSigningDate; } set { _documentSigningDate = value; } }
-        private Value<string> _drawCity;
+        private DirtyValue<string> _drawCity;
         public string DrawCity { get { return _drawCity; } set { _drawCity = value; } }
-        private Value<string> _drawCounty;
+        private DirtyValue<string> _drawCounty;
         public string DrawCounty { get { return _drawCounty; } set { _drawCounty = value; } }
-        private Value<string> _drawState;
+        private DirtyValue<string> _drawState;
         public string DrawState { get { return _drawState; } set { _drawState = value; } }
-        private Value<string> _employeeofMortgageLender;
+        private DirtyValue<string> _employeeofMortgageLender;
         public string EmployeeofMortgageLender { get { return _employeeofMortgageLender; } set { _employeeofMortgageLender = value; } }
-        private Value<string> _expectToAssignSellOrTransferPercent;
+        private DirtyValue<string> _expectToAssignSellOrTransferPercent;
         public string ExpectToAssignSellOrTransferPercent { get { return _expectToAssignSellOrTransferPercent; } set { _expectToAssignSellOrTransferPercent = value; } }
-        private Value<string> _finalVestingDescription;
+        private DirtyValue<string> _finalVestingDescription;
         public string FinalVestingDescription { get { return _finalVestingDescription; } set { _finalVestingDescription = value; } }
-        private Value<string> _firstTransferYear;
+        private DirtyValue<string> _firstTransferYear;
         public string FirstTransferYear { get { return _firstTransferYear; } set { _firstTransferYear = value; } }
-        private Value<decimal?> _firstTransferYearValue;
+        private DirtyValue<decimal?> _firstTransferYearValue;
         public decimal? FirstTransferYearValue { get { return _firstTransferYearValue; } set { _firstTransferYearValue = value; } }
-        private Value<string> _hoursDocumentsNeededPriorToDisbursementCount;
+        private DirtyValue<string> _hoursDocumentsNeededPriorToDisbursementCount;
         public string HoursDocumentsNeededPriorToDisbursementCount { get { return _hoursDocumentsNeededPriorToDisbursementCount; } set { _hoursDocumentsNeededPriorToDisbursementCount = value; } }
-        private Value<bool?> _housingIndicator;
+        private DirtyValue<bool?> _housingIndicator;
         public bool? HousingIndicator { get { return _housingIndicator; } set { _housingIndicator = value; } }
-        private Value<string> _housingProgramName;
+        private DirtyValue<string> _housingProgramName;
         public string HousingProgramName { get { return _housingProgramName; } set { _housingProgramName = value; } }
-        private Value<string> _hUD1FileNumberIdentifier;
+        private DirtyValue<string> _hUD1FileNumberIdentifier;
         public string HUD1FileNumberIdentifier { get { return _hUD1FileNumberIdentifier; } set { _hUD1FileNumberIdentifier = value; } }
-        private Value<string> _hUD1SettlementAgentUnparsedAddress;
+        private DirtyValue<string> _hUD1SettlementAgentUnparsedAddress;
         public string HUD1SettlementAgentUnparsedAddress { get { return _hUD1SettlementAgentUnparsedAddress; } set { _hUD1SettlementAgentUnparsedAddress = value; } }
-        private Value<string> _hUD1SettlementAgentUnparsedName;
+        private DirtyValue<string> _hUD1SettlementAgentUnparsedName;
         public string HUD1SettlementAgentUnparsedName { get { return _hUD1SettlementAgentUnparsedName; } set { _hUD1SettlementAgentUnparsedName = value; } }
-        private Value<DateTime?> _hUD1SettlementDate;
+        private DirtyValue<DateTime?> _hUD1SettlementDate;
         public DateTime? HUD1SettlementDate { get { return _hUD1SettlementDate; } set { _hUD1SettlementDate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _includeSafeHaborDisclosure;
+        private DirtyValue<decimal?> _includeSafeHaborDisclosure;
         public decimal? IncludeSafeHaborDisclosure { get { return _includeSafeHaborDisclosure; } set { _includeSafeHaborDisclosure = value; } }
-        private Value<string> _investorCode;
+        private DirtyValue<string> _investorCode;
         public string InvestorCode { get { return _investorCode; } set { _investorCode = value; } }
-        private Value<string> _lastAuditDate;
+        private DirtyValue<string> _lastAuditDate;
         public string LastAuditDate { get { return _lastAuditDate; } set { _lastAuditDate = value; } }
-        private Value<string> _lastDocumentOrdered;
+        private DirtyValue<string> _lastDocumentOrdered;
         public string LastDocumentOrdered { get { return _lastDocumentOrdered; } set { _lastDocumentOrdered = value; } }
-        private Value<bool?> _legalAttached;
+        private DirtyValue<bool?> _legalAttached;
         public bool? LegalAttached { get { return _legalAttached; } set { _legalAttached = value; } }
-        private Value<string> _lenderAuthorizedRepresentativeTitle;
+        private DirtyValue<string> _lenderAuthorizedRepresentativeTitle;
         public string LenderAuthorizedRepresentativeTitle { get { return _lenderAuthorizedRepresentativeTitle; } set { _lenderAuthorizedRepresentativeTitle = value; } }
-        private Value<string> _lenderBrokerRepresents;
+        private DirtyValue<string> _lenderBrokerRepresents;
         public string LenderBrokerRepresents { get { return _lenderBrokerRepresents; } set { _lenderBrokerRepresents = value; } }
-        private Value<string> _lienHolderAddress;
+        private DirtyValue<string> _lienHolderAddress;
         public string LienHolderAddress { get { return _lienHolderAddress; } set { _lienHolderAddress = value; } }
-        private Value<string> _lienHolderAddressCity;
+        private DirtyValue<string> _lienHolderAddressCity;
         public string LienHolderAddressCity { get { return _lienHolderAddressCity; } set { _lienHolderAddressCity = value; } }
-        private Value<string> _lienHolderAddressPostalCode;
+        private DirtyValue<string> _lienHolderAddressPostalCode;
         public string LienHolderAddressPostalCode { get { return _lienHolderAddressPostalCode; } set { _lienHolderAddressPostalCode = value; } }
-        private Value<string> _lienHolderAddressState;
+        private DirtyValue<string> _lienHolderAddressState;
         public string LienHolderAddressState { get { return _lienHolderAddressState; } set { _lienHolderAddressState = value; } }
-        private Value<string> _lienHolderName;
+        private DirtyValue<string> _lienHolderName;
         public string LienHolderName { get { return _lienHolderName; } set { _lienHolderName = value; } }
-        private Value<bool?> _loanIsLocked;
+        private DirtyValue<bool?> _loanIsLocked;
         public bool? LoanIsLocked { get { return _loanIsLocked; } set { _loanIsLocked = value; } }
-        private Value<string> _loanOption;
+        private DirtyValue<string> _loanOption;
         public string LoanOption { get { return _loanOption; } set { _loanOption = value; } }
-        private Value<string> _lockInFeeType;
+        private DirtyValue<string> _lockInFeeType;
         public string LockInFeeType { get { return _lockInFeeType; } set { _lockInFeeType = value; } }
-        private Value<string> _mfgHomeAnchored;
+        private DirtyValue<string> _mfgHomeAnchored;
         public string MfgHomeAnchored { get { return _mfgHomeAnchored; } set { _mfgHomeAnchored = value; } }
-        private Value<string> _mfgHomeCertificateOfTitleIdentifier;
+        private DirtyValue<string> _mfgHomeCertificateOfTitleIdentifier;
         public string MfgHomeCertificateOfTitleIdentifier { get { return _mfgHomeCertificateOfTitleIdentifier; } set { _mfgHomeCertificateOfTitleIdentifier = value; } }
-        private Value<string> _mfgHomeCertificateOfTitleType;
+        private DirtyValue<string> _mfgHomeCertificateOfTitleType;
         public string MfgHomeCertificateOfTitleType { get { return _mfgHomeCertificateOfTitleType; } set { _mfgHomeCertificateOfTitleType = value; } }
-        private Value<string> _mfgHomeDescription;
+        private DirtyValue<string> _mfgHomeDescription;
         public string MfgHomeDescription { get { return _mfgHomeDescription; } set { _mfgHomeDescription = value; } }
-        private Value<string> _mfgHomeHUDCertificationLabelIdentifier;
+        private DirtyValue<string> _mfgHomeHUDCertificationLabelIdentifier;
         public string MfgHomeHUDCertificationLabelIdentifier { get { return _mfgHomeHUDCertificationLabelIdentifier; } set { _mfgHomeHUDCertificationLabelIdentifier = value; } }
-        private Value<int?> _mfgHomeLengthFeetCount;
+        private DirtyValue<int?> _mfgHomeLengthFeetCount;
         public int? MfgHomeLengthFeetCount { get { return _mfgHomeLengthFeetCount; } set { _mfgHomeLengthFeetCount = value; } }
-        private Value<string> _mfgHomeMakeIdentifier;
+        private DirtyValue<string> _mfgHomeMakeIdentifier;
         public string MfgHomeMakeIdentifier { get { return _mfgHomeMakeIdentifier; } set { _mfgHomeMakeIdentifier = value; } }
-        private Value<string> _mfgHomeManufacturer;
+        private DirtyValue<string> _mfgHomeManufacturer;
         public string MfgHomeManufacturer { get { return _mfgHomeManufacturer; } set { _mfgHomeManufacturer = value; } }
-        private Value<string> _mfgHomeManufacturerAddress;
+        private DirtyValue<string> _mfgHomeManufacturerAddress;
         public string MfgHomeManufacturerAddress { get { return _mfgHomeManufacturerAddress; } set { _mfgHomeManufacturerAddress = value; } }
-        private Value<string> _mfgHomeManufacturerCity;
+        private DirtyValue<string> _mfgHomeManufacturerCity;
         public string MfgHomeManufacturerCity { get { return _mfgHomeManufacturerCity; } set { _mfgHomeManufacturerCity = value; } }
-        private Value<string> _mfgHomeManufacturerPhoneNumber;
+        private DirtyValue<string> _mfgHomeManufacturerPhoneNumber;
         public string MfgHomeManufacturerPhoneNumber { get { return _mfgHomeManufacturerPhoneNumber; } set { _mfgHomeManufacturerPhoneNumber = value; } }
-        private Value<string> _mfgHomeManufacturerPostalCode;
+        private DirtyValue<string> _mfgHomeManufacturerPostalCode;
         public string MfgHomeManufacturerPostalCode { get { return _mfgHomeManufacturerPostalCode; } set { _mfgHomeManufacturerPostalCode = value; } }
-        private Value<string> _mfgHomeManufacturerState;
+        private DirtyValue<string> _mfgHomeManufacturerState;
         public string MfgHomeManufacturerState { get { return _mfgHomeManufacturerState; } set { _mfgHomeManufacturerState = value; } }
-        private Value<int?> _mfgHomeManufactureYear;
+        private DirtyValue<int?> _mfgHomeManufactureYear;
         public int? MfgHomeManufactureYear { get { return _mfgHomeManufactureYear; } set { _mfgHomeManufactureYear = value; } }
-        private Value<string> _mfgHomeModelIdentifier;
+        private DirtyValue<string> _mfgHomeModelIdentifier;
         public string MfgHomeModelIdentifier { get { return _mfgHomeModelIdentifier; } set { _mfgHomeModelIdentifier = value; } }
-        private Value<string> _mfgHomeNewOrUsed;
+        private DirtyValue<string> _mfgHomeNewOrUsed;
         public string MfgHomeNewOrUsed { get { return _mfgHomeNewOrUsed; } set { _mfgHomeNewOrUsed = value; } }
-        private Value<string> _mfgHomeSerialNumberIdentifier;
+        private DirtyValue<string> _mfgHomeSerialNumberIdentifier;
         public string MfgHomeSerialNumberIdentifier { get { return _mfgHomeSerialNumberIdentifier; } set { _mfgHomeSerialNumberIdentifier = value; } }
-        private Value<int?> _mfgHomeWidthFeetCount;
+        private DirtyValue<int?> _mfgHomeWidthFeetCount;
         public int? MfgHomeWidthFeetCount { get { return _mfgHomeWidthFeetCount; } set { _mfgHomeWidthFeetCount = value; } }
-        private Value<string> _mineralRightsDescription;
+        private DirtyValue<string> _mineralRightsDescription;
         public string MineralRightsDescription { get { return _mineralRightsDescription; } set { _mineralRightsDescription = value; } }
-        private Value<string> _mortgageType;
+        private DirtyValue<string> _mortgageType;
         public string MortgageType { get { return _mortgageType; } set { _mortgageType = value; } }
-        private Value<int?> _numberBrokerAgreements;
+        private DirtyValue<int?> _numberBrokerAgreements;
         public int? NumberBrokerAgreements { get { return _numberBrokerAgreements; } set { _numberBrokerAgreements = value; } }
-        private Value<int?> _numberSuccessfulBrokerAgreements;
+        private DirtyValue<int?> _numberSuccessfulBrokerAgreements;
         public int? NumberSuccessfulBrokerAgreements { get { return _numberSuccessfulBrokerAgreements; } set { _numberSuccessfulBrokerAgreements = value; } }
-        private Value<string> _officeOfRecordationName;
+        private DirtyValue<string> _officeOfRecordationName;
         public string OfficeOfRecordationName { get { return _officeOfRecordationName; } set { _officeOfRecordationName = value; } }
-        private Value<bool?> _onlyOneEntity;
+        private DirtyValue<bool?> _onlyOneEntity;
         public bool? OnlyOneEntity { get { return _onlyOneEntity; } set { _onlyOneEntity = value; } }
-        private Value<string> _optionSelectedReason;
+        private DirtyValue<string> _optionSelectedReason;
         public string OptionSelectedReason { get { return _optionSelectedReason; } set { _optionSelectedReason = value; } }
-        private Value<decimal?> _originalPincipalAmountSecured;
+        private DirtyValue<decimal?> _originalPincipalAmountSecured;
         public decimal? OriginalPincipalAmountSecured { get { return _originalPincipalAmountSecured; } set { _originalPincipalAmountSecured = value; } }
-        private Value<string> _otherOptionDescription;
+        private DirtyValue<string> _otherOptionDescription;
         public string OtherOptionDescription { get { return _otherOptionDescription; } set { _otherOptionDescription = value; } }
-        private Value<string> _parentAffiliatedCoName;
+        private DirtyValue<string> _parentAffiliatedCoName;
         public string ParentAffiliatedCoName { get { return _parentAffiliatedCoName; } set { _parentAffiliatedCoName = value; } }
-        private Value<string> _payToTheOrderOfDescription;
+        private DirtyValue<string> _payToTheOrderOfDescription;
         public string PayToTheOrderOfDescription { get { return _payToTheOrderOfDescription; } set { _payToTheOrderOfDescription = value; } }
-        private Value<string> _perDiemCalculationMethodType;
+        private DirtyValue<string> _perDiemCalculationMethodType;
         public string PerDiemCalculationMethodType { get { return _perDiemCalculationMethodType; } set { _perDiemCalculationMethodType = value; } }
-        private Value<string> _planCode;
+        private DirtyValue<string> _planCode;
         public string PlanCode { get { return _planCode; } set { _planCode = value; } }
-        private Value<string> _planCodeDescription;
+        private DirtyValue<string> _planCodeDescription;
         public string PlanCodeDescription { get { return _planCodeDescription; } set { _planCodeDescription = value; } }
-        private Value<string> _planCodeId;
+        private DirtyValue<string> _planCodeId;
         public string PlanCodeId { get { return _planCodeId; } set { _planCodeId = value; } }
-        private Value<DateTime?> _preliminaryTitleReportDate;
+        private DirtyValue<DateTime?> _preliminaryTitleReportDate;
         public DateTime? PreliminaryTitleReportDate { get { return _preliminaryTitleReportDate; } set { _preliminaryTitleReportDate = value; } }
-        private Value<string> _prepaymentPenaltyDescriptions1;
+        private DirtyValue<string> _prepaymentPenaltyDescriptions1;
         public string PrepaymentPenaltyDescriptions1 { get { return _prepaymentPenaltyDescriptions1; } set { _prepaymentPenaltyDescriptions1 = value; } }
-        private Value<string> _prepaymentPenaltyDescriptions2;
+        private DirtyValue<string> _prepaymentPenaltyDescriptions2;
         public string PrepaymentPenaltyDescriptions2 { get { return _prepaymentPenaltyDescriptions2; } set { _prepaymentPenaltyDescriptions2 = value; } }
-        private Value<string> _prepaymentPenaltyDescriptions3;
+        private DirtyValue<string> _prepaymentPenaltyDescriptions3;
         public string PrepaymentPenaltyDescriptions3 { get { return _prepaymentPenaltyDescriptions3; } set { _prepaymentPenaltyDescriptions3 = value; } }
-        private Value<int?> _processingNumberDays;
+        private DirtyValue<int?> _processingNumberDays;
         public int? ProcessingNumberDays { get { return _processingNumberDays; } set { _processingNumberDays = value; } }
-        private Value<string> _programCode;
+        private DirtyValue<string> _programCode;
         public string ProgramCode { get { return _programCode; } set { _programCode = value; } }
-        private Value<string> _programSponsor;
+        private DirtyValue<string> _programSponsor;
         public string ProgramSponsor { get { return _programSponsor; } set { _programSponsor = value; } }
-        private Value<bool?> _propertyIsLandTrust;
+        private DirtyValue<bool?> _propertyIsLandTrust;
         public bool? PropertyIsLandTrust { get { return _propertyIsLandTrust; } set { _propertyIsLandTrust = value; } }
-        private Value<string> _propertyTaxMessageDescription;
+        private DirtyValue<string> _propertyTaxMessageDescription;
         public string PropertyTaxMessageDescription { get { return _propertyTaxMessageDescription; } set { _propertyTaxMessageDescription = value; } }
-        private Value<string> _rateLockRefundConditions1;
+        private DirtyValue<string> _rateLockRefundConditions1;
         public string RateLockRefundConditions1 { get { return _rateLockRefundConditions1; } set { _rateLockRefundConditions1 = value; } }
-        private Value<string> _rateLockRefundConditions2;
+        private DirtyValue<string> _rateLockRefundConditions2;
         public string RateLockRefundConditions2 { get { return _rateLockRefundConditions2; } set { _rateLockRefundConditions2 = value; } }
-        private Value<string> _rateLockRefundConditions3;
+        private DirtyValue<string> _rateLockRefundConditions3;
         public string RateLockRefundConditions3 { get { return _rateLockRefundConditions3; } set { _rateLockRefundConditions3 = value; } }
-        private Value<string> _recordingJurisdictionName;
+        private DirtyValue<string> _recordingJurisdictionName;
         public string RecordingJurisdictionName { get { return _recordingJurisdictionName; } set { _recordingJurisdictionName = value; } }
-        private Value<bool?> _refinanceBalloonMortgageGuarantee;
+        private DirtyValue<bool?> _refinanceBalloonMortgageGuarantee;
         public bool? RefinanceBalloonMortgageGuarantee { get { return _refinanceBalloonMortgageGuarantee; } set { _refinanceBalloonMortgageGuarantee = value; } }
-        private Value<bool?> _refinanceRightOfRescissionExemptFlag;
+        private DirtyValue<bool?> _refinanceRightOfRescissionExemptFlag;
         public bool? RefinanceRightOfRescissionExemptFlag { get { return _refinanceRightOfRescissionExemptFlag; } set { _refinanceRightOfRescissionExemptFlag = value; } }
-        private Value<string> _renewalExtensionDescription;
+        private DirtyValue<string> _renewalExtensionDescription;
         public string RenewalExtensionDescription { get { return _renewalExtensionDescription; } set { _renewalExtensionDescription = value; } }
-        private Value<DateTime?> _rescissionDate;
+        private DirtyValue<DateTime?> _rescissionDate;
         public DateTime? RescissionDate { get { return _rescissionDate; } set { _rescissionDate = value; } }
         private DirtyList<RespaHudDetail> _respaHudDetails;
         public IList<RespaHudDetail> RespaHudDetails { get { var v = _respaHudDetails; return v ?? Interlocked.CompareExchange(ref _respaHudDetails, (v = new DirtyList<RespaHudDetail>()), null) ?? v; } set { _respaHudDetails = new DirtyList<RespaHudDetail>(value); } }
-        private Value<string> _rMLANamePreceding10Years;
+        private DirtyValue<string> _rMLANamePreceding10Years;
         public string RMLANamePreceding10Years { get { return _rMLANamePreceding10Years; } set { _rMLANamePreceding10Years = value; } }
-        private Value<string> _rmlLenderBrokerRepresents;
+        private DirtyValue<string> _rmlLenderBrokerRepresents;
         public string RmlLenderBrokerRepresents { get { return _rmlLenderBrokerRepresents; } set { _rmlLenderBrokerRepresents = value; } }
-        private Value<string> _secondTransferYear;
+        private DirtyValue<string> _secondTransferYear;
         public string SecondTransferYear { get { return _secondTransferYear; } set { _secondTransferYear = value; } }
-        private Value<decimal?> _secondTransferYearValue;
+        private DirtyValue<decimal?> _secondTransferYearValue;
         public decimal? SecondTransferYearValue { get { return _secondTransferYearValue; } set { _secondTransferYearValue = value; } }
-        private Value<DateTime?> _signatureDateFor1003;
+        private DirtyValue<DateTime?> _signatureDateFor1003;
         public DateTime? SignatureDateFor1003 { get { return _signatureDateFor1003; } set { _signatureDateFor1003 = value; } }
-        private Value<string> _specialFloodHazardAreaIndictor;
+        private DirtyValue<string> _specialFloodHazardAreaIndictor;
         public string SpecialFloodHazardAreaIndictor { get { return _specialFloodHazardAreaIndictor; } set { _specialFloodHazardAreaIndictor = value; } }
         private DirtyList<StateLicense> _stateLicenses;
         public IList<StateLicense> StateLicenses { get { var v = _stateLicenses; return v ?? Interlocked.CompareExchange(ref _stateLicenses, (v = new DirtyList<StateLicense>()), null) ?? v; } set { _stateLicenses = new DirtyList<StateLicense>(value); } }
-        private Value<string> _suretyCompanyName;
+        private DirtyValue<string> _suretyCompanyName;
         public string SuretyCompanyName { get { return _suretyCompanyName; } set { _suretyCompanyName = value; } }
-        private Value<bool?> _syncInterestDateDisbursementDate;
+        private DirtyValue<bool?> _syncInterestDateDisbursementDate;
         public bool? SyncInterestDateDisbursementDate { get { return _syncInterestDateDisbursementDate; } set { _syncInterestDateDisbursementDate = value; } }
-        private Value<string> _termiteReportRequiredIndicator;
+        private DirtyValue<string> _termiteReportRequiredIndicator;
         public string TermiteReportRequiredIndicator { get { return _termiteReportRequiredIndicator; } set { _termiteReportRequiredIndicator = value; } }
-        private Value<string> _textDescription;
+        private DirtyValue<string> _textDescription;
         public string TextDescription { get { return _textDescription; } set { _textDescription = value; } }
-        private Value<string> _thirdTransferYear;
+        private DirtyValue<string> _thirdTransferYear;
         public string ThirdTransferYear { get { return _thirdTransferYear; } set { _thirdTransferYear = value; } }
-        private Value<decimal?> _thirdTransferYearValue;
+        private DirtyValue<decimal?> _thirdTransferYearValue;
         public decimal? ThirdTransferYearValue { get { return _thirdTransferYearValue; } set { _thirdTransferYearValue = value; } }
-        private Value<string> _titleReportItemsDescription;
+        private DirtyValue<string> _titleReportItemsDescription;
         public string TitleReportItemsDescription { get { return _titleReportItemsDescription; } set { _titleReportItemsDescription = value; } }
-        private Value<string> _titleReportRequiredEndorsementsDescription;
+        private DirtyValue<string> _titleReportRequiredEndorsementsDescription;
         public string TitleReportRequiredEndorsementsDescription { get { return _titleReportRequiredEndorsementsDescription; } set { _titleReportRequiredEndorsementsDescription = value; } }
-        private Value<decimal?> _totalDisbursed;
+        private DirtyValue<decimal?> _totalDisbursed;
         public decimal? TotalDisbursed { get { return _totalDisbursed; } set { _totalDisbursed = value; } }
-        private Value<string> _trust2Beneficiaries;
+        private DirtyValue<string> _trust2Beneficiaries;
         public string Trust2Beneficiaries { get { return _trust2Beneficiaries; } set { _trust2Beneficiaries = value; } }
-        private Value<string> _weConductBusiness;
+        private DirtyValue<string> _weConductBusiness;
         public string WeConductBusiness { get { return _weConductBusiness; } set { _weConductBusiness = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ClosingEntity.cs
+++ b/src/EncompassRest/Loans/ClosingEntity.cs
@@ -8,77 +8,77 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ClosingEntity : IDirty
     {
-        private Value<string> _alias;
+        private DirtyValue<string> _alias;
         public string Alias { get { return _alias; } set { _alias = value; } }
-        private Value<string> _assignee;
+        private DirtyValue<string> _assignee;
         public string Assignee { get { return _assignee; } set { _assignee = value; } }
-        private Value<bool?> _authorizedToSignIndicator;
+        private DirtyValue<bool?> _authorizedToSignIndicator;
         public bool? AuthorizedToSignIndicator { get { return _authorizedToSignIndicator; } set { _authorizedToSignIndicator = value; } }
-        private Value<string> _borrowerPair;
+        private DirtyValue<string> _borrowerPair;
         public string BorrowerPair { get { return _borrowerPair; } set { _borrowerPair = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _closingEntityType;
+        private DirtyValue<string> _closingEntityType;
         public string ClosingEntityType { get { return _closingEntityType; } set { _closingEntityType = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _county;
+        private DirtyValue<string> _county;
         public string County { get { return _county; } set { _county = value; } }
-        private Value<DateTime?> _dateOfBirth;
+        private DirtyValue<DateTime?> _dateOfBirth;
         public DateTime? DateOfBirth { get { return _dateOfBirth; } set { _dateOfBirth = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _occupancyIntent;
+        private DirtyValue<string> _occupancyIntent;
         public string OccupancyIntent { get { return _occupancyIntent; } set { _occupancyIntent = value; } }
-        private Value<string> _occupancyStatus;
+        private DirtyValue<string> _occupancyStatus;
         public string OccupancyStatus { get { return _occupancyStatus; } set { _occupancyStatus = value; } }
-        private Value<string> _organizationType;
+        private DirtyValue<string> _organizationType;
         public string OrganizationType { get { return _organizationType; } set { _organizationType = value; } }
-        private Value<string> _organizedUnderTheLawsOfJurisdictionName;
+        private DirtyValue<string> _organizedUnderTheLawsOfJurisdictionName;
         public string OrganizedUnderTheLawsOfJurisdictionName { get { return _organizedUnderTheLawsOfJurisdictionName; } set { _organizedUnderTheLawsOfJurisdictionName = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _phone1;
+        private DirtyValue<string> _phone1;
         public string Phone1 { get { return _phone1; } set { _phone1 = value; } }
-        private Value<string> _phone2;
+        private DirtyValue<string> _phone2;
         public string Phone2 { get { return _phone2; } set { _phone2 = value; } }
-        private Value<string> _poaSignatureText;
+        private DirtyValue<string> _poaSignatureText;
         public string PoaSignatureText { get { return _poaSignatureText; } set { _poaSignatureText = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _powerOfAttorney;
+        private DirtyValue<string> _powerOfAttorney;
         public string PowerOfAttorney { get { return _powerOfAttorney; } set { _powerOfAttorney = value; } }
-        private Value<DateTime?> _recordableDocumentTrustDate;
+        private DirtyValue<DateTime?> _recordableDocumentTrustDate;
         public DateTime? RecordableDocumentTrustDate { get { return _recordableDocumentTrustDate; } set { _recordableDocumentTrustDate = value; } }
-        private Value<string> _recordCity;
+        private DirtyValue<string> _recordCity;
         public string RecordCity { get { return _recordCity; } set { _recordCity = value; } }
-        private Value<string> _ssn;
+        private DirtyValue<string> _ssn;
         public string Ssn { get { return _ssn; } set { _ssn = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _streetAddress;
+        private DirtyValue<string> _streetAddress;
         public string StreetAddress { get { return _streetAddress; } set { _streetAddress = value; } }
-        private Value<string> _taxIdentificationNumberIdentifier;
+        private DirtyValue<string> _taxIdentificationNumberIdentifier;
         public string TaxIdentificationNumberIdentifier { get { return _taxIdentificationNumberIdentifier; } set { _taxIdentificationNumberIdentifier = value; } }
-        private Value<string> _trustOfficerName1;
+        private DirtyValue<string> _trustOfficerName1;
         public string TrustOfficerName1 { get { return _trustOfficerName1; } set { _trustOfficerName1 = value; } }
-        private Value<string> _trustOfficerName2;
+        private DirtyValue<string> _trustOfficerName2;
         public string TrustOfficerName2 { get { return _trustOfficerName2; } set { _trustOfficerName2 = value; } }
-        private Value<string> _trustOfficerTitle1;
+        private DirtyValue<string> _trustOfficerTitle1;
         public string TrustOfficerTitle1 { get { return _trustOfficerTitle1; } set { _trustOfficerTitle1 = value; } }
-        private Value<string> _trustOfficerTitle2;
+        private DirtyValue<string> _trustOfficerTitle2;
         public string TrustOfficerTitle2 { get { return _trustOfficerTitle2; } set { _trustOfficerTitle2 = value; } }
-        private Value<string> _unparsedName;
+        private DirtyValue<string> _unparsedName;
         public string UnparsedName { get { return _unparsedName; } set { _unparsedName = value; } }
-        private Value<string> _vesting;
+        private DirtyValue<string> _vesting;
         public string Vesting { get { return _vesting; } set { _vesting = value; } }
-        private Value<string> _vestingGuid;
+        private DirtyValue<string> _vestingGuid;
         public string VestingGuid { get { return _vestingGuid; } set { _vestingGuid = value; } }
-        private Value<string> _vestingTrusteeOfType;
+        private DirtyValue<string> _vestingTrusteeOfType;
         public string VestingTrusteeOfType { get { return _vestingTrusteeOfType; } set { _vestingTrusteeOfType = value; } }
-        private Value<string> _vestingType;
+        private DirtyValue<string> _vestingType;
         public string VestingType { get { return _vestingType; } set { _vestingType = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/CommitmentTerms.cs
+++ b/src/EncompassRest/Loans/CommitmentTerms.cs
@@ -8,61 +8,61 @@ namespace EncompassRest.Loans
 {
     public sealed partial class CommitmentTerms : IDirty
     {
-        private Value<DateTime?> _actionDate;
+        private DirtyValue<DateTime?> _actionDate;
         public DateTime? ActionDate { get { return _actionDate; } set { _actionDate = value; } }
-        private Value<string> _additionalConditions;
+        private DirtyValue<string> _additionalConditions;
         public string AdditionalConditions { get { return _additionalConditions; } set { _additionalConditions = value; } }
-        private Value<string> _additionalItems1;
+        private DirtyValue<string> _additionalItems1;
         public string AdditionalItems1 { get { return _additionalItems1; } set { _additionalItems1 = value; } }
-        private Value<string> _additionalItems2;
+        private DirtyValue<string> _additionalItems2;
         public string AdditionalItems2 { get { return _additionalItems2; } set { _additionalItems2 = value; } }
-        private Value<string> _additionalItems3;
+        private DirtyValue<string> _additionalItems3;
         public string AdditionalItems3 { get { return _additionalItems3; } set { _additionalItems3 = value; } }
-        private Value<bool?> _appraisalDone;
+        private DirtyValue<bool?> _appraisalDone;
         public bool? AppraisalDone { get { return _appraisalDone; } set { _appraisalDone = value; } }
-        private Value<decimal?> _assuranceOfCompletion;
+        private DirtyValue<decimal?> _assuranceOfCompletion;
         public decimal? AssuranceOfCompletion { get { return _assuranceOfCompletion; } set { _assuranceOfCompletion = value; } }
-        private Value<DateTime?> _commitmentDate;
+        private DirtyValue<DateTime?> _commitmentDate;
         public DateTime? CommitmentDate { get { return _commitmentDate; } set { _commitmentDate = value; } }
-        private Value<DateTime?> _commitmentExpired;
+        private DirtyValue<DateTime?> _commitmentExpired;
         public DateTime? CommitmentExpired { get { return _commitmentExpired; } set { _commitmentExpired = value; } }
-        private Value<DateTime?> _commitmentIssued;
+        private DirtyValue<DateTime?> _commitmentIssued;
         public DateTime? CommitmentIssued { get { return _commitmentIssued; } set { _commitmentIssued = value; } }
-        private Value<bool?> _conditionalCommitmentUnderActg;
+        private DirtyValue<bool?> _conditionalCommitmentUnderActg;
         public bool? ConditionalCommitmentUnderActg { get { return _conditionalCommitmentUnderActg; } set { _conditionalCommitmentUnderActg = value; } }
-        private Value<bool?> _eligibleForHighLtv;
+        private DirtyValue<bool?> _eligibleForHighLtv;
         public bool? EligibleForHighLtv { get { return _eligibleForHighLtv; } set { _eligibleForHighLtv = value; } }
-        private Value<int?> _estimatedRemainingYears;
+        private DirtyValue<int?> _estimatedRemainingYears;
         public int? EstimatedRemainingYears { get { return _estimatedRemainingYears; } set { _estimatedRemainingYears = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _improvedLivingAreas;
+        private DirtyValue<string> _improvedLivingAreas;
         public string ImprovedLivingAreas { get { return _improvedLivingAreas; } set { _improvedLivingAreas = value; } }
-        private Value<bool?> _manufacturedHousing;
+        private DirtyValue<bool?> _manufacturedHousing;
         public bool? ManufacturedHousing { get { return _manufacturedHousing; } set { _manufacturedHousing = value; } }
-        private Value<decimal?> _maxInsurableMortgage;
+        private DirtyValue<decimal?> _maxInsurableMortgage;
         public decimal? MaxInsurableMortgage { get { return _maxInsurableMortgage; } set { _maxInsurableMortgage = value; } }
-        private Value<string> _mortgageeAddress;
+        private DirtyValue<string> _mortgageeAddress;
         public string MortgageeAddress { get { return _mortgageeAddress; } set { _mortgageeAddress = value; } }
-        private Value<string> _mortgageeCity;
+        private DirtyValue<string> _mortgageeCity;
         public string MortgageeCity { get { return _mortgageeCity; } set { _mortgageeCity = value; } }
-        private Value<string> _mortgageeName;
+        private DirtyValue<string> _mortgageeName;
         public string MortgageeName { get { return _mortgageeName; } set { _mortgageeName = value; } }
-        private Value<string> _mortgageePostalCode;
+        private DirtyValue<string> _mortgageePostalCode;
         public string MortgageePostalCode { get { return _mortgageePostalCode; } set { _mortgageePostalCode = value; } }
-        private Value<string> _mortgageeState;
+        private DirtyValue<string> _mortgageeState;
         public string MortgageeState { get { return _mortgageeState; } set { _mortgageeState = value; } }
-        private Value<string> _otherMonthlyExpenseDescription;
+        private DirtyValue<string> _otherMonthlyExpenseDescription;
         public string OtherMonthlyExpenseDescription { get { return _otherMonthlyExpenseDescription; } set { _otherMonthlyExpenseDescription = value; } }
-        private Value<DateTime?> _reportDate;
+        private DirtyValue<DateTime?> _reportDate;
         public DateTime? ReportDate { get { return _reportDate; } set { _reportDate = value; } }
-        private Value<string> _requirementsNumber;
+        private DirtyValue<string> _requirementsNumber;
         public string RequirementsNumber { get { return _requirementsNumber; } set { _requirementsNumber = value; } }
-        private Value<string> _subdivisionDescription;
+        private DirtyValue<string> _subdivisionDescription;
         public string SubdivisionDescription { get { return _subdivisionDescription; } set { _subdivisionDescription = value; } }
-        private Value<string> _subdivisionRequirements;
+        private DirtyValue<string> _subdivisionRequirements;
         public string SubdivisionRequirements { get { return _subdivisionRequirements; } set { _subdivisionRequirements = value; } }
-        private Value<decimal?> _totalMonthlyExpense;
+        private DirtyValue<decimal?> _totalMonthlyExpense;
         public decimal? TotalMonthlyExpense { get { return _totalMonthlyExpense; } set { _totalMonthlyExpense = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ComplianceTestLog.cs
+++ b/src/EncompassRest/Loans/ComplianceTestLog.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ComplianceTestLog : IDirty
     {
-        private Value<string> _details;
+        private DirtyValue<string> _details;
         public string Details { get { return _details; } set { _details = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _result;
+        private DirtyValue<string> _result;
         public string Result { get { return _result; } set { _result = value; } }
-        private Value<bool?> _showAlert;
+        private DirtyValue<bool?> _showAlert;
         public bool? ShowAlert { get { return _showAlert; } set { _showAlert = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ConstructionManagement.cs
+++ b/src/EncompassRest/Loans/ConstructionManagement.cs
@@ -8,145 +8,145 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ConstructionManagement : IDirty
     {
-        private Value<string> _additionalDisbursementsConditions;
+        private DirtyValue<string> _additionalDisbursementsConditions;
         public string AdditionalDisbursementsConditions { get { return _additionalDisbursementsConditions; } set { _additionalDisbursementsConditions = value; } }
-        private Value<DateTime?> _architectsCertificateDate;
+        private DirtyValue<DateTime?> _architectsCertificateDate;
         public DateTime? ArchitectsCertificateDate { get { return _architectsCertificateDate; } set { _architectsCertificateDate = value; } }
-        private Value<bool?> _architectsCertificateIndicator;
+        private DirtyValue<bool?> _architectsCertificateIndicator;
         public bool? ArchitectsCertificateIndicator { get { return _architectsCertificateIndicator; } set { _architectsCertificateIndicator = value; } }
-        private Value<decimal?> _asCompletedAppraisedValue;
+        private DirtyValue<decimal?> _asCompletedAppraisedValue;
         public decimal? AsCompletedAppraisedValue { get { return _asCompletedAppraisedValue; } set { _asCompletedAppraisedValue = value; } }
-        private Value<decimal?> _asCompletedPurchasePrice;
+        private DirtyValue<decimal?> _asCompletedPurchasePrice;
         public decimal? AsCompletedPurchasePrice { get { return _asCompletedPurchasePrice; } set { _asCompletedPurchasePrice = value; } }
-        private Value<DateTime?> _budgetDate;
+        private DirtyValue<DateTime?> _budgetDate;
         public DateTime? BudgetDate { get { return _budgetDate; } set { _budgetDate = value; } }
-        private Value<bool?> _budgetIndicator;
+        private DirtyValue<bool?> _budgetIndicator;
         public bool? BudgetIndicator { get { return _budgetIndicator; } set { _budgetIndicator = value; } }
-        private Value<DateTime?> _commitmentExpirationDate;
+        private DirtyValue<DateTime?> _commitmentExpirationDate;
         public DateTime? CommitmentExpirationDate { get { return _commitmentExpirationDate; } set { _commitmentExpirationDate = value; } }
-        private Value<DateTime?> _commitmentLetterDate;
+        private DirtyValue<DateTime?> _commitmentLetterDate;
         public DateTime? CommitmentLetterDate { get { return _commitmentLetterDate; } set { _commitmentLetterDate = value; } }
-        private Value<DateTime?> _constCompletionDate;
+        private DirtyValue<DateTime?> _constCompletionDate;
         public DateTime? ConstCompletionDate { get { return _constCompletionDate; } set { _constCompletionDate = value; } }
-        private Value<string> _constOnlyAmortizationType;
+        private DirtyValue<string> _constOnlyAmortizationType;
         public string ConstOnlyAmortizationType { get { return _constOnlyAmortizationType; } set { _constOnlyAmortizationType = value; } }
-        private Value<bool?> _constructionContractIndicator;
+        private DirtyValue<bool?> _constructionContractIndicator;
         public bool? ConstructionContractIndicator { get { return _constructionContractIndicator; } set { _constructionContractIndicator = value; } }
-        private Value<DateTime?> _constructionContractIssuedDate;
+        private DirtyValue<DateTime?> _constructionContractIssuedDate;
         public DateTime? ConstructionContractIssuedDate { get { return _constructionContractIssuedDate; } set { _constructionContractIssuedDate = value; } }
-        private Value<DateTime?> _constructionContractReceivedDate;
+        private DirtyValue<DateTime?> _constructionContractReceivedDate;
         public DateTime? ConstructionContractReceivedDate { get { return _constructionContractReceivedDate; } set { _constructionContractReceivedDate = value; } }
-        private Value<bool?> _constructionPeriodIncludedInLoanTermFlag;
+        private DirtyValue<bool?> _constructionPeriodIncludedInLoanTermFlag;
         public bool? ConstructionPeriodIncludedInLoanTermFlag { get { return _constructionPeriodIncludedInLoanTermFlag; } set { _constructionPeriodIncludedInLoanTermFlag = value; } }
-        private Value<DateTime?> _contractorsAgreementDate;
+        private DirtyValue<DateTime?> _contractorsAgreementDate;
         public DateTime? ContractorsAgreementDate { get { return _contractorsAgreementDate; } set { _contractorsAgreementDate = value; } }
-        private Value<bool?> _contractorsAgreementIndicator;
+        private DirtyValue<bool?> _contractorsAgreementIndicator;
         public bool? ContractorsAgreementIndicator { get { return _contractorsAgreementIndicator; } set { _contractorsAgreementIndicator = value; } }
-        private Value<DateTime?> _environmentalAssessmentDate;
+        private DirtyValue<DateTime?> _environmentalAssessmentDate;
         public DateTime? EnvironmentalAssessmentDate { get { return _environmentalAssessmentDate; } set { _environmentalAssessmentDate = value; } }
-        private Value<bool?> _environmentalAssessmentIndicator;
+        private DirtyValue<bool?> _environmentalAssessmentIndicator;
         public bool? EnvironmentalAssessmentIndicator { get { return _environmentalAssessmentIndicator; } set { _environmentalAssessmentIndicator = value; } }
-        private Value<DateTime?> _floodHazardDeterminationDate;
+        private DirtyValue<DateTime?> _floodHazardDeterminationDate;
         public DateTime? FloodHazardDeterminationDate { get { return _floodHazardDeterminationDate; } set { _floodHazardDeterminationDate = value; } }
-        private Value<bool?> _floodHazardDeterminationIndicator;
+        private DirtyValue<bool?> _floodHazardDeterminationIndicator;
         public bool? FloodHazardDeterminationIndicator { get { return _floodHazardDeterminationIndicator; } set { _floodHazardDeterminationIndicator = value; } }
-        private Value<int?> _futureAdvancePeriod;
+        private DirtyValue<int?> _futureAdvancePeriod;
         public int? FutureAdvancePeriod { get { return _futureAdvancePeriod; } set { _futureAdvancePeriod = value; } }
-        private Value<decimal?> _holdbackAmount;
+        private DirtyValue<decimal?> _holdbackAmount;
         public decimal? HoldbackAmount { get { return _holdbackAmount; } set { _holdbackAmount = value; } }
-        private Value<decimal?> _holdbackPercent;
+        private DirtyValue<decimal?> _holdbackPercent;
         public decimal? HoldbackPercent { get { return _holdbackPercent; } set { _holdbackPercent = value; } }
-        private Value<DateTime?> _lienAgentNorthCarolinaDate;
+        private DirtyValue<DateTime?> _lienAgentNorthCarolinaDate;
         public DateTime? LienAgentNorthCarolinaDate { get { return _lienAgentNorthCarolinaDate; } set { _lienAgentNorthCarolinaDate = value; } }
-        private Value<bool?> _lienAgentNorthCarolinaIndicator;
+        private DirtyValue<bool?> _lienAgentNorthCarolinaIndicator;
         public bool? LienAgentNorthCarolinaIndicator { get { return _lienAgentNorthCarolinaIndicator; } set { _lienAgentNorthCarolinaIndicator = value; } }
-        private Value<DateTime?> _listOfConstructionAgreementsDate;
+        private DirtyValue<DateTime?> _listOfConstructionAgreementsDate;
         public DateTime? ListOfConstructionAgreementsDate { get { return _listOfConstructionAgreementsDate; } set { _listOfConstructionAgreementsDate = value; } }
-        private Value<bool?> _listOfConstructionAgreementsIndicator;
+        private DirtyValue<bool?> _listOfConstructionAgreementsIndicator;
         public bool? ListOfConstructionAgreementsIndicator { get { return _listOfConstructionAgreementsIndicator; } set { _listOfConstructionAgreementsIndicator = value; } }
-        private Value<decimal?> _maxLTVPercent;
+        private DirtyValue<decimal?> _maxLTVPercent;
         public decimal? MaxLTVPercent { get { return _maxLTVPercent; } set { _maxLTVPercent = value; } }
-        private Value<int?> _minimumDaysBetweenDisbursements;
+        private DirtyValue<int?> _minimumDaysBetweenDisbursements;
         public int? MinimumDaysBetweenDisbursements { get { return _minimumDaysBetweenDisbursements; } set { _minimumDaysBetweenDisbursements = value; } }
-        private Value<DateTime?> _otherDate;
+        private DirtyValue<DateTime?> _otherDate;
         public DateTime? OtherDate { get { return _otherDate; } set { _otherDate = value; } }
-        private Value<string> _otherDescription;
+        private DirtyValue<string> _otherDescription;
         public string OtherDescription { get { return _otherDescription; } set { _otherDescription = value; } }
-        private Value<bool?> _otherIndicator;
+        private DirtyValue<bool?> _otherIndicator;
         public bool? OtherIndicator { get { return _otherIndicator; } set { _otherIndicator = value; } }
-        private Value<string> _partialPrepaymentsElection;
+        private DirtyValue<string> _partialPrepaymentsElection;
         public string PartialPrepaymentsElection { get { return _partialPrepaymentsElection; } set { _partialPrepaymentsElection = value; } }
-        private Value<DateTime?> _paymentAndPerformanceBondsDate;
+        private DirtyValue<DateTime?> _paymentAndPerformanceBondsDate;
         public DateTime? PaymentAndPerformanceBondsDate { get { return _paymentAndPerformanceBondsDate; } set { _paymentAndPerformanceBondsDate = value; } }
-        private Value<bool?> _paymentAndPerformanceBondsIndicator;
+        private DirtyValue<bool?> _paymentAndPerformanceBondsIndicator;
         public bool? PaymentAndPerformanceBondsIndicator { get { return _paymentAndPerformanceBondsIndicator; } set { _paymentAndPerformanceBondsIndicator = value; } }
-        private Value<DateTime?> _percolationTestDate;
+        private DirtyValue<DateTime?> _percolationTestDate;
         public DateTime? PercolationTestDate { get { return _percolationTestDate; } set { _percolationTestDate = value; } }
-        private Value<bool?> _percolationTestIndicator;
+        private DirtyValue<bool?> _percolationTestIndicator;
         public bool? PercolationTestIndicator { get { return _percolationTestIndicator; } set { _percolationTestIndicator = value; } }
-        private Value<DateTime?> _permitsDate;
+        private DirtyValue<DateTime?> _permitsDate;
         public DateTime? PermitsDate { get { return _permitsDate; } set { _permitsDate = value; } }
-        private Value<bool?> _permitsIndicator;
+        private DirtyValue<bool?> _permitsIndicator;
         public bool? PermitsIndicator { get { return _permitsIndicator; } set { _permitsIndicator = value; } }
-        private Value<DateTime?> _plansAndSpecificationsDate;
+        private DirtyValue<DateTime?> _plansAndSpecificationsDate;
         public DateTime? PlansAndSpecificationsDate { get { return _plansAndSpecificationsDate; } set { _plansAndSpecificationsDate = value; } }
-        private Value<bool?> _plansAndSpecificationsIndicator;
+        private DirtyValue<bool?> _plansAndSpecificationsIndicator;
         public bool? PlansAndSpecificationsIndicator { get { return _plansAndSpecificationsIndicator; } set { _plansAndSpecificationsIndicator = value; } }
-        private Value<decimal?> _projectDelaySurchargePercent;
+        private DirtyValue<decimal?> _projectDelaySurchargePercent;
         public decimal? ProjectDelaySurchargePercent { get { return _projectDelaySurchargePercent; } set { _projectDelaySurchargePercent = value; } }
-        private Value<int?> _returnLendersCopyCommitmentDays;
+        private DirtyValue<int?> _returnLendersCopyCommitmentDays;
         public int? ReturnLendersCopyCommitmentDays { get { return _returnLendersCopyCommitmentDays; } set { _returnLendersCopyCommitmentDays = value; } }
-        private Value<bool?> _securedBySeparateProperty;
+        private DirtyValue<bool?> _securedBySeparateProperty;
         public bool? SecuredBySeparateProperty { get { return _securedBySeparateProperty; } set { _securedBySeparateProperty = value; } }
-        private Value<DateTime?> _soilReportDate;
+        private DirtyValue<DateTime?> _soilReportDate;
         public DateTime? SoilReportDate { get { return _soilReportDate; } set { _soilReportDate = value; } }
-        private Value<bool?> _soilReportIndicator;
+        private DirtyValue<bool?> _soilReportIndicator;
         public bool? SoilReportIndicator { get { return _soilReportIndicator; } set { _soilReportIndicator = value; } }
-        private Value<DateTime?> _surveyDate;
+        private DirtyValue<DateTime?> _surveyDate;
         public DateTime? SurveyDate { get { return _surveyDate; } set { _surveyDate = value; } }
-        private Value<bool?> _surveyIndicator;
+        private DirtyValue<bool?> _surveyIndicator;
         public bool? SurveyIndicator { get { return _surveyIndicator; } set { _surveyIndicator = value; } }
-        private Value<DateTime?> _takeOutCommitmentDate;
+        private DirtyValue<DateTime?> _takeOutCommitmentDate;
         public DateTime? TakeOutCommitmentDate { get { return _takeOutCommitmentDate; } set { _takeOutCommitmentDate = value; } }
-        private Value<bool?> _takeOutCommitmentIndicator;
+        private DirtyValue<bool?> _takeOutCommitmentIndicator;
         public bool? TakeOutCommitmentIndicator { get { return _takeOutCommitmentIndicator; } set { _takeOutCommitmentIndicator = value; } }
-        private Value<DateTime?> _takeOutCommitmentIssuedDate;
+        private DirtyValue<DateTime?> _takeOutCommitmentIssuedDate;
         public DateTime? TakeOutCommitmentIssuedDate { get { return _takeOutCommitmentIssuedDate; } set { _takeOutCommitmentIssuedDate = value; } }
-        private Value<string> _takeOutLenderAddress;
+        private DirtyValue<string> _takeOutLenderAddress;
         public string TakeOutLenderAddress { get { return _takeOutLenderAddress; } set { _takeOutLenderAddress = value; } }
-        private Value<string> _takeOutLenderCity;
+        private DirtyValue<string> _takeOutLenderCity;
         public string TakeOutLenderCity { get { return _takeOutLenderCity; } set { _takeOutLenderCity = value; } }
-        private Value<string> _takeOutLenderContactName;
+        private DirtyValue<string> _takeOutLenderContactName;
         public string TakeOutLenderContactName { get { return _takeOutLenderContactName; } set { _takeOutLenderContactName = value; } }
-        private Value<string> _takeOutLenderContactTitle;
+        private DirtyValue<string> _takeOutLenderContactTitle;
         public string TakeOutLenderContactTitle { get { return _takeOutLenderContactTitle; } set { _takeOutLenderContactTitle = value; } }
-        private Value<string> _takeOutLenderEmail;
+        private DirtyValue<string> _takeOutLenderEmail;
         public string TakeOutLenderEmail { get { return _takeOutLenderEmail; } set { _takeOutLenderEmail = value; } }
-        private Value<string> _takeOutLenderFax;
+        private DirtyValue<string> _takeOutLenderFax;
         public string TakeOutLenderFax { get { return _takeOutLenderFax; } set { _takeOutLenderFax = value; } }
-        private Value<string> _takeOutLenderLicenseNumber;
+        private DirtyValue<string> _takeOutLenderLicenseNumber;
         public string TakeOutLenderLicenseNumber { get { return _takeOutLenderLicenseNumber; } set { _takeOutLenderLicenseNumber = value; } }
-        private Value<string> _takeOutLenderName;
+        private DirtyValue<string> _takeOutLenderName;
         public string TakeOutLenderName { get { return _takeOutLenderName; } set { _takeOutLenderName = value; } }
-        private Value<string> _takeOutLenderNMLSNumber;
+        private DirtyValue<string> _takeOutLenderNMLSNumber;
         public string TakeOutLenderNMLSNumber { get { return _takeOutLenderNMLSNumber; } set { _takeOutLenderNMLSNumber = value; } }
-        private Value<string> _takeOutLenderPhone;
+        private DirtyValue<string> _takeOutLenderPhone;
         public string TakeOutLenderPhone { get { return _takeOutLenderPhone; } set { _takeOutLenderPhone = value; } }
-        private Value<string> _takeOutLenderState;
+        private DirtyValue<string> _takeOutLenderState;
         public string TakeOutLenderState { get { return _takeOutLenderState; } set { _takeOutLenderState = value; } }
-        private Value<string> _takeOutLenderZip;
+        private DirtyValue<string> _takeOutLenderZip;
         public string TakeOutLenderZip { get { return _takeOutLenderZip; } set { _takeOutLenderZip = value; } }
-        private Value<DateTime?> _titleInsuranceDate;
+        private DirtyValue<DateTime?> _titleInsuranceDate;
         public DateTime? TitleInsuranceDate { get { return _titleInsuranceDate; } set { _titleInsuranceDate = value; } }
-        private Value<bool?> _titleInsuranceIndicator;
+        private DirtyValue<bool?> _titleInsuranceIndicator;
         public bool? TitleInsuranceIndicator { get { return _titleInsuranceIndicator; } set { _titleInsuranceIndicator = value; } }
-        private Value<DateTime?> _utilityLettersDate;
+        private DirtyValue<DateTime?> _utilityLettersDate;
         public DateTime? UtilityLettersDate { get { return _utilityLettersDate; } set { _utilityLettersDate = value; } }
-        private Value<bool?> _utilityLettersIndicator;
+        private DirtyValue<bool?> _utilityLettersIndicator;
         public bool? UtilityLettersIndicator { get { return _utilityLettersIndicator; } set { _utilityLettersIndicator = value; } }
-        private Value<DateTime?> _waterTestDate;
+        private DirtyValue<DateTime?> _waterTestDate;
         public DateTime? WaterTestDate { get { return _waterTestDate; } set { _waterTestDate = value; } }
-        private Value<bool?> _waterTestIndicator;
+        private DirtyValue<bool?> _waterTestIndicator;
         public bool? WaterTestIndicator { get { return _waterTestIndicator; } set { _waterTestIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Contact.cs
+++ b/src/EncompassRest/Loans/Contact.cs
@@ -8,183 +8,183 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Contact : IDirty
     {
-        private Value<string> _aBA;
+        private DirtyValue<string> _aBA;
         public string ABA { get { return _aBA; } set { _aBA = value; } }
-        private Value<string> _accountName;
+        private DirtyValue<string> _accountName;
         public string AccountName { get { return _accountName; } set { _accountName = value; } }
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _address2;
+        private DirtyValue<string> _address2;
         public string Address2 { get { return _address2; } set { _address2 = value; } }
-        private Value<bool?> _addToCdContactInfo;
+        private DirtyValue<bool?> _addToCdContactInfo;
         public bool? AddToCdContactInfo { get { return _addToCdContactInfo; } set { _addToCdContactInfo = value; } }
-        private Value<string> _appraisalMade;
+        private DirtyValue<string> _appraisalMade;
         public string AppraisalMade { get { return _appraisalMade; } set { _appraisalMade = value; } }
-        private Value<DateTime?> _bizLicenseAuthDate;
+        private DirtyValue<DateTime?> _bizLicenseAuthDate;
         public DateTime? BizLicenseAuthDate { get { return _bizLicenseAuthDate; } set { _bizLicenseAuthDate = value; } }
-        private Value<string> _bizLicenseAuthName;
+        private DirtyValue<string> _bizLicenseAuthName;
         public string BizLicenseAuthName { get { return _bizLicenseAuthName; } set { _bizLicenseAuthName = value; } }
-        private Value<string> _bizLicenseAuthStateCode;
+        private DirtyValue<string> _bizLicenseAuthStateCode;
         public string BizLicenseAuthStateCode { get { return _bizLicenseAuthStateCode; } set { _bizLicenseAuthStateCode = value; } }
-        private Value<string> _bizLicenseAuthType;
+        private DirtyValue<string> _bizLicenseAuthType;
         public string BizLicenseAuthType { get { return _bizLicenseAuthType; } set { _bizLicenseAuthType = value; } }
-        private Value<string> _bizLicenseNumber;
+        private DirtyValue<string> _bizLicenseNumber;
         public string BizLicenseNumber { get { return _bizLicenseNumber; } set { _bizLicenseNumber = value; } }
-        private Value<bool?> _borrowerActingAsContractorIndicator;
+        private DirtyValue<bool?> _borrowerActingAsContractorIndicator;
         public bool? BorrowerActingAsContractorIndicator { get { return _borrowerActingAsContractorIndicator; } set { _borrowerActingAsContractorIndicator = value; } }
-        private Value<string> _brokerLenderType;
+        private DirtyValue<string> _brokerLenderType;
         public string BrokerLenderType { get { return _brokerLenderType; } set { _brokerLenderType = value; } }
-        private Value<bool?> _brokerLicenseExempt;
+        private DirtyValue<bool?> _brokerLicenseExempt;
         public bool? BrokerLicenseExempt { get { return _brokerLicenseExempt; } set { _brokerLicenseExempt = value; } }
-        private Value<string> _brokerLicenseType;
+        private DirtyValue<string> _brokerLicenseType;
         public string BrokerLicenseType { get { return _brokerLicenseType; } set { _brokerLicenseType = value; } }
-        private Value<string> _businessPhone;
+        private DirtyValue<string> _businessPhone;
         public string BusinessPhone { get { return _businessPhone; } set { _businessPhone = value; } }
-        private Value<string> _categoryName;
+        private DirtyValue<string> _categoryName;
         public string CategoryName { get { return _categoryName; } set { _categoryName = value; } }
-        private Value<string> _cell;
+        private DirtyValue<string> _cell;
         public string Cell { get { return _cell; } set { _cell = value; } }
-        private Value<DateTime?> _checkConfirmedDate;
+        private DirtyValue<DateTime?> _checkConfirmedDate;
         public DateTime? CheckConfirmedDate { get { return _checkConfirmedDate; } set { _checkConfirmedDate = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _clause;
+        private DirtyValue<string> _clause;
         public string Clause { get { return _clause; } set { _clause = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _companyId;
+        private DirtyValue<string> _companyId;
         public string CompanyId { get { return _companyId; } set { _companyId = value; } }
-        private Value<decimal?> _completionAffidavitPunchListTotal;
+        private DirtyValue<decimal?> _completionAffidavitPunchListTotal;
         public decimal? CompletionAffidavitPunchListTotal { get { return _completionAffidavitPunchListTotal; } set { _completionAffidavitPunchListTotal = value; } }
-        private Value<int?> _contactIndex;
+        private DirtyValue<int?> _contactIndex;
         public int? ContactIndex { get { return _contactIndex; } set { _contactIndex = value; } }
-        private Value<string> _contactName;
+        private DirtyValue<string> _contactName;
         public string ContactName { get { return _contactName; } set { _contactName = value; } }
-        private Value<string> _contactNMLSNo;
+        private DirtyValue<string> _contactNMLSNo;
         public string ContactNMLSNo { get { return _contactNMLSNo; } set { _contactNMLSNo = value; } }
-        private Value<string> _contactTitle;
+        private DirtyValue<string> _contactTitle;
         public string ContactTitle { get { return _contactTitle; } set { _contactTitle = value; } }
-        private Value<string> _contactType;
+        private DirtyValue<string> _contactType;
         public string ContactType { get { return _contactType; } set { _contactType = value; } }
-        private Value<DateTime?> _designeeAcceptedDate;
+        private DirtyValue<DateTime?> _designeeAcceptedDate;
         public DateTime? DesigneeAcceptedDate { get { return _designeeAcceptedDate; } set { _designeeAcceptedDate = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<decimal?> _employerLiabilityInsuranceMin;
+        private DirtyValue<decimal?> _employerLiabilityInsuranceMin;
         public decimal? EmployerLiabilityInsuranceMin { get { return _employerLiabilityInsuranceMin; } set { _employerLiabilityInsuranceMin = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<string> _fax2;
+        private DirtyValue<string> _fax2;
         public string Fax2 { get { return _fax2; } set { _fax2 = value; } }
-        private Value<string> _fhaLenderId;
+        private DirtyValue<string> _fhaLenderId;
         public string FhaLenderId { get { return _fhaLenderId; } set { _fhaLenderId = value; } }
-        private Value<decimal?> _generalLiabilityInsuranceMin;
+        private DirtyValue<decimal?> _generalLiabilityInsuranceMin;
         public decimal? GeneralLiabilityInsuranceMin { get { return _generalLiabilityInsuranceMin; } set { _generalLiabilityInsuranceMin = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _insuranceCertNumber;
+        private DirtyValue<string> _insuranceCertNumber;
         public string InsuranceCertNumber { get { return _insuranceCertNumber; } set { _insuranceCertNumber = value; } }
-        private Value<decimal?> _insuranceCoverageAmount;
+        private DirtyValue<decimal?> _insuranceCoverageAmount;
         public decimal? InsuranceCoverageAmount { get { return _insuranceCoverageAmount; } set { _insuranceCoverageAmount = value; } }
-        private Value<DateTime?> _insuranceDeterminationDate;
+        private DirtyValue<DateTime?> _insuranceDeterminationDate;
         public DateTime? InsuranceDeterminationDate { get { return _insuranceDeterminationDate; } set { _insuranceDeterminationDate = value; } }
-        private Value<string> _insuranceDeterminationNumber;
+        private DirtyValue<string> _insuranceDeterminationNumber;
         public string InsuranceDeterminationNumber { get { return _insuranceDeterminationNumber; } set { _insuranceDeterminationNumber = value; } }
-        private Value<bool?> _insuranceFloodZone;
+        private DirtyValue<bool?> _insuranceFloodZone;
         public bool? InsuranceFloodZone { get { return _insuranceFloodZone; } set { _insuranceFloodZone = value; } }
-        private Value<string> _insuranceMap;
+        private DirtyValue<string> _insuranceMap;
         public string InsuranceMap { get { return _insuranceMap; } set { _insuranceMap = value; } }
-        private Value<int?> _insuranceNoOfBedrooms;
+        private DirtyValue<int?> _insuranceNoOfBedrooms;
         public int? InsuranceNoOfBedrooms { get { return _insuranceNoOfBedrooms; } set { _insuranceNoOfBedrooms = value; } }
-        private Value<decimal?> _insurancePremium;
+        private DirtyValue<decimal?> _insurancePremium;
         public decimal? InsurancePremium { get { return _insurancePremium; } set { _insurancePremium = value; } }
-        private Value<string> _insuranceProjectType;
+        private DirtyValue<string> _insuranceProjectType;
         public string InsuranceProjectType { get { return _insuranceProjectType; } set { _insuranceProjectType = value; } }
-        private Value<DateTime?> _insuranceRenewalDate;
+        private DirtyValue<DateTime?> _insuranceRenewalDate;
         public DateTime? InsuranceRenewalDate { get { return _insuranceRenewalDate; } set { _insuranceRenewalDate = value; } }
-        private Value<string> _investorGrade1;
+        private DirtyValue<string> _investorGrade1;
         public string InvestorGrade1 { get { return _investorGrade1; } set { _investorGrade1 = value; } }
-        private Value<string> _investorGrade2;
+        private DirtyValue<string> _investorGrade2;
         public string InvestorGrade2 { get { return _investorGrade2; } set { _investorGrade2 = value; } }
-        private Value<string> _investorGrade3;
+        private DirtyValue<string> _investorGrade3;
         public string InvestorGrade3 { get { return _investorGrade3; } set { _investorGrade3 = value; } }
-        private Value<string> _investorLicense;
+        private DirtyValue<string> _investorLicense;
         public string InvestorLicense { get { return _investorLicense; } set { _investorLicense = value; } }
-        private Value<string> _investorLicenseType;
+        private DirtyValue<string> _investorLicenseType;
         public string InvestorLicenseType { get { return _investorLicenseType; } set { _investorLicenseType = value; } }
-        private Value<string> _investorName1;
+        private DirtyValue<string> _investorName1;
         public string InvestorName1 { get { return _investorName1; } set { _investorName1 = value; } }
-        private Value<string> _investorName2;
+        private DirtyValue<string> _investorName2;
         public string InvestorName2 { get { return _investorName2; } set { _investorName2 = value; } }
-        private Value<string> _investorName3;
+        private DirtyValue<string> _investorName3;
         public string InvestorName3 { get { return _investorName3; } set { _investorName3 = value; } }
-        private Value<string> _investorScore1;
+        private DirtyValue<string> _investorScore1;
         public string InvestorScore1 { get { return _investorScore1; } set { _investorScore1 = value; } }
-        private Value<string> _investorScore2;
+        private DirtyValue<string> _investorScore2;
         public string InvestorScore2 { get { return _investorScore2; } set { _investorScore2 = value; } }
-        private Value<string> _investorScore3;
+        private DirtyValue<string> _investorScore3;
         public string InvestorScore3 { get { return _investorScore3; } set { _investorScore3 = value; } }
-        private Value<string> _lenderType;
+        private DirtyValue<string> _lenderType;
         public string LenderType { get { return _lenderType; } set { _lenderType = value; } }
-        private Value<string> _license;
+        private DirtyValue<string> _license;
         public string License { get { return _license; } set { _license = value; } }
-        private Value<bool?> _licenseExempt;
+        private DirtyValue<bool?> _licenseExempt;
         public bool? LicenseExempt { get { return _licenseExempt; } set { _licenseExempt = value; } }
-        private Value<string> _licenseHomeState;
+        private DirtyValue<string> _licenseHomeState;
         public string LicenseHomeState { get { return _licenseHomeState; } set { _licenseHomeState = value; } }
-        private Value<string> _licenseType;
+        private DirtyValue<string> _licenseType;
         public string LicenseType { get { return _licenseType; } set { _licenseType = value; } }
-        private Value<string> _lineItemNumber;
+        private DirtyValue<string> _lineItemNumber;
         public string LineItemNumber { get { return _lineItemNumber; } set { _lineItemNumber = value; } }
-        private Value<string> _loginId;
+        private DirtyValue<string> _loginId;
         public string LoginId { get { return _loginId; } set { _loginId = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _nmlsLicense;
+        private DirtyValue<string> _nmlsLicense;
         public string NmlsLicense { get { return _nmlsLicense; } set { _nmlsLicense = value; } }
-        private Value<bool?> _notNaturalPersonFlag;
+        private DirtyValue<bool?> _notNaturalPersonFlag;
         public bool? NotNaturalPersonFlag { get { return _notNaturalPersonFlag; } set { _notNaturalPersonFlag = value; } }
-        private Value<string> _organizationState;
+        private DirtyValue<string> _organizationState;
         public string OrganizationState { get { return _organizationState; } set { _organizationState = value; } }
-        private Value<string> _organizationType;
+        private DirtyValue<string> _organizationType;
         public string OrganizationType { get { return _organizationType; } set { _organizationType = value; } }
-        private Value<DateTime?> _personalLicenseAuthDate;
+        private DirtyValue<DateTime?> _personalLicenseAuthDate;
         public DateTime? PersonalLicenseAuthDate { get { return _personalLicenseAuthDate; } set { _personalLicenseAuthDate = value; } }
-        private Value<string> _personalLicenseAuthName;
+        private DirtyValue<string> _personalLicenseAuthName;
         public string PersonalLicenseAuthName { get { return _personalLicenseAuthName; } set { _personalLicenseAuthName = value; } }
-        private Value<string> _personalLicenseAuthStateCode;
+        private DirtyValue<string> _personalLicenseAuthStateCode;
         public string PersonalLicenseAuthStateCode { get { return _personalLicenseAuthStateCode; } set { _personalLicenseAuthStateCode = value; } }
-        private Value<string> _personalLicenseAuthType;
+        private DirtyValue<string> _personalLicenseAuthType;
         public string PersonalLicenseAuthType { get { return _personalLicenseAuthType; } set { _personalLicenseAuthType = value; } }
-        private Value<string> _personalLicenseNumber;
+        private DirtyValue<string> _personalLicenseNumber;
         public string PersonalLicenseNumber { get { return _personalLicenseNumber; } set { _personalLicenseNumber = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _phone2;
+        private DirtyValue<string> _phone2;
         public string Phone2 { get { return _phone2; } set { _phone2 = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _recCity;
+        private DirtyValue<string> _recCity;
         public string RecCity { get { return _recCity; } set { _recCity = value; } }
-        private Value<string> _referenceNumber;
+        private DirtyValue<string> _referenceNumber;
         public string ReferenceNumber { get { return _referenceNumber; } set { _referenceNumber = value; } }
-        private Value<string> _relationship;
+        private DirtyValue<string> _relationship;
         public string Relationship { get { return _relationship; } set { _relationship = value; } }
-        private Value<bool?> _settlementAgent;
+        private DirtyValue<bool?> _settlementAgent;
         public bool? SettlementAgent { get { return _settlementAgent; } set { _settlementAgent = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _taxID;
+        private DirtyValue<string> _taxID;
         public string TaxID { get { return _taxID; } set { _taxID = value; } }
-        private Value<string> _tqlCommentHistory;
+        private DirtyValue<string> _tqlCommentHistory;
         public string TqlCommentHistory { get { return _tqlCommentHistory; } set { _tqlCommentHistory = value; } }
-        private Value<string> _tQLConsentSelection;
+        private DirtyValue<string> _tQLConsentSelection;
         public string TQLConsentSelection { get { return _tQLConsentSelection; } set { _tQLConsentSelection = value; } }
-        private Value<int?> _tqlId;
+        private DirtyValue<int?> _tqlId;
         public int? TqlId { get { return _tqlId; } set { _tqlId = value; } }
-        private Value<bool?> _tqlIsPublishingIndicator;
+        private DirtyValue<bool?> _tqlIsPublishingIndicator;
         public bool? TqlIsPublishingIndicator { get { return _tqlIsPublishingIndicator; } set { _tqlIsPublishingIndicator = value; } }
-        private Value<string> _tqlName;
+        private DirtyValue<string> _tqlName;
         public string TqlName { get { return _tqlName; } set { _tqlName = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ConversationLog.cs
+++ b/src/EncompassRest/Loans/ConversationLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ConversationLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _company;
@@ -49,9 +49,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _company.Dirty
                     || _dateUtc.Dirty
                     || _email.Dirty
@@ -65,15 +63,15 @@ namespace EncompassRest.Loans
                     || _name.Dirty
                     || _phone.Dirty
                     || _systemId.Dirty
-                    || _userId.Dirty;
+                    || _userId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _company.Dirty = value;
                 _dateUtc.Dirty = value;
@@ -89,6 +87,8 @@ namespace EncompassRest.Loans
                 _phone.Dirty = value;
                 _systemId.Dirty = value;
                 _userId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/ConversationLog.cs
+++ b/src/EncompassRest/Loans/ConversationLog.cs
@@ -12,35 +12,35 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _company;
+        private DirtyValue<string> _company;
         public string Company { get { return _company; } set { _company = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _inLogIndicator;
+        private DirtyValue<bool?> _inLogIndicator;
         public bool? InLogIndicator { get { return _inLogIndicator; } set { _inLogIndicator = value; } }
-        private Value<bool?> _isEmailIndicator;
+        private DirtyValue<bool?> _isEmailIndicator;
         public bool? IsEmailIndicator { get { return _isEmailIndicator; } set { _isEmailIndicator = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _userId;
+        private DirtyValue<string> _userId;
         public string UserId { get { return _userId; } set { _userId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Correspondent.cs
+++ b/src/EncompassRest/Loans/Correspondent.cs
@@ -14,6 +14,8 @@ namespace EncompassRest.Loans
         public DateTime? ApprovedToFundDate { get { return _approvedToFundDate; } set { _approvedToFundDate = value; } }
         private Value<decimal?> _basePrice;
         public decimal? BasePrice { get { return _basePrice; } set { _basePrice = value; } }
+        private Value<DateTime?> _cancelledDate;
+        public DateTime? CancelledDate { get { return _cancelledDate; } set { _cancelledDate = value; } }
         private Value<string> _commitmentType;
         public string CommitmentType { get { return _commitmentType; } set { _commitmentType = value; } }
         private Value<DateTime?> _conditionsReceivedDate;
@@ -102,6 +104,8 @@ namespace EncompassRest.Loans
         public decimal? TotalLateFee { get { return _totalLateFee; } set { _totalLateFee = value; } }
         private Value<decimal?> _unpaidPrincipalBalance;
         public decimal? UnpaidPrincipalBalance { get { return _unpaidPrincipalBalance; } set { _unpaidPrincipalBalance = value; } }
+        private Value<DateTime?> _voidedDate;
+        public DateTime? VoidedDate { get { return _voidedDate; } set { _voidedDate = value; } }
         private Value<DateTime?> _withdrawnDate;
         public DateTime? WithdrawnDate { get { return _withdrawnDate; } set { _withdrawnDate = value; } }
         private int _gettingDirty;
@@ -114,6 +118,7 @@ namespace EncompassRest.Loans
                 var dirty = _additionalLateFeeCharge.Dirty
                     || _approvedToFundDate.Dirty
                     || _basePrice.Dirty
+                    || _cancelledDate.Dirty
                     || _commitmentType.Dirty
                     || _conditionsReceivedDate.Dirty
                     || _correspondentStatus.Dirty
@@ -158,6 +163,7 @@ namespace EncompassRest.Loans
                     || _totalLateDays.Dirty
                     || _totalLateFee.Dirty
                     || _unpaidPrincipalBalance.Dirty
+                    || _voidedDate.Dirty
                     || _withdrawnDate.Dirty;
                 _gettingDirty = 0;
                 return dirty;
@@ -168,6 +174,7 @@ namespace EncompassRest.Loans
                 _additionalLateFeeCharge.Dirty = value;
                 _approvedToFundDate.Dirty = value;
                 _basePrice.Dirty = value;
+                _cancelledDate.Dirty = value;
                 _commitmentType.Dirty = value;
                 _conditionsReceivedDate.Dirty = value;
                 _correspondentStatus.Dirty = value;
@@ -212,6 +219,7 @@ namespace EncompassRest.Loans
                 _totalLateDays.Dirty = value;
                 _totalLateFee.Dirty = value;
                 _unpaidPrincipalBalance.Dirty = value;
+                _voidedDate.Dirty = value;
                 _withdrawnDate.Dirty = value;
                 _settingDirty = 0;
             }

--- a/src/EncompassRest/Loans/Correspondent.cs
+++ b/src/EncompassRest/Loans/Correspondent.cs
@@ -8,105 +8,105 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Correspondent : IDirty
     {
-        private Value<decimal?> _additionalLateFeeCharge;
+        private DirtyValue<decimal?> _additionalLateFeeCharge;
         public decimal? AdditionalLateFeeCharge { get { return _additionalLateFeeCharge; } set { _additionalLateFeeCharge = value; } }
-        private Value<DateTime?> _approvedToFundDate;
+        private DirtyValue<DateTime?> _approvedToFundDate;
         public DateTime? ApprovedToFundDate { get { return _approvedToFundDate; } set { _approvedToFundDate = value; } }
-        private Value<decimal?> _basePrice;
+        private DirtyValue<decimal?> _basePrice;
         public decimal? BasePrice { get { return _basePrice; } set { _basePrice = value; } }
-        private Value<DateTime?> _cancelledDate;
+        private DirtyValue<DateTime?> _cancelledDate;
         public DateTime? CancelledDate { get { return _cancelledDate; } set { _cancelledDate = value; } }
-        private Value<string> _commitmentType;
+        private DirtyValue<string> _commitmentType;
         public string CommitmentType { get { return _commitmentType; } set { _commitmentType = value; } }
-        private Value<DateTime?> _conditionsReceivedDate;
+        private DirtyValue<DateTime?> _conditionsReceivedDate;
         public DateTime? ConditionsReceivedDate { get { return _conditionsReceivedDate; } set { _conditionsReceivedDate = value; } }
-        private Value<string> _correspondentStatus;
+        private DirtyValue<string> _correspondentStatus;
         public string CorrespondentStatus { get { return _correspondentStatus; } set { _correspondentStatus = value; } }
-        private Value<DateTime?> _deliveryExpirationDate;
+        private DirtyValue<DateTime?> _deliveryExpirationDate;
         public DateTime? DeliveryExpirationDate { get { return _deliveryExpirationDate; } set { _deliveryExpirationDate = value; } }
-        private Value<string> _deliveryType;
+        private DirtyValue<string> _deliveryType;
         public string DeliveryType { get { return _deliveryType; } set { _deliveryType = value; } }
-        private Value<DateTime?> _fundedDate;
+        private DirtyValue<DateTime?> _fundedDate;
         public DateTime? FundedDate { get { return _fundedDate; } set { _fundedDate = value; } }
-        private Value<int?> _gracePeriodDays;
+        private DirtyValue<int?> _gracePeriodDays;
         public int? GracePeriodDays { get { return _gracePeriodDays; } set { _gracePeriodDays = value; } }
-        private Value<DateTime?> _gracePeriodStartDate;
+        private DirtyValue<DateTime?> _gracePeriodStartDate;
         public DateTime? GracePeriodStartDate { get { return _gracePeriodStartDate; } set { _gracePeriodStartDate = value; } }
-        private Value<string> _gracePeriodStartTrigger;
+        private DirtyValue<string> _gracePeriodStartTrigger;
         public string GracePeriodStartTrigger { get { return _gracePeriodStartTrigger; } set { _gracePeriodStartTrigger = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _initialSuspenseDate;
+        private DirtyValue<DateTime?> _initialSuspenseDate;
         public DateTime? InitialSuspenseDate { get { return _initialSuspenseDate; } set { _initialSuspenseDate = value; } }
-        private Value<DateTime?> _lateDaysBegin;
+        private DirtyValue<DateTime?> _lateDaysBegin;
         public DateTime? LateDaysBegin { get { return _lateDaysBegin; } set { _lateDaysBegin = value; } }
-        private Value<DateTime?> _lateDaysEnd;
+        private DirtyValue<DateTime?> _lateDaysEnd;
         public DateTime? LateDaysEnd { get { return _lateDaysEnd; } set { _lateDaysEnd = value; } }
-        private Value<string> _lateDaysEndTrigger;
+        private DirtyValue<string> _lateDaysEndTrigger;
         public string LateDaysEndTrigger { get { return _lateDaysEndTrigger; } set { _lateDaysEndTrigger = value; } }
-        private Value<string> _lateFeeChargeType;
+        private DirtyValue<string> _lateFeeChargeType;
         public string LateFeeChargeType { get { return _lateFeeChargeType; } set { _lateFeeChargeType = value; } }
-        private Value<string> _lateFeeFrequency;
+        private DirtyValue<string> _lateFeeFrequency;
         public string LateFeeFrequency { get { return _lateFeeFrequency; } set { _lateFeeFrequency = value; } }
-        private Value<string> _lateFeeNotes;
+        private DirtyValue<string> _lateFeeNotes;
         public string LateFeeNotes { get { return _lateFeeNotes; } set { _lateFeeNotes = value; } }
-        private Value<decimal?> _lateFeePercentage;
+        private DirtyValue<decimal?> _lateFeePercentage;
         public decimal? LateFeePercentage { get { return _lateFeePercentage; } set { _lateFeePercentage = value; } }
-        private Value<decimal?> _lateFeeTotalPriceAdjustment;
+        private DirtyValue<decimal?> _lateFeeTotalPriceAdjustment;
         public decimal? LateFeeTotalPriceAdjustment { get { return _lateFeeTotalPriceAdjustment; } set { _lateFeeTotalPriceAdjustment = value; } }
-        private Value<DateTime?> _latestConditionsDate;
+        private DirtyValue<DateTime?> _latestConditionsDate;
         public DateTime? LatestConditionsDate { get { return _latestConditionsDate; } set { _latestConditionsDate = value; } }
-        private Value<int?> _lFS_CalculateAs;
+        private DirtyValue<int?> _lFS_CalculateAs;
         public int? LFS_CalculateAs { get { return _lFS_CalculateAs; } set { _lFS_CalculateAs = value; } }
-        private Value<int?> _lFS_DayCleared;
+        private DirtyValue<int?> _lFS_DayCleared;
         public int? LFS_DayCleared { get { return _lFS_DayCleared; } set { _lFS_DayCleared = value; } }
-        private Value<string> _lFS_DayClearedOtherDate;
+        private DirtyValue<string> _lFS_DayClearedOtherDate;
         public string LFS_DayClearedOtherDate { get { return _lFS_DayClearedOtherDate; } set { _lFS_DayClearedOtherDate = value; } }
-        private Value<string> _lFS_DayClearedOtherDateValue;
+        private DirtyValue<string> _lFS_DayClearedOtherDateValue;
         public string LFS_DayClearedOtherDateValue { get { return _lFS_DayClearedOtherDateValue; } set { _lFS_DayClearedOtherDateValue = value; } }
-        private Value<int?> _lFS_FeeHandledAs;
+        private DirtyValue<int?> _lFS_FeeHandledAs;
         public int? LFS_FeeHandledAs { get { return _lFS_FeeHandledAs; } set { _lFS_FeeHandledAs = value; } }
-        private Value<int?> _lFS_GracePeriodCalendar;
+        private DirtyValue<int?> _lFS_GracePeriodCalendar;
         public int? LFS_GracePeriodCalendar { get { return _lFS_GracePeriodCalendar; } set { _lFS_GracePeriodCalendar = value; } }
-        private Value<int?> _lFS_GracePeriodDays;
+        private DirtyValue<int?> _lFS_GracePeriodDays;
         public int? LFS_GracePeriodDays { get { return _lFS_GracePeriodDays; } set { _lFS_GracePeriodDays = value; } }
-        private Value<int?> _lFS_GracePeriodLaterOf;
+        private DirtyValue<int?> _lFS_GracePeriodLaterOf;
         public int? LFS_GracePeriodLaterOf { get { return _lFS_GracePeriodLaterOf; } set { _lFS_GracePeriodLaterOf = value; } }
-        private Value<int?> _lFS_GracePeriodStarts;
+        private DirtyValue<int?> _lFS_GracePeriodStarts;
         public int? LFS_GracePeriodStarts { get { return _lFS_GracePeriodStarts; } set { _lFS_GracePeriodStarts = value; } }
-        private Value<int?> _lFS_IncludeDay;
+        private DirtyValue<int?> _lFS_IncludeDay;
         public int? LFS_IncludeDay { get { return _lFS_IncludeDay; } set { _lFS_IncludeDay = value; } }
-        private Value<int?> _lFS_LateFeeBasedOn;
+        private DirtyValue<int?> _lFS_LateFeeBasedOn;
         public int? LFS_LateFeeBasedOn { get { return _lFS_LateFeeBasedOn; } set { _lFS_LateFeeBasedOn = value; } }
-        private Value<int?> _lFS_MaxLateDays;
+        private DirtyValue<int?> _lFS_MaxLateDays;
         public int? LFS_MaxLateDays { get { return _lFS_MaxLateDays; } set { _lFS_MaxLateDays = value; } }
-        private Value<string> _lFS_OtherDate;
+        private DirtyValue<string> _lFS_OtherDate;
         public string LFS_OtherDate { get { return _lFS_OtherDate; } set { _lFS_OtherDate = value; } }
-        private Value<string> _lFS_OtherDateValue;
+        private DirtyValue<string> _lFS_OtherDateValue;
         public string LFS_OtherDateValue { get { return _lFS_OtherDateValue; } set { _lFS_OtherDateValue = value; } }
-        private Value<int?> _lFS_StartOnWeekend;
+        private DirtyValue<int?> _lFS_StartOnWeekend;
         public int? LFS_StartOnWeekend { get { return _lFS_StartOnWeekend; } set { _lFS_StartOnWeekend = value; } }
-        private Value<DateTime?> _noteDate;
+        private DirtyValue<DateTime?> _noteDate;
         public DateTime? NoteDate { get { return _noteDate; } set { _noteDate = value; } }
-        private Value<decimal?> _originalPrincipalBalance;
+        private DirtyValue<decimal?> _originalPrincipalBalance;
         public decimal? OriginalPrincipalBalance { get { return _originalPrincipalBalance; } set { _originalPrincipalBalance = value; } }
-        private Value<string> _ratesheet;
+        private DirtyValue<string> _ratesheet;
         public string Ratesheet { get { return _ratesheet; } set { _ratesheet = value; } }
-        private Value<DateTime?> _receivedDate;
+        private DirtyValue<DateTime?> _receivedDate;
         public DateTime? ReceivedDate { get { return _receivedDate; } set { _receivedDate = value; } }
-        private Value<DateTime?> _rejectedDate;
+        private DirtyValue<DateTime?> _rejectedDate;
         public DateTime? RejectedDate { get { return _rejectedDate; } set { _rejectedDate = value; } }
-        private Value<DateTime?> _submittedforPurchaseDate;
+        private DirtyValue<DateTime?> _submittedforPurchaseDate;
         public DateTime? SubmittedforPurchaseDate { get { return _submittedforPurchaseDate; } set { _submittedforPurchaseDate = value; } }
-        private Value<int?> _totalLateDays;
+        private DirtyValue<int?> _totalLateDays;
         public int? TotalLateDays { get { return _totalLateDays; } set { _totalLateDays = value; } }
-        private Value<decimal?> _totalLateFee;
+        private DirtyValue<decimal?> _totalLateFee;
         public decimal? TotalLateFee { get { return _totalLateFee; } set { _totalLateFee = value; } }
-        private Value<decimal?> _unpaidPrincipalBalance;
+        private DirtyValue<decimal?> _unpaidPrincipalBalance;
         public decimal? UnpaidPrincipalBalance { get { return _unpaidPrincipalBalance; } set { _unpaidPrincipalBalance = value; } }
-        private Value<DateTime?> _voidedDate;
+        private DirtyValue<DateTime?> _voidedDate;
         public DateTime? VoidedDate { get { return _voidedDate; } set { _voidedDate = value; } }
-        private Value<DateTime?> _withdrawnDate;
+        private DirtyValue<DateTime?> _withdrawnDate;
         public DateTime? WithdrawnDate { get { return _withdrawnDate; } set { _withdrawnDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/CrmLog.cs
+++ b/src/EncompassRest/Loans/CrmLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class CrmLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _contactGuid;
@@ -43,9 +43,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _contactGuid.Dirty
                     || _dateUtc.Dirty
                     || _fileAttachmentsMigrated.Dirty
@@ -56,15 +54,15 @@ namespace EncompassRest.Loans
                     || _mappingId.Dirty
                     || _mappingType.Dirty
                     || _roleType.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _contactGuid.Dirty = value;
                 _dateUtc.Dirty = value;
@@ -77,6 +75,8 @@ namespace EncompassRest.Loans
                 _mappingType.Dirty = value;
                 _roleType.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/CrmLog.cs
+++ b/src/EncompassRest/Loans/CrmLog.cs
@@ -12,29 +12,29 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _contactGuid;
+        private DirtyValue<string> _contactGuid;
         public string ContactGuid { get { return _contactGuid; } set { _contactGuid = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _mappingId;
+        private DirtyValue<string> _mappingId;
         public string MappingId { get { return _mappingId; } set { _mappingId = value; } }
-        private Value<int?> _mappingType;
+        private DirtyValue<int?> _mappingType;
         public int? MappingType { get { return _mappingType; } set { _mappingType = value; } }
-        private Value<int?> _roleType;
+        private DirtyValue<int?> _roleType;
         public int? RoleType { get { return _roleType; } set { _roleType = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/CustomField.cs
+++ b/src/EncompassRest/Loans/CustomField.cs
@@ -8,15 +8,15 @@ namespace EncompassRest.Loans
 {
     public sealed partial class CustomField : IDirty
     {
-        private Value<DateTime?> _dateValue;
+        private DirtyValue<DateTime?> _dateValue;
         public DateTime? DateValue { get { return _dateValue; } set { _dateValue = value; } }
-        private Value<string> _fieldName;
+        private DirtyValue<string> _fieldName;
         public string FieldName { get { return _fieldName; } set { _fieldName = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _numericValue;
+        private DirtyValue<decimal?> _numericValue;
         public decimal? NumericValue { get { return _numericValue; } set { _numericValue = value; } }
-        private Value<string> _stringValue;
+        private DirtyValue<string> _stringValue;
         public string StringValue { get { return _stringValue; } set { _stringValue = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/CustomModelFields.cs
+++ b/src/EncompassRest/Loans/CustomModelFields.cs
@@ -8,15 +8,15 @@ namespace EncompassRest.Loans
 {
     public sealed partial class CustomModelFields : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _provideAmortizationScenario;
+        private DirtyValue<bool?> _provideAmortizationScenario;
         public bool? ProvideAmortizationScenario { get { return _provideAmortizationScenario; } set { _provideAmortizationScenario = value; } }
-        private Value<bool?> _provideBestCaseScenario;
+        private DirtyValue<bool?> _provideBestCaseScenario;
         public bool? ProvideBestCaseScenario { get { return _provideBestCaseScenario; } set { _provideBestCaseScenario = value; } }
-        private Value<bool?> _provideFHAScenario;
+        private DirtyValue<bool?> _provideFHAScenario;
         public bool? ProvideFHAScenario { get { return _provideFHAScenario; } set { _provideFHAScenario = value; } }
-        private Value<bool?> _provideWorstCaseScenario;
+        private DirtyValue<bool?> _provideWorstCaseScenario;
         public bool? ProvideWorstCaseScenario { get { return _provideWorstCaseScenario; } set { _provideWorstCaseScenario = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DataTracLog.cs
+++ b/src/EncompassRest/Loans/DataTracLog.cs
@@ -12,27 +12,27 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _creator;
+        private DirtyValue<string> _creator;
         public string Creator { get { return _creator; } set { _creator = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _fileId;
+        private DirtyValue<string> _fileId;
         public string FileId { get { return _fileId; } set { _fileId = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _message;
+        private DirtyValue<string> _message;
         public string Message { get { return _message; } set { _message = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DisclosureForm.cs
+++ b/src/EncompassRest/Loans/DisclosureForm.cs
@@ -8,11 +8,11 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DisclosureForm : IDirty
     {
-        private Value<string> _formName;
+        private DirtyValue<string> _formName;
         public string FormName { get { return _formName; } set { _formName = value; } }
-        private Value<string> _formType;
+        private DirtyValue<string> _formType;
         public string FormType { get { return _formType; } set { _formType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DisclosureNotices.cs
+++ b/src/EncompassRest/Loans/DisclosureNotices.cs
@@ -8,105 +8,105 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DisclosureNotices : IDirty
     {
-        private Value<bool?> _antiCoercionStatementIndicator;
+        private DirtyValue<bool?> _antiCoercionStatementIndicator;
         public bool? AntiCoercionStatementIndicator { get { return _antiCoercionStatementIndicator; } set { _antiCoercionStatementIndicator = value; } }
-        private Value<string> _commitmentIssuedByAddress;
+        private DirtyValue<string> _commitmentIssuedByAddress;
         public string CommitmentIssuedByAddress { get { return _commitmentIssuedByAddress; } set { _commitmentIssuedByAddress = value; } }
-        private Value<string> _commitmentIssuedByCity;
+        private DirtyValue<string> _commitmentIssuedByCity;
         public string CommitmentIssuedByCity { get { return _commitmentIssuedByCity; } set { _commitmentIssuedByCity = value; } }
-        private Value<string> _commitmentIssuedByContactName;
+        private DirtyValue<string> _commitmentIssuedByContactName;
         public string CommitmentIssuedByContactName { get { return _commitmentIssuedByContactName; } set { _commitmentIssuedByContactName = value; } }
-        private Value<string> _commitmentIssuedByName;
+        private DirtyValue<string> _commitmentIssuedByName;
         public string CommitmentIssuedByName { get { return _commitmentIssuedByName; } set { _commitmentIssuedByName = value; } }
-        private Value<string> _commitmentIssuedByPhone;
+        private DirtyValue<string> _commitmentIssuedByPhone;
         public string CommitmentIssuedByPhone { get { return _commitmentIssuedByPhone; } set { _commitmentIssuedByPhone = value; } }
-        private Value<string> _commitmentIssuedByPostalCode;
+        private DirtyValue<string> _commitmentIssuedByPostalCode;
         public string CommitmentIssuedByPostalCode { get { return _commitmentIssuedByPostalCode; } set { _commitmentIssuedByPostalCode = value; } }
-        private Value<string> _commitmentIssuedByState;
+        private DirtyValue<string> _commitmentIssuedByState;
         public string CommitmentIssuedByState { get { return _commitmentIssuedByState; } set { _commitmentIssuedByState = value; } }
-        private Value<string> _consumerHandbookOnAdjustableRateMortgages;
+        private DirtyValue<string> _consumerHandbookOnAdjustableRateMortgages;
         public string ConsumerHandbookOnAdjustableRateMortgages { get { return _consumerHandbookOnAdjustableRateMortgages; } set { _consumerHandbookOnAdjustableRateMortgages = value; } }
-        private Value<string> _daysToReceiveWrittenRequest;
+        private DirtyValue<string> _daysToReceiveWrittenRequest;
         public string DaysToReceiveWrittenRequest { get { return _daysToReceiveWrittenRequest; } set { _daysToReceiveWrittenRequest = value; } }
-        private Value<int?> _daysToReturnToLender;
+        private DirtyValue<int?> _daysToReturnToLender;
         public int? DaysToReturnToLender { get { return _daysToReturnToLender; } set { _daysToReturnToLender = value; } }
-        private Value<string> _discloseNonPublicPersonalInformation;
+        private DirtyValue<string> _discloseNonPublicPersonalInformation;
         public string DiscloseNonPublicPersonalInformation { get { return _discloseNonPublicPersonalInformation; } set { _discloseNonPublicPersonalInformation = value; } }
-        private Value<string> _ecoaAddress;
+        private DirtyValue<string> _ecoaAddress;
         public string EcoaAddress { get { return _ecoaAddress; } set { _ecoaAddress = value; } }
-        private Value<string> _ecoaAddress2;
+        private DirtyValue<string> _ecoaAddress2;
         public string EcoaAddress2 { get { return _ecoaAddress2; } set { _ecoaAddress2 = value; } }
-        private Value<string> _ecoaCity;
+        private DirtyValue<string> _ecoaCity;
         public string EcoaCity { get { return _ecoaCity; } set { _ecoaCity = value; } }
-        private Value<string> _ecoaName;
+        private DirtyValue<string> _ecoaName;
         public string EcoaName { get { return _ecoaName; } set { _ecoaName = value; } }
-        private Value<string> _ecoaPhone;
+        private DirtyValue<string> _ecoaPhone;
         public string EcoaPhone { get { return _ecoaPhone; } set { _ecoaPhone = value; } }
-        private Value<string> _ecoaPostalCode;
+        private DirtyValue<string> _ecoaPostalCode;
         public string EcoaPostalCode { get { return _ecoaPostalCode; } set { _ecoaPostalCode = value; } }
-        private Value<string> _ecoaState;
+        private DirtyValue<string> _ecoaState;
         public string EcoaState { get { return _ecoaState; } set { _ecoaState = value; } }
-        private Value<string> _fairLendingNoticeDescription1;
+        private DirtyValue<string> _fairLendingNoticeDescription1;
         public string FairLendingNoticeDescription1 { get { return _fairLendingNoticeDescription1; } set { _fairLendingNoticeDescription1 = value; } }
-        private Value<string> _fairLendingNoticeDescription2;
+        private DirtyValue<string> _fairLendingNoticeDescription2;
         public string FairLendingNoticeDescription2 { get { return _fairLendingNoticeDescription2; } set { _fairLendingNoticeDescription2 = value; } }
-        private Value<string> _fairLendingNoticeDescription3;
+        private DirtyValue<string> _fairLendingNoticeDescription3;
         public string FairLendingNoticeDescription3 { get { return _fairLendingNoticeDescription3; } set { _fairLendingNoticeDescription3 = value; } }
-        private Value<string> _fairLendingNoticeDescription4;
+        private DirtyValue<string> _fairLendingNoticeDescription4;
         public string FairLendingNoticeDescription4 { get { return _fairLendingNoticeDescription4; } set { _fairLendingNoticeDescription4 = value; } }
-        private Value<string> _fairLendingNoticeDescription5;
+        private DirtyValue<string> _fairLendingNoticeDescription5;
         public string FairLendingNoticeDescription5 { get { return _fairLendingNoticeDescription5; } set { _fairLendingNoticeDescription5 = value; } }
-        private Value<string> _fairLendingNoticeDescription6;
+        private DirtyValue<string> _fairLendingNoticeDescription6;
         public string FairLendingNoticeDescription6 { get { return _fairLendingNoticeDescription6; } set { _fairLendingNoticeDescription6 = value; } }
-        private Value<string> _fairLendingNoticeDescription7;
+        private DirtyValue<string> _fairLendingNoticeDescription7;
         public string FairLendingNoticeDescription7 { get { return _fairLendingNoticeDescription7; } set { _fairLendingNoticeDescription7 = value; } }
-        private Value<string> _fairLendingNoticeDescription8;
+        private DirtyValue<string> _fairLendingNoticeDescription8;
         public string FairLendingNoticeDescription8 { get { return _fairLendingNoticeDescription8; } set { _fairLendingNoticeDescription8 = value; } }
-        private Value<string> _femaCommunityName;
+        private DirtyValue<string> _femaCommunityName;
         public string FemaCommunityName { get { return _femaCommunityName; } set { _femaCommunityName = value; } }
-        private Value<bool?> _floodInsuranceNotificationIndicator;
+        private DirtyValue<bool?> _floodInsuranceNotificationIndicator;
         public bool? FloodInsuranceNotificationIndicator { get { return _floodInsuranceNotificationIndicator; } set { _floodInsuranceNotificationIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _informationDisclosureAuthorizationIndicator;
+        private DirtyValue<bool?> _informationDisclosureAuthorizationIndicator;
         public bool? InformationDisclosureAuthorizationIndicator { get { return _informationDisclosureAuthorizationIndicator; } set { _informationDisclosureAuthorizationIndicator = value; } }
-        private Value<string> _licensedMortgageBrokerUnder;
+        private DirtyValue<string> _licensedMortgageBrokerUnder;
         public string LicensedMortgageBrokerUnder { get { return _licensedMortgageBrokerUnder; } set { _licensedMortgageBrokerUnder = value; } }
-        private Value<bool?> _locatedInNfipIndicator;
+        private DirtyValue<bool?> _locatedInNfipIndicator;
         public bool? LocatedInNfipIndicator { get { return _locatedInNfipIndicator; } set { _locatedInNfipIndicator = value; } }
-        private Value<string> _lossPayeeClause;
+        private DirtyValue<string> _lossPayeeClause;
         public string LossPayeeClause { get { return _lossPayeeClause; } set { _lossPayeeClause = value; } }
-        private Value<string> _mapPanelNumber;
+        private DirtyValue<string> _mapPanelNumber;
         public string MapPanelNumber { get { return _mapPanelNumber; } set { _mapPanelNumber = value; } }
-        private Value<string> _nFIPCommunityNumber;
+        private DirtyValue<string> _nFIPCommunityNumber;
         public string NFIPCommunityNumber { get { return _nFIPCommunityNumber; } set { _nFIPCommunityNumber = value; } }
-        private Value<DateTime?> _nFIPMapEffectiveRevisedDate;
+        private DirtyValue<DateTime?> _nFIPMapEffectiveRevisedDate;
         public DateTime? NFIPMapEffectiveRevisedDate { get { return _nFIPMapEffectiveRevisedDate; } set { _nFIPMapEffectiveRevisedDate = value; } }
-        private Value<string> _nonFinancialCompaniesDescription1;
+        private DirtyValue<string> _nonFinancialCompaniesDescription1;
         public string NonFinancialCompaniesDescription1 { get { return _nonFinancialCompaniesDescription1; } set { _nonFinancialCompaniesDescription1 = value; } }
-        private Value<string> _nonFinancialCompaniesDescription2;
+        private DirtyValue<string> _nonFinancialCompaniesDescription2;
         public string NonFinancialCompaniesDescription2 { get { return _nonFinancialCompaniesDescription2; } set { _nonFinancialCompaniesDescription2 = value; } }
-        private Value<string> _nonFinancialCompaniesDescription3;
+        private DirtyValue<string> _nonFinancialCompaniesDescription3;
         public string NonFinancialCompaniesDescription3 { get { return _nonFinancialCompaniesDescription3; } set { _nonFinancialCompaniesDescription3 = value; } }
-        private Value<string> _nonFinancialCompaniesDescription4;
+        private DirtyValue<string> _nonFinancialCompaniesDescription4;
         public string NonFinancialCompaniesDescription4 { get { return _nonFinancialCompaniesDescription4; } set { _nonFinancialCompaniesDescription4 = value; } }
-        private Value<bool?> _notLocatedInNfipIndicator;
+        private DirtyValue<bool?> _notLocatedInNfipIndicator;
         public bool? NotLocatedInNfipIndicator { get { return _notLocatedInNfipIndicator; } set { _notLocatedInNfipIndicator = value; } }
-        private Value<bool?> _occupancyStatementIndicator;
+        private DirtyValue<bool?> _occupancyStatementIndicator;
         public bool? OccupancyStatementIndicator { get { return _occupancyStatementIndicator; } set { _occupancyStatementIndicator = value; } }
-        private Value<string> _optOut;
+        private DirtyValue<string> _optOut;
         public string OptOut { get { return _optOut; } set { _optOut = value; } }
-        private Value<string> _optOutPhone;
+        private DirtyValue<string> _optOutPhone;
         public string OptOutPhone { get { return _optOutPhone; } set { _optOutPhone = value; } }
-        private Value<bool?> _releaseBankingInformationIndicator;
+        private DirtyValue<bool?> _releaseBankingInformationIndicator;
         public bool? ReleaseBankingInformationIndicator { get { return _releaseBankingInformationIndicator; } set { _releaseBankingInformationIndicator = value; } }
-        private Value<bool?> _releaseEmploymentInformationIndicator;
+        private DirtyValue<bool?> _releaseEmploymentInformationIndicator;
         public bool? ReleaseEmploymentInformationIndicator { get { return _releaseEmploymentInformationIndicator; } set { _releaseEmploymentInformationIndicator = value; } }
-        private Value<bool?> _releaseInformationInConnectionWithCreditReportIndicator;
+        private DirtyValue<bool?> _releaseInformationInConnectionWithCreditReportIndicator;
         public bool? ReleaseInformationInConnectionWithCreditReportIndicator { get { return _releaseInformationInConnectionWithCreditReportIndicator; } set { _releaseInformationInConnectionWithCreditReportIndicator = value; } }
-        private Value<bool?> _releaseMortgageInformationIndicator;
+        private DirtyValue<bool?> _releaseMortgageInformationIndicator;
         public bool? ReleaseMortgageInformationIndicator { get { return _releaseMortgageInformationIndicator; } set { _releaseMortgageInformationIndicator = value; } }
-        private Value<bool?> _rightToFinancialPrivacyActIndicator;
+        private DirtyValue<bool?> _rightToFinancialPrivacyActIndicator;
         public bool? RightToFinancialPrivacyActIndicator { get { return _rightToFinancialPrivacyActIndicator; } set { _rightToFinancialPrivacyActIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DisclosureTracking2015Log.cs
+++ b/src/EncompassRest/Loans/DisclosureTracking2015Log.cs
@@ -10,399 +10,399 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<DateTime?> _applicationDate;
+        private DirtyValue<DateTime?> _applicationDate;
         public DateTime? ApplicationDate { get { return _applicationDate; } set { _applicationDate = value; } }
-        private Value<string> _appliedCureAmount;
+        private DirtyValue<string> _appliedCureAmount;
         public string AppliedCureAmount { get { return _appliedCureAmount; } set { _appliedCureAmount = value; } }
-        private Value<DateTime?> _borrowerActualReceivedDate;
+        private DirtyValue<DateTime?> _borrowerActualReceivedDate;
         public DateTime? BorrowerActualReceivedDate { get { return _borrowerActualReceivedDate; } set { _borrowerActualReceivedDate = value; } }
-        private Value<string> _borrowerDisclosedMethod;
+        private DirtyValue<string> _borrowerDisclosedMethod;
         public string BorrowerDisclosedMethod { get { return _borrowerDisclosedMethod; } set { _borrowerDisclosedMethod = value; } }
-        private Value<string> _borrowerDisclosedMethodOther;
+        private DirtyValue<string> _borrowerDisclosedMethodOther;
         public string BorrowerDisclosedMethodOther { get { return _borrowerDisclosedMethodOther; } set { _borrowerDisclosedMethodOther = value; } }
-        private Value<string> _borrowerName;
+        private DirtyValue<string> _borrowerName;
         public string BorrowerName { get { return _borrowerName; } set { _borrowerName = value; } }
-        private Value<string> _borrowerPairId;
+        private DirtyValue<string> _borrowerPairId;
         public string BorrowerPairId { get { return _borrowerPairId; } set { _borrowerPairId = value; } }
-        private Value<DateTime?> _borrowerPresumedReceivedDate;
+        private DirtyValue<DateTime?> _borrowerPresumedReceivedDate;
         public DateTime? BorrowerPresumedReceivedDate { get { return _borrowerPresumedReceivedDate; } set { _borrowerPresumedReceivedDate = value; } }
-        private Value<string> _borrowerType;
+        private DirtyValue<string> _borrowerType;
         public string BorrowerType { get { return _borrowerType; } set { _borrowerType = value; } }
-        private Value<bool?> _cDReasonIs24HourAdvancePreview;
+        private DirtyValue<bool?> _cDReasonIs24HourAdvancePreview;
         public bool? CDReasonIs24HourAdvancePreview { get { return _cDReasonIs24HourAdvancePreview; } set { _cDReasonIs24HourAdvancePreview = value; } }
-        private Value<bool?> _cDReasonIsChangeInAPR;
+        private DirtyValue<bool?> _cDReasonIsChangeInAPR;
         public bool? CDReasonIsChangeInAPR { get { return _cDReasonIsChangeInAPR; } set { _cDReasonIsChangeInAPR = value; } }
-        private Value<bool?> _cDReasonIsChangeInLoanProduct;
+        private DirtyValue<bool?> _cDReasonIsChangeInLoanProduct;
         public bool? CDReasonIsChangeInLoanProduct { get { return _cDReasonIsChangeInLoanProduct; } set { _cDReasonIsChangeInLoanProduct = value; } }
-        private Value<bool?> _cDReasonIsChangeInSettlementCharges;
+        private DirtyValue<bool?> _cDReasonIsChangeInSettlementCharges;
         public bool? CDReasonIsChangeInSettlementCharges { get { return _cDReasonIsChangeInSettlementCharges; } set { _cDReasonIsChangeInSettlementCharges = value; } }
-        private Value<bool?> _cDReasonIsClericalErrorCorrection;
+        private DirtyValue<bool?> _cDReasonIsClericalErrorCorrection;
         public bool? CDReasonIsClericalErrorCorrection { get { return _cDReasonIsClericalErrorCorrection; } set { _cDReasonIsClericalErrorCorrection = value; } }
-        private Value<bool?> _cDReasonIsOther;
+        private DirtyValue<bool?> _cDReasonIsOther;
         public bool? CDReasonIsOther { get { return _cDReasonIsOther; } set { _cDReasonIsOther = value; } }
-        private Value<bool?> _cDReasonIsPrepaymentPenaltyAdded;
+        private DirtyValue<bool?> _cDReasonIsPrepaymentPenaltyAdded;
         public bool? CDReasonIsPrepaymentPenaltyAdded { get { return _cDReasonIsPrepaymentPenaltyAdded; } set { _cDReasonIsPrepaymentPenaltyAdded = value; } }
-        private Value<bool?> _cDReasonIsToleranceCure;
+        private DirtyValue<bool?> _cDReasonIsToleranceCure;
         public bool? CDReasonIsToleranceCure { get { return _cDReasonIsToleranceCure; } set { _cDReasonIsToleranceCure = value; } }
-        private Value<string> _cDReasonOther;
+        private DirtyValue<string> _cDReasonOther;
         public string CDReasonOther { get { return _cDReasonOther; } set { _cDReasonOther = value; } }
-        private Value<string> _changeInCircumstance;
+        private DirtyValue<string> _changeInCircumstance;
         public string ChangeInCircumstance { get { return _changeInCircumstance; } set { _changeInCircumstance = value; } }
-        private Value<string> _changeInCircumstanceComments;
+        private DirtyValue<string> _changeInCircumstanceComments;
         public string ChangeInCircumstanceComments { get { return _changeInCircumstanceComments; } set { _changeInCircumstanceComments = value; } }
-        private Value<string> _chargesCannotIncrease10Itemization34;
+        private DirtyValue<string> _chargesCannotIncrease10Itemization34;
         public string ChargesCannotIncrease10Itemization34 { get { return _chargesCannotIncrease10Itemization34; } set { _chargesCannotIncrease10Itemization34 = value; } }
-        private Value<string> _chargesCannotIncrease10LE32;
+        private DirtyValue<string> _chargesCannotIncrease10LE32;
         public string ChargesCannotIncrease10LE32 { get { return _chargesCannotIncrease10LE32; } set { _chargesCannotIncrease10LE32 = value; } }
-        private Value<string> _chargesThatCannotDecreaseItemization9;
+        private DirtyValue<string> _chargesThatCannotDecreaseItemization9;
         public string ChargesThatCannotDecreaseItemization9 { get { return _chargesThatCannotDecreaseItemization9; } set { _chargesThatCannotDecreaseItemization9 = value; } }
-        private Value<string> _chargesThatCannotDecreaseLE7;
+        private DirtyValue<string> _chargesThatCannotDecreaseLE7;
         public string ChargesThatCannotDecreaseLE7 { get { return _chargesThatCannotDecreaseLE7; } set { _chargesThatCannotDecreaseLE7 = value; } }
-        private Value<string> _chargesThatCannotIncreaseItemization13;
+        private DirtyValue<string> _chargesThatCannotIncreaseItemization13;
         public string ChargesThatCannotIncreaseItemization13 { get { return _chargesThatCannotIncreaseItemization13; } set { _chargesThatCannotIncreaseItemization13 = value; } }
-        private Value<string> _chargesThatCannotIncreaseLE11;
+        private DirtyValue<string> _chargesThatCannotIncreaseLE11;
         public string ChargesThatCannotIncreaseLE11 { get { return _chargesThatCannotIncreaseLE11; } set { _chargesThatCannotIncreaseLE11 = value; } }
-        private Value<DateTime?> _coBorrowerActualReceivedDate;
+        private DirtyValue<DateTime?> _coBorrowerActualReceivedDate;
         public DateTime? CoBorrowerActualReceivedDate { get { return _coBorrowerActualReceivedDate; } set { _coBorrowerActualReceivedDate = value; } }
-        private Value<string> _coBorrowerDisclosedMethod;
+        private DirtyValue<string> _coBorrowerDisclosedMethod;
         public string CoBorrowerDisclosedMethod { get { return _coBorrowerDisclosedMethod; } set { _coBorrowerDisclosedMethod = value; } }
-        private Value<string> _coBorrowerDisclosedMethodOther;
+        private DirtyValue<string> _coBorrowerDisclosedMethodOther;
         public string CoBorrowerDisclosedMethodOther { get { return _coBorrowerDisclosedMethodOther; } set { _coBorrowerDisclosedMethodOther = value; } }
-        private Value<string> _coBorrowerName;
+        private DirtyValue<string> _coBorrowerName;
         public string CoBorrowerName { get { return _coBorrowerName; } set { _coBorrowerName = value; } }
-        private Value<DateTime?> _coBorrowerPresumedReceivedDate;
+        private DirtyValue<DateTime?> _coBorrowerPresumedReceivedDate;
         public DateTime? CoBorrowerPresumedReceivedDate { get { return _coBorrowerPresumedReceivedDate; } set { _coBorrowerPresumedReceivedDate = value; } }
-        private Value<string> _coBorrowerType;
+        private DirtyValue<string> _coBorrowerType;
         public string CoBorrowerType { get { return _coBorrowerType; } set { _coBorrowerType = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<bool?> _containCD;
+        private DirtyValue<bool?> _containCD;
         public bool? ContainCD { get { return _containCD; } set { _containCD = value; } }
-        private Value<bool?> _containLE;
+        private DirtyValue<bool?> _containLE;
         public bool? ContainLE { get { return _containLE; } set { _containLE = value; } }
-        private Value<bool?> _containSafeHarbor;
+        private DirtyValue<bool?> _containSafeHarbor;
         public bool? ContainSafeHarbor { get { return _containSafeHarbor; } set { _containSafeHarbor = value; } }
-        private Value<DateTime?> _dateAdded;
+        private DirtyValue<DateTime?> _dateAdded;
         public DateTime? DateAdded { get { return _dateAdded; } set { _dateAdded = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _disclosedAPR;
+        private DirtyValue<string> _disclosedAPR;
         public string DisclosedAPR { get { return _disclosedAPR; } set { _disclosedAPR = value; } }
-        private Value<string> _disclosedBy;
+        private DirtyValue<string> _disclosedBy;
         public string DisclosedBy { get { return _disclosedBy; } set { _disclosedBy = value; } }
-        private Value<string> _disclosedByFullName;
+        private DirtyValue<string> _disclosedByFullName;
         public string DisclosedByFullName { get { return _disclosedByFullName; } set { _disclosedByFullName = value; } }
-        private Value<string> _disclosedDailyInterest;
+        private DirtyValue<string> _disclosedDailyInterest;
         public string DisclosedDailyInterest { get { return _disclosedDailyInterest; } set { _disclosedDailyInterest = value; } }
-        private Value<DateTime?> _disclosedDate;
+        private DirtyValue<DateTime?> _disclosedDate;
         public DateTime? DisclosedDate { get { return _disclosedDate; } set { _disclosedDate = value; } }
-        private Value<bool?> _disclosedForCD;
+        private DirtyValue<bool?> _disclosedForCD;
         public bool? DisclosedForCD { get { return _disclosedForCD; } set { _disclosedForCD = value; } }
-        private Value<bool?> _disclosedForLE;
+        private DirtyValue<bool?> _disclosedForLE;
         public bool? DisclosedForLE { get { return _disclosedForLE; } set { _disclosedForLE = value; } }
-        private Value<string> _disclosedMethod;
+        private DirtyValue<string> _disclosedMethod;
         public string DisclosedMethod { get { return _disclosedMethod; } set { _disclosedMethod = value; } }
-        private Value<string> _disclosedMethodName;
+        private DirtyValue<string> _disclosedMethodName;
         public string DisclosedMethodName { get { return _disclosedMethodName; } set { _disclosedMethodName = value; } }
-        private Value<string> _disclosedMethodOther;
+        private DirtyValue<string> _disclosedMethodOther;
         public string DisclosedMethodOther { get { return _disclosedMethodOther; } set { _disclosedMethodOther = value; } }
-        private Value<string> _disclosedSalesPrice;
+        private DirtyValue<string> _disclosedSalesPrice;
         public string DisclosedSalesPrice { get { return _disclosedSalesPrice; } set { _disclosedSalesPrice = value; } }
-        private Value<DateTime?> _disclosureCreatedDttmUtc;
+        private DirtyValue<DateTime?> _disclosureCreatedDttmUtc;
         public DateTime? DisclosureCreatedDttmUtc { get { return _disclosureCreatedDttmUtc; } set { _disclosureCreatedDttmUtc = value; } }
-        private Value<string> _disclosureMethod;
+        private DirtyValue<string> _disclosureMethod;
         public string DisclosureMethod { get { return _disclosureMethod; } set { _disclosureMethod = value; } }
-        private Value<string> _disclosureType;
+        private DirtyValue<string> _disclosureType;
         public string DisclosureType { get { return _disclosureType; } set { _disclosureType = value; } }
-        private Value<bool?> _eDisclosureApplicationPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureApplicationPackageIndicator;
         public bool? EDisclosureApplicationPackageIndicator { get { return _eDisclosureApplicationPackageIndicator; } set { _eDisclosureApplicationPackageIndicator = value; } }
-        private Value<bool?> _eDisclosureApprovalPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureApprovalPackageIndicator;
         public bool? EDisclosureApprovalPackageIndicator { get { return _eDisclosureApprovalPackageIndicator; } set { _eDisclosureApprovalPackageIndicator = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerAcceptConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerAcceptConsentDate;
         public DateTime? EDisclosureBorrowerAcceptConsentDate { get { return _eDisclosureBorrowerAcceptConsentDate; } set { _eDisclosureBorrowerAcceptConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowereSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowereSignedDate;
         public DateTime? EDisclosureBorrowereSignedDate { get { return _eDisclosureBorrowereSignedDate; } set { _eDisclosureBorrowereSignedDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerRejectConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerRejectConsentDate;
         public DateTime? EDisclosureBorrowerRejectConsentDate { get { return _eDisclosureBorrowerRejectConsentDate; } set { _eDisclosureBorrowerRejectConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerViewConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerViewConsentDate;
         public DateTime? EDisclosureBorrowerViewConsentDate { get { return _eDisclosureBorrowerViewConsentDate; } set { _eDisclosureBorrowerViewConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerViewMessageDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerViewMessageDate;
         public DateTime? EDisclosureBorrowerViewMessageDate { get { return _eDisclosureBorrowerViewMessageDate; } set { _eDisclosureBorrowerViewMessageDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerWetSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerWetSignedDate;
         public DateTime? EDisclosureBorrowerWetSignedDate { get { return _eDisclosureBorrowerWetSignedDate; } set { _eDisclosureBorrowerWetSignedDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerAcceptConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerAcceptConsentDate;
         public DateTime? EDisclosureCoBorrowerAcceptConsentDate { get { return _eDisclosureCoBorrowerAcceptConsentDate; } set { _eDisclosureCoBorrowerAcceptConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowereSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowereSignedDate;
         public DateTime? EDisclosureCoBorrowereSignedDate { get { return _eDisclosureCoBorrowereSignedDate; } set { _eDisclosureCoBorrowereSignedDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerRejectConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerRejectConsentDate;
         public DateTime? EDisclosureCoBorrowerRejectConsentDate { get { return _eDisclosureCoBorrowerRejectConsentDate; } set { _eDisclosureCoBorrowerRejectConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerViewConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerViewConsentDate;
         public DateTime? EDisclosureCoBorrowerViewConsentDate { get { return _eDisclosureCoBorrowerViewConsentDate; } set { _eDisclosureCoBorrowerViewConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerViewMessageDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerViewMessageDate;
         public DateTime? EDisclosureCoBorrowerViewMessageDate { get { return _eDisclosureCoBorrowerViewMessageDate; } set { _eDisclosureCoBorrowerViewMessageDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerWebSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerWebSignedDate;
         public DateTime? EDisclosureCoBorrowerWebSignedDate { get { return _eDisclosureCoBorrowerWebSignedDate; } set { _eDisclosureCoBorrowerWebSignedDate = value; } }
-        private Value<string> _eDisclosureConsentPdf;
+        private DirtyValue<string> _eDisclosureConsentPdf;
         public string EDisclosureConsentPdf { get { return _eDisclosureConsentPdf; } set { _eDisclosureConsentPdf = value; } }
-        private Value<string> _eDisclosureDisclosedMessage;
+        private DirtyValue<string> _eDisclosureDisclosedMessage;
         public string EDisclosureDisclosedMessage { get { return _eDisclosureDisclosedMessage; } set { _eDisclosureDisclosedMessage = value; } }
-        private Value<bool?> _eDisclosureLockPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureLockPackageIndicator;
         public bool? EDisclosureLockPackageIndicator { get { return _eDisclosureLockPackageIndicator; } set { _eDisclosureLockPackageIndicator = value; } }
-        private Value<string> _eDisclosureManualFulfillmentComment;
+        private DirtyValue<string> _eDisclosureManualFulfillmentComment;
         public string EDisclosureManualFulfillmentComment { get { return _eDisclosureManualFulfillmentComment; } set { _eDisclosureManualFulfillmentComment = value; } }
-        private Value<DateTime?> _eDisclosureManualFulfillmentDate;
+        private DirtyValue<DateTime?> _eDisclosureManualFulfillmentDate;
         public DateTime? EDisclosureManualFulfillmentDate { get { return _eDisclosureManualFulfillmentDate; } set { _eDisclosureManualFulfillmentDate = value; } }
-        private Value<string> _eDisclosureManualFulfillmentMethod;
+        private DirtyValue<string> _eDisclosureManualFulfillmentMethod;
         public string EDisclosureManualFulfillmentMethod { get { return _eDisclosureManualFulfillmentMethod; } set { _eDisclosureManualFulfillmentMethod = value; } }
-        private Value<string> _eDisclosureManuallyFulfilledBy;
+        private DirtyValue<string> _eDisclosureManuallyFulfilledBy;
         public string EDisclosureManuallyFulfilledBy { get { return _eDisclosureManuallyFulfilledBy; } set { _eDisclosureManuallyFulfilledBy = value; } }
-        private Value<DateTime?> _eDisclosurePackageCreatedDate;
+        private DirtyValue<DateTime?> _eDisclosurePackageCreatedDate;
         public DateTime? EDisclosurePackageCreatedDate { get { return _eDisclosurePackageCreatedDate; } set { _eDisclosurePackageCreatedDate = value; } }
-        private Value<string> _eDisclosurePackageId;
+        private DirtyValue<string> _eDisclosurePackageId;
         public string EDisclosurePackageId { get { return _eDisclosurePackageId; } set { _eDisclosurePackageId = value; } }
-        private Value<string> _eDisclosurePackageViewableFile;
+        private DirtyValue<string> _eDisclosurePackageViewableFile;
         public string EDisclosurePackageViewableFile { get { return _eDisclosurePackageViewableFile; } set { _eDisclosurePackageViewableFile = value; } }
-        private Value<bool?> _eDisclosureThreeDayPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureThreeDayPackageIndicator;
         public bool? EDisclosureThreeDayPackageIndicator { get { return _eDisclosureThreeDayPackageIndicator; } set { _eDisclosureThreeDayPackageIndicator = value; } }
-        private Value<string> _estimatedTotalPayoffsAndPaymentsAmount;
+        private DirtyValue<string> _estimatedTotalPayoffsAndPaymentsAmount;
         public string EstimatedTotalPayoffsAndPaymentsAmount { get { return _estimatedTotalPayoffsAndPaymentsAmount; } set { _estimatedTotalPayoffsAndPaymentsAmount = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _financeCharge;
+        private DirtyValue<string> _financeCharge;
         public string FinanceCharge { get { return _financeCharge; } set { _financeCharge = value; } }
         private DirtyList<DisclosureForm> _forms;
         public IList<DisclosureForm> Forms { get { var v = _forms; return v ?? Interlocked.CompareExchange(ref _forms, (v = new DirtyList<DisclosureForm>()), null) ?? v; } set { _forms = new DirtyList<DisclosureForm>(value); } }
-        private Value<string> _formsXml;
+        private DirtyValue<string> _formsXml;
         public string FormsXml { get { return _formsXml; } set { _formsXml = value; } }
-        private Value<string> _fulfillmentOrderedBy;
+        private DirtyValue<string> _fulfillmentOrderedBy;
         public string FulfillmentOrderedBy { get { return _fulfillmentOrderedBy; } set { _fulfillmentOrderedBy = value; } }
-        private Value<string> _fullfillmentProcessedDate;
+        private DirtyValue<string> _fullfillmentProcessedDate;
         public string FullfillmentProcessedDate { get { return _fullfillmentProcessedDate; } set { _fullfillmentProcessedDate = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _intentToProceed;
+        private DirtyValue<bool?> _intentToProceed;
         public bool? IntentToProceed { get { return _intentToProceed; } set { _intentToProceed = value; } }
-        private Value<string> _intentToProceedComments;
+        private DirtyValue<string> _intentToProceedComments;
         public string IntentToProceedComments { get { return _intentToProceedComments; } set { _intentToProceedComments = value; } }
-        private Value<DateTime?> _intentToProceedDate;
+        private DirtyValue<DateTime?> _intentToProceedDate;
         public DateTime? IntentToProceedDate { get { return _intentToProceedDate; } set { _intentToProceedDate = value; } }
-        private Value<string> _intentToProceedReceivedBy;
+        private DirtyValue<string> _intentToProceedReceivedBy;
         public string IntentToProceedReceivedBy { get { return _intentToProceedReceivedBy; } set { _intentToProceedReceivedBy = value; } }
-        private Value<string> _intentToProceedReceivedMethod;
+        private DirtyValue<string> _intentToProceedReceivedMethod;
         public string IntentToProceedReceivedMethod { get { return _intentToProceedReceivedMethod; } set { _intentToProceedReceivedMethod = value; } }
-        private Value<string> _intentToProceedReceivedMethodOther;
+        private DirtyValue<string> _intentToProceedReceivedMethodOther;
         public string IntentToProceedReceivedMethodOther { get { return _intentToProceedReceivedMethodOther; } set { _intentToProceedReceivedMethodOther = value; } }
-        private Value<bool?> _isBorrowerPresumedDateLocked;
+        private DirtyValue<bool?> _isBorrowerPresumedDateLocked;
         public bool? IsBorrowerPresumedDateLocked { get { return _isBorrowerPresumedDateLocked; } set { _isBorrowerPresumedDateLocked = value; } }
-        private Value<bool?> _isBorrowerTypeLocked;
+        private DirtyValue<bool?> _isBorrowerTypeLocked;
         public bool? IsBorrowerTypeLocked { get { return _isBorrowerTypeLocked; } set { _isBorrowerTypeLocked = value; } }
-        private Value<bool?> _isCoBorrowerPresumedDateLocked;
+        private DirtyValue<bool?> _isCoBorrowerPresumedDateLocked;
         public bool? IsCoBorrowerPresumedDateLocked { get { return _isCoBorrowerPresumedDateLocked; } set { _isCoBorrowerPresumedDateLocked = value; } }
-        private Value<bool?> _isCoBorrowerTypeLocked;
+        private DirtyValue<bool?> _isCoBorrowerTypeLocked;
         public bool? IsCoBorrowerTypeLocked { get { return _isCoBorrowerTypeLocked; } set { _isCoBorrowerTypeLocked = value; } }
-        private Value<string> _isDisclosed;
+        private DirtyValue<string> _isDisclosed;
         public string IsDisclosed { get { return _isDisclosed; } set { _isDisclosed = value; } }
-        private Value<string> _isDisclosedAprLocked;
+        private DirtyValue<string> _isDisclosedAprLocked;
         public string IsDisclosedAprLocked { get { return _isDisclosedAprLocked; } set { _isDisclosedAprLocked = value; } }
-        private Value<string> _isDisclosedByLocked;
+        private DirtyValue<string> _isDisclosedByLocked;
         public string IsDisclosedByLocked { get { return _isDisclosedByLocked; } set { _isDisclosedByLocked = value; } }
-        private Value<string> _isDisclosedFinanceChargeLocked;
+        private DirtyValue<string> _isDisclosedFinanceChargeLocked;
         public string IsDisclosedFinanceChargeLocked { get { return _isDisclosedFinanceChargeLocked; } set { _isDisclosedFinanceChargeLocked = value; } }
-        private Value<string> _isDisclosedReceivedDateLocked;
+        private DirtyValue<string> _isDisclosedReceivedDateLocked;
         public string IsDisclosedReceivedDateLocked { get { return _isDisclosedReceivedDateLocked; } set { _isDisclosedReceivedDateLocked = value; } }
-        private Value<string> _isLocked;
+        private DirtyValue<string> _isLocked;
         public string IsLocked { get { return _isLocked; } set { _isLocked = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<bool?> _isWetSignedIndicator;
+        private DirtyValue<bool?> _isWetSignedIndicator;
         public bool? IsWetSignedIndicator { get { return _isWetSignedIndicator; } set { _isWetSignedIndicator = value; } }
-        private Value<string> _lenderCompensationCreditAmount2;
+        private DirtyValue<string> _lenderCompensationCreditAmount2;
         public string LenderCompensationCreditAmount2 { get { return _lenderCompensationCreditAmount2; } set { _lenderCompensationCreditAmount2 = value; } }
-        private Value<string> _lenderTotalPaidOriginatorAmount;
+        private DirtyValue<string> _lenderTotalPaidOriginatorAmount;
         public string LenderTotalPaidOriginatorAmount { get { return _lenderTotalPaidOriginatorAmount; } set { _lenderTotalPaidOriginatorAmount = value; } }
-        private Value<bool?> _lEReasonIsChangedCircumstanceEligibility;
+        private DirtyValue<bool?> _lEReasonIsChangedCircumstanceEligibility;
         public bool? LEReasonIsChangedCircumstanceEligibility { get { return _lEReasonIsChangedCircumstanceEligibility; } set { _lEReasonIsChangedCircumstanceEligibility = value; } }
-        private Value<bool?> _lEReasonIsChangedCircumstanceSettlementCharges;
+        private DirtyValue<bool?> _lEReasonIsChangedCircumstanceSettlementCharges;
         public bool? LEReasonIsChangedCircumstanceSettlementCharges { get { return _lEReasonIsChangedCircumstanceSettlementCharges; } set { _lEReasonIsChangedCircumstanceSettlementCharges = value; } }
-        private Value<bool?> _lEReasonIsDelayedSettlementOnConstructionLoans;
+        private DirtyValue<bool?> _lEReasonIsDelayedSettlementOnConstructionLoans;
         public bool? LEReasonIsDelayedSettlementOnConstructionLoans { get { return _lEReasonIsDelayedSettlementOnConstructionLoans; } set { _lEReasonIsDelayedSettlementOnConstructionLoans = value; } }
-        private Value<bool?> _lEReasonIsExpiration;
+        private DirtyValue<bool?> _lEReasonIsExpiration;
         public bool? LEReasonIsExpiration { get { return _lEReasonIsExpiration; } set { _lEReasonIsExpiration = value; } }
-        private Value<bool?> _lEReasonIsInterestRateDependentCharges;
+        private DirtyValue<bool?> _lEReasonIsInterestRateDependentCharges;
         public bool? LEReasonIsInterestRateDependentCharges { get { return _lEReasonIsInterestRateDependentCharges; } set { _lEReasonIsInterestRateDependentCharges = value; } }
-        private Value<bool?> _lEReasonIsOther;
+        private DirtyValue<bool?> _lEReasonIsOther;
         public bool? LEReasonIsOther { get { return _lEReasonIsOther; } set { _lEReasonIsOther = value; } }
-        private Value<bool?> _lEReasonIsRevisionsRequestedByConsumer;
+        private DirtyValue<bool?> _lEReasonIsRevisionsRequestedByConsumer;
         public bool? LEReasonIsRevisionsRequestedByConsumer { get { return _lEReasonIsRevisionsRequestedByConsumer; } set { _lEReasonIsRevisionsRequestedByConsumer = value; } }
-        private Value<string> _lEReasonOther;
+        private DirtyValue<string> _lEReasonOther;
         public string LEReasonOther { get { return _lEReasonOther; } set { _lEReasonOther = value; } }
-        private Value<string> _line802LOCompAdditionalAmount1;
+        private DirtyValue<string> _line802LOCompAdditionalAmount1;
         public string Line802LOCompAdditionalAmount1 { get { return _line802LOCompAdditionalAmount1; } set { _line802LOCompAdditionalAmount1 = value; } }
-        private Value<string> _line802LOCompAdditionalAmount2;
+        private DirtyValue<string> _line802LOCompAdditionalAmount2;
         public string Line802LOCompAdditionalAmount2 { get { return _line802LOCompAdditionalAmount2; } set { _line802LOCompAdditionalAmount2 = value; } }
-        private Value<string> _line907InsuranceIndicator2015;
+        private DirtyValue<string> _line907InsuranceIndicator2015;
         public string Line907InsuranceIndicator2015 { get { return _line907InsuranceIndicator2015; } set { _line907InsuranceIndicator2015 = value; } }
-        private Value<string> _line907PropertyIndicator2015;
+        private DirtyValue<string> _line907PropertyIndicator2015;
         public string Line907PropertyIndicator2015 { get { return _line907PropertyIndicator2015; } set { _line907PropertyIndicator2015 = value; } }
-        private Value<string> _line907TaxesIndicator2015;
+        private DirtyValue<string> _line907TaxesIndicator2015;
         public string Line907TaxesIndicator2015 { get { return _line907TaxesIndicator2015; } set { _line907TaxesIndicator2015 = value; } }
-        private Value<string> _line908InsuranceIndicator2015;
+        private DirtyValue<string> _line908InsuranceIndicator2015;
         public string Line908InsuranceIndicator2015 { get { return _line908InsuranceIndicator2015; } set { _line908InsuranceIndicator2015 = value; } }
-        private Value<string> _line908PropertyIndicator2015;
+        private DirtyValue<string> _line908PropertyIndicator2015;
         public string Line908PropertyIndicator2015 { get { return _line908PropertyIndicator2015; } set { _line908PropertyIndicator2015 = value; } }
-        private Value<string> _line908TaxesIndicator2015;
+        private DirtyValue<string> _line908TaxesIndicator2015;
         public string Line908TaxesIndicator2015 { get { return _line908TaxesIndicator2015; } set { _line908TaxesIndicator2015 = value; } }
-        private Value<string> _line909InsuranceIndicator2015;
+        private DirtyValue<string> _line909InsuranceIndicator2015;
         public string Line909InsuranceIndicator2015 { get { return _line909InsuranceIndicator2015; } set { _line909InsuranceIndicator2015 = value; } }
-        private Value<string> _line909PropertyIndicator2015;
+        private DirtyValue<string> _line909PropertyIndicator2015;
         public string Line909PropertyIndicator2015 { get { return _line909PropertyIndicator2015; } set { _line909PropertyIndicator2015 = value; } }
-        private Value<string> _line909TaxesIndicator2015;
+        private DirtyValue<string> _line909TaxesIndicator2015;
         public string Line909TaxesIndicator2015 { get { return _line909TaxesIndicator2015; } set { _line909TaxesIndicator2015 = value; } }
-        private Value<string> _line910InsuranceIndicator2015;
+        private DirtyValue<string> _line910InsuranceIndicator2015;
         public string Line910InsuranceIndicator2015 { get { return _line910InsuranceIndicator2015; } set { _line910InsuranceIndicator2015 = value; } }
-        private Value<string> _line910PropertyIndicator2015;
+        private DirtyValue<string> _line910PropertyIndicator2015;
         public string Line910PropertyIndicator2015 { get { return _line910PropertyIndicator2015; } set { _line910PropertyIndicator2015 = value; } }
-        private Value<string> _line910TaxesIndicator2015;
+        private DirtyValue<string> _line910TaxesIndicator2015;
         public string Line910TaxesIndicator2015 { get { return _line910TaxesIndicator2015; } set { _line910TaxesIndicator2015 = value; } }
-        private Value<string> _line911InsuranceIndicator2015;
+        private DirtyValue<string> _line911InsuranceIndicator2015;
         public string Line911InsuranceIndicator2015 { get { return _line911InsuranceIndicator2015; } set { _line911InsuranceIndicator2015 = value; } }
-        private Value<string> _line911PropertyIndicator2015;
+        private DirtyValue<string> _line911PropertyIndicator2015;
         public string Line911PropertyIndicator2015 { get { return _line911PropertyIndicator2015; } set { _line911PropertyIndicator2015 = value; } }
-        private Value<string> _line911TaxesIndicator2015;
+        private DirtyValue<string> _line911TaxesIndicator2015;
         public string Line911TaxesIndicator2015 { get { return _line911TaxesIndicator2015; } set { _line911TaxesIndicator2015 = value; } }
-        private Value<string> _line912InsuranceIndicator2015;
+        private DirtyValue<string> _line912InsuranceIndicator2015;
         public string Line912InsuranceIndicator2015 { get { return _line912InsuranceIndicator2015; } set { _line912InsuranceIndicator2015 = value; } }
-        private Value<string> _line912PropertyIndicator2015;
+        private DirtyValue<string> _line912PropertyIndicator2015;
         public string Line912PropertyIndicator2015 { get { return _line912PropertyIndicator2015; } set { _line912PropertyIndicator2015 = value; } }
-        private Value<string> _line912TaxesIndicator2015;
+        private DirtyValue<string> _line912TaxesIndicator2015;
         public string Line912TaxesIndicator2015 { get { return _line912TaxesIndicator2015; } set { _line912TaxesIndicator2015 = value; } }
-        private Value<string> _loanAdjustmentsOtherCredits;
+        private DirtyValue<string> _loanAdjustmentsOtherCredits;
         public string LoanAdjustmentsOtherCredits { get { return _loanAdjustmentsOtherCredits; } set { _loanAdjustmentsOtherCredits = value; } }
-        private Value<string> _loanAmount;
+        private DirtyValue<string> _loanAmount;
         public string LoanAmount { get { return _loanAmount; } set { _loanAmount = value; } }
-        private Value<string> _loanClosingCost2BorrowerClosingCostAtClosing;
+        private DirtyValue<string> _loanClosingCost2BorrowerClosingCostAtClosing;
         public string LoanClosingCost2BorrowerClosingCostAtClosing { get { return _loanClosingCost2BorrowerClosingCostAtClosing; } set { _loanClosingCost2BorrowerClosingCostAtClosing = value; } }
-        private Value<string> _loanClosingCost2LenderCredits;
+        private DirtyValue<string> _loanClosingCost2LenderCredits;
         public string LoanClosingCost2LenderCredits { get { return _loanClosingCost2LenderCredits; } set { _loanClosingCost2LenderCredits = value; } }
-        private Value<string> _loanClosingCost2TotalLoanCost;
+        private DirtyValue<string> _loanClosingCost2TotalLoanCost;
         public string LoanClosingCost2TotalLoanCost { get { return _loanClosingCost2TotalLoanCost; } set { _loanClosingCost2TotalLoanCost = value; } }
-        private Value<string> _loanClosingCost2TotalOtherCost;
+        private DirtyValue<string> _loanClosingCost2TotalOtherCost;
         public string LoanClosingCost2TotalOtherCost { get { return _loanClosingCost2TotalOtherCost; } set { _loanClosingCost2TotalOtherCost = value; } }
-        private Value<string> _loanClosingCost3StdLegalLimit;
+        private DirtyValue<string> _loanClosingCost3StdLegalLimit;
         public string LoanClosingCost3StdLegalLimit { get { return _loanClosingCost3StdLegalLimit; } set { _loanClosingCost3StdLegalLimit = value; } }
-        private Value<string> _loanClosingCostGfe1200BorPaidAmount;
+        private DirtyValue<string> _loanClosingCostGfe1200BorPaidAmount;
         public string LoanClosingCostGfe1200BorPaidAmount { get { return _loanClosingCostGfe1200BorPaidAmount; } set { _loanClosingCostGfe1200BorPaidAmount = value; } }
-        private Value<string> _loanClosingCostGfe800BorPaidAmount;
+        private DirtyValue<string> _loanClosingCostGfe800BorPaidAmount;
         public string LoanClosingCostGfe800BorPaidAmount { get { return _loanClosingCostGfe800BorPaidAmount; } set { _loanClosingCostGfe800BorPaidAmount = value; } }
-        private Value<string> _loanClosingCostLenderCredits;
+        private DirtyValue<string> _loanClosingCostLenderCredits;
         public string LoanClosingCostLenderCredits { get { return _loanClosingCostLenderCredits; } set { _loanClosingCostLenderCredits = value; } }
-        private Value<string> _loanClosingCostSection1000BorrowerTotalPaidAmount;
+        private DirtyValue<string> _loanClosingCostSection1000BorrowerTotalPaidAmount;
         public string LoanClosingCostSection1000BorrowerTotalPaidAmount { get { return _loanClosingCostSection1000BorrowerTotalPaidAmount; } set { _loanClosingCostSection1000BorrowerTotalPaidAmount = value; } }
-        private Value<string> _loanClosingCostsFinanced;
+        private DirtyValue<string> _loanClosingCostsFinanced;
         public string LoanClosingCostsFinanced { get { return _loanClosingCostsFinanced; } set { _loanClosingCostsFinanced = value; } }
-        private Value<string> _loanClosingCostTotalFeeAmount2015;
+        private DirtyValue<string> _loanClosingCostTotalFeeAmount2015;
         public string LoanClosingCostTotalFeeAmount2015 { get { return _loanClosingCostTotalFeeAmount2015; } set { _loanClosingCostTotalFeeAmount2015 = value; } }
-        private Value<string> _loanDownPayment;
+        private DirtyValue<string> _loanDownPayment;
         public string LoanDownPayment { get { return _loanDownPayment; } set { _loanDownPayment = value; } }
-        private Value<string> _loanEstimate2TotalLoanAndOtherCosts;
+        private DirtyValue<string> _loanEstimate2TotalLoanAndOtherCosts;
         public string LoanEstimate2TotalLoanAndOtherCosts { get { return _loanEstimate2TotalLoanAndOtherCosts; } set { _loanEstimate2TotalLoanAndOtherCosts = value; } }
-        private Value<string> _loanEstimate2TotalLoanCosts;
+        private DirtyValue<string> _loanEstimate2TotalLoanCosts;
         public string LoanEstimate2TotalLoanCosts { get { return _loanEstimate2TotalLoanCosts; } set { _loanEstimate2TotalLoanCosts = value; } }
-        private Value<string> _loanEstimate2TotalOtherCosts;
+        private DirtyValue<string> _loanEstimate2TotalOtherCosts;
         public string LoanEstimate2TotalOtherCosts { get { return _loanEstimate2TotalOtherCosts; } set { _loanEstimate2TotalOtherCosts = value; } }
-        private Value<string> _loanEstimate2UnroundedTotalLoanCosts;
+        private DirtyValue<string> _loanEstimate2UnroundedTotalLoanCosts;
         public string LoanEstimate2UnroundedTotalLoanCosts { get { return _loanEstimate2UnroundedTotalLoanCosts; } set { _loanEstimate2UnroundedTotalLoanCosts = value; } }
-        private Value<string> _loanEstimate2UnroundedTotalOtherCosts;
+        private DirtyValue<string> _loanEstimate2UnroundedTotalOtherCosts;
         public string LoanEstimate2UnroundedTotalOtherCosts { get { return _loanEstimate2UnroundedTotalOtherCosts; } set { _loanEstimate2UnroundedTotalOtherCosts = value; } }
-        private Value<string> _loanEstimateLoanProduct;
+        private DirtyValue<string> _loanEstimateLoanProduct;
         public string LoanEstimateLoanProduct { get { return _loanEstimateLoanProduct; } set { _loanEstimateLoanProduct = value; } }
-        private Value<string> _loanFeesCityTaxBorPaidAmount;
+        private DirtyValue<string> _loanFeesCityTaxBorPaidAmount;
         public string LoanFeesCityTaxBorPaidAmount { get { return _loanFeesCityTaxBorPaidAmount; } set { _loanFeesCityTaxBorPaidAmount = value; } }
-        private Value<string> _loanFeesStateTaxBorPaidAmount;
+        private DirtyValue<string> _loanFeesStateTaxBorPaidAmount;
         public string LoanFeesStateTaxBorPaidAmount { get { return _loanFeesStateTaxBorPaidAmount; } set { _loanFeesStateTaxBorPaidAmount = value; } }
-        private Value<string> _loanFundsForBorrower;
+        private DirtyValue<string> _loanFundsForBorrower;
         public string LoanFundsForBorrower { get { return _loanFundsForBorrower; } set { _loanFundsForBorrower = value; } }
-        private Value<string> _loanGfeAgregateAdjustment;
+        private DirtyValue<string> _loanGfeAgregateAdjustment;
         public string LoanGfeAgregateAdjustment { get { return _loanGfeAgregateAdjustment; } set { _loanGfeAgregateAdjustment = value; } }
-        private Value<string> _loanGfeGovermentRecordingCharges;
+        private DirtyValue<string> _loanGfeGovermentRecordingCharges;
         public string LoanGfeGovermentRecordingCharges { get { return _loanGfeGovermentRecordingCharges; } set { _loanGfeGovermentRecordingCharges = value; } }
-        private Value<string> _loanLineItemAmount;
+        private DirtyValue<string> _loanLineItemAmount;
         public string LoanLineItemAmount { get { return _loanLineItemAmount; } set { _loanLineItemAmount = value; } }
-        private Value<string> _loanProgram;
+        private DirtyValue<string> _loanProgram;
         public string LoanProgram { get { return _loanProgram; } set { _loanProgram = value; } }
-        private Value<string> _loanPurchaseCreditAmount1;
+        private DirtyValue<string> _loanPurchaseCreditAmount1;
         public string LoanPurchaseCreditAmount1 { get { return _loanPurchaseCreditAmount1; } set { _loanPurchaseCreditAmount1 = value; } }
-        private Value<string> _loanPurchaseCreditAmount2;
+        private DirtyValue<string> _loanPurchaseCreditAmount2;
         public string LoanPurchaseCreditAmount2 { get { return _loanPurchaseCreditAmount2; } set { _loanPurchaseCreditAmount2 = value; } }
-        private Value<string> _loanPurchaseCreditAmount3;
+        private DirtyValue<string> _loanPurchaseCreditAmount3;
         public string LoanPurchaseCreditAmount3 { get { return _loanPurchaseCreditAmount3; } set { _loanPurchaseCreditAmount3 = value; } }
-        private Value<string> _loanPurchaseCreditAmount4;
+        private DirtyValue<string> _loanPurchaseCreditAmount4;
         public string LoanPurchaseCreditAmount4 { get { return _loanPurchaseCreditAmount4; } set { _loanPurchaseCreditAmount4 = value; } }
-        private Value<string> _loanPurchaseCreditType1;
+        private DirtyValue<string> _loanPurchaseCreditType1;
         public string LoanPurchaseCreditType1 { get { return _loanPurchaseCreditType1; } set { _loanPurchaseCreditType1 = value; } }
-        private Value<string> _loanPurchaseCreditType2;
+        private DirtyValue<string> _loanPurchaseCreditType2;
         public string LoanPurchaseCreditType2 { get { return _loanPurchaseCreditType2; } set { _loanPurchaseCreditType2 = value; } }
-        private Value<string> _loanPurchaseCreditType3;
+        private DirtyValue<string> _loanPurchaseCreditType3;
         public string LoanPurchaseCreditType3 { get { return _loanPurchaseCreditType3; } set { _loanPurchaseCreditType3 = value; } }
-        private Value<string> _loanPurchaseCreditType4;
+        private DirtyValue<string> _loanPurchaseCreditType4;
         public string LoanPurchaseCreditType4 { get { return _loanPurchaseCreditType4; } set { _loanPurchaseCreditType4 = value; } }
-        private Value<string> _loanRefinanceIncludingDebtsToBePaidOffAmount;
+        private DirtyValue<string> _loanRefinanceIncludingDebtsToBePaidOffAmount;
         public string LoanRefinanceIncludingDebtsToBePaidOffAmount { get { return _loanRefinanceIncludingDebtsToBePaidOffAmount; } set { _loanRefinanceIncludingDebtsToBePaidOffAmount = value; } }
-        private Value<string> _loanSection1000SellerPaidTotalAmount;
+        private DirtyValue<string> _loanSection1000SellerPaidTotalAmount;
         public string LoanSection1000SellerPaidTotalAmount { get { return _loanSection1000SellerPaidTotalAmount; } set { _loanSection1000SellerPaidTotalAmount = value; } }
-        private Value<string> _loanSellerCreditAmount;
+        private DirtyValue<string> _loanSellerCreditAmount;
         public string LoanSellerCreditAmount { get { return _loanSellerCreditAmount; } set { _loanSellerCreditAmount = value; } }
-        private Value<string> _loanTotalClosingCosts;
+        private DirtyValue<string> _loanTotalClosingCosts;
         public string LoanTotalClosingCosts { get { return _loanTotalClosingCosts; } set { _loanTotalClosingCosts = value; } }
-        private Value<DateTime?> _lockedBorrowerPresumedReceivedDate;
+        private DirtyValue<DateTime?> _lockedBorrowerPresumedReceivedDate;
         public DateTime? LockedBorrowerPresumedReceivedDate { get { return _lockedBorrowerPresumedReceivedDate; } set { _lockedBorrowerPresumedReceivedDate = value; } }
-        private Value<string> _lockedBorrowerType;
+        private DirtyValue<string> _lockedBorrowerType;
         public string LockedBorrowerType { get { return _lockedBorrowerType; } set { _lockedBorrowerType = value; } }
-        private Value<DateTime?> _lockedCoBorrowerPresumedReceivedDate;
+        private DirtyValue<DateTime?> _lockedCoBorrowerPresumedReceivedDate;
         public DateTime? LockedCoBorrowerPresumedReceivedDate { get { return _lockedCoBorrowerPresumedReceivedDate; } set { _lockedCoBorrowerPresumedReceivedDate = value; } }
-        private Value<string> _lockedCoBorrowerType;
+        private DirtyValue<string> _lockedCoBorrowerType;
         public string LockedCoBorrowerType { get { return _lockedCoBorrowerType; } set { _lockedCoBorrowerType = value; } }
-        private Value<string> _lockedDisclosedAprField;
+        private DirtyValue<string> _lockedDisclosedAprField;
         public string LockedDisclosedAprField { get { return _lockedDisclosedAprField; } set { _lockedDisclosedAprField = value; } }
-        private Value<string> _lockedDisclosedByField;
+        private DirtyValue<string> _lockedDisclosedByField;
         public string LockedDisclosedByField { get { return _lockedDisclosedByField; } set { _lockedDisclosedByField = value; } }
-        private Value<string> _lockedDisclosedFinanceChargeField;
+        private DirtyValue<string> _lockedDisclosedFinanceChargeField;
         public string LockedDisclosedFinanceChargeField { get { return _lockedDisclosedFinanceChargeField; } set { _lockedDisclosedFinanceChargeField = value; } }
-        private Value<DateTime?> _lockedDisclosedReceivedDate;
+        private DirtyValue<DateTime?> _lockedDisclosedReceivedDate;
         public DateTime? LockedDisclosedReceivedDate { get { return _lockedDisclosedReceivedDate; } set { _lockedDisclosedReceivedDate = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _manuallyCreated;
+        private DirtyValue<string> _manuallyCreated;
         public string ManuallyCreated { get { return _manuallyCreated; } set { _manuallyCreated = value; } }
-        private Value<string> _prepaymentPenaltyIndicator;
+        private DirtyValue<string> _prepaymentPenaltyIndicator;
         public string PrepaymentPenaltyIndicator { get { return _prepaymentPenaltyIndicator; } set { _prepaymentPenaltyIndicator = value; } }
-        private Value<string> _propertyAddress;
+        private DirtyValue<string> _propertyAddress;
         public string PropertyAddress { get { return _propertyAddress; } set { _propertyAddress = value; } }
-        private Value<string> _propertyCity;
+        private DirtyValue<string> _propertyCity;
         public string PropertyCity { get { return _propertyCity; } set { _propertyCity = value; } }
-        private Value<string> _propertyState;
+        private DirtyValue<string> _propertyState;
         public string PropertyState { get { return _propertyState; } set { _propertyState = value; } }
-        private Value<string> _propertyZip;
+        private DirtyValue<string> _propertyZip;
         public string PropertyZip { get { return _propertyZip; } set { _propertyZip = value; } }
-        private Value<bool?> _providerListSent;
+        private DirtyValue<bool?> _providerListSent;
         public bool? ProviderListSent { get { return _providerListSent; } set { _providerListSent = value; } }
-        private Value<string> _purchasePriceAmount;
+        private DirtyValue<string> _purchasePriceAmount;
         public string PurchasePriceAmount { get { return _purchasePriceAmount; } set { _purchasePriceAmount = value; } }
-        private Value<DateTime?> _receivedDate;
+        private DirtyValue<DateTime?> _receivedDate;
         public DateTime? ReceivedDate { get { return _receivedDate; } set { _receivedDate = value; } }
         private DirtyList<LogSnapshotField> _snapshotFields;
         public IList<LogSnapshotField> SnapshotFields { get { var v = _snapshotFields; return v ?? Interlocked.CompareExchange(ref _snapshotFields, (v = new DirtyList<LogSnapshotField>()), null) ?? v; } set { _snapshotFields = new DirtyList<LogSnapshotField>(value); } }
-        private Value<string> _snapshotXml;
+        private DirtyValue<string> _snapshotXml;
         public string SnapshotXml { get { return _snapshotXml; } set { _snapshotXml = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DisclosureTracking2015Log.cs
+++ b/src/EncompassRest/Loans/DisclosureTracking2015Log.cs
@@ -8,8 +8,8 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DisclosureTracking2015Log : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<DateTime?> _applicationDate;
@@ -76,8 +76,8 @@ namespace EncompassRest.Loans
         public DateTime? CoBorrowerPresumedReceivedDate { get { return _coBorrowerPresumedReceivedDate; } set { _coBorrowerPresumedReceivedDate = value; } }
         private Value<string> _coBorrowerType;
         public string CoBorrowerType { get { return _coBorrowerType; } set { _coBorrowerType = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -176,8 +176,8 @@ namespace EncompassRest.Loans
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
         private Value<string> _financeCharge;
         public string FinanceCharge { get { return _financeCharge; } set { _financeCharge = value; } }
-        private Value<List<DisclosureForm>> _forms;
-        public List<DisclosureForm> Forms { get { return _forms; } set { _forms = value; } }
+        private DirtyList<DisclosureForm> _forms;
+        public IList<DisclosureForm> Forms { get { var v = _forms; return v ?? Interlocked.CompareExchange(ref _forms, (v = new DirtyList<DisclosureForm>()), null) ?? v; } set { _forms = new DirtyList<DisclosureForm>(value); } }
         private Value<string> _formsXml;
         public string FormsXml { get { return _formsXml; } set { _formsXml = value; } }
         private Value<string> _fulfillmentOrderedBy;
@@ -398,8 +398,8 @@ namespace EncompassRest.Loans
         public string PurchasePriceAmount { get { return _purchasePriceAmount; } set { _purchasePriceAmount = value; } }
         private Value<DateTime?> _receivedDate;
         public DateTime? ReceivedDate { get { return _receivedDate; } set { _receivedDate = value; } }
-        private Value<List<LogSnapshotField>> _snapshotFields;
-        public List<LogSnapshotField> SnapshotFields { get { return _snapshotFields; } set { _snapshotFields = value; } }
+        private DirtyList<LogSnapshotField> _snapshotFields;
+        public IList<LogSnapshotField> SnapshotFields { get { var v = _snapshotFields; return v ?? Interlocked.CompareExchange(ref _snapshotFields, (v = new DirtyList<LogSnapshotField>()), null) ?? v; } set { _snapshotFields = new DirtyList<LogSnapshotField>(value); } }
         private Value<string> _snapshotXml;
         public string SnapshotXml { get { return _snapshotXml; } set { _snapshotXml = value; } }
         private Value<string> _systemId;
@@ -411,8 +411,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _alertsXml.Dirty
+                var dirty = _alertsXml.Dirty
                     || _applicationDate.Dirty
                     || _appliedCureAmount.Dirty
                     || _borrowerActualReceivedDate.Dirty
@@ -445,7 +444,6 @@ namespace EncompassRest.Loans
                     || _coBorrowerName.Dirty
                     || _coBorrowerPresumedReceivedDate.Dirty
                     || _coBorrowerType.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _containCD.Dirty
@@ -495,7 +493,6 @@ namespace EncompassRest.Loans
                     || _estimatedTotalPayoffsAndPaymentsAmount.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _financeCharge.Dirty
-                    || _forms.Dirty
                     || _formsXml.Dirty
                     || _fulfillmentOrderedBy.Dirty
                     || _fullfillmentProcessedDate.Dirty
@@ -606,16 +603,18 @@ namespace EncompassRest.Loans
                     || _providerListSent.Dirty
                     || _purchasePriceAmount.Dirty
                     || _receivedDate.Dirty
-                    || _snapshotFields.Dirty
                     || _snapshotXml.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _forms?.Dirty == true
+                    || _snapshotFields?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _applicationDate.Dirty = value;
                 _appliedCureAmount.Dirty = value;
@@ -649,7 +648,6 @@ namespace EncompassRest.Loans
                 _coBorrowerName.Dirty = value;
                 _coBorrowerPresumedReceivedDate.Dirty = value;
                 _coBorrowerType.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _containCD.Dirty = value;
@@ -699,7 +697,6 @@ namespace EncompassRest.Loans
                 _estimatedTotalPayoffsAndPaymentsAmount.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
                 _financeCharge.Dirty = value;
-                _forms.Dirty = value;
                 _formsXml.Dirty = value;
                 _fulfillmentOrderedBy.Dirty = value;
                 _fullfillmentProcessedDate.Dirty = value;
@@ -810,9 +807,12 @@ namespace EncompassRest.Loans
                 _providerListSent.Dirty = value;
                 _purchasePriceAmount.Dirty = value;
                 _receivedDate.Dirty = value;
-                _snapshotFields.Dirty = value;
                 _snapshotXml.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_forms != null) _forms.Dirty = value;
+                if (_snapshotFields != null) _snapshotFields.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/DisclosureTrackingLog.cs
+++ b/src/EncompassRest/Loans/DisclosureTrackingLog.cs
@@ -10,153 +10,153 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<DateTime?> _applicationDate;
+        private DirtyValue<DateTime?> _applicationDate;
         public DateTime? ApplicationDate { get { return _applicationDate; } set { _applicationDate = value; } }
-        private Value<string> _borrowerName;
+        private DirtyValue<string> _borrowerName;
         public string BorrowerName { get { return _borrowerName; } set { _borrowerName = value; } }
-        private Value<string> _borrowerPairId;
+        private DirtyValue<string> _borrowerPairId;
         public string BorrowerPairId { get { return _borrowerPairId; } set { _borrowerPairId = value; } }
-        private Value<string> _coBorrowerName;
+        private DirtyValue<string> _coBorrowerName;
         public string CoBorrowerName { get { return _coBorrowerName; } set { _coBorrowerName = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<bool?> _containGfe;
+        private DirtyValue<bool?> _containGfe;
         public bool? ContainGfe { get { return _containGfe; } set { _containGfe = value; } }
-        private Value<bool?> _containSafeHarbor;
+        private DirtyValue<bool?> _containSafeHarbor;
         public bool? ContainSafeHarbor { get { return _containSafeHarbor; } set { _containSafeHarbor = value; } }
-        private Value<bool?> _containTil;
+        private DirtyValue<bool?> _containTil;
         public bool? ContainTil { get { return _containTil; } set { _containTil = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _disclosedAPR;
+        private DirtyValue<string> _disclosedAPR;
         public string DisclosedAPR { get { return _disclosedAPR; } set { _disclosedAPR = value; } }
-        private Value<string> _disclosedBy;
+        private DirtyValue<string> _disclosedBy;
         public string DisclosedBy { get { return _disclosedBy; } set { _disclosedBy = value; } }
-        private Value<string> _disclosedByFullName;
+        private DirtyValue<string> _disclosedByFullName;
         public string DisclosedByFullName { get { return _disclosedByFullName; } set { _disclosedByFullName = value; } }
-        private Value<string> _disclosedMethod;
+        private DirtyValue<string> _disclosedMethod;
         public string DisclosedMethod { get { return _disclosedMethod; } set { _disclosedMethod = value; } }
-        private Value<DateTime?> _disclosureCreatedDttmUtc;
+        private DirtyValue<DateTime?> _disclosureCreatedDttmUtc;
         public DateTime? DisclosureCreatedDttmUtc { get { return _disclosureCreatedDttmUtc; } set { _disclosureCreatedDttmUtc = value; } }
-        private Value<bool?> _eDisclosureApplicationPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureApplicationPackageIndicator;
         public bool? EDisclosureApplicationPackageIndicator { get { return _eDisclosureApplicationPackageIndicator; } set { _eDisclosureApplicationPackageIndicator = value; } }
-        private Value<bool?> _eDisclosureApprovalPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureApprovalPackageIndicator;
         public bool? EDisclosureApprovalPackageIndicator { get { return _eDisclosureApprovalPackageIndicator; } set { _eDisclosureApprovalPackageIndicator = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerAcceptConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerAcceptConsentDate;
         public DateTime? EDisclosureBorrowerAcceptConsentDate { get { return _eDisclosureBorrowerAcceptConsentDate; } set { _eDisclosureBorrowerAcceptConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowereSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowereSignedDate;
         public DateTime? EDisclosureBorrowereSignedDate { get { return _eDisclosureBorrowereSignedDate; } set { _eDisclosureBorrowereSignedDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerRejectConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerRejectConsentDate;
         public DateTime? EDisclosureBorrowerRejectConsentDate { get { return _eDisclosureBorrowerRejectConsentDate; } set { _eDisclosureBorrowerRejectConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerViewConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerViewConsentDate;
         public DateTime? EDisclosureBorrowerViewConsentDate { get { return _eDisclosureBorrowerViewConsentDate; } set { _eDisclosureBorrowerViewConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerViewMessageDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerViewMessageDate;
         public DateTime? EDisclosureBorrowerViewMessageDate { get { return _eDisclosureBorrowerViewMessageDate; } set { _eDisclosureBorrowerViewMessageDate = value; } }
-        private Value<DateTime?> _eDisclosureBorrowerWetSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureBorrowerWetSignedDate;
         public DateTime? EDisclosureBorrowerWetSignedDate { get { return _eDisclosureBorrowerWetSignedDate; } set { _eDisclosureBorrowerWetSignedDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerAcceptConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerAcceptConsentDate;
         public DateTime? EDisclosureCoBorrowerAcceptConsentDate { get { return _eDisclosureCoBorrowerAcceptConsentDate; } set { _eDisclosureCoBorrowerAcceptConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowereSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowereSignedDate;
         public DateTime? EDisclosureCoBorrowereSignedDate { get { return _eDisclosureCoBorrowereSignedDate; } set { _eDisclosureCoBorrowereSignedDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerRejectConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerRejectConsentDate;
         public DateTime? EDisclosureCoBorrowerRejectConsentDate { get { return _eDisclosureCoBorrowerRejectConsentDate; } set { _eDisclosureCoBorrowerRejectConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerViewConsentDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerViewConsentDate;
         public DateTime? EDisclosureCoBorrowerViewConsentDate { get { return _eDisclosureCoBorrowerViewConsentDate; } set { _eDisclosureCoBorrowerViewConsentDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerViewMessageDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerViewMessageDate;
         public DateTime? EDisclosureCoBorrowerViewMessageDate { get { return _eDisclosureCoBorrowerViewMessageDate; } set { _eDisclosureCoBorrowerViewMessageDate = value; } }
-        private Value<DateTime?> _eDisclosureCoBorrowerWebSignedDate;
+        private DirtyValue<DateTime?> _eDisclosureCoBorrowerWebSignedDate;
         public DateTime? EDisclosureCoBorrowerWebSignedDate { get { return _eDisclosureCoBorrowerWebSignedDate; } set { _eDisclosureCoBorrowerWebSignedDate = value; } }
-        private Value<string> _eDisclosureConsentPdf;
+        private DirtyValue<string> _eDisclosureConsentPdf;
         public string EDisclosureConsentPdf { get { return _eDisclosureConsentPdf; } set { _eDisclosureConsentPdf = value; } }
-        private Value<string> _eDisclosureDisclosedMessage;
+        private DirtyValue<string> _eDisclosureDisclosedMessage;
         public string EDisclosureDisclosedMessage { get { return _eDisclosureDisclosedMessage; } set { _eDisclosureDisclosedMessage = value; } }
-        private Value<bool?> _eDisclosureLockPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureLockPackageIndicator;
         public bool? EDisclosureLockPackageIndicator { get { return _eDisclosureLockPackageIndicator; } set { _eDisclosureLockPackageIndicator = value; } }
-        private Value<string> _eDisclosureManualFulfillmentComment;
+        private DirtyValue<string> _eDisclosureManualFulfillmentComment;
         public string EDisclosureManualFulfillmentComment { get { return _eDisclosureManualFulfillmentComment; } set { _eDisclosureManualFulfillmentComment = value; } }
-        private Value<DateTime?> _eDisclosureManualFulfillmentDate;
+        private DirtyValue<DateTime?> _eDisclosureManualFulfillmentDate;
         public DateTime? EDisclosureManualFulfillmentDate { get { return _eDisclosureManualFulfillmentDate; } set { _eDisclosureManualFulfillmentDate = value; } }
-        private Value<string> _eDisclosureManualFulfillmentMethod;
+        private DirtyValue<string> _eDisclosureManualFulfillmentMethod;
         public string EDisclosureManualFulfillmentMethod { get { return _eDisclosureManualFulfillmentMethod; } set { _eDisclosureManualFulfillmentMethod = value; } }
-        private Value<string> _eDisclosureManuallyFulfilledBy;
+        private DirtyValue<string> _eDisclosureManuallyFulfilledBy;
         public string EDisclosureManuallyFulfilledBy { get { return _eDisclosureManuallyFulfilledBy; } set { _eDisclosureManuallyFulfilledBy = value; } }
-        private Value<DateTime?> _eDisclosurePackageCreatedDate;
+        private DirtyValue<DateTime?> _eDisclosurePackageCreatedDate;
         public DateTime? EDisclosurePackageCreatedDate { get { return _eDisclosurePackageCreatedDate; } set { _eDisclosurePackageCreatedDate = value; } }
-        private Value<string> _eDisclosurePackageId;
+        private DirtyValue<string> _eDisclosurePackageId;
         public string EDisclosurePackageId { get { return _eDisclosurePackageId; } set { _eDisclosurePackageId = value; } }
-        private Value<string> _eDisclosurePackageViewableFile;
+        private DirtyValue<string> _eDisclosurePackageViewableFile;
         public string EDisclosurePackageViewableFile { get { return _eDisclosurePackageViewableFile; } set { _eDisclosurePackageViewableFile = value; } }
-        private Value<bool?> _eDisclosureThreeDayPackageIndicator;
+        private DirtyValue<bool?> _eDisclosureThreeDayPackageIndicator;
         public bool? EDisclosureThreeDayPackageIndicator { get { return _eDisclosureThreeDayPackageIndicator; } set { _eDisclosureThreeDayPackageIndicator = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _financeCharge;
+        private DirtyValue<string> _financeCharge;
         public string FinanceCharge { get { return _financeCharge; } set { _financeCharge = value; } }
         private DirtyList<DisclosureForm> _forms;
         public IList<DisclosureForm> Forms { get { var v = _forms; return v ?? Interlocked.CompareExchange(ref _forms, (v = new DirtyList<DisclosureForm>()), null) ?? v; } set { _forms = new DirtyList<DisclosureForm>(value); } }
-        private Value<string> _formsXml;
+        private DirtyValue<string> _formsXml;
         public string FormsXml { get { return _formsXml; } set { _formsXml = value; } }
-        private Value<string> _fulfillmentOrderedBy;
+        private DirtyValue<string> _fulfillmentOrderedBy;
         public string FulfillmentOrderedBy { get { return _fulfillmentOrderedBy; } set { _fulfillmentOrderedBy = value; } }
-        private Value<string> _fullfillmentProcessedDate;
+        private DirtyValue<string> _fullfillmentProcessedDate;
         public string FullfillmentProcessedDate { get { return _fullfillmentProcessedDate; } set { _fullfillmentProcessedDate = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _isDisclosed;
+        private DirtyValue<string> _isDisclosed;
         public string IsDisclosed { get { return _isDisclosed; } set { _isDisclosed = value; } }
-        private Value<string> _isDisclosedAprLocked;
+        private DirtyValue<string> _isDisclosedAprLocked;
         public string IsDisclosedAprLocked { get { return _isDisclosedAprLocked; } set { _isDisclosedAprLocked = value; } }
-        private Value<string> _isDisclosedByLocked;
+        private DirtyValue<string> _isDisclosedByLocked;
         public string IsDisclosedByLocked { get { return _isDisclosedByLocked; } set { _isDisclosedByLocked = value; } }
-        private Value<string> _isDisclosedFinanceChargeLocked;
+        private DirtyValue<string> _isDisclosedFinanceChargeLocked;
         public string IsDisclosedFinanceChargeLocked { get { return _isDisclosedFinanceChargeLocked; } set { _isDisclosedFinanceChargeLocked = value; } }
-        private Value<string> _isDisclosedReceivedDateLocked;
+        private DirtyValue<string> _isDisclosedReceivedDateLocked;
         public string IsDisclosedReceivedDateLocked { get { return _isDisclosedReceivedDateLocked; } set { _isDisclosedReceivedDateLocked = value; } }
-        private Value<string> _isLocked;
+        private DirtyValue<string> _isLocked;
         public string IsLocked { get { return _isLocked; } set { _isLocked = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<bool?> _isWetSignedIndicator;
+        private DirtyValue<bool?> _isWetSignedIndicator;
         public bool? IsWetSignedIndicator { get { return _isWetSignedIndicator; } set { _isWetSignedIndicator = value; } }
-        private Value<string> _loanAmount;
+        private DirtyValue<string> _loanAmount;
         public string LoanAmount { get { return _loanAmount; } set { _loanAmount = value; } }
-        private Value<string> _loanProgram;
+        private DirtyValue<string> _loanProgram;
         public string LoanProgram { get { return _loanProgram; } set { _loanProgram = value; } }
-        private Value<string> _lockedDisclosedAprField;
+        private DirtyValue<string> _lockedDisclosedAprField;
         public string LockedDisclosedAprField { get { return _lockedDisclosedAprField; } set { _lockedDisclosedAprField = value; } }
-        private Value<string> _lockedDisclosedByField;
+        private DirtyValue<string> _lockedDisclosedByField;
         public string LockedDisclosedByField { get { return _lockedDisclosedByField; } set { _lockedDisclosedByField = value; } }
-        private Value<string> _lockedDisclosedFinanceChargeField;
+        private DirtyValue<string> _lockedDisclosedFinanceChargeField;
         public string LockedDisclosedFinanceChargeField { get { return _lockedDisclosedFinanceChargeField; } set { _lockedDisclosedFinanceChargeField = value; } }
-        private Value<DateTime?> _lockedDisclosedReceivedDate;
+        private DirtyValue<DateTime?> _lockedDisclosedReceivedDate;
         public DateTime? LockedDisclosedReceivedDate { get { return _lockedDisclosedReceivedDate; } set { _lockedDisclosedReceivedDate = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _manuallyCreated;
+        private DirtyValue<string> _manuallyCreated;
         public string ManuallyCreated { get { return _manuallyCreated; } set { _manuallyCreated = value; } }
-        private Value<string> _propertyAddress;
+        private DirtyValue<string> _propertyAddress;
         public string PropertyAddress { get { return _propertyAddress; } set { _propertyAddress = value; } }
-        private Value<string> _propertyCity;
+        private DirtyValue<string> _propertyCity;
         public string PropertyCity { get { return _propertyCity; } set { _propertyCity = value; } }
-        private Value<string> _propertyState;
+        private DirtyValue<string> _propertyState;
         public string PropertyState { get { return _propertyState; } set { _propertyState = value; } }
-        private Value<string> _propertyZip;
+        private DirtyValue<string> _propertyZip;
         public string PropertyZip { get { return _propertyZip; } set { _propertyZip = value; } }
-        private Value<DateTime?> _receivedDate;
+        private DirtyValue<DateTime?> _receivedDate;
         public DateTime? ReceivedDate { get { return _receivedDate; } set { _receivedDate = value; } }
         private DirtyList<LogSnapshotField> _snapshotFields;
         public IList<LogSnapshotField> SnapshotFields { get { var v = _snapshotFields; return v ?? Interlocked.CompareExchange(ref _snapshotFields, (v = new DirtyList<LogSnapshotField>()), null) ?? v; } set { _snapshotFields = new DirtyList<LogSnapshotField>(value); } }
-        private Value<string> _snapshotXml;
+        private DirtyValue<string> _snapshotXml;
         public string SnapshotXml { get { return _snapshotXml; } set { _snapshotXml = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DisclosureTrackingLog.cs
+++ b/src/EncompassRest/Loans/DisclosureTrackingLog.cs
@@ -8,8 +8,8 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DisclosureTrackingLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<DateTime?> _applicationDate;
@@ -20,8 +20,8 @@ namespace EncompassRest.Loans
         public string BorrowerPairId { get { return _borrowerPairId; } set { _borrowerPairId = value; } }
         private Value<string> _coBorrowerName;
         public string CoBorrowerName { get { return _coBorrowerName; } set { _coBorrowerName = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -98,8 +98,8 @@ namespace EncompassRest.Loans
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
         private Value<string> _financeCharge;
         public string FinanceCharge { get { return _financeCharge; } set { _financeCharge = value; } }
-        private Value<List<DisclosureForm>> _forms;
-        public List<DisclosureForm> Forms { get { return _forms; } set { _forms = value; } }
+        private DirtyList<DisclosureForm> _forms;
+        public IList<DisclosureForm> Forms { get { var v = _forms; return v ?? Interlocked.CompareExchange(ref _forms, (v = new DirtyList<DisclosureForm>()), null) ?? v; } set { _forms = new DirtyList<DisclosureForm>(value); } }
         private Value<string> _formsXml;
         public string FormsXml { get { return _formsXml; } set { _formsXml = value; } }
         private Value<string> _fulfillmentOrderedBy;
@@ -152,8 +152,8 @@ namespace EncompassRest.Loans
         public string PropertyZip { get { return _propertyZip; } set { _propertyZip = value; } }
         private Value<DateTime?> _receivedDate;
         public DateTime? ReceivedDate { get { return _receivedDate; } set { _receivedDate = value; } }
-        private Value<List<LogSnapshotField>> _snapshotFields;
-        public List<LogSnapshotField> SnapshotFields { get { return _snapshotFields; } set { _snapshotFields = value; } }
+        private DirtyList<LogSnapshotField> _snapshotFields;
+        public IList<LogSnapshotField> SnapshotFields { get { var v = _snapshotFields; return v ?? Interlocked.CompareExchange(ref _snapshotFields, (v = new DirtyList<LogSnapshotField>()), null) ?? v; } set { _snapshotFields = new DirtyList<LogSnapshotField>(value); } }
         private Value<string> _snapshotXml;
         public string SnapshotXml { get { return _snapshotXml; } set { _snapshotXml = value; } }
         private Value<string> _systemId;
@@ -165,13 +165,11 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _alertsXml.Dirty
+                var dirty = _alertsXml.Dirty
                     || _applicationDate.Dirty
                     || _borrowerName.Dirty
                     || _borrowerPairId.Dirty
                     || _coBorrowerName.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _containGfe.Dirty
@@ -210,7 +208,6 @@ namespace EncompassRest.Loans
                     || _eDisclosureThreeDayPackageIndicator.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _financeCharge.Dirty
-                    || _forms.Dirty
                     || _formsXml.Dirty
                     || _fulfillmentOrderedBy.Dirty
                     || _fullfillmentProcessedDate.Dirty
@@ -237,22 +234,23 @@ namespace EncompassRest.Loans
                     || _propertyState.Dirty
                     || _propertyZip.Dirty
                     || _receivedDate.Dirty
-                    || _snapshotFields.Dirty
                     || _snapshotXml.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _forms?.Dirty == true
+                    || _snapshotFields?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _applicationDate.Dirty = value;
                 _borrowerName.Dirty = value;
                 _borrowerPairId.Dirty = value;
                 _coBorrowerName.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _containGfe.Dirty = value;
@@ -291,7 +289,6 @@ namespace EncompassRest.Loans
                 _eDisclosureThreeDayPackageIndicator.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
                 _financeCharge.Dirty = value;
-                _forms.Dirty = value;
                 _formsXml.Dirty = value;
                 _fulfillmentOrderedBy.Dirty = value;
                 _fullfillmentProcessedDate.Dirty = value;
@@ -318,9 +315,12 @@ namespace EncompassRest.Loans
                 _propertyState.Dirty = value;
                 _propertyZip.Dirty = value;
                 _receivedDate.Dirty = value;
-                _snapshotFields.Dirty = value;
                 _snapshotXml.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_forms != null) _forms.Dirty = value;
+                if (_snapshotFields != null) _snapshotFields.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/DocumentLog.cs
+++ b/src/EncompassRest/Loans/DocumentLog.cs
@@ -14,14 +14,14 @@ namespace EncompassRest.Loans
         public DateTime? AccessedDateUtc { get { return _accessedDateUtc; } set { _accessedDateUtc = value; } }
         private Value<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<string> _allowedRoleDelimitedList;
         public string AllowedRoleDelimitedList { get { return _allowedRoleDelimitedList; } set { _allowedRoleDelimitedList = value; } }
-        private Value<List<EntityReference>> _allowedRoles;
-        public List<EntityReference> AllowedRoles { get { return _allowedRoles; } set { _allowedRoles = value; } }
+        private DirtyList<EntityReference> _allowedRoles;
+        public IList<EntityReference> AllowedRoles { get { var v = _allowedRoles; return v ?? Interlocked.CompareExchange(ref _allowedRoles, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _allowedRoles = new DirtyList<EntityReference>(value); } }
         private Value<string> _allowedRolesXml;
         public string AllowedRolesXml { get { return _allowedRolesXml; } set { _allowedRolesXml = value; } }
         private Value<DateTime?> _archiveDateUtc;
@@ -30,16 +30,16 @@ namespace EncompassRest.Loans
         public string ArchivedBy { get { return _archivedBy; } set { _archivedBy = value; } }
         private Value<bool?> _closingDocumentIndicator;
         public bool? ClosingDocumentIndicator { get { return _closingDocumentIndicator; } set { _closingDocumentIndicator = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _company;
         public string Company { get { return _company; } set { _company = value; } }
-        private Value<List<EntityReference>> _conditions;
-        public List<EntityReference> Conditions { get { return _conditions; } set { _conditions = value; } }
+        private DirtyList<EntityReference> _conditions;
+        public IList<EntityReference> Conditions { get { var v = _conditions; return v ?? Interlocked.CompareExchange(ref _conditions, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _conditions = new DirtyList<EntityReference>(value); } }
         private Value<string> _conditionsXml;
         public string ConditionsXml { get { return _conditionsXml; } set { _conditionsXml = value; } }
         private Value<DateTime?> _dateAddedUtc;
@@ -70,8 +70,8 @@ namespace EncompassRest.Loans
         public bool? Expected { get { return _expected; } set { _expected = value; } }
         private Value<bool?> _expires;
         public bool? Expires { get { return _expires; } set { _expires = value; } }
-        private Value<List<FileAttachmentReference>> _fileAttachmentReferences;
-        public List<FileAttachmentReference> FileAttachmentReferences { get { return _fileAttachmentReferences; } set { _fileAttachmentReferences = value; } }
+        private DirtyList<FileAttachmentReference> _fileAttachmentReferences;
+        public IList<FileAttachmentReference> FileAttachmentReferences { get { var v = _fileAttachmentReferences; return v ?? Interlocked.CompareExchange(ref _fileAttachmentReferences, (v = new DirtyList<FileAttachmentReference>()), null) ?? v; } set { _fileAttachmentReferences = new DirtyList<FileAttachmentReference>(value); } }
         private Value<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
         private Value<string> _fileAttachmentsXml;
@@ -156,19 +156,15 @@ namespace EncompassRest.Loans
                 var dirty = _accessedBy.Dirty
                     || _accessedDateUtc.Dirty
                     || _addedBy.Dirty
-                    || _alerts.Dirty
                     || _alertsXml.Dirty
                     || _allowedRoleDelimitedList.Dirty
-                    || _allowedRoles.Dirty
                     || _allowedRolesXml.Dirty
                     || _archiveDateUtc.Dirty
                     || _archivedBy.Dirty
                     || _closingDocumentIndicator.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _company.Dirty
-                    || _conditions.Dirty
                     || _conditionsXml.Dirty
                     || _dateAddedUtc.Dirty
                     || _dateExpected.Dirty
@@ -184,7 +180,6 @@ namespace EncompassRest.Loans
                     || _ePassSignature.Dirty
                     || _expected.Dirty
                     || _expires.Dirty
-                    || _fileAttachmentReferences.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _fileAttachmentsXml.Dirty
                     || _guid.Dirty
@@ -221,7 +216,12 @@ namespace EncompassRest.Loans
                     || _title.Dirty
                     || _underwritingReady.Dirty
                     || _underwritingReadyBy.Dirty
-                    || _underwritingReadyDateUtc.Dirty;
+                    || _underwritingReadyDateUtc.Dirty
+                    || _alerts?.Dirty == true
+                    || _allowedRoles?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _conditions?.Dirty == true
+                    || _fileAttachmentReferences?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -231,19 +231,15 @@ namespace EncompassRest.Loans
                 _accessedBy.Dirty = value;
                 _accessedDateUtc.Dirty = value;
                 _addedBy.Dirty = value;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _allowedRoleDelimitedList.Dirty = value;
-                _allowedRoles.Dirty = value;
                 _allowedRolesXml.Dirty = value;
                 _archiveDateUtc.Dirty = value;
                 _archivedBy.Dirty = value;
                 _closingDocumentIndicator.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _company.Dirty = value;
-                _conditions.Dirty = value;
                 _conditionsXml.Dirty = value;
                 _dateAddedUtc.Dirty = value;
                 _dateExpected.Dirty = value;
@@ -259,7 +255,6 @@ namespace EncompassRest.Loans
                 _ePassSignature.Dirty = value;
                 _expected.Dirty = value;
                 _expires.Dirty = value;
-                _fileAttachmentReferences.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
                 _fileAttachmentsXml.Dirty = value;
                 _guid.Dirty = value;
@@ -297,6 +292,11 @@ namespace EncompassRest.Loans
                 _underwritingReady.Dirty = value;
                 _underwritingReadyBy.Dirty = value;
                 _underwritingReadyDateUtc.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_allowedRoles != null) _allowedRoles.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_conditions != null) _conditions.Dirty = value;
+                if (_fileAttachmentReferences != null) _fileAttachmentReferences.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/DocumentLog.cs
+++ b/src/EncompassRest/Loans/DocumentLog.cs
@@ -8,143 +8,143 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DocumentLog : IDirty
     {
-        private Value<string> _accessedBy;
+        private DirtyValue<string> _accessedBy;
         public string AccessedBy { get { return _accessedBy; } set { _accessedBy = value; } }
-        private Value<DateTime?> _accessedDateUtc;
+        private DirtyValue<DateTime?> _accessedDateUtc;
         public DateTime? AccessedDateUtc { get { return _accessedDateUtc; } set { _accessedDateUtc = value; } }
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<string> _allowedRoleDelimitedList;
+        private DirtyValue<string> _allowedRoleDelimitedList;
         public string AllowedRoleDelimitedList { get { return _allowedRoleDelimitedList; } set { _allowedRoleDelimitedList = value; } }
         private DirtyList<EntityReference> _allowedRoles;
         public IList<EntityReference> AllowedRoles { get { var v = _allowedRoles; return v ?? Interlocked.CompareExchange(ref _allowedRoles, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _allowedRoles = new DirtyList<EntityReference>(value); } }
-        private Value<string> _allowedRolesXml;
+        private DirtyValue<string> _allowedRolesXml;
         public string AllowedRolesXml { get { return _allowedRolesXml; } set { _allowedRolesXml = value; } }
-        private Value<DateTime?> _archiveDateUtc;
+        private DirtyValue<DateTime?> _archiveDateUtc;
         public DateTime? ArchiveDateUtc { get { return _archiveDateUtc; } set { _archiveDateUtc = value; } }
-        private Value<string> _archivedBy;
+        private DirtyValue<string> _archivedBy;
         public string ArchivedBy { get { return _archivedBy; } set { _archivedBy = value; } }
-        private Value<bool?> _closingDocumentIndicator;
+        private DirtyValue<bool?> _closingDocumentIndicator;
         public bool? ClosingDocumentIndicator { get { return _closingDocumentIndicator; } set { _closingDocumentIndicator = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _company;
+        private DirtyValue<string> _company;
         public string Company { get { return _company; } set { _company = value; } }
         private DirtyList<EntityReference> _conditions;
         public IList<EntityReference> Conditions { get { var v = _conditions; return v ?? Interlocked.CompareExchange(ref _conditions, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _conditions = new DirtyList<EntityReference>(value); } }
-        private Value<string> _conditionsXml;
+        private DirtyValue<string> _conditionsXml;
         public string ConditionsXml { get { return _conditionsXml; } set { _conditionsXml = value; } }
-        private Value<DateTime?> _dateAddedUtc;
+        private DirtyValue<DateTime?> _dateAddedUtc;
         public DateTime? DateAddedUtc { get { return _dateAddedUtc; } set { _dateAddedUtc = value; } }
-        private Value<DateTime?> _dateExpected;
+        private DirtyValue<DateTime?> _dateExpected;
         public DateTime? DateExpected { get { return _dateExpected; } set { _dateExpected = value; } }
-        private Value<DateTime?> _dateExpires;
+        private DirtyValue<DateTime?> _dateExpires;
         public DateTime? DateExpires { get { return _dateExpires; } set { _dateExpires = value; } }
-        private Value<DateTime?> _dateReceived;
+        private DirtyValue<DateTime?> _dateReceived;
         public DateTime? DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateRequested;
+        private DirtyValue<DateTime?> _dateRequested;
         public DateTime? DateRequested { get { return _dateRequested; } set { _dateRequested = value; } }
-        private Value<DateTime?> _dateRerequested;
+        private DirtyValue<DateTime?> _dateRerequested;
         public DateTime? DateRerequested { get { return _dateRerequested; } set { _dateRerequested = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<int?> _daysDue;
+        private DirtyValue<int?> _daysDue;
         public int? DaysDue { get { return _daysDue; } set { _daysDue = value; } }
-        private Value<int?> _daysTillExpire;
+        private DirtyValue<int?> _daysTillExpire;
         public int? DaysTillExpire { get { return _daysTillExpire; } set { _daysTillExpire = value; } }
-        private Value<string> _documentDateTimeType;
+        private DirtyValue<string> _documentDateTimeType;
         public string DocumentDateTimeType { get { return _documentDateTimeType; } set { _documentDateTimeType = value; } }
-        private Value<bool?> _eDisclosureIndicator;
+        private DirtyValue<bool?> _eDisclosureIndicator;
         public bool? EDisclosureIndicator { get { return _eDisclosureIndicator; } set { _eDisclosureIndicator = value; } }
-        private Value<string> _ePassSignature;
+        private DirtyValue<string> _ePassSignature;
         public string EPassSignature { get { return _ePassSignature; } set { _ePassSignature = value; } }
-        private Value<bool?> _expected;
+        private DirtyValue<bool?> _expected;
         public bool? Expected { get { return _expected; } set { _expected = value; } }
-        private Value<bool?> _expires;
+        private DirtyValue<bool?> _expires;
         public bool? Expires { get { return _expires; } set { _expires = value; } }
         private DirtyList<FileAttachmentReference> _fileAttachmentReferences;
         public IList<FileAttachmentReference> FileAttachmentReferences { get { var v = _fileAttachmentReferences; return v ?? Interlocked.CompareExchange(ref _fileAttachmentReferences, (v = new DirtyList<FileAttachmentReference>()), null) ?? v; } set { _fileAttachmentReferences = new DirtyList<FileAttachmentReference>(value); } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _fileAttachmentsXml;
+        private DirtyValue<string> _fileAttachmentsXml;
         public string FileAttachmentsXml { get { return _fileAttachmentsXml; } set { _fileAttachmentsXml = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEPassIndicator;
+        private DirtyValue<bool?> _isEPassIndicator;
         public bool? IsEPassIndicator { get { return _isEPassIndicator; } set { _isEPassIndicator = value; } }
-        private Value<bool?> _isExpired;
+        private DirtyValue<bool?> _isExpired;
         public bool? IsExpired { get { return _isExpired; } set { _isExpired = value; } }
-        private Value<bool?> _isPastDue;
+        private DirtyValue<bool?> _isPastDue;
         public bool? IsPastDue { get { return _isPastDue; } set { _isPastDue = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<bool?> _isThirdPartyDocIndicator;
+        private DirtyValue<bool?> _isThirdPartyDocIndicator;
         public bool? IsThirdPartyDocIndicator { get { return _isThirdPartyDocIndicator; } set { _isThirdPartyDocIndicator = value; } }
-        private Value<bool?> _isTPOWebcenterPortalIndicator;
+        private DirtyValue<bool?> _isTPOWebcenterPortalIndicator;
         public bool? IsTPOWebcenterPortalIndicator { get { return _isTPOWebcenterPortalIndicator; } set { _isTPOWebcenterPortalIndicator = value; } }
-        private Value<bool?> _isWebCenterIndicator;
+        private DirtyValue<bool?> _isWebCenterIndicator;
         public bool? IsWebCenterIndicator { get { return _isWebCenterIndicator; } set { _isWebCenterIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<DateTime?> _orderDateUtc;
+        private DirtyValue<DateTime?> _orderDateUtc;
         public DateTime? OrderDateUtc { get { return _orderDateUtc; } set { _orderDateUtc = value; } }
-        private Value<string> _pairId;
+        private DirtyValue<string> _pairId;
         public string PairId { get { return _pairId; } set { _pairId = value; } }
-        private Value<bool?> _preClosingDocumentIndicator;
+        private DirtyValue<bool?> _preClosingDocumentIndicator;
         public bool? PreClosingDocumentIndicator { get { return _preClosingDocumentIndicator; } set { _preClosingDocumentIndicator = value; } }
-        private Value<bool?> _received;
+        private DirtyValue<bool?> _received;
         public bool? Received { get { return _received; } set { _received = value; } }
-        private Value<DateTime?> _receiveDateUtc;
+        private DirtyValue<DateTime?> _receiveDateUtc;
         public DateTime? ReceiveDateUtc { get { return _receiveDateUtc; } set { _receiveDateUtc = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<DateTime?> _reorderDateUtc;
+        private DirtyValue<DateTime?> _reorderDateUtc;
         public DateTime? ReorderDateUtc { get { return _reorderDateUtc; } set { _reorderDateUtc = value; } }
-        private Value<bool?> _requested;
+        private DirtyValue<bool?> _requested;
         public bool? Requested { get { return _requested; } set { _requested = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<string> _requestedFrom;
+        private DirtyValue<string> _requestedFrom;
         public string RequestedFrom { get { return _requestedFrom; } set { _requestedFrom = value; } }
-        private Value<bool?> _rerequested;
+        private DirtyValue<bool?> _rerequested;
         public bool? Rerequested { get { return _rerequested; } set { _rerequested = value; } }
-        private Value<string> _rerequestedBy;
+        private DirtyValue<string> _rerequestedBy;
         public string RerequestedBy { get { return _rerequestedBy; } set { _rerequestedBy = value; } }
-        private Value<bool?> _reviewed;
+        private DirtyValue<bool?> _reviewed;
         public bool? Reviewed { get { return _reviewed; } set { _reviewed = value; } }
-        private Value<string> _reviewedBy;
+        private DirtyValue<string> _reviewedBy;
         public string ReviewedBy { get { return _reviewedBy; } set { _reviewedBy = value; } }
-        private Value<DateTime?> _reviewedDateUtc;
+        private DirtyValue<DateTime?> _reviewedDateUtc;
         public DateTime? ReviewedDateUtc { get { return _reviewedDateUtc; } set { _reviewedDateUtc = value; } }
-        private Value<bool?> _shippingReady;
+        private DirtyValue<bool?> _shippingReady;
         public bool? ShippingReady { get { return _shippingReady; } set { _shippingReady = value; } }
-        private Value<string> _shippingReadyBy;
+        private DirtyValue<string> _shippingReadyBy;
         public string ShippingReadyBy { get { return _shippingReadyBy; } set { _shippingReadyBy = value; } }
-        private Value<DateTime?> _shippingReadyDateUtc;
+        private DirtyValue<DateTime?> _shippingReadyDateUtc;
         public DateTime? ShippingReadyDateUtc { get { return _shippingReadyDateUtc; } set { _shippingReadyDateUtc = value; } }
-        private Value<string> _stage;
+        private DirtyValue<string> _stage;
         public string Stage { get { return _stage; } set { _stage = value; } }
-        private Value<string> _status;
+        private DirtyValue<string> _status;
         public string Status { get { return _status; } set { _status = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<bool?> _underwritingReady;
+        private DirtyValue<bool?> _underwritingReady;
         public bool? UnderwritingReady { get { return _underwritingReady; } set { _underwritingReady = value; } }
-        private Value<string> _underwritingReadyBy;
+        private DirtyValue<string> _underwritingReadyBy;
         public string UnderwritingReadyBy { get { return _underwritingReadyBy; } set { _underwritingReadyBy = value; } }
-        private Value<DateTime?> _underwritingReadyDateUtc;
+        private DirtyValue<DateTime?> _underwritingReadyDateUtc;
         public DateTime? UnderwritingReadyDateUtc { get { return _underwritingReadyDateUtc; } set { _underwritingReadyDateUtc = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Documents/DocumentComment.cs
+++ b/src/EncompassRest/Loans/Documents/DocumentComment.cs
@@ -5,21 +5,21 @@ namespace EncompassRest.Loans.Documents
 {
     public sealed class DocumentComment : IDirty
     {
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<int?> _forRoleId;
+        private DirtyValue<int?> _forRoleId;
         public int? ForRoleId { get { return _forRoleId; } set { _forRoleId = value; } }
-        private Value<Guid?> _commentId;
+        private DirtyValue<Guid?> _commentId;
         public Guid? CommentId { get { return _commentId; } set { _commentId = value; } }
-        private Value<DateTime?> _dateCreated;
+        private DirtyValue<DateTime?> _dateCreated;
         public DateTime? DateCreated { get { return _dateCreated; } set { _dateCreated = value; } }
-        private Value<string> _createdBy;
+        private DirtyValue<string> _createdBy;
         public string CreatedBy { get { return _createdBy; } set { _createdBy = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _dateReviewed;
+        private DirtyValue<DateTime?> _dateReviewed;
         public DateTime? DateReviewed { get { return _dateReviewed; } set { _dateReviewed = value; } }
-        private Value<string> _reviewedBy;
+        private DirtyValue<string> _reviewedBy;
         public string ReviewedBy { get { return _reviewedBy; } set { _reviewedBy = value; } }
         private int _gettingDirty;
         private int _settingDirty;

--- a/src/EncompassRest/Loans/Documents/LoanDocument.cs
+++ b/src/EncompassRest/Loans/Documents/LoanDocument.cs
@@ -6,87 +6,87 @@ namespace EncompassRest.Loans.Documents
 {
     public sealed class LoanDocument : IDirty
     {
-        private Value<string> _documentId;
+        private DirtyValue<string> _documentId;
         public string DocumentId { get { return _documentId; } set { _documentId = value; } }
-        private Value<string> _titleWithIndex;
+        private DirtyValue<string> _titleWithIndex;
         public string TitleWithIndex { get { return _titleWithIndex; } set { _titleWithIndex = value; } }
-        private Value<string> _applicationName;
+        private DirtyValue<string> _applicationName;
         public string ApplicationName { get { return _applicationName; } set { _applicationName = value; } }
-        private Value<string> _milestoneId;
+        private DirtyValue<string> _milestoneId;
         public string MilestoneId { get { return _milestoneId; } set { _milestoneId = value; } }
-        private Value<bool?> _webCenterAllowed;
+        private DirtyValue<bool?> _webCenterAllowed;
         public bool? WebCenterAllowed { get { return _webCenterAllowed; } set { _webCenterAllowed = value; } }
-        private Value<bool?> _tpoAllowed;
+        private DirtyValue<bool?> _tpoAllowed;
         public bool? TpoAllowed { get { return _tpoAllowed; } set { _tpoAllowed = value; } }
-        private Value<bool?> _thirdPartyAllowed;
+        private DirtyValue<bool?> _thirdPartyAllowed;
         public bool? ThirdPartyAllowed { get { return _thirdPartyAllowed; } set { _thirdPartyAllowed = value; } }
-        private Value<bool?> _isRequested;
+        private DirtyValue<bool?> _isRequested;
         public bool? IsRequested { get { return _isRequested; } set { _isRequested = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<bool?> _isRerequested;
+        private DirtyValue<bool?> _isRerequested;
         public bool? IsRerequested { get { return _isRerequested; } set { _isRerequested = value; } }
-        private Value<DateTime?> _dateRerequested;
+        private DirtyValue<DateTime?> _dateRerequested;
         public DateTime? DateRerequested { get { return _dateRerequested; } set { _dateRerequested = value; } }
-        private Value<string> _rerequestedBy;
+        private DirtyValue<string> _rerequestedBy;
         public string RerequestedBy { get { return _rerequestedBy; } set { _rerequestedBy = value; } }
-        private Value<int?> _daysDue;
+        private DirtyValue<int?> _daysDue;
         public int? DaysDue { get { return _daysDue; } set { _daysDue = value; } }
-        private Value<bool?> _isReceived;
+        private DirtyValue<bool?> _isReceived;
         public bool? IsReceived { get { return _isReceived; } set { _isReceived = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<int?> _daysTillExpire;
+        private DirtyValue<int?> _daysTillExpire;
         public int? DaysTillExpire { get { return _daysTillExpire; } set { _daysTillExpire = value; } }
-        private Value<bool?> _isReviewed;
+        private DirtyValue<bool?> _isReviewed;
         public bool? IsReviewed { get { return _isReviewed; } set { _isReviewed = value; } }
-        private Value<string> _reviewedBy;
+        private DirtyValue<string> _reviewedBy;
         public string ReviewedBy { get { return _reviewedBy; } set { _reviewedBy = value; } }
-        private Value<bool?> _isReadyForUw;
+        private DirtyValue<bool?> _isReadyForUw;
         public bool? IsReadyForUw { get { return _isReadyForUw; } set { _isReadyForUw = value; } }
-        private Value<string> _readyForUwBy;
+        private DirtyValue<string> _readyForUwBy;
         public string ReadyForUwBy { get { return _readyForUwBy; } set { _readyForUwBy = value; } }
-        private Value<bool?> _isReadyToShip;
+        private DirtyValue<bool?> _isReadyToShip;
         public bool? IsReadyToShip { get { return _isReadyToShip; } set { _isReadyToShip = value; } }
-        private Value<string> _readyToShipBy;
+        private DirtyValue<string> _readyToShipBy;
         public string ReadyToShipBy { get { return _readyToShipBy; } set { _readyToShipBy = value; } }
-        private Value<DateTime?> _dateExpires;
+        private DirtyValue<DateTime?> _dateExpires;
         public DateTime? DateExpires { get { return _dateExpires; } set { _dateExpires = value; } }
-        private Value<string> _createdBy;
+        private DirtyValue<string> _createdBy;
         public string CreatedBy { get { return _createdBy; } set { _createdBy = value; } }
-        private Value<DateTime?> _dateCreated;
+        private DirtyValue<DateTime?> _dateCreated;
         public DateTime? DateCreated { get { return _dateCreated; } set { _dateCreated = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _requestedFrom;
+        private DirtyValue<string> _requestedFrom;
         public string RequestedFrom { get { return _requestedFrom; } set { _requestedFrom = value; } }
-        private Value<string> _applicationId;
+        private DirtyValue<string> _applicationId;
         public string ApplicationId { get { return _applicationId; } set { _applicationId = value; } }
-        private Value<string> _emnSignature;
+        private DirtyValue<string> _emnSignature;
         public string EmnSignature { get { return _emnSignature; } set { _emnSignature = value; } }
-        private Value<DocumentStatus?> _status;
+        private DirtyValue<DocumentStatus?> _status;
         public DocumentStatus? Status { get { return _status; } set { _status = value; } }
-        private Value<DateTime?> _statusDate;
+        private DirtyValue<DateTime?> _statusDate;
         public DateTime? StatusDate { get { return _statusDate; } set { _statusDate = value; } }
-        private Value<DateTime?> _dateRequested;
+        private DirtyValue<DateTime?> _dateRequested;
         public DateTime? DateRequested { get { return _dateRequested; } set { _dateRequested = value; } }
-        private Value<DateTime?> _dateExpected;
+        private DirtyValue<DateTime?> _dateExpected;
         public DateTime? DateExpected { get { return _dateExpected; } set { _dateExpected = value; } }
-        private Value<DateTime?> _dateReceived;
+        private DirtyValue<DateTime?> _dateReceived;
         public DateTime? DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateReviewed;
+        private DirtyValue<DateTime?> _dateReviewed;
         public DateTime? DateReviewed { get { return _dateReviewed; } set { _dateReviewed = value; } }
-        private Value<DateTime?> _dateReadyForUw;
+        private DirtyValue<DateTime?> _dateReadyForUw;
         public DateTime? DateReadyForUw { get { return _dateReadyForUw; } set { _dateReadyForUw = value; } }
-        private Value<DateTime?> _dateReadyToShip;
+        private DirtyValue<DateTime?> _dateReadyToShip;
         public DateTime? DateReadyToShip { get { return _dateReadyToShip; } set { _dateReadyToShip = value; } }
-        private Value<List<DocumentComment>> _comments;
+        private DirtyValue<List<DocumentComment>> _comments;
         public List<DocumentComment> Comments { get { return _comments; } set { _comments = value; } }
-        private Value<List<FileAttachmentReference>> _attachments;
+        private DirtyValue<List<FileAttachmentReference>> _attachments;
         public List<FileAttachmentReference> Attachments { get { return _attachments; } set { _attachments = value; } }
-        private Value<List<EntityReference>> _roles;
+        private DirtyValue<List<EntityReference>> _roles;
         public List<EntityReference> Roles { get { return _roles; } set { _roles = value; } }
         private int _gettingDirty;
         private int _settingDirty;

--- a/src/EncompassRest/Loans/DownPayment.cs
+++ b/src/EncompassRest/Loans/DownPayment.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DownPayment : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<string> _downPaymentType;
+        private DirtyValue<string> _downPaymentType;
         public string DownPaymentType { get { return _downPaymentType; } set { _downPaymentType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _sourceDescription;
+        private DirtyValue<string> _sourceDescription;
         public string SourceDescription { get { return _sourceDescription; } set { _sourceDescription = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DownloadLog.cs
+++ b/src/EncompassRest/Loans/DownloadLog.cs
@@ -10,41 +10,41 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _barcodePage;
+        private DirtyValue<string> _barcodePage;
         public string BarcodePage { get { return _barcodePage; } set { _barcodePage = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _dateReceived;
+        private DirtyValue<string> _dateReceived;
         public string DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _documentId;
+        private DirtyValue<string> _documentId;
         public string DocumentId { get { return _documentId; } set { _documentId = value; } }
-        private Value<string> _downloadId;
+        private DirtyValue<string> _downloadId;
         public string DownloadId { get { return _downloadId; } set { _downloadId = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _fileSource;
+        private DirtyValue<string> _fileSource;
         public string FileSource { get { return _fileSource; } set { _fileSource = value; } }
-        private Value<string> _fileType;
+        private DirtyValue<string> _fileType;
         public string FileType { get { return _fileType; } set { _fileType = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<string> _sender;
+        private DirtyValue<string> _sender;
         public string Sender { get { return _sender; } set { _sender = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/DownloadLog.cs
+++ b/src/EncompassRest/Loans/DownloadLog.cs
@@ -8,12 +8,12 @@ namespace EncompassRest.Loans
 {
     public sealed partial class DownloadLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _barcodePage;
         public string BarcodePage { get { return _barcodePage; } set { _barcodePage = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _dateReceived;
@@ -53,9 +53,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _barcodePage.Dirty
-                    || _commentList.Dirty
+                var dirty = _barcodePage.Dirty
                     || _comments.Dirty
                     || _dateReceived.Dirty
                     || _dateUtc.Dirty
@@ -71,16 +69,16 @@ namespace EncompassRest.Loans
                     || _receivedBy.Dirty
                     || _sender.Dirty
                     || _systemId.Dirty
-                    || _title.Dirty;
+                    || _title.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
                 _barcodePage.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateReceived.Dirty = value;
                 _dateUtc.Dirty = value;
@@ -97,6 +95,8 @@ namespace EncompassRest.Loans
                 _sender.Dirty = value;
                 _systemId.Dirty = value;
                 _title.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/EdmDocument.cs
+++ b/src/EncompassRest/Loans/EdmDocument.cs
@@ -8,9 +8,9 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EdmDocument : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EdmLog.cs
+++ b/src/EncompassRest/Loans/EdmLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EdmLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _creator;
@@ -20,8 +20,8 @@ namespace EncompassRest.Loans
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
         private Value<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<List<EdmDocument>> _documents;
-        public List<EdmDocument> Documents { get { return _documents; } set { _documents = value; } }
+        private DirtyList<EdmDocument> _documents;
+        public IList<EdmDocument> Documents { get { var v = _documents; return v ?? Interlocked.CompareExchange(ref _documents, (v = new DirtyList<EdmDocument>()), null) ?? v; } set { _documents = new DirtyList<EdmDocument>(value); } }
         private Value<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
         private Value<string> _guid;
@@ -43,33 +43,30 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _creator.Dirty
                     || _dateUtc.Dirty
                     || _description.Dirty
-                    || _documents.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _guid.Dirty
                     || _id.Dirty
                     || _isSystemSpecificIndicator.Dirty
                     || _logRecordIndex.Dirty
                     || _systemId.Dirty
-                    || _url.Dirty;
+                    || _url.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _documents?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _creator.Dirty = value;
                 _dateUtc.Dirty = value;
                 _description.Dirty = value;
-                _documents.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
                 _guid.Dirty = value;
                 _id.Dirty = value;
@@ -77,6 +74,9 @@ namespace EncompassRest.Loans
                 _logRecordIndex.Dirty = value;
                 _systemId.Dirty = value;
                 _url.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_documents != null) _documents.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/EdmLog.cs
+++ b/src/EncompassRest/Loans/EdmLog.cs
@@ -12,29 +12,29 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _creator;
+        private DirtyValue<string> _creator;
         public string Creator { get { return _creator; } set { _creator = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
         private DirtyList<EdmDocument> _documents;
         public IList<EdmDocument> Documents { get { var v = _documents; return v ?? Interlocked.CompareExchange(ref _documents, (v = new DirtyList<EdmDocument>()), null) ?? v; } set { _documents = new DirtyList<EdmDocument>(value); } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _url;
+        private DirtyValue<string> _url;
         public string Url { get { return _url; } set { _url = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ElliLOCompensation.cs
+++ b/src/EncompassRest/Loans/ElliLOCompensation.cs
@@ -8,83 +8,83 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ElliLOCompensation : IDirty
     {
-        private Value<decimal?> _adjustedPlanAdditonalAmountForBroker;
+        private DirtyValue<decimal?> _adjustedPlanAdditonalAmountForBroker;
         public decimal? AdjustedPlanAdditonalAmountForBroker { get { return _adjustedPlanAdditonalAmountForBroker; } set { _adjustedPlanAdditonalAmountForBroker = value; } }
-        private Value<decimal?> _adjustedPlanAdditonalAmountForOfficer;
+        private DirtyValue<decimal?> _adjustedPlanAdditonalAmountForOfficer;
         public decimal? AdjustedPlanAdditonalAmountForOfficer { get { return _adjustedPlanAdditonalAmountForOfficer; } set { _adjustedPlanAdditonalAmountForOfficer = value; } }
-        private Value<decimal?> _adjustedPlanAmountForBroker;
+        private DirtyValue<decimal?> _adjustedPlanAmountForBroker;
         public decimal? AdjustedPlanAmountForBroker { get { return _adjustedPlanAmountForBroker; } set { _adjustedPlanAmountForBroker = value; } }
-        private Value<decimal?> _adjustedPlanAmountForOfficer;
+        private DirtyValue<decimal?> _adjustedPlanAmountForOfficer;
         public decimal? AdjustedPlanAmountForOfficer { get { return _adjustedPlanAmountForOfficer; } set { _adjustedPlanAmountForOfficer = value; } }
-        private Value<decimal?> _adjustedPlanRateForBroker;
+        private DirtyValue<decimal?> _adjustedPlanRateForBroker;
         public decimal? AdjustedPlanRateForBroker { get { return _adjustedPlanRateForBroker; } set { _adjustedPlanRateForBroker = value; } }
-        private Value<decimal?> _adjustedPlanRateForOfficer;
+        private DirtyValue<decimal?> _adjustedPlanRateForOfficer;
         public decimal? AdjustedPlanRateForOfficer { get { return _adjustedPlanRateForOfficer; } set { _adjustedPlanRateForOfficer = value; } }
-        private Value<string> _adjustmentDescription;
+        private DirtyValue<string> _adjustmentDescription;
         public string AdjustmentDescription { get { return _adjustmentDescription; } set { _adjustmentDescription = value; } }
-        private Value<string> _adjustmentDescriptionForOfficer;
+        private DirtyValue<string> _adjustmentDescriptionForOfficer;
         public string AdjustmentDescriptionForOfficer { get { return _adjustmentDescriptionForOfficer; } set { _adjustmentDescriptionForOfficer = value; } }
-        private Value<decimal?> _basePlanAdditonalAmountForBroker;
+        private DirtyValue<decimal?> _basePlanAdditonalAmountForBroker;
         public decimal? BasePlanAdditonalAmountForBroker { get { return _basePlanAdditonalAmountForBroker; } set { _basePlanAdditonalAmountForBroker = value; } }
-        private Value<decimal?> _basePlanAdditonalAmountForOfficer;
+        private DirtyValue<decimal?> _basePlanAdditonalAmountForOfficer;
         public decimal? BasePlanAdditonalAmountForOfficer { get { return _basePlanAdditonalAmountForOfficer; } set { _basePlanAdditonalAmountForOfficer = value; } }
-        private Value<decimal?> _basePlanAmountForBroker;
+        private DirtyValue<decimal?> _basePlanAmountForBroker;
         public decimal? BasePlanAmountForBroker { get { return _basePlanAmountForBroker; } set { _basePlanAmountForBroker = value; } }
-        private Value<decimal?> _basePlanAmountForOfficer;
+        private DirtyValue<decimal?> _basePlanAmountForOfficer;
         public decimal? BasePlanAmountForOfficer { get { return _basePlanAmountForOfficer; } set { _basePlanAmountForOfficer = value; } }
-        private Value<decimal?> _basePlanMaximumAmountForBroker;
+        private DirtyValue<decimal?> _basePlanMaximumAmountForBroker;
         public decimal? BasePlanMaximumAmountForBroker { get { return _basePlanMaximumAmountForBroker; } set { _basePlanMaximumAmountForBroker = value; } }
-        private Value<decimal?> _basePlanMaximumAmountForOfficer;
+        private DirtyValue<decimal?> _basePlanMaximumAmountForOfficer;
         public decimal? BasePlanMaximumAmountForOfficer { get { return _basePlanMaximumAmountForOfficer; } set { _basePlanMaximumAmountForOfficer = value; } }
-        private Value<decimal?> _basePlanMinimumAmountForBroker;
+        private DirtyValue<decimal?> _basePlanMinimumAmountForBroker;
         public decimal? BasePlanMinimumAmountForBroker { get { return _basePlanMinimumAmountForBroker; } set { _basePlanMinimumAmountForBroker = value; } }
-        private Value<decimal?> _basePlanMinimumAmountForOfficer;
+        private DirtyValue<decimal?> _basePlanMinimumAmountForOfficer;
         public decimal? BasePlanMinimumAmountForOfficer { get { return _basePlanMinimumAmountForOfficer; } set { _basePlanMinimumAmountForOfficer = value; } }
-        private Value<decimal?> _basePlanRateForBroker;
+        private DirtyValue<decimal?> _basePlanRateForBroker;
         public decimal? BasePlanRateForBroker { get { return _basePlanRateForBroker; } set { _basePlanRateForBroker = value; } }
-        private Value<decimal?> _basePlanRateForOfficer;
+        private DirtyValue<decimal?> _basePlanRateForOfficer;
         public decimal? BasePlanRateForOfficer { get { return _basePlanRateForOfficer; } set { _basePlanRateForOfficer = value; } }
-        private Value<decimal?> _bonusCompAdditonalAmount;
+        private DirtyValue<decimal?> _bonusCompAdditonalAmount;
         public decimal? BonusCompAdditonalAmount { get { return _bonusCompAdditonalAmount; } set { _bonusCompAdditonalAmount = value; } }
-        private Value<decimal?> _bonusCompAmount;
+        private DirtyValue<decimal?> _bonusCompAmount;
         public decimal? BonusCompAmount { get { return _bonusCompAmount; } set { _bonusCompAmount = value; } }
-        private Value<decimal?> _bonusCompRate;
+        private DirtyValue<decimal?> _bonusCompRate;
         public decimal? BonusCompRate { get { return _bonusCompRate; } set { _bonusCompRate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _lastAppliedDate;
+        private DirtyValue<DateTime?> _lastAppliedDate;
         public DateTime? LastAppliedDate { get { return _lastAppliedDate; } set { _lastAppliedDate = value; } }
-        private Value<string> _lastAppliedDateTime;
+        private DirtyValue<string> _lastAppliedDateTime;
         public string LastAppliedDateTime { get { return _lastAppliedDateTime; } set { _lastAppliedDateTime = value; } }
-        private Value<string> _loanAmountType;
+        private DirtyValue<string> _loanAmountType;
         public string LoanAmountType { get { return _loanAmountType; } set { _loanAmountType = value; } }
-        private Value<string> _loanAmountTypeForOfficer;
+        private DirtyValue<string> _loanAmountTypeForOfficer;
         public string LoanAmountTypeForOfficer { get { return _loanAmountTypeForOfficer; } set { _loanAmountTypeForOfficer = value; } }
-        private Value<string> _loanOriginatorID;
+        private DirtyValue<string> _loanOriginatorID;
         public string LoanOriginatorID { get { return _loanOriginatorID; } set { _loanOriginatorID = value; } }
-        private Value<string> _loanOriginatorIDForOfficer;
+        private DirtyValue<string> _loanOriginatorIDForOfficer;
         public string LoanOriginatorIDForOfficer { get { return _loanOriginatorIDForOfficer; } set { _loanOriginatorIDForOfficer = value; } }
-        private Value<string> _loanOriginatorName;
+        private DirtyValue<string> _loanOriginatorName;
         public string LoanOriginatorName { get { return _loanOriginatorName; } set { _loanOriginatorName = value; } }
-        private Value<string> _loanOriginatorNameForOfficer;
+        private DirtyValue<string> _loanOriginatorNameForOfficer;
         public string LoanOriginatorNameForOfficer { get { return _loanOriginatorNameForOfficer; } set { _loanOriginatorNameForOfficer = value; } }
-        private Value<decimal?> _netAdjustedAmountForBroker;
+        private DirtyValue<decimal?> _netAdjustedAmountForBroker;
         public decimal? NetAdjustedAmountForBroker { get { return _netAdjustedAmountForBroker; } set { _netAdjustedAmountForBroker = value; } }
-        private Value<decimal?> _netAdjustedAmountForOfficer;
+        private DirtyValue<decimal?> _netAdjustedAmountForOfficer;
         public decimal? NetAdjustedAmountForOfficer { get { return _netAdjustedAmountForOfficer; } set { _netAdjustedAmountForOfficer = value; } }
-        private Value<DateTime?> _planDate;
+        private DirtyValue<DateTime?> _planDate;
         public DateTime? PlanDate { get { return _planDate; } set { _planDate = value; } }
-        private Value<string> _planName;
+        private DirtyValue<string> _planName;
         public string PlanName { get { return _planName; } set { _planName = value; } }
-        private Value<string> _planNameForOfficer;
+        private DirtyValue<string> _planNameForOfficer;
         public string PlanNameForOfficer { get { return _planNameForOfficer; } set { _planNameForOfficer = value; } }
-        private Value<string> _roundingMethod;
+        private DirtyValue<string> _roundingMethod;
         public string RoundingMethod { get { return _roundingMethod; } set { _roundingMethod = value; } }
-        private Value<string> _roundingMethodForOfficer;
+        private DirtyValue<string> _roundingMethodForOfficer;
         public string RoundingMethodForOfficer { get { return _roundingMethodForOfficer; } set { _roundingMethodForOfficer = value; } }
-        private Value<string> _triggerField;
+        private DirtyValue<string> _triggerField;
         public string TriggerField { get { return _triggerField; } set { _triggerField = value; } }
-        private Value<string> _whoPaidCompensation;
+        private DirtyValue<string> _whoPaidCompensation;
         public string WhoPaidCompensation { get { return _whoPaidCompensation; } set { _whoPaidCompensation = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EmDocument.cs
+++ b/src/EncompassRest/Loans/EmDocument.cs
@@ -8,445 +8,445 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EmDocument : IDirty
     {
-        private Value<string> _allngToNtPayToJrsdctn;
+        private DirtyValue<string> _allngToNtPayToJrsdctn;
         public string AllngToNtPayToJrsdctn { get { return _allngToNtPayToJrsdctn; } set { _allngToNtPayToJrsdctn = value; } }
-        private Value<string> _allngToNtPayToOrdNm;
+        private DirtyValue<string> _allngToNtPayToOrdNm;
         public string AllngToNtPayToOrdNm { get { return _allngToNtPayToOrdNm; } set { _allngToNtPayToOrdNm = value; } }
-        private Value<string> _allngToNtPayToOrgTyp;
+        private DirtyValue<string> _allngToNtPayToOrgTyp;
         public string AllngToNtPayToOrgTyp { get { return _allngToNtPayToOrgTyp; } set { _allngToNtPayToOrgTyp = value; } }
-        private Value<string> _allngToNtPayToScsrsClaus;
+        private DirtyValue<string> _allngToNtPayToScsrsClaus;
         public string AllngToNtPayToScsrsClaus { get { return _allngToNtPayToScsrsClaus; } set { _allngToNtPayToScsrsClaus = value; } }
-        private Value<string> _allngToNtSignedByNm;
+        private DirtyValue<string> _allngToNtSignedByNm;
         public string AllngToNtSignedByNm { get { return _allngToNtSignedByNm; } set { _allngToNtSignedByNm = value; } }
-        private Value<string> _allngToNtSignedByNm2;
+        private DirtyValue<string> _allngToNtSignedByNm2;
         public string AllngToNtSignedByNm2 { get { return _allngToNtSignedByNm2; } set { _allngToNtSignedByNm2 = value; } }
-        private Value<string> _allngToNtSignedByNm3;
+        private DirtyValue<string> _allngToNtSignedByNm3;
         public string AllngToNtSignedByNm3 { get { return _allngToNtSignedByNm3; } set { _allngToNtSignedByNm3 = value; } }
-        private Value<string> _allngToNtSignedByTtl;
+        private DirtyValue<string> _allngToNtSignedByTtl;
         public string AllngToNtSignedByTtl { get { return _allngToNtSignedByTtl; } set { _allngToNtSignedByTtl = value; } }
-        private Value<string> _allngToNtSignedByTtl2;
+        private DirtyValue<string> _allngToNtSignedByTtl2;
         public string AllngToNtSignedByTtl2 { get { return _allngToNtSignedByTtl2; } set { _allngToNtSignedByTtl2 = value; } }
-        private Value<string> _allngToNtSignedByTtl3;
+        private DirtyValue<string> _allngToNtSignedByTtl3;
         public string AllngToNtSignedByTtl3 { get { return _allngToNtSignedByTtl3; } set { _allngToNtSignedByTtl3 = value; } }
-        private Value<string> _allngToNtSignedByTyp;
+        private DirtyValue<string> _allngToNtSignedByTyp;
         public string AllngToNtSignedByTyp { get { return _allngToNtSignedByTyp; } set { _allngToNtSignedByTyp = value; } }
-        private Value<string> _allngToNtWithoutRcrse;
+        private DirtyValue<string> _allngToNtWithoutRcrse;
         public string AllngToNtWithoutRcrse { get { return _allngToNtWithoutRcrse; } set { _allngToNtWithoutRcrse = value; } }
-        private Value<string> _apnLbl;
+        private DirtyValue<string> _apnLbl;
         public string ApnLbl { get { return _apnLbl; } set { _apnLbl = value; } }
-        private Value<bool?> _asgnPrepByLblTxtDesc;
+        private DirtyValue<bool?> _asgnPrepByLblTxtDesc;
         public bool? AsgnPrepByLblTxtDesc { get { return _asgnPrepByLblTxtDesc; } set { _asgnPrepByLblTxtDesc = value; } }
-        private Value<bool?> _asgnRecRtrnLblTxtDesc;
+        private DirtyValue<bool?> _asgnRecRtrnLblTxtDesc;
         public bool? AsgnRecRtrnLblTxtDesc { get { return _asgnRecRtrnLblTxtDesc; } set { _asgnRecRtrnLblTxtDesc = value; } }
-        private Value<string> _benCty;
+        private DirtyValue<string> _benCty;
         public string BenCty { get { return _benCty; } set { _benCty = value; } }
-        private Value<string> _benJrsdctn;
+        private DirtyValue<string> _benJrsdctn;
         public string BenJrsdctn { get { return _benJrsdctn; } set { _benJrsdctn = value; } }
-        private Value<string> _benNm;
+        private DirtyValue<string> _benNm;
         public string BenNm { get { return _benNm; } set { _benNm = value; } }
-        private Value<string> _benOrgTyp;
+        private DirtyValue<string> _benOrgTyp;
         public string BenOrgTyp { get { return _benOrgTyp; } set { _benOrgTyp = value; } }
-        private Value<string> _benStCd;
+        private DirtyValue<string> _benStCd;
         public string BenStCd { get { return _benStCd; } set { _benStCd = value; } }
-        private Value<string> _benStreetAddr1;
+        private DirtyValue<string> _benStreetAddr1;
         public string BenStreetAddr1 { get { return _benStreetAddr1; } set { _benStreetAddr1 = value; } }
-        private Value<string> _benStreetAddr2;
+        private DirtyValue<string> _benStreetAddr2;
         public string BenStreetAddr2 { get { return _benStreetAddr2; } set { _benStreetAddr2 = value; } }
-        private Value<string> _benZip;
+        private DirtyValue<string> _benZip;
         public string BenZip { get { return _benZip; } set { _benZip = value; } }
-        private Value<string> _closInstrLndCntcInfoCity;
+        private DirtyValue<string> _closInstrLndCntcInfoCity;
         public string ClosInstrLndCntcInfoCity { get { return _closInstrLndCntcInfoCity; } set { _closInstrLndCntcInfoCity = value; } }
-        private Value<string> _closInstrLndCntcInfoCoNm;
+        private DirtyValue<string> _closInstrLndCntcInfoCoNm;
         public string ClosInstrLndCntcInfoCoNm { get { return _closInstrLndCntcInfoCoNm; } set { _closInstrLndCntcInfoCoNm = value; } }
-        private Value<string> _closInstrLndCntcInfoSamePtyTypDesc;
+        private DirtyValue<string> _closInstrLndCntcInfoSamePtyTypDesc;
         public string ClosInstrLndCntcInfoSamePtyTypDesc { get { return _closInstrLndCntcInfoSamePtyTypDesc; } set { _closInstrLndCntcInfoSamePtyTypDesc = value; } }
-        private Value<string> _closInstrLndCntcInfoStCd;
+        private DirtyValue<string> _closInstrLndCntcInfoStCd;
         public string ClosInstrLndCntcInfoStCd { get { return _closInstrLndCntcInfoStCd; } set { _closInstrLndCntcInfoStCd = value; } }
-        private Value<string> _closInstrLndCntcInfoStreetAddr1;
+        private DirtyValue<string> _closInstrLndCntcInfoStreetAddr1;
         public string ClosInstrLndCntcInfoStreetAddr1 { get { return _closInstrLndCntcInfoStreetAddr1; } set { _closInstrLndCntcInfoStreetAddr1 = value; } }
-        private Value<string> _closInstrLndCntcInfoStreetAddr2;
+        private DirtyValue<string> _closInstrLndCntcInfoStreetAddr2;
         public string ClosInstrLndCntcInfoStreetAddr2 { get { return _closInstrLndCntcInfoStreetAddr2; } set { _closInstrLndCntcInfoStreetAddr2 = value; } }
-        private Value<string> _closInstrLndCntcInfoZip;
+        private DirtyValue<string> _closInstrLndCntcInfoZip;
         public string ClosInstrLndCntcInfoZip { get { return _closInstrLndCntcInfoZip; } set { _closInstrLndCntcInfoZip = value; } }
-        private Value<bool?> _closInstrPrtInvLossPayee;
+        private DirtyValue<bool?> _closInstrPrtInvLossPayee;
         public bool? ClosInstrPrtInvLossPayee { get { return _closInstrPrtInvLossPayee; } set { _closInstrPrtInvLossPayee = value; } }
-        private Value<bool?> _closInstrStlmtAgtUseLndHud1;
+        private DirtyValue<bool?> _closInstrStlmtAgtUseLndHud1;
         public bool? ClosInstrStlmtAgtUseLndHud1 { get { return _closInstrStlmtAgtUseLndHud1; } set { _closInstrStlmtAgtUseLndHud1 = value; } }
-        private Value<string> _closInstrTtlPlcyTyp;
+        private DirtyValue<string> _closInstrTtlPlcyTyp;
         public string ClosInstrTtlPlcyTyp { get { return _closInstrTtlPlcyTyp; } set { _closInstrTtlPlcyTyp = value; } }
-        private Value<string> _emxmlVersionId;
+        private DirtyValue<string> _emxmlVersionId;
         public string EmxmlVersionId { get { return _emxmlVersionId; } set { _emxmlVersionId = value; } }
-        private Value<string> _exeClosDocDlvrdToCty;
+        private DirtyValue<string> _exeClosDocDlvrdToCty;
         public string ExeClosDocDlvrdToCty { get { return _exeClosDocDlvrdToCty; } set { _exeClosDocDlvrdToCty = value; } }
-        private Value<string> _exeClosDocDlvrdToMiscTxtDesc;
+        private DirtyValue<string> _exeClosDocDlvrdToMiscTxtDesc;
         public string ExeClosDocDlvrdToMiscTxtDesc { get { return _exeClosDocDlvrdToMiscTxtDesc; } set { _exeClosDocDlvrdToMiscTxtDesc = value; } }
-        private Value<string> _exeClosDocDlvrdToNm;
+        private DirtyValue<string> _exeClosDocDlvrdToNm;
         public string ExeClosDocDlvrdToNm { get { return _exeClosDocDlvrdToNm; } set { _exeClosDocDlvrdToNm = value; } }
-        private Value<string> _exeClosDocDlvrdToSamePtyTypDesc;
+        private DirtyValue<string> _exeClosDocDlvrdToSamePtyTypDesc;
         public string ExeClosDocDlvrdToSamePtyTypDesc { get { return _exeClosDocDlvrdToSamePtyTypDesc; } set { _exeClosDocDlvrdToSamePtyTypDesc = value; } }
-        private Value<string> _exeClosDocDlvrdToStCd;
+        private DirtyValue<string> _exeClosDocDlvrdToStCd;
         public string ExeClosDocDlvrdToStCd { get { return _exeClosDocDlvrdToStCd; } set { _exeClosDocDlvrdToStCd = value; } }
-        private Value<string> _exeClosDocDlvrdToStreetAddr1;
+        private DirtyValue<string> _exeClosDocDlvrdToStreetAddr1;
         public string ExeClosDocDlvrdToStreetAddr1 { get { return _exeClosDocDlvrdToStreetAddr1; } set { _exeClosDocDlvrdToStreetAddr1 = value; } }
-        private Value<string> _exeClosDocDlvrdToStreetAddr2;
+        private DirtyValue<string> _exeClosDocDlvrdToStreetAddr2;
         public string ExeClosDocDlvrdToStreetAddr2 { get { return _exeClosDocDlvrdToStreetAddr2; } set { _exeClosDocDlvrdToStreetAddr2 = value; } }
-        private Value<string> _exeClosDocDlvrdToZip;
+        private DirtyValue<string> _exeClosDocDlvrdToZip;
         public string ExeClosDocDlvrdToZip { get { return _exeClosDocDlvrdToZip; } set { _exeClosDocDlvrdToZip = value; } }
-        private Value<string> _exeClosDocExprDt;
+        private DirtyValue<string> _exeClosDocExprDt;
         public string ExeClosDocExprDt { get { return _exeClosDocExprDt; } set { _exeClosDocExprDt = value; } }
-        private Value<string> _exeClosDocToBeRtrnd;
+        private DirtyValue<string> _exeClosDocToBeRtrnd;
         public string ExeClosDocToBeRtrnd { get { return _exeClosDocToBeRtrnd; } set { _exeClosDocToBeRtrnd = value; } }
-        private Value<string> _exeClosDocToBeRtrndHrs;
+        private DirtyValue<string> _exeClosDocToBeRtrndHrs;
         public string ExeClosDocToBeRtrndHrs { get { return _exeClosDocToBeRtrndHrs; } set { _exeClosDocToBeRtrndHrs = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToAddlLine1;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToAddlLine1;
         public string FnlTtlePcyRecDocsSentToAddlLine1 { get { return _fnlTtlePcyRecDocsSentToAddlLine1; } set { _fnlTtlePcyRecDocsSentToAddlLine1 = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToAddlLine2;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToAddlLine2;
         public string FnlTtlePcyRecDocsSentToAddlLine2 { get { return _fnlTtlePcyRecDocsSentToAddlLine2; } set { _fnlTtlePcyRecDocsSentToAddlLine2 = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToCty;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToCty;
         public string FnlTtlePcyRecDocsSentToCty { get { return _fnlTtlePcyRecDocsSentToCty; } set { _fnlTtlePcyRecDocsSentToCty = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToNm;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToNm;
         public string FnlTtlePcyRecDocsSentToNm { get { return _fnlTtlePcyRecDocsSentToNm; } set { _fnlTtlePcyRecDocsSentToNm = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToSamePtyTypDesc;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToSamePtyTypDesc;
         public string FnlTtlePcyRecDocsSentToSamePtyTypDesc { get { return _fnlTtlePcyRecDocsSentToSamePtyTypDesc; } set { _fnlTtlePcyRecDocsSentToSamePtyTypDesc = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToStcd;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToStcd;
         public string FnlTtlePcyRecDocsSentToStcd { get { return _fnlTtlePcyRecDocsSentToStcd; } set { _fnlTtlePcyRecDocsSentToStcd = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToStreetAddr1;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToStreetAddr1;
         public string FnlTtlePcyRecDocsSentToStreetAddr1 { get { return _fnlTtlePcyRecDocsSentToStreetAddr1; } set { _fnlTtlePcyRecDocsSentToStreetAddr1 = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToStreetAddr2;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToStreetAddr2;
         public string FnlTtlePcyRecDocsSentToStreetAddr2 { get { return _fnlTtlePcyRecDocsSentToStreetAddr2; } set { _fnlTtlePcyRecDocsSentToStreetAddr2 = value; } }
-        private Value<string> _fnlTtlePcyRecDocsSentToZip;
+        private DirtyValue<string> _fnlTtlePcyRecDocsSentToZip;
         public string FnlTtlePcyRecDocsSentToZip { get { return _fnlTtlePcyRecDocsSentToZip; } set { _fnlTtlePcyRecDocsSentToZip = value; } }
-        private Value<string> _hazInsurEndsmtMailToAdtlTxt;
+        private DirtyValue<string> _hazInsurEndsmtMailToAdtlTxt;
         public string HazInsurEndsmtMailToAdtlTxt { get { return _hazInsurEndsmtMailToAdtlTxt; } set { _hazInsurEndsmtMailToAdtlTxt = value; } }
-        private Value<string> _hazInsurEndsmtMailToCty;
+        private DirtyValue<string> _hazInsurEndsmtMailToCty;
         public string HazInsurEndsmtMailToCty { get { return _hazInsurEndsmtMailToCty; } set { _hazInsurEndsmtMailToCty = value; } }
-        private Value<string> _hazInsurEndsmtMailToNm;
+        private DirtyValue<string> _hazInsurEndsmtMailToNm;
         public string HazInsurEndsmtMailToNm { get { return _hazInsurEndsmtMailToNm; } set { _hazInsurEndsmtMailToNm = value; } }
-        private Value<string> _hazInsurEndsmtMailToStCd;
+        private DirtyValue<string> _hazInsurEndsmtMailToStCd;
         public string HazInsurEndsmtMailToStCd { get { return _hazInsurEndsmtMailToStCd; } set { _hazInsurEndsmtMailToStCd = value; } }
-        private Value<string> _hazInsurEndsmtMailToStreetAddr1;
+        private DirtyValue<string> _hazInsurEndsmtMailToStreetAddr1;
         public string HazInsurEndsmtMailToStreetAddr1 { get { return _hazInsurEndsmtMailToStreetAddr1; } set { _hazInsurEndsmtMailToStreetAddr1 = value; } }
-        private Value<string> _hazInsurEndsmtMailToStreetAddr2;
+        private DirtyValue<string> _hazInsurEndsmtMailToStreetAddr2;
         public string HazInsurEndsmtMailToStreetAddr2 { get { return _hazInsurEndsmtMailToStreetAddr2; } set { _hazInsurEndsmtMailToStreetAddr2 = value; } }
-        private Value<string> _hazInsurEndsmtMailToZip;
+        private DirtyValue<string> _hazInsurEndsmtMailToZip;
         public string HazInsurEndsmtMailToZip { get { return _hazInsurEndsmtMailToZip; } set { _hazInsurEndsmtMailToZip = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _mersAdtlCity;
+        private DirtyValue<string> _mersAdtlCity;
         public string MersAdtlCity { get { return _mersAdtlCity; } set { _mersAdtlCity = value; } }
-        private Value<string> _mersAdtlStCd;
+        private DirtyValue<string> _mersAdtlStCd;
         public string MersAdtlStCd { get { return _mersAdtlStCd; } set { _mersAdtlStCd = value; } }
-        private Value<string> _mersAdtlStreetAddr1;
+        private DirtyValue<string> _mersAdtlStreetAddr1;
         public string MersAdtlStreetAddr1 { get { return _mersAdtlStreetAddr1; } set { _mersAdtlStreetAddr1 = value; } }
-        private Value<string> _mersAdtlStreetAddr2;
+        private DirtyValue<string> _mersAdtlStreetAddr2;
         public string MersAdtlStreetAddr2 { get { return _mersAdtlStreetAddr2; } set { _mersAdtlStreetAddr2 = value; } }
-        private Value<string> _mersAdtlZip;
+        private DirtyValue<string> _mersAdtlZip;
         public string MersAdtlZip { get { return _mersAdtlZip; } set { _mersAdtlZip = value; } }
-        private Value<string> _mersCty;
+        private DirtyValue<string> _mersCty;
         public string MersCty { get { return _mersCty; } set { _mersCty = value; } }
-        private Value<string> _mersJrsdctn;
+        private DirtyValue<string> _mersJrsdctn;
         public string MersJrsdctn { get { return _mersJrsdctn; } set { _mersJrsdctn = value; } }
-        private Value<string> _mersName;
+        private DirtyValue<string> _mersName;
         public string MersName { get { return _mersName; } set { _mersName = value; } }
-        private Value<string> _mersOrgTyp;
+        private DirtyValue<string> _mersOrgTyp;
         public string MersOrgTyp { get { return _mersOrgTyp; } set { _mersOrgTyp = value; } }
-        private Value<string> _mersPhoneNum;
+        private DirtyValue<string> _mersPhoneNum;
         public string MersPhoneNum { get { return _mersPhoneNum; } set { _mersPhoneNum = value; } }
-        private Value<string> _mersStCd;
+        private DirtyValue<string> _mersStCd;
         public string MersStCd { get { return _mersStCd; } set { _mersStCd = value; } }
-        private Value<string> _mersStreetAddr1;
+        private DirtyValue<string> _mersStreetAddr1;
         public string MersStreetAddr1 { get { return _mersStreetAddr1; } set { _mersStreetAddr1 = value; } }
-        private Value<string> _mersStreetAddr2;
+        private DirtyValue<string> _mersStreetAddr2;
         public string MersStreetAddr2 { get { return _mersStreetAddr2; } set { _mersStreetAddr2 = value; } }
-        private Value<string> _mersZip;
+        private DirtyValue<string> _mersZip;
         public string MersZip { get { return _mersZip; } set { _mersZip = value; } }
-        private Value<string> _ntEndrsmtPayToJrsdctn;
+        private DirtyValue<string> _ntEndrsmtPayToJrsdctn;
         public string NtEndrsmtPayToJrsdctn { get { return _ntEndrsmtPayToJrsdctn; } set { _ntEndrsmtPayToJrsdctn = value; } }
-        private Value<string> _ntEndrsmtPayToOrdNm;
+        private DirtyValue<string> _ntEndrsmtPayToOrdNm;
         public string NtEndrsmtPayToOrdNm { get { return _ntEndrsmtPayToOrdNm; } set { _ntEndrsmtPayToOrdNm = value; } }
-        private Value<string> _ntEndrsmtPayToOrgTyp;
+        private DirtyValue<string> _ntEndrsmtPayToOrgTyp;
         public string NtEndrsmtPayToOrgTyp { get { return _ntEndrsmtPayToOrgTyp; } set { _ntEndrsmtPayToOrgTyp = value; } }
-        private Value<string> _ntEndrsmtPayToScsrsClaus;
+        private DirtyValue<string> _ntEndrsmtPayToScsrsClaus;
         public string NtEndrsmtPayToScsrsClaus { get { return _ntEndrsmtPayToScsrsClaus; } set { _ntEndrsmtPayToScsrsClaus = value; } }
-        private Value<string> _ntEndrsmtSgndBy1MiscTxt;
+        private DirtyValue<string> _ntEndrsmtSgndBy1MiscTxt;
         public string NtEndrsmtSgndBy1MiscTxt { get { return _ntEndrsmtSgndBy1MiscTxt; } set { _ntEndrsmtSgndBy1MiscTxt = value; } }
-        private Value<string> _ntEndrsmtSgndBy2MiscTxt;
+        private DirtyValue<string> _ntEndrsmtSgndBy2MiscTxt;
         public string NtEndrsmtSgndBy2MiscTxt { get { return _ntEndrsmtSgndBy2MiscTxt; } set { _ntEndrsmtSgndBy2MiscTxt = value; } }
-        private Value<string> _ntEndrsmtSignedByNm;
+        private DirtyValue<string> _ntEndrsmtSignedByNm;
         public string NtEndrsmtSignedByNm { get { return _ntEndrsmtSignedByNm; } set { _ntEndrsmtSignedByNm = value; } }
-        private Value<string> _ntEndrsmtSignedByNm2;
+        private DirtyValue<string> _ntEndrsmtSignedByNm2;
         public string NtEndrsmtSignedByNm2 { get { return _ntEndrsmtSignedByNm2; } set { _ntEndrsmtSignedByNm2 = value; } }
-        private Value<string> _ntEndrsmtSignedByNm3;
+        private DirtyValue<string> _ntEndrsmtSignedByNm3;
         public string NtEndrsmtSignedByNm3 { get { return _ntEndrsmtSignedByNm3; } set { _ntEndrsmtSignedByNm3 = value; } }
-        private Value<string> _ntEndrsmtSignedByTtl;
+        private DirtyValue<string> _ntEndrsmtSignedByTtl;
         public string NtEndrsmtSignedByTtl { get { return _ntEndrsmtSignedByTtl; } set { _ntEndrsmtSignedByTtl = value; } }
-        private Value<string> _ntEndrsmtSignedByTtl2;
+        private DirtyValue<string> _ntEndrsmtSignedByTtl2;
         public string NtEndrsmtSignedByTtl2 { get { return _ntEndrsmtSignedByTtl2; } set { _ntEndrsmtSignedByTtl2 = value; } }
-        private Value<string> _ntEndrsmtSignedByTtl3;
+        private DirtyValue<string> _ntEndrsmtSignedByTtl3;
         public string NtEndrsmtSignedByTtl3 { get { return _ntEndrsmtSignedByTtl3; } set { _ntEndrsmtSignedByTtl3 = value; } }
-        private Value<string> _ntEndrsmtSignedByTyp;
+        private DirtyValue<string> _ntEndrsmtSignedByTyp;
         public string NtEndrsmtSignedByTyp { get { return _ntEndrsmtSignedByTyp; } set { _ntEndrsmtSignedByTyp = value; } }
-        private Value<string> _ntEndrsmtWithoutRcrse;
+        private DirtyValue<string> _ntEndrsmtWithoutRcrse;
         public string NtEndrsmtWithoutRcrse { get { return _ntEndrsmtWithoutRcrse; } set { _ntEndrsmtWithoutRcrse = value; } }
-        private Value<string> _ntEndsmtThrdPtyAddr1;
+        private DirtyValue<string> _ntEndsmtThrdPtyAddr1;
         public string NtEndsmtThrdPtyAddr1 { get { return _ntEndsmtThrdPtyAddr1; } set { _ntEndsmtThrdPtyAddr1 = value; } }
-        private Value<string> _ntEndsmtThrdPtyAddr2;
+        private DirtyValue<string> _ntEndsmtThrdPtyAddr2;
         public string NtEndsmtThrdPtyAddr2 { get { return _ntEndsmtThrdPtyAddr2; } set { _ntEndsmtThrdPtyAddr2 = value; } }
-        private Value<string> _ntEndsmtThrdPtyCty;
+        private DirtyValue<string> _ntEndsmtThrdPtyCty;
         public string NtEndsmtThrdPtyCty { get { return _ntEndsmtThrdPtyCty; } set { _ntEndsmtThrdPtyCty = value; } }
-        private Value<string> _ntEndsmtThrdPtyJrsdctn;
+        private DirtyValue<string> _ntEndsmtThrdPtyJrsdctn;
         public string NtEndsmtThrdPtyJrsdctn { get { return _ntEndsmtThrdPtyJrsdctn; } set { _ntEndsmtThrdPtyJrsdctn = value; } }
-        private Value<string> _ntEndsmtThrdPtyName;
+        private DirtyValue<string> _ntEndsmtThrdPtyName;
         public string NtEndsmtThrdPtyName { get { return _ntEndsmtThrdPtyName; } set { _ntEndsmtThrdPtyName = value; } }
-        private Value<string> _ntEndsmtThrdPtyOrgTyp;
+        private DirtyValue<string> _ntEndsmtThrdPtyOrgTyp;
         public string NtEndsmtThrdPtyOrgTyp { get { return _ntEndsmtThrdPtyOrgTyp; } set { _ntEndsmtThrdPtyOrgTyp = value; } }
-        private Value<string> _ntEndsmtThrdPtyPhone;
+        private DirtyValue<string> _ntEndsmtThrdPtyPhone;
         public string NtEndsmtThrdPtyPhone { get { return _ntEndsmtThrdPtyPhone; } set { _ntEndsmtThrdPtyPhone = value; } }
-        private Value<string> _ntEndsmtThrdPtyScsrClaus;
+        private DirtyValue<string> _ntEndsmtThrdPtyScsrClaus;
         public string NtEndsmtThrdPtyScsrClaus { get { return _ntEndsmtThrdPtyScsrClaus; } set { _ntEndsmtThrdPtyScsrClaus = value; } }
-        private Value<string> _ntEndsmtThrdPtyStCd;
+        private DirtyValue<string> _ntEndsmtThrdPtyStCd;
         public string NtEndsmtThrdPtyStCd { get { return _ntEndsmtThrdPtyStCd; } set { _ntEndsmtThrdPtyStCd = value; } }
-        private Value<string> _ntEndsmtThrdPtyZip;
+        private DirtyValue<string> _ntEndsmtThrdPtyZip;
         public string NtEndsmtThrdPtyZip { get { return _ntEndsmtThrdPtyZip; } set { _ntEndsmtThrdPtyZip = value; } }
-        private Value<string> _ntPayToAdtlTxt;
+        private DirtyValue<string> _ntPayToAdtlTxt;
         public string NtPayToAdtlTxt { get { return _ntPayToAdtlTxt; } set { _ntPayToAdtlTxt = value; } }
-        private Value<string> _ntPayToCty;
+        private DirtyValue<string> _ntPayToCty;
         public string NtPayToCty { get { return _ntPayToCty; } set { _ntPayToCty = value; } }
-        private Value<string> _ntPayToJrsdctn;
+        private DirtyValue<string> _ntPayToJrsdctn;
         public string NtPayToJrsdctn { get { return _ntPayToJrsdctn; } set { _ntPayToJrsdctn = value; } }
-        private Value<string> _ntPayToNm;
+        private DirtyValue<string> _ntPayToNm;
         public string NtPayToNm { get { return _ntPayToNm; } set { _ntPayToNm = value; } }
-        private Value<string> _ntPayToOrgTyp;
+        private DirtyValue<string> _ntPayToOrgTyp;
         public string NtPayToOrgTyp { get { return _ntPayToOrgTyp; } set { _ntPayToOrgTyp = value; } }
-        private Value<string> _ntPayToStCd;
+        private DirtyValue<string> _ntPayToStCd;
         public string NtPayToStCd { get { return _ntPayToStCd; } set { _ntPayToStCd = value; } }
-        private Value<string> _ntPayToStreetAddr1;
+        private DirtyValue<string> _ntPayToStreetAddr1;
         public string NtPayToStreetAddr1 { get { return _ntPayToStreetAddr1; } set { _ntPayToStreetAddr1 = value; } }
-        private Value<string> _ntPayToStreetAddr2;
+        private DirtyValue<string> _ntPayToStreetAddr2;
         public string NtPayToStreetAddr2 { get { return _ntPayToStreetAddr2; } set { _ntPayToStreetAddr2 = value; } }
-        private Value<string> _ntPayToZip;
+        private DirtyValue<string> _ntPayToZip;
         public string NtPayToZip { get { return _ntPayToZip; } set { _ntPayToZip = value; } }
-        private Value<string> _pmtCpn2PayToAdtlTxt;
+        private DirtyValue<string> _pmtCpn2PayToAdtlTxt;
         public string PmtCpn2PayToAdtlTxt { get { return _pmtCpn2PayToAdtlTxt; } set { _pmtCpn2PayToAdtlTxt = value; } }
-        private Value<string> _pmtCpn2PayToAdtlTxt2;
+        private DirtyValue<string> _pmtCpn2PayToAdtlTxt2;
         public string PmtCpn2PayToAdtlTxt2 { get { return _pmtCpn2PayToAdtlTxt2; } set { _pmtCpn2PayToAdtlTxt2 = value; } }
-        private Value<string> _pmtCpn2PayToCty;
+        private DirtyValue<string> _pmtCpn2PayToCty;
         public string PmtCpn2PayToCty { get { return _pmtCpn2PayToCty; } set { _pmtCpn2PayToCty = value; } }
-        private Value<string> _pmtCpn2PayToNm;
+        private DirtyValue<string> _pmtCpn2PayToNm;
         public string PmtCpn2PayToNm { get { return _pmtCpn2PayToNm; } set { _pmtCpn2PayToNm = value; } }
-        private Value<string> _pmtCpn2PayToStCd;
+        private DirtyValue<string> _pmtCpn2PayToStCd;
         public string PmtCpn2PayToStCd { get { return _pmtCpn2PayToStCd; } set { _pmtCpn2PayToStCd = value; } }
-        private Value<string> _pmtCpn2PayToStreetAddr1;
+        private DirtyValue<string> _pmtCpn2PayToStreetAddr1;
         public string PmtCpn2PayToStreetAddr1 { get { return _pmtCpn2PayToStreetAddr1; } set { _pmtCpn2PayToStreetAddr1 = value; } }
-        private Value<string> _pmtCpn2PayToStreetAddr2;
+        private DirtyValue<string> _pmtCpn2PayToStreetAddr2;
         public string PmtCpn2PayToStreetAddr2 { get { return _pmtCpn2PayToStreetAddr2; } set { _pmtCpn2PayToStreetAddr2 = value; } }
-        private Value<string> _pmtCpn2PayToZip;
+        private DirtyValue<string> _pmtCpn2PayToZip;
         public string PmtCpn2PayToZip { get { return _pmtCpn2PayToZip; } set { _pmtCpn2PayToZip = value; } }
-        private Value<string> _pmtCpnPayToAdtlTxt;
+        private DirtyValue<string> _pmtCpnPayToAdtlTxt;
         public string PmtCpnPayToAdtlTxt { get { return _pmtCpnPayToAdtlTxt; } set { _pmtCpnPayToAdtlTxt = value; } }
-        private Value<string> _pmtCpnPayToAdtlTxt2;
+        private DirtyValue<string> _pmtCpnPayToAdtlTxt2;
         public string PmtCpnPayToAdtlTxt2 { get { return _pmtCpnPayToAdtlTxt2; } set { _pmtCpnPayToAdtlTxt2 = value; } }
-        private Value<string> _pmtCpnPayToCty;
+        private DirtyValue<string> _pmtCpnPayToCty;
         public string PmtCpnPayToCty { get { return _pmtCpnPayToCty; } set { _pmtCpnPayToCty = value; } }
-        private Value<string> _pmtCpnPayToNm;
+        private DirtyValue<string> _pmtCpnPayToNm;
         public string PmtCpnPayToNm { get { return _pmtCpnPayToNm; } set { _pmtCpnPayToNm = value; } }
-        private Value<string> _pmtCpnPayToStCd;
+        private DirtyValue<string> _pmtCpnPayToStCd;
         public string PmtCpnPayToStCd { get { return _pmtCpnPayToStCd; } set { _pmtCpnPayToStCd = value; } }
-        private Value<string> _pmtCpnPayToStreetAddr1;
+        private DirtyValue<string> _pmtCpnPayToStreetAddr1;
         public string PmtCpnPayToStreetAddr1 { get { return _pmtCpnPayToStreetAddr1; } set { _pmtCpnPayToStreetAddr1 = value; } }
-        private Value<string> _pmtCpnPayToStreetAddr2;
+        private DirtyValue<string> _pmtCpnPayToStreetAddr2;
         public string PmtCpnPayToStreetAddr2 { get { return _pmtCpnPayToStreetAddr2; } set { _pmtCpnPayToStreetAddr2 = value; } }
-        private Value<string> _pmtCpnPayToZip;
+        private DirtyValue<string> _pmtCpnPayToZip;
         public string PmtCpnPayToZip { get { return _pmtCpnPayToZip; } set { _pmtCpnPayToZip = value; } }
-        private Value<string> _prtAdtlDateHud1;
+        private DirtyValue<string> _prtAdtlDateHud1;
         public string PrtAdtlDateHud1 { get { return _prtAdtlDateHud1; } set { _prtAdtlDateHud1 = value; } }
-        private Value<bool?> _prtAllngToNtBool;
+        private DirtyValue<bool?> _prtAllngToNtBool;
         public bool? PrtAllngToNtBool { get { return _prtAllngToNtBool; } set { _prtAllngToNtBool = value; } }
-        private Value<bool?> _prtCorpMsgAsgnBool;
+        private DirtyValue<bool?> _prtCorpMsgAsgnBool;
         public bool? PrtCorpMsgAsgnBool { get { return _prtCorpMsgAsgnBool; } set { _prtCorpMsgAsgnBool = value; } }
-        private Value<string> _prtDocDtSctyIstrmtNtryAprncDt;
+        private DirtyValue<string> _prtDocDtSctyIstrmtNtryAprncDt;
         public string PrtDocDtSctyIstrmtNtryAprncDt { get { return _prtDocDtSctyIstrmtNtryAprncDt; } set { _prtDocDtSctyIstrmtNtryAprncDt = value; } }
-        private Value<bool?> _prtIndxTilBool;
+        private DirtyValue<bool?> _prtIndxTilBool;
         public bool? PrtIndxTilBool { get { return _prtIndxTilBool; } set { _prtIndxTilBool = value; } }
-        private Value<bool?> _prtInitBlckNtBool;
+        private DirtyValue<bool?> _prtInitBlckNtBool;
         public bool? PrtInitBlckNtBool { get { return _prtInitBlckNtBool; } set { _prtInitBlckNtBool = value; } }
-        private Value<bool?> _prtInitBlckSctyIstrmtBool;
+        private DirtyValue<bool?> _prtInitBlckSctyIstrmtBool;
         public bool? PrtInitBlckSctyIstrmtBool { get { return _prtInitBlckSctyIstrmtBool; } set { _prtInitBlckSctyIstrmtBool = value; } }
-        private Value<bool?> _prtInvLoanNumBool;
+        private DirtyValue<bool?> _prtInvLoanNumBool;
         public bool? PrtInvLoanNumBool { get { return _prtInvLoanNumBool; } set { _prtInvLoanNumBool = value; } }
-        private Value<bool?> _prtInvLoanNumPmtCpn2Ind;
+        private DirtyValue<bool?> _prtInvLoanNumPmtCpn2Ind;
         public bool? PrtInvLoanNumPmtCpn2Ind { get { return _prtInvLoanNumPmtCpn2Ind; } set { _prtInvLoanNumPmtCpn2Ind = value; } }
-        private Value<bool?> _prtInvLoanNumPmtCpnInd;
+        private DirtyValue<bool?> _prtInvLoanNumPmtCpnInd;
         public bool? PrtInvLoanNumPmtCpnInd { get { return _prtInvLoanNumPmtCpnInd; } set { _prtInvLoanNumPmtCpnInd = value; } }
-        private Value<bool?> _prtInvLossPayeeHazInsurDisBool;
+        private DirtyValue<bool?> _prtInvLossPayeeHazInsurDisBool;
         public bool? PrtInvLossPayeeHazInsurDisBool { get { return _prtInvLossPayeeHazInsurDisBool; } set { _prtInvLossPayeeHazInsurDisBool = value; } }
-        private Value<bool?> _prtLoanNumDeedBool;
+        private DirtyValue<bool?> _prtLoanNumDeedBool;
         public bool? PrtLoanNumDeedBool { get { return _prtLoanNumDeedBool; } set { _prtLoanNumDeedBool = value; } }
-        private Value<bool?> _prtNtEndsmtBool;
+        private DirtyValue<bool?> _prtNtEndsmtBool;
         public bool? PrtNtEndsmtBool { get { return _prtNtEndsmtBool; } set { _prtNtEndsmtBool = value; } }
-        private Value<bool?> _prtNtPayToCorpMsgBool;
+        private DirtyValue<bool?> _prtNtPayToCorpMsgBool;
         public bool? PrtNtPayToCorpMsgBool { get { return _prtNtPayToCorpMsgBool; } set { _prtNtPayToCorpMsgBool = value; } }
-        private Value<bool?> _prtScsrsClausClosInstBool;
+        private DirtyValue<bool?> _prtScsrsClausClosInstBool;
         public bool? PrtScsrsClausClosInstBool { get { return _prtScsrsClausClosInstBool; } set { _prtScsrsClausClosInstBool = value; } }
-        private Value<bool?> _prtScsrsClausHazInsurDisBool;
+        private DirtyValue<bool?> _prtScsrsClausHazInsurDisBool;
         public bool? PrtScsrsClausHazInsurDisBool { get { return _prtScsrsClausHazInsurDisBool; } set { _prtScsrsClausHazInsurDisBool = value; } }
-        private Value<bool?> _prtScsrsClausHazInsurLtrBool;
+        private DirtyValue<bool?> _prtScsrsClausHazInsurLtrBool;
         public bool? PrtScsrsClausHazInsurLtrBool { get { return _prtScsrsClausHazInsurLtrBool; } set { _prtScsrsClausHazInsurLtrBool = value; } }
-        private Value<bool?> _prtScsrsClausPmtCpnBool;
+        private DirtyValue<bool?> _prtScsrsClausPmtCpnBool;
         public bool? PrtScsrsClausPmtCpnBool { get { return _prtScsrsClausPmtCpnBool; } set { _prtScsrsClausPmtCpnBool = value; } }
-        private Value<bool?> _prtSctyIstrmtCorpMsgBool;
+        private DirtyValue<bool?> _prtSctyIstrmtCorpMsgBool;
         public bool? PrtSctyIstrmtCorpMsgBool { get { return _prtSctyIstrmtCorpMsgBool; } set { _prtSctyIstrmtCorpMsgBool = value; } }
-        private Value<string> _recRtrnAttnLnNmTxtDesc;
+        private DirtyValue<string> _recRtrnAttnLnNmTxtDesc;
         public string RecRtrnAttnLnNmTxtDesc { get { return _recRtrnAttnLnNmTxtDesc; } set { _recRtrnAttnLnNmTxtDesc = value; } }
-        private Value<string> _recRtrnCty;
+        private DirtyValue<string> _recRtrnCty;
         public string RecRtrnCty { get { return _recRtrnCty; } set { _recRtrnCty = value; } }
-        private Value<string> _recRtrnLblTxtDesc;
+        private DirtyValue<string> _recRtrnLblTxtDesc;
         public string RecRtrnLblTxtDesc { get { return _recRtrnLblTxtDesc; } set { _recRtrnLblTxtDesc = value; } }
-        private Value<string> _recRtrnNm;
+        private DirtyValue<string> _recRtrnNm;
         public string RecRtrnNm { get { return _recRtrnNm; } set { _recRtrnNm = value; } }
-        private Value<string> _recRtrnNmSamePtyTypDesc;
+        private DirtyValue<string> _recRtrnNmSamePtyTypDesc;
         public string RecRtrnNmSamePtyTypDesc { get { return _recRtrnNmSamePtyTypDesc; } set { _recRtrnNmSamePtyTypDesc = value; } }
-        private Value<string> _recRtrnPhoneNum;
+        private DirtyValue<string> _recRtrnPhoneNum;
         public string RecRtrnPhoneNum { get { return _recRtrnPhoneNum; } set { _recRtrnPhoneNum = value; } }
-        private Value<string> _recRtrnStCd;
+        private DirtyValue<string> _recRtrnStCd;
         public string RecRtrnStCd { get { return _recRtrnStCd; } set { _recRtrnStCd = value; } }
-        private Value<string> _recRtrnStreetAddr1;
+        private DirtyValue<string> _recRtrnStreetAddr1;
         public string RecRtrnStreetAddr1 { get { return _recRtrnStreetAddr1; } set { _recRtrnStreetAddr1 = value; } }
-        private Value<string> _recRtrnStreetAddr2;
+        private DirtyValue<string> _recRtrnStreetAddr2;
         public string RecRtrnStreetAddr2 { get { return _recRtrnStreetAddr2; } set { _recRtrnStreetAddr2 = value; } }
-        private Value<string> _recRtrnTollFreePhoneNum;
+        private DirtyValue<string> _recRtrnTollFreePhoneNum;
         public string RecRtrnTollFreePhoneNum { get { return _recRtrnTollFreePhoneNum; } set { _recRtrnTollFreePhoneNum = value; } }
-        private Value<string> _recRtrnZip;
+        private DirtyValue<string> _recRtrnZip;
         public string RecRtrnZip { get { return _recRtrnZip; } set { _recRtrnZip = value; } }
-        private Value<bool?> _rtrnExeClosPkgToLndBrchBool;
+        private DirtyValue<bool?> _rtrnExeClosPkgToLndBrchBool;
         public bool? RtrnExeClosPkgToLndBrchBool { get { return _rtrnExeClosPkgToLndBrchBool; } set { _rtrnExeClosPkgToLndBrchBool = value; } }
-        private Value<string> _rtToCancelNtfcAdtlTxt;
+        private DirtyValue<string> _rtToCancelNtfcAdtlTxt;
         public string RtToCancelNtfcAdtlTxt { get { return _rtToCancelNtfcAdtlTxt; } set { _rtToCancelNtfcAdtlTxt = value; } }
-        private Value<string> _rtToCancelNtfcCty;
+        private DirtyValue<string> _rtToCancelNtfcCty;
         public string RtToCancelNtfcCty { get { return _rtToCancelNtfcCty; } set { _rtToCancelNtfcCty = value; } }
-        private Value<string> _rtToCancelNtfcEmail;
+        private DirtyValue<string> _rtToCancelNtfcEmail;
         public string RtToCancelNtfcEmail { get { return _rtToCancelNtfcEmail; } set { _rtToCancelNtfcEmail = value; } }
-        private Value<string> _rtToCancelNtfcFax;
+        private DirtyValue<string> _rtToCancelNtfcFax;
         public string RtToCancelNtfcFax { get { return _rtToCancelNtfcFax; } set { _rtToCancelNtfcFax = value; } }
-        private Value<string> _rtToCancelNtfcNm;
+        private DirtyValue<string> _rtToCancelNtfcNm;
         public string RtToCancelNtfcNm { get { return _rtToCancelNtfcNm; } set { _rtToCancelNtfcNm = value; } }
-        private Value<string> _rtToCancelNtfcStCd;
+        private DirtyValue<string> _rtToCancelNtfcStCd;
         public string RtToCancelNtfcStCd { get { return _rtToCancelNtfcStCd; } set { _rtToCancelNtfcStCd = value; } }
-        private Value<string> _rtToCancelNtfcStreetAddr1;
+        private DirtyValue<string> _rtToCancelNtfcStreetAddr1;
         public string RtToCancelNtfcStreetAddr1 { get { return _rtToCancelNtfcStreetAddr1; } set { _rtToCancelNtfcStreetAddr1 = value; } }
-        private Value<string> _rtToCancelNtfcStreetAddr2;
+        private DirtyValue<string> _rtToCancelNtfcStreetAddr2;
         public string RtToCancelNtfcStreetAddr2 { get { return _rtToCancelNtfcStreetAddr2; } set { _rtToCancelNtfcStreetAddr2 = value; } }
-        private Value<string> _rtToCancelNtfcZip;
+        private DirtyValue<string> _rtToCancelNtfcZip;
         public string RtToCancelNtfcZip { get { return _rtToCancelNtfcZip; } set { _rtToCancelNtfcZip = value; } }
-        private Value<string> _rtToCancelTransDtTyp;
+        private DirtyValue<string> _rtToCancelTransDtTyp;
         public string RtToCancelTransDtTyp { get { return _rtToCancelTransDtTyp; } set { _rtToCancelTransDtTyp = value; } }
-        private Value<string> _sctyIstrmtDCTrstFeePct;
+        private DirtyValue<string> _sctyIstrmtDCTrstFeePct;
         public string SctyIstrmtDCTrstFeePct { get { return _sctyIstrmtDCTrstFeePct; } set { _sctyIstrmtDCTrstFeePct = value; } }
-        private Value<string> _sctyIstrmtDEAttyFeePct;
+        private DirtyValue<string> _sctyIstrmtDEAttyFeePct;
         public string SctyIstrmtDEAttyFeePct { get { return _sctyIstrmtDEAttyFeePct; } set { _sctyIstrmtDEAttyFeePct = value; } }
-        private Value<decimal?> _sctyIstrmtLAAttyFeePct;
+        private DirtyValue<decimal?> _sctyIstrmtLAAttyFeePct;
         public decimal? SctyIstrmtLAAttyFeePct { get { return _sctyIstrmtLAAttyFeePct; } set { _sctyIstrmtLAAttyFeePct = value; } }
-        private Value<decimal?> _sctyIstrmtLAMinAttyFeeAmt;
+        private DirtyValue<decimal?> _sctyIstrmtLAMinAttyFeeAmt;
         public decimal? SctyIstrmtLAMinAttyFeeAmt { get { return _sctyIstrmtLAMinAttyFeeAmt; } set { _sctyIstrmtLAMinAttyFeeAmt = value; } }
-        private Value<string> _sctyIstrmtMDTrstFeePct;
+        private DirtyValue<string> _sctyIstrmtMDTrstFeePct;
         public string SctyIstrmtMDTrstFeePct { get { return _sctyIstrmtMDTrstFeePct; } set { _sctyIstrmtMDTrstFeePct = value; } }
-        private Value<string> _sctyIstrmtMSTrstFeePct;
+        private DirtyValue<string> _sctyIstrmtMSTrstFeePct;
         public string SctyIstrmtMSTrstFeePct { get { return _sctyIstrmtMSTrstFeePct; } set { _sctyIstrmtMSTrstFeePct = value; } }
-        private Value<string> _sctyIstrmtNCAttyFeePct;
+        private DirtyValue<string> _sctyIstrmtNCAttyFeePct;
         public string SctyIstrmtNCAttyFeePct { get { return _sctyIstrmtNCAttyFeePct; } set { _sctyIstrmtNCAttyFeePct = value; } }
-        private Value<string> _sctyIstrmtNETrstFeePct;
+        private DirtyValue<string> _sctyIstrmtNETrstFeePct;
         public string SctyIstrmtNETrstFeePct { get { return _sctyIstrmtNETrstFeePct; } set { _sctyIstrmtNETrstFeePct = value; } }
-        private Value<string> _sctyIstrmtNVAssmFeeAmt;
+        private DirtyValue<string> _sctyIstrmtNVAssmFeeAmt;
         public string SctyIstrmtNVAssmFeeAmt { get { return _sctyIstrmtNVAssmFeeAmt; } set { _sctyIstrmtNVAssmFeeAmt = value; } }
-        private Value<string> _sctyIstrmtNVTrstFeePct;
+        private DirtyValue<string> _sctyIstrmtNVTrstFeePct;
         public string SctyIstrmtNVTrstFeePct { get { return _sctyIstrmtNVTrstFeePct; } set { _sctyIstrmtNVTrstFeePct = value; } }
-        private Value<string> _sctyIstrmtOKAssmFeeAmt;
+        private DirtyValue<string> _sctyIstrmtOKAssmFeeAmt;
         public string SctyIstrmtOKAssmFeeAmt { get { return _sctyIstrmtOKAssmFeeAmt; } set { _sctyIstrmtOKAssmFeeAmt = value; } }
-        private Value<string> _sctyIstrmtPOBoxAddr1;
+        private DirtyValue<string> _sctyIstrmtPOBoxAddr1;
         public string SctyIstrmtPOBoxAddr1 { get { return _sctyIstrmtPOBoxAddr1; } set { _sctyIstrmtPOBoxAddr1 = value; } }
-        private Value<string> _sctyIstrmtPOBoxAddr2;
+        private DirtyValue<string> _sctyIstrmtPOBoxAddr2;
         public string SctyIstrmtPOBoxAddr2 { get { return _sctyIstrmtPOBoxAddr2; } set { _sctyIstrmtPOBoxAddr2 = value; } }
-        private Value<string> _sctyIstrmtPrepByAdtlTxt;
+        private DirtyValue<string> _sctyIstrmtPrepByAdtlTxt;
         public string SctyIstrmtPrepByAdtlTxt { get { return _sctyIstrmtPrepByAdtlTxt; } set { _sctyIstrmtPrepByAdtlTxt = value; } }
-        private Value<string> _sctyIstrmtPrepByCoNm;
+        private DirtyValue<string> _sctyIstrmtPrepByCoNm;
         public string SctyIstrmtPrepByCoNm { get { return _sctyIstrmtPrepByCoNm; } set { _sctyIstrmtPrepByCoNm = value; } }
-        private Value<string> _sctyIstrmtPrepByCty;
+        private DirtyValue<string> _sctyIstrmtPrepByCty;
         public string SctyIstrmtPrepByCty { get { return _sctyIstrmtPrepByCty; } set { _sctyIstrmtPrepByCty = value; } }
-        private Value<string> _sctyIstrmtPrepByIndvNm;
+        private DirtyValue<string> _sctyIstrmtPrepByIndvNm;
         public string SctyIstrmtPrepByIndvNm { get { return _sctyIstrmtPrepByIndvNm; } set { _sctyIstrmtPrepByIndvNm = value; } }
-        private Value<string> _sctyIstrmtPrepByIndvTtl;
+        private DirtyValue<string> _sctyIstrmtPrepByIndvTtl;
         public string SctyIstrmtPrepByIndvTtl { get { return _sctyIstrmtPrepByIndvTtl; } set { _sctyIstrmtPrepByIndvTtl = value; } }
-        private Value<string> _sctyIstrmtPrepByPhone;
+        private DirtyValue<string> _sctyIstrmtPrepByPhone;
         public string SctyIstrmtPrepByPhone { get { return _sctyIstrmtPrepByPhone; } set { _sctyIstrmtPrepByPhone = value; } }
-        private Value<string> _sctyIstrmtPrepBySamePtyTypDesc;
+        private DirtyValue<string> _sctyIstrmtPrepBySamePtyTypDesc;
         public string SctyIstrmtPrepBySamePtyTypDesc { get { return _sctyIstrmtPrepBySamePtyTypDesc; } set { _sctyIstrmtPrepBySamePtyTypDesc = value; } }
-        private Value<string> _sctyIstrmtPrepByStCd;
+        private DirtyValue<string> _sctyIstrmtPrepByStCd;
         public string SctyIstrmtPrepByStCd { get { return _sctyIstrmtPrepByStCd; } set { _sctyIstrmtPrepByStCd = value; } }
-        private Value<string> _sctyIstrmtPrepByStreetAddr1;
+        private DirtyValue<string> _sctyIstrmtPrepByStreetAddr1;
         public string SctyIstrmtPrepByStreetAddr1 { get { return _sctyIstrmtPrepByStreetAddr1; } set { _sctyIstrmtPrepByStreetAddr1 = value; } }
-        private Value<string> _sctyIstrmtPrepByStreetAddr2;
+        private DirtyValue<string> _sctyIstrmtPrepByStreetAddr2;
         public string SctyIstrmtPrepByStreetAddr2 { get { return _sctyIstrmtPrepByStreetAddr2; } set { _sctyIstrmtPrepByStreetAddr2 = value; } }
-        private Value<string> _sctyIstrmtPrepByTxt;
+        private DirtyValue<string> _sctyIstrmtPrepByTxt;
         public string SctyIstrmtPrepByTxt { get { return _sctyIstrmtPrepByTxt; } set { _sctyIstrmtPrepByTxt = value; } }
-        private Value<string> _sctyIstrmtPrepByZip;
+        private DirtyValue<string> _sctyIstrmtPrepByZip;
         public string SctyIstrmtPrepByZip { get { return _sctyIstrmtPrepByZip; } set { _sctyIstrmtPrepByZip = value; } }
-        private Value<string> _sctyIstrmtTtlAdtlTxt;
+        private DirtyValue<string> _sctyIstrmtTtlAdtlTxt;
         public string SctyIstrmtTtlAdtlTxt { get { return _sctyIstrmtTtlAdtlTxt; } set { _sctyIstrmtTtlAdtlTxt = value; } }
-        private Value<bool?> _sctyIstrmtTtlAdtlTxtAbvTtl;
+        private DirtyValue<bool?> _sctyIstrmtTtlAdtlTxtAbvTtl;
         public bool? SctyIstrmtTtlAdtlTxtAbvTtl { get { return _sctyIstrmtTtlAdtlTxtAbvTtl; } set { _sctyIstrmtTtlAdtlTxtAbvTtl = value; } }
-        private Value<string> _sctyIstrmtVATrstFeePct;
+        private DirtyValue<string> _sctyIstrmtVATrstFeePct;
         public string SctyIstrmtVATrstFeePct { get { return _sctyIstrmtVATrstFeePct; } set { _sctyIstrmtVATrstFeePct = value; } }
-        private Value<string> _trst1Cnty;
+        private DirtyValue<string> _trst1Cnty;
         public string Trst1Cnty { get { return _trst1Cnty; } set { _trst1Cnty = value; } }
-        private Value<string> _trst1Cty;
+        private DirtyValue<string> _trst1Cty;
         public string Trst1Cty { get { return _trst1Cty; } set { _trst1Cty = value; } }
-        private Value<bool?> _trst1IndvBool;
+        private DirtyValue<bool?> _trst1IndvBool;
         public bool? Trst1IndvBool { get { return _trst1IndvBool; } set { _trst1IndvBool = value; } }
-        private Value<string> _trst1Jrsdctn;
+        private DirtyValue<string> _trst1Jrsdctn;
         public string Trst1Jrsdctn { get { return _trst1Jrsdctn; } set { _trst1Jrsdctn = value; } }
-        private Value<string> _trst1Nm;
+        private DirtyValue<string> _trst1Nm;
         public string Trst1Nm { get { return _trst1Nm; } set { _trst1Nm = value; } }
-        private Value<string> _trst1OrgTyp;
+        private DirtyValue<string> _trst1OrgTyp;
         public string Trst1OrgTyp { get { return _trst1OrgTyp; } set { _trst1OrgTyp = value; } }
-        private Value<string> _trst1Phone;
+        private DirtyValue<string> _trst1Phone;
         public string Trst1Phone { get { return _trst1Phone; } set { _trst1Phone = value; } }
-        private Value<string> _trst1RsdtTxtDesc;
+        private DirtyValue<string> _trst1RsdtTxtDesc;
         public string Trst1RsdtTxtDesc { get { return _trst1RsdtTxtDesc; } set { _trst1RsdtTxtDesc = value; } }
-        private Value<string> _trst1SamePtyTypDesc;
+        private DirtyValue<string> _trst1SamePtyTypDesc;
         public string Trst1SamePtyTypDesc { get { return _trst1SamePtyTypDesc; } set { _trst1SamePtyTypDesc = value; } }
-        private Value<string> _trst1StCd;
+        private DirtyValue<string> _trst1StCd;
         public string Trst1StCd { get { return _trst1StCd; } set { _trst1StCd = value; } }
-        private Value<string> _trst1StreetAddr1;
+        private DirtyValue<string> _trst1StreetAddr1;
         public string Trst1StreetAddr1 { get { return _trst1StreetAddr1; } set { _trst1StreetAddr1 = value; } }
-        private Value<string> _trst1StreetAddr2;
+        private DirtyValue<string> _trst1StreetAddr2;
         public string Trst1StreetAddr2 { get { return _trst1StreetAddr2; } set { _trst1StreetAddr2 = value; } }
-        private Value<string> _trst1Zip;
+        private DirtyValue<string> _trst1Zip;
         public string Trst1Zip { get { return _trst1Zip; } set { _trst1Zip = value; } }
-        private Value<string> _trst2Cnty;
+        private DirtyValue<string> _trst2Cnty;
         public string Trst2Cnty { get { return _trst2Cnty; } set { _trst2Cnty = value; } }
-        private Value<string> _trst2Cty;
+        private DirtyValue<string> _trst2Cty;
         public string Trst2Cty { get { return _trst2Cty; } set { _trst2Cty = value; } }
-        private Value<bool?> _trst2IndvBool;
+        private DirtyValue<bool?> _trst2IndvBool;
         public bool? Trst2IndvBool { get { return _trst2IndvBool; } set { _trst2IndvBool = value; } }
-        private Value<string> _trst2Jrsdctn;
+        private DirtyValue<string> _trst2Jrsdctn;
         public string Trst2Jrsdctn { get { return _trst2Jrsdctn; } set { _trst2Jrsdctn = value; } }
-        private Value<string> _trst2Nm;
+        private DirtyValue<string> _trst2Nm;
         public string Trst2Nm { get { return _trst2Nm; } set { _trst2Nm = value; } }
-        private Value<string> _trst2OrgTyp;
+        private DirtyValue<string> _trst2OrgTyp;
         public string Trst2OrgTyp { get { return _trst2OrgTyp; } set { _trst2OrgTyp = value; } }
-        private Value<string> _trst2Phone;
+        private DirtyValue<string> _trst2Phone;
         public string Trst2Phone { get { return _trst2Phone; } set { _trst2Phone = value; } }
-        private Value<string> _trst2RsdtTxtDesc;
+        private DirtyValue<string> _trst2RsdtTxtDesc;
         public string Trst2RsdtTxtDesc { get { return _trst2RsdtTxtDesc; } set { _trst2RsdtTxtDesc = value; } }
-        private Value<string> _trst2SamePtyTypDesc;
+        private DirtyValue<string> _trst2SamePtyTypDesc;
         public string Trst2SamePtyTypDesc { get { return _trst2SamePtyTypDesc; } set { _trst2SamePtyTypDesc = value; } }
-        private Value<string> _trst2StCd;
+        private DirtyValue<string> _trst2StCd;
         public string Trst2StCd { get { return _trst2StCd; } set { _trst2StCd = value; } }
-        private Value<string> _trst2StreetAddr1;
+        private DirtyValue<string> _trst2StreetAddr1;
         public string Trst2StreetAddr1 { get { return _trst2StreetAddr1; } set { _trst2StreetAddr1 = value; } }
-        private Value<string> _trst2StreetAddr2;
+        private DirtyValue<string> _trst2StreetAddr2;
         public string Trst2StreetAddr2 { get { return _trst2StreetAddr2; } set { _trst2StreetAddr2 = value; } }
-        private Value<string> _trst2Zip;
+        private DirtyValue<string> _trst2Zip;
         public string Trst2Zip { get { return _trst2Zip; } set { _trst2Zip = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EmDocumentInvestor.cs
+++ b/src/EncompassRest/Loans/EmDocumentInvestor.cs
@@ -8,183 +8,183 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EmDocumentInvestor : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _invAsgnCty;
+        private DirtyValue<string> _invAsgnCty;
         public string InvAsgnCty { get { return _invAsgnCty; } set { _invAsgnCty = value; } }
-        private Value<string> _invAsgnJrsdctn;
+        private DirtyValue<string> _invAsgnJrsdctn;
         public string InvAsgnJrsdctn { get { return _invAsgnJrsdctn; } set { _invAsgnJrsdctn = value; } }
-        private Value<string> _invAsgnNm;
+        private DirtyValue<string> _invAsgnNm;
         public string InvAsgnNm { get { return _invAsgnNm; } set { _invAsgnNm = value; } }
-        private Value<string> _invAsgnOrgTyp;
+        private DirtyValue<string> _invAsgnOrgTyp;
         public string InvAsgnOrgTyp { get { return _invAsgnOrgTyp; } set { _invAsgnOrgTyp = value; } }
-        private Value<string> _invAsgnStCd;
+        private DirtyValue<string> _invAsgnStCd;
         public string InvAsgnStCd { get { return _invAsgnStCd; } set { _invAsgnStCd = value; } }
-        private Value<string> _invAsgnStreetAddr1;
+        private DirtyValue<string> _invAsgnStreetAddr1;
         public string InvAsgnStreetAddr1 { get { return _invAsgnStreetAddr1; } set { _invAsgnStreetAddr1 = value; } }
-        private Value<string> _invAsgnStreetAddr2;
+        private DirtyValue<string> _invAsgnStreetAddr2;
         public string InvAsgnStreetAddr2 { get { return _invAsgnStreetAddr2; } set { _invAsgnStreetAddr2 = value; } }
-        private Value<string> _invAsgnZip;
+        private DirtyValue<string> _invAsgnZip;
         public string InvAsgnZip { get { return _invAsgnZip; } set { _invAsgnZip = value; } }
-        private Value<string> _invCty;
+        private DirtyValue<string> _invCty;
         public string InvCty { get { return _invCty; } set { _invCty = value; } }
-        private Value<string> _invFaxNum;
+        private DirtyValue<string> _invFaxNum;
         public string InvFaxNum { get { return _invFaxNum; } set { _invFaxNum = value; } }
-        private Value<string> _invJrsdctn;
+        private DirtyValue<string> _invJrsdctn;
         public string InvJrsdctn { get { return _invJrsdctn; } set { _invJrsdctn = value; } }
-        private Value<string> _invLossPayeeAdtlTxt;
+        private DirtyValue<string> _invLossPayeeAdtlTxt;
         public string InvLossPayeeAdtlTxt { get { return _invLossPayeeAdtlTxt; } set { _invLossPayeeAdtlTxt = value; } }
-        private Value<string> _invLossPayeeCntctEmail;
+        private DirtyValue<string> _invLossPayeeCntctEmail;
         public string InvLossPayeeCntctEmail { get { return _invLossPayeeCntctEmail; } set { _invLossPayeeCntctEmail = value; } }
-        private Value<string> _invLossPayeeCntctFax;
+        private DirtyValue<string> _invLossPayeeCntctFax;
         public string InvLossPayeeCntctFax { get { return _invLossPayeeCntctFax; } set { _invLossPayeeCntctFax = value; } }
-        private Value<string> _invLossPayeeCntctNm;
+        private DirtyValue<string> _invLossPayeeCntctNm;
         public string InvLossPayeeCntctNm { get { return _invLossPayeeCntctNm; } set { _invLossPayeeCntctNm = value; } }
-        private Value<string> _invLossPayeeCntctPhone;
+        private DirtyValue<string> _invLossPayeeCntctPhone;
         public string InvLossPayeeCntctPhone { get { return _invLossPayeeCntctPhone; } set { _invLossPayeeCntctPhone = value; } }
-        private Value<string> _invLossPayeeCty;
+        private DirtyValue<string> _invLossPayeeCty;
         public string InvLossPayeeCty { get { return _invLossPayeeCty; } set { _invLossPayeeCty = value; } }
-        private Value<string> _invLossPayeeJrsdctn;
+        private DirtyValue<string> _invLossPayeeJrsdctn;
         public string InvLossPayeeJrsdctn { get { return _invLossPayeeJrsdctn; } set { _invLossPayeeJrsdctn = value; } }
-        private Value<string> _invLossPayeeNm;
+        private DirtyValue<string> _invLossPayeeNm;
         public string InvLossPayeeNm { get { return _invLossPayeeNm; } set { _invLossPayeeNm = value; } }
-        private Value<string> _invLossPayeeOrgTyp;
+        private DirtyValue<string> _invLossPayeeOrgTyp;
         public string InvLossPayeeOrgTyp { get { return _invLossPayeeOrgTyp; } set { _invLossPayeeOrgTyp = value; } }
-        private Value<string> _invLossPayeeScsrClausTxtDesc;
+        private DirtyValue<string> _invLossPayeeScsrClausTxtDesc;
         public string InvLossPayeeScsrClausTxtDesc { get { return _invLossPayeeScsrClausTxtDesc; } set { _invLossPayeeScsrClausTxtDesc = value; } }
-        private Value<string> _invLossPayeeStCd;
+        private DirtyValue<string> _invLossPayeeStCd;
         public string InvLossPayeeStCd { get { return _invLossPayeeStCd; } set { _invLossPayeeStCd = value; } }
-        private Value<string> _invLossPayeeStreetAddr1;
+        private DirtyValue<string> _invLossPayeeStreetAddr1;
         public string InvLossPayeeStreetAddr1 { get { return _invLossPayeeStreetAddr1; } set { _invLossPayeeStreetAddr1 = value; } }
-        private Value<string> _invLossPayeeStreetAddr2;
+        private DirtyValue<string> _invLossPayeeStreetAddr2;
         public string InvLossPayeeStreetAddr2 { get { return _invLossPayeeStreetAddr2; } set { _invLossPayeeStreetAddr2 = value; } }
-        private Value<string> _invLossPayeeZip;
+        private DirtyValue<string> _invLossPayeeZip;
         public string InvLossPayeeZip { get { return _invLossPayeeZip; } set { _invLossPayeeZip = value; } }
-        private Value<string> _invNm;
+        private DirtyValue<string> _invNm;
         public string InvNm { get { return _invNm; } set { _invNm = value; } }
-        private Value<string> _invOrgTyp;
+        private DirtyValue<string> _invOrgTyp;
         public string InvOrgTyp { get { return _invOrgTyp; } set { _invOrgTyp = value; } }
-        private Value<string> _invPhoneNum;
+        private DirtyValue<string> _invPhoneNum;
         public string InvPhoneNum { get { return _invPhoneNum; } set { _invPhoneNum = value; } }
-        private Value<string> _invPmtCpn2PayToAdtlTxt;
+        private DirtyValue<string> _invPmtCpn2PayToAdtlTxt;
         public string InvPmtCpn2PayToAdtlTxt { get { return _invPmtCpn2PayToAdtlTxt; } set { _invPmtCpn2PayToAdtlTxt = value; } }
-        private Value<string> _invPmtCpn2PayToAdtlTxt2;
+        private DirtyValue<string> _invPmtCpn2PayToAdtlTxt2;
         public string InvPmtCpn2PayToAdtlTxt2 { get { return _invPmtCpn2PayToAdtlTxt2; } set { _invPmtCpn2PayToAdtlTxt2 = value; } }
-        private Value<string> _invPmtCpn2PayToCty;
+        private DirtyValue<string> _invPmtCpn2PayToCty;
         public string InvPmtCpn2PayToCty { get { return _invPmtCpn2PayToCty; } set { _invPmtCpn2PayToCty = value; } }
-        private Value<string> _invPmtCpn2PayToNm;
+        private DirtyValue<string> _invPmtCpn2PayToNm;
         public string InvPmtCpn2PayToNm { get { return _invPmtCpn2PayToNm; } set { _invPmtCpn2PayToNm = value; } }
-        private Value<string> _invPmtCpn2PayToStCd;
+        private DirtyValue<string> _invPmtCpn2PayToStCd;
         public string InvPmtCpn2PayToStCd { get { return _invPmtCpn2PayToStCd; } set { _invPmtCpn2PayToStCd = value; } }
-        private Value<string> _invPmtCpn2PayToStreetAddr1;
+        private DirtyValue<string> _invPmtCpn2PayToStreetAddr1;
         public string InvPmtCpn2PayToStreetAddr1 { get { return _invPmtCpn2PayToStreetAddr1; } set { _invPmtCpn2PayToStreetAddr1 = value; } }
-        private Value<string> _invPmtCpn2PayToStreetAddr2;
+        private DirtyValue<string> _invPmtCpn2PayToStreetAddr2;
         public string InvPmtCpn2PayToStreetAddr2 { get { return _invPmtCpn2PayToStreetAddr2; } set { _invPmtCpn2PayToStreetAddr2 = value; } }
-        private Value<string> _invPmtCpn2PayToZip;
+        private DirtyValue<string> _invPmtCpn2PayToZip;
         public string InvPmtCpn2PayToZip { get { return _invPmtCpn2PayToZip; } set { _invPmtCpn2PayToZip = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToAdtlTxt;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToAdtlTxt;
         public string InvPmtCpnLoanTrsfToAdtlTxt { get { return _invPmtCpnLoanTrsfToAdtlTxt; } set { _invPmtCpnLoanTrsfToAdtlTxt = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToCty;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToCty;
         public string InvPmtCpnLoanTrsfToCty { get { return _invPmtCpnLoanTrsfToCty; } set { _invPmtCpnLoanTrsfToCty = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToNm;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToNm;
         public string InvPmtCpnLoanTrsfToNm { get { return _invPmtCpnLoanTrsfToNm; } set { _invPmtCpnLoanTrsfToNm = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToStCd;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToStCd;
         public string InvPmtCpnLoanTrsfToStCd { get { return _invPmtCpnLoanTrsfToStCd; } set { _invPmtCpnLoanTrsfToStCd = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToStreetAddr1;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToStreetAddr1;
         public string InvPmtCpnLoanTrsfToStreetAddr1 { get { return _invPmtCpnLoanTrsfToStreetAddr1; } set { _invPmtCpnLoanTrsfToStreetAddr1 = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToStreetAddr2;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToStreetAddr2;
         public string InvPmtCpnLoanTrsfToStreetAddr2 { get { return _invPmtCpnLoanTrsfToStreetAddr2; } set { _invPmtCpnLoanTrsfToStreetAddr2 = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcAdtlTxt;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcAdtlTxt;
         public string InvPmtCpnLoanTrsfToSvcAdtlTxt { get { return _invPmtCpnLoanTrsfToSvcAdtlTxt; } set { _invPmtCpnLoanTrsfToSvcAdtlTxt = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcCty;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcCty;
         public string InvPmtCpnLoanTrsfToSvcCty { get { return _invPmtCpnLoanTrsfToSvcCty; } set { _invPmtCpnLoanTrsfToSvcCty = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcNm;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcNm;
         public string InvPmtCpnLoanTrsfToSvcNm { get { return _invPmtCpnLoanTrsfToSvcNm; } set { _invPmtCpnLoanTrsfToSvcNm = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcStCd;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcStCd;
         public string InvPmtCpnLoanTrsfToSvcStCd { get { return _invPmtCpnLoanTrsfToSvcStCd; } set { _invPmtCpnLoanTrsfToSvcStCd = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcStreetAddr1;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcStreetAddr1;
         public string InvPmtCpnLoanTrsfToSvcStreetAddr1 { get { return _invPmtCpnLoanTrsfToSvcStreetAddr1; } set { _invPmtCpnLoanTrsfToSvcStreetAddr1 = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcStreetAddr2;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcStreetAddr2;
         public string InvPmtCpnLoanTrsfToSvcStreetAddr2 { get { return _invPmtCpnLoanTrsfToSvcStreetAddr2; } set { _invPmtCpnLoanTrsfToSvcStreetAddr2 = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToSvcZip;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToSvcZip;
         public string InvPmtCpnLoanTrsfToSvcZip { get { return _invPmtCpnLoanTrsfToSvcZip; } set { _invPmtCpnLoanTrsfToSvcZip = value; } }
-        private Value<string> _invPmtCpnLoanTrsfToZip;
+        private DirtyValue<string> _invPmtCpnLoanTrsfToZip;
         public string InvPmtCpnLoanTrsfToZip { get { return _invPmtCpnLoanTrsfToZip; } set { _invPmtCpnLoanTrsfToZip = value; } }
-        private Value<string> _invPmtCpnPayToAdtlTxt;
+        private DirtyValue<string> _invPmtCpnPayToAdtlTxt;
         public string InvPmtCpnPayToAdtlTxt { get { return _invPmtCpnPayToAdtlTxt; } set { _invPmtCpnPayToAdtlTxt = value; } }
-        private Value<string> _invPmtCpnPayToAdtlTxt2;
+        private DirtyValue<string> _invPmtCpnPayToAdtlTxt2;
         public string InvPmtCpnPayToAdtlTxt2 { get { return _invPmtCpnPayToAdtlTxt2; } set { _invPmtCpnPayToAdtlTxt2 = value; } }
-        private Value<string> _invPmtCpnPayToCty;
+        private DirtyValue<string> _invPmtCpnPayToCty;
         public string InvPmtCpnPayToCty { get { return _invPmtCpnPayToCty; } set { _invPmtCpnPayToCty = value; } }
-        private Value<string> _invPmtCpnPayToNm;
+        private DirtyValue<string> _invPmtCpnPayToNm;
         public string InvPmtCpnPayToNm { get { return _invPmtCpnPayToNm; } set { _invPmtCpnPayToNm = value; } }
-        private Value<string> _invPmtCpnPayToStCd;
+        private DirtyValue<string> _invPmtCpnPayToStCd;
         public string InvPmtCpnPayToStCd { get { return _invPmtCpnPayToStCd; } set { _invPmtCpnPayToStCd = value; } }
-        private Value<string> _invPmtCpnPayToStreetAddr1;
+        private DirtyValue<string> _invPmtCpnPayToStreetAddr1;
         public string InvPmtCpnPayToStreetAddr1 { get { return _invPmtCpnPayToStreetAddr1; } set { _invPmtCpnPayToStreetAddr1 = value; } }
-        private Value<string> _invPmtCpnPayToStreetAddr2;
+        private DirtyValue<string> _invPmtCpnPayToStreetAddr2;
         public string InvPmtCpnPayToStreetAddr2 { get { return _invPmtCpnPayToStreetAddr2; } set { _invPmtCpnPayToStreetAddr2 = value; } }
-        private Value<string> _invPmtCpnPayToZip;
+        private DirtyValue<string> _invPmtCpnPayToZip;
         public string InvPmtCpnPayToZip { get { return _invPmtCpnPayToZip; } set { _invPmtCpnPayToZip = value; } }
-        private Value<string> _invStCd;
+        private DirtyValue<string> _invStCd;
         public string InvStCd { get { return _invStCd; } set { _invStCd = value; } }
-        private Value<string> _invStreetAddr1;
+        private DirtyValue<string> _invStreetAddr1;
         public string InvStreetAddr1 { get { return _invStreetAddr1; } set { _invStreetAddr1 = value; } }
-        private Value<string> _invStreetAddr2;
+        private DirtyValue<string> _invStreetAddr2;
         public string InvStreetAddr2 { get { return _invStreetAddr2; } set { _invStreetAddr2 = value; } }
-        private Value<string> _invSvcrAdtlTxt;
+        private DirtyValue<string> _invSvcrAdtlTxt;
         public string InvSvcrAdtlTxt { get { return _invSvcrAdtlTxt; } set { _invSvcrAdtlTxt = value; } }
-        private Value<string> _invSvcrCntctNm;
+        private DirtyValue<string> _invSvcrCntctNm;
         public string InvSvcrCntctNm { get { return _invSvcrCntctNm; } set { _invSvcrCntctNm = value; } }
-        private Value<string> _invSvcrCntctPhoneNum;
+        private DirtyValue<string> _invSvcrCntctPhoneNum;
         public string InvSvcrCntctPhoneNum { get { return _invSvcrCntctPhoneNum; } set { _invSvcrCntctPhoneNum = value; } }
-        private Value<string> _invSvcrCntctTollFreePhoneNum;
+        private DirtyValue<string> _invSvcrCntctTollFreePhoneNum;
         public string InvSvcrCntctTollFreePhoneNum { get { return _invSvcrCntctTollFreePhoneNum; } set { _invSvcrCntctTollFreePhoneNum = value; } }
-        private Value<string> _invSvcrCty;
+        private DirtyValue<string> _invSvcrCty;
         public string InvSvcrCty { get { return _invSvcrCty; } set { _invSvcrCty = value; } }
-        private Value<string> _invSvcrDayOp;
+        private DirtyValue<string> _invSvcrDayOp;
         public string InvSvcrDayOp { get { return _invSvcrDayOp; } set { _invSvcrDayOp = value; } }
-        private Value<string> _invSvcrDayOpAddl;
+        private DirtyValue<string> _invSvcrDayOpAddl;
         public string InvSvcrDayOpAddl { get { return _invSvcrDayOpAddl; } set { _invSvcrDayOpAddl = value; } }
-        private Value<string> _invSvcrHrsOp;
+        private DirtyValue<string> _invSvcrHrsOp;
         public string InvSvcrHrsOp { get { return _invSvcrHrsOp; } set { _invSvcrHrsOp = value; } }
-        private Value<string> _invSvcrHrsOpAddl;
+        private DirtyValue<string> _invSvcrHrsOpAddl;
         public string InvSvcrHrsOpAddl { get { return _invSvcrHrsOpAddl; } set { _invSvcrHrsOpAddl = value; } }
-        private Value<string> _invSvcrJrsdctn;
+        private DirtyValue<string> _invSvcrJrsdctn;
         public string InvSvcrJrsdctn { get { return _invSvcrJrsdctn; } set { _invSvcrJrsdctn = value; } }
-        private Value<string> _invSvcrNm;
+        private DirtyValue<string> _invSvcrNm;
         public string InvSvcrNm { get { return _invSvcrNm; } set { _invSvcrNm = value; } }
-        private Value<string> _invSvcrOrgTyp;
+        private DirtyValue<string> _invSvcrOrgTyp;
         public string InvSvcrOrgTyp { get { return _invSvcrOrgTyp; } set { _invSvcrOrgTyp = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToAdtlTxt;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToAdtlTxt;
         public string InvSvcrQlfdWrtnRqstMailToAdtlTxt { get { return _invSvcrQlfdWrtnRqstMailToAdtlTxt; } set { _invSvcrQlfdWrtnRqstMailToAdtlTxt = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToCty;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToCty;
         public string InvSvcrQlfdWrtnRqstMailToCty { get { return _invSvcrQlfdWrtnRqstMailToCty; } set { _invSvcrQlfdWrtnRqstMailToCty = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToNm;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToNm;
         public string InvSvcrQlfdWrtnRqstMailToNm { get { return _invSvcrQlfdWrtnRqstMailToNm; } set { _invSvcrQlfdWrtnRqstMailToNm = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToStCd;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToStCd;
         public string InvSvcrQlfdWrtnRqstMailToStCd { get { return _invSvcrQlfdWrtnRqstMailToStCd; } set { _invSvcrQlfdWrtnRqstMailToStCd = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToStreetAddr1;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToStreetAddr1;
         public string InvSvcrQlfdWrtnRqstMailToStreetAddr1 { get { return _invSvcrQlfdWrtnRqstMailToStreetAddr1; } set { _invSvcrQlfdWrtnRqstMailToStreetAddr1 = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToStreetAddr2;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToStreetAddr2;
         public string InvSvcrQlfdWrtnRqstMailToStreetAddr2 { get { return _invSvcrQlfdWrtnRqstMailToStreetAddr2; } set { _invSvcrQlfdWrtnRqstMailToStreetAddr2 = value; } }
-        private Value<string> _invSvcrQlfdWrtnRqstMailToZip;
+        private DirtyValue<string> _invSvcrQlfdWrtnRqstMailToZip;
         public string InvSvcrQlfdWrtnRqstMailToZip { get { return _invSvcrQlfdWrtnRqstMailToZip; } set { _invSvcrQlfdWrtnRqstMailToZip = value; } }
-        private Value<string> _invSvcrStCd;
+        private DirtyValue<string> _invSvcrStCd;
         public string InvSvcrStCd { get { return _invSvcrStCd; } set { _invSvcrStCd = value; } }
-        private Value<string> _invSvcrStreetAddr1;
+        private DirtyValue<string> _invSvcrStreetAddr1;
         public string InvSvcrStreetAddr1 { get { return _invSvcrStreetAddr1; } set { _invSvcrStreetAddr1 = value; } }
-        private Value<string> _invSvcrStreetAddr2;
+        private DirtyValue<string> _invSvcrStreetAddr2;
         public string InvSvcrStreetAddr2 { get { return _invSvcrStreetAddr2; } set { _invSvcrStreetAddr2 = value; } }
-        private Value<string> _invSvcrZip;
+        private DirtyValue<string> _invSvcrZip;
         public string InvSvcrZip { get { return _invSvcrZip; } set { _invSvcrZip = value; } }
-        private Value<string> _invTaxIDNum;
+        private DirtyValue<string> _invTaxIDNum;
         public string InvTaxIDNum { get { return _invTaxIDNum; } set { _invTaxIDNum = value; } }
-        private Value<string> _invTollFreePhoneNum;
+        private DirtyValue<string> _invTollFreePhoneNum;
         public string InvTollFreePhoneNum { get { return _invTollFreePhoneNum; } set { _invTollFreePhoneNum = value; } }
-        private Value<string> _invUrl;
+        private DirtyValue<string> _invUrl;
         public string InvUrl { get { return _invUrl; } set { _invUrl = value; } }
-        private Value<string> _invZip;
+        private DirtyValue<string> _invZip;
         public string InvZip { get { return _invZip; } set { _invZip = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EmDocumentLender.cs
+++ b/src/EncompassRest/Loans/EmDocumentLender.cs
@@ -8,153 +8,153 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EmDocumentLender : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lndBrchCty;
+        private DirtyValue<string> _lndBrchCty;
         public string LndBrchCty { get { return _lndBrchCty; } set { _lndBrchCty = value; } }
-        private Value<string> _lndBrchFax;
+        private DirtyValue<string> _lndBrchFax;
         public string LndBrchFax { get { return _lndBrchFax; } set { _lndBrchFax = value; } }
-        private Value<string> _lndBrchJrsdctn;
+        private DirtyValue<string> _lndBrchJrsdctn;
         public string LndBrchJrsdctn { get { return _lndBrchJrsdctn; } set { _lndBrchJrsdctn = value; } }
-        private Value<string> _lndBrchNm;
+        private DirtyValue<string> _lndBrchNm;
         public string LndBrchNm { get { return _lndBrchNm; } set { _lndBrchNm = value; } }
-        private Value<string> _lndBrchOrgTyp;
+        private DirtyValue<string> _lndBrchOrgTyp;
         public string LndBrchOrgTyp { get { return _lndBrchOrgTyp; } set { _lndBrchOrgTyp = value; } }
-        private Value<string> _lndBrchPhone;
+        private DirtyValue<string> _lndBrchPhone;
         public string LndBrchPhone { get { return _lndBrchPhone; } set { _lndBrchPhone = value; } }
-        private Value<string> _lndBrchStCd;
+        private DirtyValue<string> _lndBrchStCd;
         public string LndBrchStCd { get { return _lndBrchStCd; } set { _lndBrchStCd = value; } }
-        private Value<string> _lndBrchStreetAddr1;
+        private DirtyValue<string> _lndBrchStreetAddr1;
         public string LndBrchStreetAddr1 { get { return _lndBrchStreetAddr1; } set { _lndBrchStreetAddr1 = value; } }
-        private Value<string> _lndBrchStreetAddr2;
+        private DirtyValue<string> _lndBrchStreetAddr2;
         public string LndBrchStreetAddr2 { get { return _lndBrchStreetAddr2; } set { _lndBrchStreetAddr2 = value; } }
-        private Value<string> _lndBrchTollFreePhone;
+        private DirtyValue<string> _lndBrchTollFreePhone;
         public string LndBrchTollFreePhone { get { return _lndBrchTollFreePhone; } set { _lndBrchTollFreePhone = value; } }
-        private Value<string> _lndBrchUrl;
+        private DirtyValue<string> _lndBrchUrl;
         public string LndBrchUrl { get { return _lndBrchUrl; } set { _lndBrchUrl = value; } }
-        private Value<string> _lndBrchZip;
+        private DirtyValue<string> _lndBrchZip;
         public string LndBrchZip { get { return _lndBrchZip; } set { _lndBrchZip = value; } }
-        private Value<string> _lndCnty;
+        private DirtyValue<string> _lndCnty;
         public string LndCnty { get { return _lndCnty; } set { _lndCnty = value; } }
-        private Value<string> _lndCty;
+        private DirtyValue<string> _lndCty;
         public string LndCty { get { return _lndCty; } set { _lndCty = value; } }
-        private Value<string> _lndFaxNum;
+        private DirtyValue<string> _lndFaxNum;
         public string LndFaxNum { get { return _lndFaxNum; } set { _lndFaxNum = value; } }
-        private Value<string> _lndFhaOrgntrId;
+        private DirtyValue<string> _lndFhaOrgntrId;
         public string LndFhaOrgntrId { get { return _lndFhaOrgntrId; } set { _lndFhaOrgntrId = value; } }
-        private Value<string> _lndFhaSpnsrId;
+        private DirtyValue<string> _lndFhaSpnsrId;
         public string LndFhaSpnsrId { get { return _lndFhaSpnsrId; } set { _lndFhaSpnsrId = value; } }
-        private Value<string> _lndJrsdctn;
+        private DirtyValue<string> _lndJrsdctn;
         public string LndJrsdctn { get { return _lndJrsdctn; } set { _lndJrsdctn = value; } }
-        private Value<string> _lndLossPayeeAdtlTxt;
+        private DirtyValue<string> _lndLossPayeeAdtlTxt;
         public string LndLossPayeeAdtlTxt { get { return _lndLossPayeeAdtlTxt; } set { _lndLossPayeeAdtlTxt = value; } }
-        private Value<string> _lndLossPayeeCntctEmail;
+        private DirtyValue<string> _lndLossPayeeCntctEmail;
         public string LndLossPayeeCntctEmail { get { return _lndLossPayeeCntctEmail; } set { _lndLossPayeeCntctEmail = value; } }
-        private Value<string> _lndLossPayeeCntctFax;
+        private DirtyValue<string> _lndLossPayeeCntctFax;
         public string LndLossPayeeCntctFax { get { return _lndLossPayeeCntctFax; } set { _lndLossPayeeCntctFax = value; } }
-        private Value<string> _lndLossPayeeCntctNm;
+        private DirtyValue<string> _lndLossPayeeCntctNm;
         public string LndLossPayeeCntctNm { get { return _lndLossPayeeCntctNm; } set { _lndLossPayeeCntctNm = value; } }
-        private Value<string> _lndLossPayeeCntctPhone;
+        private DirtyValue<string> _lndLossPayeeCntctPhone;
         public string LndLossPayeeCntctPhone { get { return _lndLossPayeeCntctPhone; } set { _lndLossPayeeCntctPhone = value; } }
-        private Value<string> _lndLossPayeeCty;
+        private DirtyValue<string> _lndLossPayeeCty;
         public string LndLossPayeeCty { get { return _lndLossPayeeCty; } set { _lndLossPayeeCty = value; } }
-        private Value<string> _lndLossPayeeJrsdctn;
+        private DirtyValue<string> _lndLossPayeeJrsdctn;
         public string LndLossPayeeJrsdctn { get { return _lndLossPayeeJrsdctn; } set { _lndLossPayeeJrsdctn = value; } }
-        private Value<string> _lndLossPayeeNm;
+        private DirtyValue<string> _lndLossPayeeNm;
         public string LndLossPayeeNm { get { return _lndLossPayeeNm; } set { _lndLossPayeeNm = value; } }
-        private Value<string> _lndLossPayeeOrgTyp;
+        private DirtyValue<string> _lndLossPayeeOrgTyp;
         public string LndLossPayeeOrgTyp { get { return _lndLossPayeeOrgTyp; } set { _lndLossPayeeOrgTyp = value; } }
-        private Value<string> _lndLossPayeeScsrsClausTxtDesc;
+        private DirtyValue<string> _lndLossPayeeScsrsClausTxtDesc;
         public string LndLossPayeeScsrsClausTxtDesc { get { return _lndLossPayeeScsrsClausTxtDesc; } set { _lndLossPayeeScsrsClausTxtDesc = value; } }
-        private Value<string> _lndLossPayeeStCd;
+        private DirtyValue<string> _lndLossPayeeStCd;
         public string LndLossPayeeStCd { get { return _lndLossPayeeStCd; } set { _lndLossPayeeStCd = value; } }
-        private Value<string> _lndLossPayeeStreetAddr1;
+        private DirtyValue<string> _lndLossPayeeStreetAddr1;
         public string LndLossPayeeStreetAddr1 { get { return _lndLossPayeeStreetAddr1; } set { _lndLossPayeeStreetAddr1 = value; } }
-        private Value<string> _lndLossPayeeStreetAddr2;
+        private DirtyValue<string> _lndLossPayeeStreetAddr2;
         public string LndLossPayeeStreetAddr2 { get { return _lndLossPayeeStreetAddr2; } set { _lndLossPayeeStreetAddr2 = value; } }
-        private Value<string> _lndLossPayeeZip;
+        private DirtyValue<string> _lndLossPayeeZip;
         public string LndLossPayeeZip { get { return _lndLossPayeeZip; } set { _lndLossPayeeZip = value; } }
-        private Value<string> _lndMersIdNum;
+        private DirtyValue<string> _lndMersIdNum;
         public string LndMersIdNum { get { return _lndMersIdNum; } set { _lndMersIdNum = value; } }
-        private Value<string> _lndNm;
+        private DirtyValue<string> _lndNm;
         public string LndNm { get { return _lndNm; } set { _lndNm = value; } }
-        private Value<string> _lndNmlsIdNum;
+        private DirtyValue<string> _lndNmlsIdNum;
         public string LndNmlsIdNum { get { return _lndNmlsIdNum; } set { _lndNmlsIdNum = value; } }
-        private Value<string> _lndNtryCmsnBndNumIdntfr;
+        private DirtyValue<string> _lndNtryCmsnBndNumIdntfr;
         public string LndNtryCmsnBndNumIdntfr { get { return _lndNtryCmsnBndNumIdntfr; } set { _lndNtryCmsnBndNumIdntfr = value; } }
-        private Value<string> _lndNtryCmsnCnty;
+        private DirtyValue<string> _lndNtryCmsnCnty;
         public string LndNtryCmsnCnty { get { return _lndNtryCmsnCnty; } set { _lndNtryCmsnCnty = value; } }
-        private Value<DateTime?> _lndNtryCmsnExprDt;
+        private DirtyValue<DateTime?> _lndNtryCmsnExprDt;
         public DateTime? LndNtryCmsnExprDt { get { return _lndNtryCmsnExprDt; } set { _lndNtryCmsnExprDt = value; } }
-        private Value<string> _lndNtryCmsnNumIdntfr;
+        private DirtyValue<string> _lndNtryCmsnNumIdntfr;
         public string LndNtryCmsnNumIdntfr { get { return _lndNtryCmsnNumIdntfr; } set { _lndNtryCmsnNumIdntfr = value; } }
-        private Value<string> _lndNtryCmsnSt;
+        private DirtyValue<string> _lndNtryCmsnSt;
         public string LndNtryCmsnSt { get { return _lndNtryCmsnSt; } set { _lndNtryCmsnSt = value; } }
-        private Value<string> _lndNtryCty;
+        private DirtyValue<string> _lndNtryCty;
         public string LndNtryCty { get { return _lndNtryCty; } set { _lndNtryCty = value; } }
-        private Value<string> _lndNtryNm;
+        private DirtyValue<string> _lndNtryNm;
         public string LndNtryNm { get { return _lndNtryNm; } set { _lndNtryNm = value; } }
-        private Value<string> _lndNtryStCd;
+        private DirtyValue<string> _lndNtryStCd;
         public string LndNtryStCd { get { return _lndNtryStCd; } set { _lndNtryStCd = value; } }
-        private Value<string> _lndNtryStreetAddr1;
+        private DirtyValue<string> _lndNtryStreetAddr1;
         public string LndNtryStreetAddr1 { get { return _lndNtryStreetAddr1; } set { _lndNtryStreetAddr1 = value; } }
-        private Value<string> _lndNtryStreetAddr2;
+        private DirtyValue<string> _lndNtryStreetAddr2;
         public string LndNtryStreetAddr2 { get { return _lndNtryStreetAddr2; } set { _lndNtryStreetAddr2 = value; } }
-        private Value<string> _lndNtryTtlOrRank;
+        private DirtyValue<string> _lndNtryTtlOrRank;
         public string LndNtryTtlOrRank { get { return _lndNtryTtlOrRank; } set { _lndNtryTtlOrRank = value; } }
-        private Value<string> _lndNtryZip;
+        private DirtyValue<string> _lndNtryZip;
         public string LndNtryZip { get { return _lndNtryZip; } set { _lndNtryZip = value; } }
-        private Value<string> _lndOrgTyp;
+        private DirtyValue<string> _lndOrgTyp;
         public string LndOrgTyp { get { return _lndOrgTyp; } set { _lndOrgTyp = value; } }
-        private Value<string> _lndPhoneNum;
+        private DirtyValue<string> _lndPhoneNum;
         public string LndPhoneNum { get { return _lndPhoneNum; } set { _lndPhoneNum = value; } }
-        private Value<string> _lndStCd;
+        private DirtyValue<string> _lndStCd;
         public string LndStCd { get { return _lndStCd; } set { _lndStCd = value; } }
-        private Value<string> _lndStreetAddr1;
+        private DirtyValue<string> _lndStreetAddr1;
         public string LndStreetAddr1 { get { return _lndStreetAddr1; } set { _lndStreetAddr1 = value; } }
-        private Value<string> _lndStreetAddr2;
+        private DirtyValue<string> _lndStreetAddr2;
         public string LndStreetAddr2 { get { return _lndStreetAddr2; } set { _lndStreetAddr2 = value; } }
-        private Value<string> _lndSvcrAdtlTxt;
+        private DirtyValue<string> _lndSvcrAdtlTxt;
         public string LndSvcrAdtlTxt { get { return _lndSvcrAdtlTxt; } set { _lndSvcrAdtlTxt = value; } }
-        private Value<string> _lndSvcrCntctNm;
+        private DirtyValue<string> _lndSvcrCntctNm;
         public string LndSvcrCntctNm { get { return _lndSvcrCntctNm; } set { _lndSvcrCntctNm = value; } }
-        private Value<string> _lndSvcrCntctPhoneNum;
+        private DirtyValue<string> _lndSvcrCntctPhoneNum;
         public string LndSvcrCntctPhoneNum { get { return _lndSvcrCntctPhoneNum; } set { _lndSvcrCntctPhoneNum = value; } }
-        private Value<string> _lndSvcrCntctTollFreePhoneNum;
+        private DirtyValue<string> _lndSvcrCntctTollFreePhoneNum;
         public string LndSvcrCntctTollFreePhoneNum { get { return _lndSvcrCntctTollFreePhoneNum; } set { _lndSvcrCntctTollFreePhoneNum = value; } }
-        private Value<string> _lndSvcrCty;
+        private DirtyValue<string> _lndSvcrCty;
         public string LndSvcrCty { get { return _lndSvcrCty; } set { _lndSvcrCty = value; } }
-        private Value<string> _lndSvcrDayOp;
+        private DirtyValue<string> _lndSvcrDayOp;
         public string LndSvcrDayOp { get { return _lndSvcrDayOp; } set { _lndSvcrDayOp = value; } }
-        private Value<string> _lndSvcrDayOpAddl;
+        private DirtyValue<string> _lndSvcrDayOpAddl;
         public string LndSvcrDayOpAddl { get { return _lndSvcrDayOpAddl; } set { _lndSvcrDayOpAddl = value; } }
-        private Value<string> _lndSvcrHrsOp;
+        private DirtyValue<string> _lndSvcrHrsOp;
         public string LndSvcrHrsOp { get { return _lndSvcrHrsOp; } set { _lndSvcrHrsOp = value; } }
-        private Value<string> _lndSvcrHrsOpAddl;
+        private DirtyValue<string> _lndSvcrHrsOpAddl;
         public string LndSvcrHrsOpAddl { get { return _lndSvcrHrsOpAddl; } set { _lndSvcrHrsOpAddl = value; } }
-        private Value<string> _lndSvcrJrsdctn;
+        private DirtyValue<string> _lndSvcrJrsdctn;
         public string LndSvcrJrsdctn { get { return _lndSvcrJrsdctn; } set { _lndSvcrJrsdctn = value; } }
-        private Value<string> _lndSvcrNm;
+        private DirtyValue<string> _lndSvcrNm;
         public string LndSvcrNm { get { return _lndSvcrNm; } set { _lndSvcrNm = value; } }
-        private Value<string> _lndSvcrOrgTyp;
+        private DirtyValue<string> _lndSvcrOrgTyp;
         public string LndSvcrOrgTyp { get { return _lndSvcrOrgTyp; } set { _lndSvcrOrgTyp = value; } }
-        private Value<string> _lndSvcrStCd;
+        private DirtyValue<string> _lndSvcrStCd;
         public string LndSvcrStCd { get { return _lndSvcrStCd; } set { _lndSvcrStCd = value; } }
-        private Value<string> _lndSvcrStreetAddr1;
+        private DirtyValue<string> _lndSvcrStreetAddr1;
         public string LndSvcrStreetAddr1 { get { return _lndSvcrStreetAddr1; } set { _lndSvcrStreetAddr1 = value; } }
-        private Value<string> _lndSvcrStreetAddr2;
+        private DirtyValue<string> _lndSvcrStreetAddr2;
         public string LndSvcrStreetAddr2 { get { return _lndSvcrStreetAddr2; } set { _lndSvcrStreetAddr2 = value; } }
-        private Value<string> _lndSvcrZip;
+        private DirtyValue<string> _lndSvcrZip;
         public string LndSvcrZip { get { return _lndSvcrZip; } set { _lndSvcrZip = value; } }
-        private Value<string> _lndTaxIDNum;
+        private DirtyValue<string> _lndTaxIDNum;
         public string LndTaxIDNum { get { return _lndTaxIDNum; } set { _lndTaxIDNum = value; } }
-        private Value<string> _lndTollFreePhoneNum;
+        private DirtyValue<string> _lndTollFreePhoneNum;
         public string LndTollFreePhoneNum { get { return _lndTollFreePhoneNum; } set { _lndTollFreePhoneNum = value; } }
-        private Value<string> _lndUrl;
+        private DirtyValue<string> _lndUrl;
         public string LndUrl { get { return _lndUrl; } set { _lndUrl = value; } }
-        private Value<string> _lndVaIdNum;
+        private DirtyValue<string> _lndVaIdNum;
         public string LndVaIdNum { get { return _lndVaIdNum; } set { _lndVaIdNum = value; } }
-        private Value<string> _lndZip;
+        private DirtyValue<string> _lndZip;
         public string LndZip { get { return _lndZip; } set { _lndZip = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EmailTriggerLog.cs
+++ b/src/EncompassRest/Loans/EmailTriggerLog.cs
@@ -8,12 +8,12 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EmailTriggerLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _body;
         public string Body { get { return _body; } set { _body = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -45,9 +45,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _body.Dirty
-                    || _commentList.Dirty
+                var dirty = _body.Dirty
                     || _comments.Dirty
                     || _dateUtc.Dirty
                     || _fileAttachmentsMigrated.Dirty
@@ -59,16 +57,16 @@ namespace EncompassRest.Loans
                     || _recipients.Dirty
                     || _sender.Dirty
                     || _subject.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
                 _body.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
@@ -81,6 +79,8 @@ namespace EncompassRest.Loans
                 _sender.Dirty = value;
                 _subject.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/EmailTriggerLog.cs
+++ b/src/EncompassRest/Loans/EmailTriggerLog.cs
@@ -10,33 +10,33 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _body;
+        private DirtyValue<string> _body;
         public string Body { get { return _body; } set { _body = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _inLogIndicator;
+        private DirtyValue<bool?> _inLogIndicator;
         public bool? InLogIndicator { get { return _inLogIndicator; } set { _inLogIndicator = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _recipients;
+        private DirtyValue<string> _recipients;
         public string Recipients { get { return _recipients; } set { _recipients = value; } }
-        private Value<string> _sender;
+        private DirtyValue<string> _sender;
         public string Sender { get { return _sender; } set { _sender = value; } }
-        private Value<string> _subject;
+        private DirtyValue<string> _subject;
         public string Subject { get { return _subject; } set { _subject = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Employment.cs
+++ b/src/EncompassRest/Loans/Employment.cs
@@ -8,85 +8,85 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Employment : IDirty
     {
-        private Value<string> _addressCity;
+        private DirtyValue<string> _addressCity;
         public string AddressCity { get { return _addressCity; } set { _addressCity = value; } }
-        private Value<string> _addressPostalCode;
+        private DirtyValue<string> _addressPostalCode;
         public string AddressPostalCode { get { return _addressPostalCode; } set { _addressPostalCode = value; } }
-        private Value<string> _addressState;
+        private DirtyValue<string> _addressState;
         public string AddressState { get { return _addressState; } set { _addressState = value; } }
-        private Value<string> _addressStreetLine1;
+        private DirtyValue<string> _addressStreetLine1;
         public string AddressStreetLine1 { get { return _addressStreetLine1; } set { _addressStreetLine1 = value; } }
-        private Value<string> _altId;
+        private DirtyValue<string> _altId;
         public string AltId { get { return _altId; } set { _altId = value; } }
-        private Value<string> _attention;
+        private DirtyValue<string> _attention;
         public string Attention { get { return _attention; } set { _attention = value; } }
-        private Value<string> _badgeOrEmployeeID;
+        private DirtyValue<string> _badgeOrEmployeeID;
         public string BadgeOrEmployeeID { get { return _badgeOrEmployeeID; } set { _badgeOrEmployeeID = value; } }
-        private Value<decimal?> _basePayAmount;
+        private DirtyValue<decimal?> _basePayAmount;
         public decimal? BasePayAmount { get { return _basePayAmount; } set { _basePayAmount = value; } }
-        private Value<decimal?> _bonusAmount;
+        private DirtyValue<decimal?> _bonusAmount;
         public decimal? BonusAmount { get { return _bonusAmount; } set { _bonusAmount = value; } }
-        private Value<string> _businessName;
+        private DirtyValue<string> _businessName;
         public string BusinessName { get { return _businessName; } set { _businessName = value; } }
-        private Value<decimal?> _businessOwnedPercent;
+        private DirtyValue<decimal?> _businessOwnedPercent;
         public decimal? BusinessOwnedPercent { get { return _businessOwnedPercent; } set { _businessOwnedPercent = value; } }
-        private Value<string> _businessPhone;
+        private DirtyValue<string> _businessPhone;
         public string BusinessPhone { get { return _businessPhone; } set { _businessPhone = value; } }
-        private Value<decimal?> _commissionsAmount;
+        private DirtyValue<decimal?> _commissionsAmount;
         public decimal? CommissionsAmount { get { return _commissionsAmount; } set { _commissionsAmount = value; } }
-        private Value<bool?> _currentEmploymentIndicator;
+        private DirtyValue<bool?> _currentEmploymentIndicator;
         public bool? CurrentEmploymentIndicator { get { return _currentEmploymentIndicator; } set { _currentEmploymentIndicator = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<string> _employerComments;
+        private DirtyValue<string> _employerComments;
         public string EmployerComments { get { return _employerComments; } set { _employerComments = value; } }
-        private Value<string> _employerName;
+        private DirtyValue<string> _employerName;
         public string EmployerName { get { return _employerName; } set { _employerName = value; } }
-        private Value<DateTime?> _endDate;
+        private DirtyValue<DateTime?> _endDate;
         public DateTime? EndDate { get { return _endDate; } set { _endDate = value; } }
-        private Value<bool?> _entityDeleted;
+        private DirtyValue<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _monthlyIncomeAmount;
+        private DirtyValue<int?> _monthlyIncomeAmount;
         public int? MonthlyIncomeAmount { get { return _monthlyIncomeAmount; } set { _monthlyIncomeAmount = value; } }
-        private Value<bool?> _noLinkToDocTrackIndicator;
+        private DirtyValue<bool?> _noLinkToDocTrackIndicator;
         public bool? NoLinkToDocTrackIndicator { get { return _noLinkToDocTrackIndicator; } set { _noLinkToDocTrackIndicator = value; } }
-        private Value<decimal?> _otherAmount;
+        private DirtyValue<decimal?> _otherAmount;
         public decimal? OtherAmount { get { return _otherAmount; } set { _otherAmount = value; } }
-        private Value<decimal?> _overtimeAmount;
+        private DirtyValue<decimal?> _overtimeAmount;
         public decimal? OvertimeAmount { get { return _overtimeAmount; } set { _overtimeAmount = value; } }
-        private Value<string> _owner;
+        private DirtyValue<string> _owner;
         public string Owner { get { return _owner; } set { _owner = value; } }
-        private Value<string> _phoneNumber;
+        private DirtyValue<string> _phoneNumber;
         public string PhoneNumber { get { return _phoneNumber; } set { _phoneNumber = value; } }
-        private Value<string> _positionDescription;
+        private DirtyValue<string> _positionDescription;
         public string PositionDescription { get { return _positionDescription; } set { _positionDescription = value; } }
-        private Value<bool?> _printAttachmentIndicator;
+        private DirtyValue<bool?> _printAttachmentIndicator;
         public bool? PrintAttachmentIndicator { get { return _printAttachmentIndicator; } set { _printAttachmentIndicator = value; } }
-        private Value<bool?> _printUserNameIndicator;
+        private DirtyValue<bool?> _printUserNameIndicator;
         public bool? PrintUserNameIndicator { get { return _printUserNameIndicator; } set { _printUserNameIndicator = value; } }
-        private Value<bool?> _selfEmployedIndicator;
+        private DirtyValue<bool?> _selfEmployedIndicator;
         public bool? SelfEmployedIndicator { get { return _selfEmployedIndicator; } set { _selfEmployedIndicator = value; } }
-        private Value<DateTime?> _startDate;
+        private DirtyValue<DateTime?> _startDate;
         public DateTime? StartDate { get { return _startDate; } set { _startDate = value; } }
-        private Value<int?> _timeInLineOfWorkMonths;
+        private DirtyValue<int?> _timeInLineOfWorkMonths;
         public int? TimeInLineOfWorkMonths { get { return _timeInLineOfWorkMonths; } set { _timeInLineOfWorkMonths = value; } }
-        private Value<int?> _timeInLineOfWorkYears;
+        private DirtyValue<int?> _timeInLineOfWorkYears;
         public int? TimeInLineOfWorkYears { get { return _timeInLineOfWorkYears; } set { _timeInLineOfWorkYears = value; } }
-        private Value<int?> _timeOnJobTermMonths;
+        private DirtyValue<int?> _timeOnJobTermMonths;
         public int? TimeOnJobTermMonths { get { return _timeOnJobTermMonths; } set { _timeOnJobTermMonths = value; } }
-        private Value<int?> _timeOnJobTermYears;
+        private DirtyValue<int?> _timeOnJobTermYears;
         public int? TimeOnJobTermYears { get { return _timeOnJobTermYears; } set { _timeOnJobTermYears = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _titleFax;
+        private DirtyValue<string> _titleFax;
         public string TitleFax { get { return _titleFax; } set { _titleFax = value; } }
-        private Value<string> _titlePhone;
+        private DirtyValue<string> _titlePhone;
         public string TitlePhone { get { return _titlePhone; } set { _titlePhone = value; } }
-        private Value<DateTime?> _verificationRequestDate;
+        private DirtyValue<DateTime?> _verificationRequestDate;
         public DateTime? VerificationRequestDate { get { return _verificationRequestDate; } set { _verificationRequestDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EnergyEfficientMortgage.cs
+++ b/src/EncompassRest/Loans/EnergyEfficientMortgage.cs
@@ -8,67 +8,67 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EnergyEfficientMortgage : IDirty
     {
-        private Value<decimal?> _appraisedValue;
+        private DirtyValue<decimal?> _appraisedValue;
         public decimal? AppraisedValue { get { return _appraisedValue; } set { _appraisedValue = value; } }
-        private Value<decimal?> _auditCost;
+        private DirtyValue<decimal?> _auditCost;
         public decimal? AuditCost { get { return _auditCost; } set { _auditCost = value; } }
-        private Value<decimal?> _backRatio;
+        private DirtyValue<decimal?> _backRatio;
         public decimal? BackRatio { get { return _backRatio; } set { _backRatio = value; } }
-        private Value<decimal?> _baseLoanAmtFromTsum;
+        private DirtyValue<decimal?> _baseLoanAmtFromTsum;
         public decimal? BaseLoanAmtFromTsum { get { return _baseLoanAmtFromTsum; } set { _baseLoanAmtFromTsum = value; } }
-        private Value<decimal?> _costEffectiveEnergyPackage;
+        private DirtyValue<decimal?> _costEffectiveEnergyPackage;
         public decimal? CostEffectiveEnergyPackage { get { return _costEffectiveEnergyPackage; } set { _costEffectiveEnergyPackage = value; } }
-        private Value<decimal?> _eeCostMaximumAmount;
+        private DirtyValue<decimal?> _eeCostMaximumAmount;
         public decimal? EeCostMaximumAmount { get { return _eeCostMaximumAmount; } set { _eeCostMaximumAmount = value; } }
-        private Value<decimal?> _eeImprovementsInstalledCost;
+        private DirtyValue<decimal?> _eeImprovementsInstalledCost;
         public decimal? EeImprovementsInstalledCost { get { return _eeImprovementsInstalledCost; } set { _eeImprovementsInstalledCost = value; } }
-        private Value<decimal?> _energyCost;
+        private DirtyValue<decimal?> _energyCost;
         public decimal? EnergyCost { get { return _energyCost; } set { _energyCost = value; } }
-        private Value<decimal?> _energySavings;
+        private DirtyValue<decimal?> _energySavings;
         public decimal? EnergySavings { get { return _energySavings; } set { _energySavings = value; } }
-        private Value<decimal?> _hoa;
+        private DirtyValue<decimal?> _hoa;
         public decimal? Hoa { get { return _hoa; } set { _hoa = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _improvementCostExceed2000;
+        private DirtyValue<decimal?> _improvementCostExceed2000;
         public decimal? ImprovementCostExceed2000 { get { return _improvementCostExceed2000; } set { _improvementCostExceed2000 = value; } }
-        private Value<decimal?> _inspectionCost;
+        private DirtyValue<decimal?> _inspectionCost;
         public decimal? InspectionCost { get { return _inspectionCost; } set { _inspectionCost = value; } }
-        private Value<decimal?> _lesserC1ORC2;
+        private DirtyValue<decimal?> _lesserC1ORC2;
         public decimal? LesserC1ORC2 { get { return _lesserC1ORC2; } set { _lesserC1ORC2 = value; } }
-        private Value<decimal?> _monthlyHousingPayment;
+        private DirtyValue<decimal?> _monthlyHousingPayment;
         public decimal? MonthlyHousingPayment { get { return _monthlyHousingPayment; } set { _monthlyHousingPayment = value; } }
-        private Value<decimal?> _monthlyMI;
+        private DirtyValue<decimal?> _monthlyMI;
         public decimal? MonthlyMI { get { return _monthlyMI; } set { _monthlyMI = value; } }
-        private Value<decimal?> _mortgageAmountUsedForQualifyingRate;
+        private DirtyValue<decimal?> _mortgageAmountUsedForQualifyingRate;
         public decimal? MortgageAmountUsedForQualifyingRate { get { return _mortgageAmountUsedForQualifyingRate; } set { _mortgageAmountUsedForQualifyingRate = value; } }
-        private Value<decimal?> _mortgageAmountUsedForQualifyingRateD1;
+        private DirtyValue<decimal?> _mortgageAmountUsedForQualifyingRateD1;
         public decimal? MortgageAmountUsedForQualifyingRateD1 { get { return _mortgageAmountUsedForQualifyingRateD1; } set { _mortgageAmountUsedForQualifyingRateD1 = value; } }
-        private Value<bool?> _newOrExisting;
+        private DirtyValue<bool?> _newOrExisting;
         public bool? NewOrExisting { get { return _newOrExisting; } set { _newOrExisting = value; } }
-        private Value<decimal?> _originalSalesPriceIfLess12Months;
+        private DirtyValue<decimal?> _originalSalesPriceIfLess12Months;
         public decimal? OriginalSalesPriceIfLess12Months { get { return _originalSalesPriceIfLess12Months; } set { _originalSalesPriceIfLess12Months = value; } }
-        private Value<decimal?> _otherHousingPayment;
+        private DirtyValue<decimal?> _otherHousingPayment;
         public decimal? OtherHousingPayment { get { return _otherHousingPayment; } set { _otherHousingPayment = value; } }
-        private Value<decimal?> _solarNotIncluded;
+        private DirtyValue<decimal?> _solarNotIncluded;
         public decimal? SolarNotIncluded { get { return _solarNotIncluded; } set { _solarNotIncluded = value; } }
-        private Value<decimal?> _solarSystemCostAllowance;
+        private DirtyValue<decimal?> _solarSystemCostAllowance;
         public decimal? SolarSystemCostAllowance { get { return _solarSystemCostAllowance; } set { _solarSystemCostAllowance = value; } }
-        private Value<decimal?> _totalActualAmount;
+        private DirtyValue<decimal?> _totalActualAmount;
         public decimal? TotalActualAmount { get { return _totalActualAmount; } set { _totalActualAmount = value; } }
-        private Value<decimal?> _totalAllowedAmount;
+        private DirtyValue<decimal?> _totalAllowedAmount;
         public decimal? TotalAllowedAmount { get { return _totalAllowedAmount; } set { _totalAllowedAmount = value; } }
-        private Value<decimal?> _totalBaseEemLoanAmount;
+        private DirtyValue<decimal?> _totalBaseEemLoanAmount;
         public decimal? TotalBaseEemLoanAmount { get { return _totalBaseEemLoanAmount; } set { _totalBaseEemLoanAmount = value; } }
-        private Value<decimal?> _totalCombinedLoanAmount;
+        private DirtyValue<decimal?> _totalCombinedLoanAmount;
         public decimal? TotalCombinedLoanAmount { get { return _totalCombinedLoanAmount; } set { _totalCombinedLoanAmount = value; } }
-        private Value<decimal?> _totalMonthlyHousingPayment;
+        private DirtyValue<decimal?> _totalMonthlyHousingPayment;
         public decimal? TotalMonthlyHousingPayment { get { return _totalMonthlyHousingPayment; } set { _totalMonthlyHousingPayment = value; } }
-        private Value<decimal?> _totalMonthlyObligations;
+        private DirtyValue<decimal?> _totalMonthlyObligations;
         public decimal? TotalMonthlyObligations { get { return _totalMonthlyObligations; } set { _totalMonthlyObligations = value; } }
-        private Value<decimal?> _ufmipBasedOn;
+        private DirtyValue<decimal?> _ufmipBasedOn;
         public decimal? UfmipBasedOn { get { return _ufmipBasedOn; } set { _ufmipBasedOn = value; } }
-        private Value<decimal?> _ufmipFactor;
+        private DirtyValue<decimal?> _ufmipFactor;
         public decimal? UfmipFactor { get { return _ufmipFactor; } set { _ufmipFactor = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EnergyEfficientMortgageItem.cs
+++ b/src/EncompassRest/Loans/EnergyEfficientMortgageItem.cs
@@ -8,17 +8,17 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EnergyEfficientMortgageItem : IDirty
     {
-        private Value<decimal?> _actualAmount;
+        private DirtyValue<decimal?> _actualAmount;
         public decimal? ActualAmount { get { return _actualAmount; } set { _actualAmount = value; } }
-        private Value<decimal?> _allowedAmount;
+        private DirtyValue<decimal?> _allowedAmount;
         public decimal? AllowedAmount { get { return _allowedAmount; } set { _allowedAmount = value; } }
-        private Value<int?> _energyEfficientMortgageItemIndex;
+        private DirtyValue<int?> _energyEfficientMortgageItemIndex;
         public int? EnergyEfficientMortgageItemIndex { get { return _energyEfficientMortgageItemIndex; } set { _energyEfficientMortgageItemIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _item;
+        private DirtyValue<string> _item;
         public string Item { get { return _item; } set { _item = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EscrowDisbursementTransaction.cs
+++ b/src/EncompassRest/Loans/EscrowDisbursementTransaction.cs
@@ -8,39 +8,39 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EscrowDisbursementTransaction : IDirty
     {
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<DateTime?> _disbursementDueDate;
+        private DirtyValue<DateTime?> _disbursementDueDate;
         public DateTime? DisbursementDueDate { get { return _disbursementDueDate; } set { _disbursementDueDate = value; } }
-        private Value<int?> _disbursementNumber;
+        private DirtyValue<int?> _disbursementNumber;
         public int? DisbursementNumber { get { return _disbursementNumber; } set { _disbursementNumber = value; } }
-        private Value<string> _disbursementType;
+        private DirtyValue<string> _disbursementType;
         public string DisbursementType { get { return _disbursementType; } set { _disbursementType = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _institutionName;
+        private DirtyValue<string> _institutionName;
         public string InstitutionName { get { return _institutionName; } set { _institutionName = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/EscrowInterestTransaction.cs
+++ b/src/EncompassRest/Loans/EscrowInterestTransaction.cs
@@ -8,31 +8,31 @@ namespace EncompassRest.Loans
 {
     public sealed partial class EscrowInterestTransaction : IDirty
     {
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ExtraPayment.cs
+++ b/src/EncompassRest/Loans/ExtraPayment.cs
@@ -8,15 +8,15 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ExtraPayment : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<DateTime?> _date;
+        private DirtyValue<DateTime?> _date;
         public DateTime? Date { get { return _date; } set { _date = value; } }
-        private Value<int?> _extraPaymentIndex;
+        private DirtyValue<int?> _extraPaymentIndex;
         public int? ExtraPaymentIndex { get { return _extraPaymentIndex; } set { _extraPaymentIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FannieMae.cs
+++ b/src/EncompassRest/Loans/FannieMae.cs
@@ -8,37 +8,37 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FannieMae : IDirty
     {
-        private Value<decimal?> _cltv;
+        private DirtyValue<decimal?> _cltv;
         public decimal? Cltv { get { return _cltv; } set { _cltv = value; } }
-        private Value<string> _collateralUnderwriterScore;
+        private DirtyValue<string> _collateralUnderwriterScore;
         public string CollateralUnderwriterScore { get { return _collateralUnderwriterScore; } set { _collateralUnderwriterScore = value; } }
-        private Value<string> _community2ndRepaymentStructure;
+        private DirtyValue<string> _community2ndRepaymentStructure;
         public string Community2ndRepaymentStructure { get { return _community2ndRepaymentStructure; } set { _community2ndRepaymentStructure = value; } }
-        private Value<bool?> _communityLending;
+        private DirtyValue<bool?> _communityLending;
         public bool? CommunityLending { get { return _communityLending; } set { _communityLending = value; } }
-        private Value<string> _duVersion;
+        private DirtyValue<string> _duVersion;
         public string DuVersion { get { return _duVersion; } set { _duVersion = value; } }
-        private Value<string> _eCStatus1003;
+        private DirtyValue<string> _eCStatus1003;
         public string ECStatus1003 { get { return _eCStatus1003; } set { _eCStatus1003 = value; } }
-        private Value<decimal?> _hcltv;
+        private DirtyValue<decimal?> _hcltv;
         public decimal? Hcltv { get { return _hcltv; } set { _hcltv = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _interestedPartyContribution;
+        private DirtyValue<decimal?> _interestedPartyContribution;
         public decimal? InterestedPartyContribution { get { return _interestedPartyContribution; } set { _interestedPartyContribution = value; } }
-        private Value<decimal?> _ltv;
+        private DirtyValue<decimal?> _ltv;
         public decimal? Ltv { get { return _ltv; } set { _ltv = value; } }
-        private Value<string> _mornetPlusCaseFileId;
+        private DirtyValue<string> _mornetPlusCaseFileId;
         public string MornetPlusCaseFileId { get { return _mornetPlusCaseFileId; } set { _mornetPlusCaseFileId = value; } }
-        private Value<string> _propertyInspectionWaiverMessage;
+        private DirtyValue<string> _propertyInspectionWaiverMessage;
         public string PropertyInspectionWaiverMessage { get { return _propertyInspectionWaiverMessage; } set { _propertyInspectionWaiverMessage = value; } }
-        private Value<bool?> _startUpMortgage;
+        private DirtyValue<bool?> _startUpMortgage;
         public bool? StartUpMortgage { get { return _startUpMortgage; } set { _startUpMortgage = value; } }
-        private Value<string> _uCDCollectionStatus;
+        private DirtyValue<string> _uCDCollectionStatus;
         public string UCDCollectionStatus { get { return _uCDCollectionStatus; } set { _uCDCollectionStatus = value; } }
-        private Value<string> _uCDPStatus;
+        private DirtyValue<string> _uCDPStatus;
         public string UCDPStatus { get { return _uCDPStatus; } set { _uCDPStatus = value; } }
-        private Value<string> _uLDDECStatus;
+        private DirtyValue<string> _uLDDECStatus;
         public string ULDDECStatus { get { return _uLDDECStatus; } set { _uLDDECStatus = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Fee.cs
+++ b/src/EncompassRest/Loans/Fee.cs
@@ -8,71 +8,71 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Fee : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<decimal?> _amountPerDay;
+        private DirtyValue<decimal?> _amountPerDay;
         public decimal? AmountPerDay { get { return _amountPerDay; } set { _amountPerDay = value; } }
-        private Value<decimal?> _borPaidAmount;
+        private DirtyValue<decimal?> _borPaidAmount;
         public decimal? BorPaidAmount { get { return _borPaidAmount; } set { _borPaidAmount = value; } }
-        private Value<DateTime?> _dateFrom;
+        private DirtyValue<DateTime?> _dateFrom;
         public DateTime? DateFrom { get { return _dateFrom; } set { _dateFrom = value; } }
-        private Value<DateTime?> _dateTo;
+        private DirtyValue<DateTime?> _dateTo;
         public DateTime? DateTo { get { return _dateTo; } set { _dateTo = value; } }
-        private Value<int?> _days;
+        private DirtyValue<int?> _days;
         public int? Days { get { return _days; } set { _days = value; } }
-        private Value<decimal?> _deedAmount;
+        private DirtyValue<decimal?> _deedAmount;
         public decimal? DeedAmount { get { return _deedAmount; } set { _deedAmount = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _feeType;
+        private DirtyValue<string> _feeType;
         public string FeeType { get { return _feeType; } set { _feeType = value; } }
-        private Value<bool?> _fHA;
+        private DirtyValue<bool?> _fHA;
         public bool? FHA { get { return _fHA; } set { _fHA = value; } }
-        private Value<string> _fWBC;
+        private DirtyValue<string> _fWBC;
         public string FWBC { get { return _fWBC; } set { _fWBC = value; } }
-        private Value<string> _fWSC;
+        private DirtyValue<string> _fWSC;
         public string FWSC { get { return _fWSC; } set { _fWSC = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _includeAboveNumber;
+        private DirtyValue<string> _includeAboveNumber;
         public string IncludeAboveNumber { get { return _includeAboveNumber; } set { _includeAboveNumber = value; } }
-        private Value<decimal?> _lenderCoverage;
+        private DirtyValue<decimal?> _lenderCoverage;
         public decimal? LenderCoverage { get { return _lenderCoverage; } set { _lenderCoverage = value; } }
-        private Value<decimal?> _monthlyPayment;
+        private DirtyValue<decimal?> _monthlyPayment;
         public decimal? MonthlyPayment { get { return _monthlyPayment; } set { _monthlyPayment = value; } }
-        private Value<decimal?> _mortgageAmount;
+        private DirtyValue<decimal?> _mortgageAmount;
         public decimal? MortgageAmount { get { return _mortgageAmount; } set { _mortgageAmount = value; } }
-        private Value<NA<decimal>?> _newHUDBorPaidAmount;
+        private DirtyValue<NA<decimal>?> _newHUDBorPaidAmount;
         public NA<decimal>? NewHUDBorPaidAmount { get { return _newHUDBorPaidAmount; } set { _newHUDBorPaidAmount = value; } }
-        private Value<int?> _numberOfMonths;
+        private DirtyValue<int?> _numberOfMonths;
         public int? NumberOfMonths { get { return _numberOfMonths; } set { _numberOfMonths = value; } }
-        private Value<decimal?> _ownerCoverage;
+        private DirtyValue<decimal?> _ownerCoverage;
         public decimal? OwnerCoverage { get { return _ownerCoverage; } set { _ownerCoverage = value; } }
-        private Value<string> _paidBy;
+        private DirtyValue<string> _paidBy;
         public string PaidBy { get { return _paidBy; } set { _paidBy = value; } }
-        private Value<decimal?> _paidInAdvance;
+        private DirtyValue<decimal?> _paidInAdvance;
         public decimal? PaidInAdvance { get { return _paidInAdvance; } set { _paidInAdvance = value; } }
-        private Value<decimal?> _paidToBroker;
+        private DirtyValue<decimal?> _paidToBroker;
         public decimal? PaidToBroker { get { return _paidToBroker; } set { _paidToBroker = value; } }
-        private Value<string> _paidToName;
+        private DirtyValue<string> _paidToName;
         public string PaidToName { get { return _paidToName; } set { _paidToName = value; } }
-        private Value<decimal?> _paidToOthers;
+        private DirtyValue<decimal?> _paidToOthers;
         public decimal? PaidToOthers { get { return _paidToOthers; } set { _paidToOthers = value; } }
-        private Value<decimal?> _percentage;
+        private DirtyValue<decimal?> _percentage;
         public decimal? Percentage { get { return _percentage; } set { _percentage = value; } }
-        private Value<bool?> _pFC;
+        private DirtyValue<bool?> _pFC;
         public bool? PFC { get { return _pFC; } set { _pFC = value; } }
-        private Value<bool?> _pOC;
+        private DirtyValue<bool?> _pOC;
         public bool? POC { get { return _pOC; } set { _pOC = value; } }
-        private Value<string> _pTB;
+        private DirtyValue<string> _pTB;
         public string PTB { get { return _pTB; } set { _pTB = value; } }
-        private Value<decimal?> _releasesAmount;
+        private DirtyValue<decimal?> _releasesAmount;
         public decimal? ReleasesAmount { get { return _releasesAmount; } set { _releasesAmount = value; } }
-        private Value<decimal?> _sellerPaidAmount;
+        private DirtyValue<decimal?> _sellerPaidAmount;
         public decimal? SellerPaidAmount { get { return _sellerPaidAmount; } set { _sellerPaidAmount = value; } }
-        private Value<decimal?> _truncatedAmountPerDay;
+        private DirtyValue<decimal?> _truncatedAmountPerDay;
         public decimal? TruncatedAmountPerDay { get { return _truncatedAmountPerDay; } set { _truncatedAmountPerDay = value; } }
-        private Value<bool?> _use4Decimals;
+        private DirtyValue<bool?> _use4Decimals;
         public bool? Use4Decimals { get { return _use4Decimals; } set { _use4Decimals = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FeeVariance.cs
+++ b/src/EncompassRest/Loans/FeeVariance.cs
@@ -8,23 +8,23 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FeeVariance : IDirty
     {
-        private Value<decimal?> _cD;
+        private DirtyValue<decimal?> _cD;
         public decimal? CD { get { return _cD; } set { _cD = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<int?> _feeVarianceChargeIndex;
+        private DirtyValue<int?> _feeVarianceChargeIndex;
         public int? FeeVarianceChargeIndex { get { return _feeVarianceChargeIndex; } set { _feeVarianceChargeIndex = value; } }
-        private Value<string> _feeVarianceFeeType;
+        private DirtyValue<string> _feeVarianceFeeType;
         public string FeeVarianceFeeType { get { return _feeVarianceFeeType; } set { _feeVarianceFeeType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _initialLE;
+        private DirtyValue<decimal?> _initialLE;
         public decimal? InitialLE { get { return _initialLE; } set { _initialLE = value; } }
-        private Value<decimal?> _itemization;
+        private DirtyValue<decimal?> _itemization;
         public decimal? Itemization { get { return _itemization; } set { _itemization = value; } }
-        private Value<decimal?> _lE;
+        private DirtyValue<decimal?> _lE;
         public decimal? LE { get { return _lE; } set { _lE = value; } }
-        private Value<string> _line;
+        private DirtyValue<string> _line;
         public string Line { get { return _line; } set { _line = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FeeVarianceOther.cs
+++ b/src/EncompassRest/Loans/FeeVarianceOther.cs
@@ -8,87 +8,87 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FeeVarianceOther : IDirty
     {
-        private Value<decimal?> _appliedCureAmount;
+        private DirtyValue<decimal?> _appliedCureAmount;
         public decimal? AppliedCureAmount { get { return _appliedCureAmount; } set { _appliedCureAmount = value; } }
-        private Value<string> _cannotDecreaseCDBaselineGuid;
+        private DirtyValue<string> _cannotDecreaseCDBaselineGuid;
         public string CannotDecreaseCDBaselineGuid { get { return _cannotDecreaseCDBaselineGuid; } set { _cannotDecreaseCDBaselineGuid = value; } }
-        private Value<string> _cannotDecreaseLEBaselineGuid;
+        private DirtyValue<string> _cannotDecreaseLEBaselineGuid;
         public string CannotDecreaseLEBaselineGuid { get { return _cannotDecreaseLEBaselineGuid; } set { _cannotDecreaseLEBaselineGuid = value; } }
-        private Value<string> _cannotIncrease10CDBaselineGuid;
+        private DirtyValue<string> _cannotIncrease10CDBaselineGuid;
         public string CannotIncrease10CDBaselineGuid { get { return _cannotIncrease10CDBaselineGuid; } set { _cannotIncrease10CDBaselineGuid = value; } }
-        private Value<string> _cannotIncrease10LEBaselineGuid;
+        private DirtyValue<string> _cannotIncrease10LEBaselineGuid;
         public string CannotIncrease10LEBaselineGuid { get { return _cannotIncrease10LEBaselineGuid; } set { _cannotIncrease10LEBaselineGuid = value; } }
-        private Value<string> _cannotIncreaseCDBaselineGuid;
+        private DirtyValue<string> _cannotIncreaseCDBaselineGuid;
         public string CannotIncreaseCDBaselineGuid { get { return _cannotIncreaseCDBaselineGuid; } set { _cannotIncreaseCDBaselineGuid = value; } }
-        private Value<string> _cannotIncreaseLEBaselineGuid;
+        private DirtyValue<string> _cannotIncreaseLEBaselineGuid;
         public string CannotIncreaseLEBaselineGuid { get { return _cannotIncreaseLEBaselineGuid; } set { _cannotIncreaseLEBaselineGuid = value; } }
-        private Value<string> _cDInitialGuid;
+        private DirtyValue<string> _cDInitialGuid;
         public string CDInitialGuid { get { return _cDInitialGuid; } set { _cDInitialGuid = value; } }
-        private Value<string> _cDInitialReceivedDateGuid;
+        private DirtyValue<string> _cDInitialReceivedDateGuid;
         public string CDInitialReceivedDateGuid { get { return _cDInitialReceivedDateGuid; } set { _cDInitialReceivedDateGuid = value; } }
-        private Value<string> _cDLatestGuid;
+        private DirtyValue<string> _cDLatestGuid;
         public string CDLatestGuid { get { return _cDLatestGuid; } set { _cDLatestGuid = value; } }
-        private Value<string> _cDPostConGuid;
+        private DirtyValue<string> _cDPostConGuid;
         public string CDPostConGuid { get { return _cDPostConGuid; } set { _cDPostConGuid = value; } }
-        private Value<string> _cDRecentAppliedCure;
+        private DirtyValue<string> _cDRecentAppliedCure;
         public string CDRecentAppliedCure { get { return _cDRecentAppliedCure; } set { _cDRecentAppliedCure = value; } }
-        private Value<string> _cDRevisedReceivedDateGuid;
+        private DirtyValue<string> _cDRevisedReceivedDateGuid;
         public string CDRevisedReceivedDateGuid { get { return _cDRevisedReceivedDateGuid; } set { _cDRevisedReceivedDateGuid = value; } }
-        private Value<DateTime?> _chargesCannotIncrease10CD1;
+        private DirtyValue<DateTime?> _chargesCannotIncrease10CD1;
         public DateTime? ChargesCannotIncrease10CD1 { get { return _chargesCannotIncrease10CD1; } set { _chargesCannotIncrease10CD1 = value; } }
-        private Value<DateTime?> _chargesCannotIncrease10InitialLE1;
+        private DirtyValue<DateTime?> _chargesCannotIncrease10InitialLE1;
         public DateTime? ChargesCannotIncrease10InitialLE1 { get { return _chargesCannotIncrease10InitialLE1; } set { _chargesCannotIncrease10InitialLE1 = value; } }
-        private Value<DateTime?> _chargesCannotIncrease10LE1;
+        private DirtyValue<DateTime?> _chargesCannotIncrease10LE1;
         public DateTime? ChargesCannotIncrease10LE1 { get { return _chargesCannotIncrease10LE1; } set { _chargesCannotIncrease10LE1 = value; } }
-        private Value<DateTime?> _chargesThatCanChangeCD1;
+        private DirtyValue<DateTime?> _chargesThatCanChangeCD1;
         public DateTime? ChargesThatCanChangeCD1 { get { return _chargesThatCanChangeCD1; } set { _chargesThatCanChangeCD1 = value; } }
-        private Value<DateTime?> _chargesThatCanChangeInitialLE1;
+        private DirtyValue<DateTime?> _chargesThatCanChangeInitialLE1;
         public DateTime? ChargesThatCanChangeInitialLE1 { get { return _chargesThatCanChangeInitialLE1; } set { _chargesThatCanChangeInitialLE1 = value; } }
-        private Value<DateTime?> _chargesThatCanChangeLE1;
+        private DirtyValue<DateTime?> _chargesThatCanChangeLE1;
         public DateTime? ChargesThatCanChangeLE1 { get { return _chargesThatCanChangeLE1; } set { _chargesThatCanChangeLE1 = value; } }
-        private Value<DateTime?> _chargesThatCannotDecreaseCD1;
+        private DirtyValue<DateTime?> _chargesThatCannotDecreaseCD1;
         public DateTime? ChargesThatCannotDecreaseCD1 { get { return _chargesThatCannotDecreaseCD1; } set { _chargesThatCannotDecreaseCD1 = value; } }
-        private Value<DateTime?> _chargesThatCannotDecreaseInitialLE1;
+        private DirtyValue<DateTime?> _chargesThatCannotDecreaseInitialLE1;
         public DateTime? ChargesThatCannotDecreaseInitialLE1 { get { return _chargesThatCannotDecreaseInitialLE1; } set { _chargesThatCannotDecreaseInitialLE1 = value; } }
-        private Value<DateTime?> _chargesThatCannotDecreaseLE1;
+        private DirtyValue<DateTime?> _chargesThatCannotDecreaseLE1;
         public DateTime? ChargesThatCannotDecreaseLE1 { get { return _chargesThatCannotDecreaseLE1; } set { _chargesThatCannotDecreaseLE1 = value; } }
-        private Value<DateTime?> _chargesThatCannotIncreaseCD1;
+        private DirtyValue<DateTime?> _chargesThatCannotIncreaseCD1;
         public DateTime? ChargesThatCannotIncreaseCD1 { get { return _chargesThatCannotIncreaseCD1; } set { _chargesThatCannotIncreaseCD1 = value; } }
-        private Value<DateTime?> _chargesThatCannotIncreaseInitialLE1;
+        private DirtyValue<DateTime?> _chargesThatCannotIncreaseInitialLE1;
         public DateTime? ChargesThatCannotIncreaseInitialLE1 { get { return _chargesThatCannotIncreaseInitialLE1; } set { _chargesThatCannotIncreaseInitialLE1 = value; } }
-        private Value<DateTime?> _chargesThatCannotIncreaseLE1;
+        private DirtyValue<DateTime?> _chargesThatCannotIncreaseLE1;
         public DateTime? ChargesThatCannotIncreaseLE1 { get { return _chargesThatCannotIncreaseLE1; } set { _chargesThatCannotIncreaseLE1 = value; } }
-        private Value<string> _disclosureLogGUIDForECD;
+        private DirtyValue<string> _disclosureLogGUIDForECD;
         public string DisclosureLogGUIDForECD { get { return _disclosureLogGUIDForECD; } set { _disclosureLogGUIDForECD = value; } }
-        private Value<string> _disclosureLogGUIDReceivedForECD;
+        private DirtyValue<string> _disclosureLogGUIDReceivedForECD;
         public string DisclosureLogGUIDReceivedForECD { get { return _disclosureLogGUIDReceivedForECD; } set { _disclosureLogGUIDReceivedForECD = value; } }
-        private Value<DateTime?> _goodFaithAmountInitialLE1;
+        private DirtyValue<DateTime?> _goodFaithAmountInitialLE1;
         public DateTime? GoodFaithAmountInitialLE1 { get { return _goodFaithAmountInitialLE1; } set { _goodFaithAmountInitialLE1 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _lEBaselineUsedCannotDecrease;
+        private DirtyValue<bool?> _lEBaselineUsedCannotDecrease;
         public bool? LEBaselineUsedCannotDecrease { get { return _lEBaselineUsedCannotDecrease; } set { _lEBaselineUsedCannotDecrease = value; } }
-        private Value<bool?> _lEBaselineUsedCannotIncrease;
+        private DirtyValue<bool?> _lEBaselineUsedCannotIncrease;
         public bool? LEBaselineUsedCannotIncrease { get { return _lEBaselineUsedCannotIncrease; } set { _lEBaselineUsedCannotIncrease = value; } }
-        private Value<bool?> _lEBaselineUsedCannotIncrease10;
+        private DirtyValue<bool?> _lEBaselineUsedCannotIncrease10;
         public bool? LEBaselineUsedCannotIncrease10 { get { return _lEBaselineUsedCannotIncrease10; } set { _lEBaselineUsedCannotIncrease10 = value; } }
-        private Value<string> _lEInitialDTGuid;
+        private DirtyValue<string> _lEInitialDTGuid;
         public string LEInitialDTGuid { get { return _lEInitialDTGuid; } set { _lEInitialDTGuid = value; } }
-        private Value<string> _lEInitialGuid;
+        private DirtyValue<string> _lEInitialGuid;
         public string LEInitialGuid { get { return _lEInitialGuid; } set { _lEInitialGuid = value; } }
-        private Value<string> _lEInitialReceivedDateGuid;
+        private DirtyValue<string> _lEInitialReceivedDateGuid;
         public string LEInitialReceivedDateGuid { get { return _lEInitialReceivedDateGuid; } set { _lEInitialReceivedDateGuid = value; } }
-        private Value<string> _lELatestGuid;
+        private DirtyValue<string> _lELatestGuid;
         public string LELatestGuid { get { return _lELatestGuid; } set { _lELatestGuid = value; } }
-        private Value<string> _lERevisedReceivedDateGuid;
+        private DirtyValue<string> _lERevisedReceivedDateGuid;
         public string LERevisedReceivedDateGuid { get { return _lERevisedReceivedDateGuid; } set { _lERevisedReceivedDateGuid = value; } }
-        private Value<string> _lERevisedSentDateGuid;
+        private DirtyValue<string> _lERevisedSentDateGuid;
         public string LERevisedSentDateGuid { get { return _lERevisedSentDateGuid; } set { _lERevisedSentDateGuid = value; } }
-        private Value<decimal?> _requiredCureAmount;
+        private DirtyValue<decimal?> _requiredCureAmount;
         public decimal? RequiredCureAmount { get { return _requiredCureAmount; } set { _requiredCureAmount = value; } }
-        private Value<string> _safeHarborGuid;
+        private DirtyValue<string> _safeHarborGuid;
         public string SafeHarborGuid { get { return _safeHarborGuid; } set { _safeHarborGuid = value; } }
-        private Value<string> _sSPLGuid;
+        private DirtyValue<string> _sSPLGuid;
         public string SSPLGuid { get { return _sSPLGuid; } set { _sSPLGuid = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FhaVaLoan.cs
+++ b/src/EncompassRest/Loans/FhaVaLoan.cs
@@ -8,281 +8,281 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FhaVaLoan : IDirty
     {
-        private Value<string> _addendumType;
+        private DirtyValue<string> _addendumType;
         public string AddendumType { get { return _addendumType; } set { _addendumType = value; } }
-        private Value<bool?> _additionalCondition1;
+        private DirtyValue<bool?> _additionalCondition1;
         public bool? AdditionalCondition1 { get { return _additionalCondition1; } set { _additionalCondition1 = value; } }
-        private Value<bool?> _additionalCondition2;
+        private DirtyValue<bool?> _additionalCondition2;
         public bool? AdditionalCondition2 { get { return _additionalCondition2; } set { _additionalCondition2 = value; } }
-        private Value<bool?> _additionalCondition3;
+        private DirtyValue<bool?> _additionalCondition3;
         public bool? AdditionalCondition3 { get { return _additionalCondition3; } set { _additionalCondition3 = value; } }
-        private Value<bool?> _additionalCondition4;
+        private DirtyValue<bool?> _additionalCondition4;
         public bool? AdditionalCondition4 { get { return _additionalCondition4; } set { _additionalCondition4 = value; } }
-        private Value<bool?> _additionalCondition5;
+        private DirtyValue<bool?> _additionalCondition5;
         public bool? AdditionalCondition5 { get { return _additionalCondition5; } set { _additionalCondition5 = value; } }
-        private Value<bool?> _additionalCondition6;
+        private DirtyValue<bool?> _additionalCondition6;
         public bool? AdditionalCondition6 { get { return _additionalCondition6; } set { _additionalCondition6 = value; } }
-        private Value<bool?> _additionalCondition7;
+        private DirtyValue<bool?> _additionalCondition7;
         public bool? AdditionalCondition7 { get { return _additionalCondition7; } set { _additionalCondition7 = value; } }
-        private Value<bool?> _additionalCondition8;
+        private DirtyValue<bool?> _additionalCondition8;
         public bool? AdditionalCondition8 { get { return _additionalCondition8; } set { _additionalCondition8 = value; } }
-        private Value<bool?> _additionalCondition9;
+        private DirtyValue<bool?> _additionalCondition9;
         public bool? AdditionalCondition9 { get { return _additionalCondition9; } set { _additionalCondition9 = value; } }
-        private Value<string> _addressValidatedBy;
+        private DirtyValue<string> _addressValidatedBy;
         public string AddressValidatedBy { get { return _addressValidatedBy; } set { _addressValidatedBy = value; } }
-        private Value<string> _addressValidationMessage;
+        private DirtyValue<string> _addressValidationMessage;
         public string AddressValidationMessage { get { return _addressValidationMessage; } set { _addressValidationMessage = value; } }
-        private Value<bool?> _allConditionsSatisfied;
+        private DirtyValue<bool?> _allConditionsSatisfied;
         public bool? AllConditionsSatisfied { get { return _allConditionsSatisfied; } set { _allConditionsSatisfied = value; } }
-        private Value<DateTime?> _appraisalLoggedDate;
+        private DirtyValue<DateTime?> _appraisalLoggedDate;
         public DateTime? AppraisalLoggedDate { get { return _appraisalLoggedDate; } set { _appraisalLoggedDate = value; } }
-        private Value<string> _appraisalLookupBy;
+        private DirtyValue<string> _appraisalLookupBy;
         public string AppraisalLookupBy { get { return _appraisalLookupBy; } set { _appraisalLookupBy = value; } }
-        private Value<string> _beenInformed;
+        private DirtyValue<string> _beenInformed;
         public string BeenInformed { get { return _beenInformed; } set { _beenInformed = value; } }
-        private Value<string> _borrowerCertificationAddress;
+        private DirtyValue<string> _borrowerCertificationAddress;
         public string BorrowerCertificationAddress { get { return _borrowerCertificationAddress; } set { _borrowerCertificationAddress = value; } }
-        private Value<string> _borrowerCertificationCity;
+        private DirtyValue<string> _borrowerCertificationCity;
         public string BorrowerCertificationCity { get { return _borrowerCertificationCity; } set { _borrowerCertificationCity = value; } }
-        private Value<string> _borrowerCertificationPostalCode;
+        private DirtyValue<string> _borrowerCertificationPostalCode;
         public string BorrowerCertificationPostalCode { get { return _borrowerCertificationPostalCode; } set { _borrowerCertificationPostalCode = value; } }
-        private Value<string> _borrowerCertificationState;
+        private DirtyValue<string> _borrowerCertificationState;
         public string BorrowerCertificationState { get { return _borrowerCertificationState; } set { _borrowerCertificationState = value; } }
-        private Value<string> _cAIVRSObtainedBy;
+        private DirtyValue<string> _cAIVRSObtainedBy;
         public string CAIVRSObtainedBy { get { return _cAIVRSObtainedBy; } set { _cAIVRSObtainedBy = value; } }
-        private Value<string> _caseBinderShippedBy;
+        private DirtyValue<string> _caseBinderShippedBy;
         public string CaseBinderShippedBy { get { return _caseBinderShippedBy; } set { _caseBinderShippedBy = value; } }
-        private Value<DateTime?> _caseBinderShippedDate;
+        private DirtyValue<DateTime?> _caseBinderShippedDate;
         public DateTime? CaseBinderShippedDate { get { return _caseBinderShippedDate; } set { _caseBinderShippedDate = value; } }
-        private Value<DateTime?> _closingDate;
+        private DirtyValue<DateTime?> _closingDate;
         public DateTime? ClosingDate { get { return _closingDate; } set { _closingDate = value; } }
-        private Value<string> _condoPudID;
+        private DirtyValue<string> _condoPudID;
         public string CondoPudID { get { return _condoPudID; } set { _condoPudID = value; } }
-        private Value<string> _condoPudLookupBy;
+        private DirtyValue<string> _condoPudLookupBy;
         public string CondoPudLookupBy { get { return _condoPudLookupBy; } set { _condoPudLookupBy = value; } }
-        private Value<DateTime?> _condoPudLookupDate;
+        private DirtyValue<DateTime?> _condoPudLookupDate;
         public DateTime? CondoPudLookupDate { get { return _condoPudLookupDate; } set { _condoPudLookupDate = value; } }
-        private Value<DateTime?> _dateApprovalExpires;
+        private DirtyValue<DateTime?> _dateApprovalExpires;
         public DateTime? DateApprovalExpires { get { return _dateApprovalExpires; } set { _dateApprovalExpires = value; } }
-        private Value<DateTime?> _dateMortgageApproved;
+        private DirtyValue<DateTime?> _dateMortgageApproved;
         public DateTime? DateMortgageApproved { get { return _dateMortgageApproved; } set { _dateMortgageApproved = value; } }
-        private Value<string> _detailForOther;
+        private DirtyValue<string> _detailForOther;
         public string DetailForOther { get { return _detailForOther; } set { _detailForOther = value; } }
-        private Value<decimal?> _discountPoints;
+        private DirtyValue<decimal?> _discountPoints;
         public decimal? DiscountPoints { get { return _discountPoints; } set { _discountPoints = value; } }
-        private Value<string> _dulyAgentAddress;
+        private DirtyValue<string> _dulyAgentAddress;
         public string DulyAgentAddress { get { return _dulyAgentAddress; } set { _dulyAgentAddress = value; } }
-        private Value<string> _dulyAgentCity;
+        private DirtyValue<string> _dulyAgentCity;
         public string DulyAgentCity { get { return _dulyAgentCity; } set { _dulyAgentCity = value; } }
-        private Value<string> _dulyAgentFunction1;
+        private DirtyValue<string> _dulyAgentFunction1;
         public string DulyAgentFunction1 { get { return _dulyAgentFunction1; } set { _dulyAgentFunction1 = value; } }
-        private Value<string> _dulyAgentFunction2;
+        private DirtyValue<string> _dulyAgentFunction2;
         public string DulyAgentFunction2 { get { return _dulyAgentFunction2; } set { _dulyAgentFunction2 = value; } }
-        private Value<string> _dulyAgentName;
+        private DirtyValue<string> _dulyAgentName;
         public string DulyAgentName { get { return _dulyAgentName; } set { _dulyAgentName = value; } }
-        private Value<string> _dulyAgentState;
+        private DirtyValue<string> _dulyAgentState;
         public string DulyAgentState { get { return _dulyAgentState; } set { _dulyAgentState = value; } }
-        private Value<bool?> _dwellingCoveredBy;
+        private DirtyValue<bool?> _dwellingCoveredBy;
         public bool? DwellingCoveredBy { get { return _dwellingCoveredBy; } set { _dwellingCoveredBy = value; } }
         private EnergyEfficientMortgage _eem;
         public EnergyEfficientMortgage Eem { get { var v = _eem; return v ?? Interlocked.CompareExchange(ref _eem, (v = new EnergyEfficientMortgage()), null) ?? v; } set { _eem = value; } }
-        private Value<string> _eligibilityAssessment;
+        private DirtyValue<string> _eligibilityAssessment;
         public string EligibilityAssessment { get { return _eligibilityAssessment; } set { _eligibilityAssessment = value; } }
-        private Value<decimal?> _energyEfficientMortgageAmount;
+        private DirtyValue<decimal?> _energyEfficientMortgageAmount;
         public decimal? EnergyEfficientMortgageAmount { get { return _energyEfficientMortgageAmount; } set { _energyEfficientMortgageAmount = value; } }
         private DirtyList<EnergyEfficientMortgageItem> _energyEfficientMortgageItems;
         public IList<EnergyEfficientMortgageItem> EnergyEfficientMortgageItems { get { var v = _energyEfficientMortgageItems; return v ?? Interlocked.CompareExchange(ref _energyEfficientMortgageItems, (v = new DirtyList<EnergyEfficientMortgageItem>()), null) ?? v; } set { _energyEfficientMortgageItems = new DirtyList<EnergyEfficientMortgageItem>(value); } }
-        private Value<bool?> _everHadVAHomeLoan;
+        private DirtyValue<bool?> _everHadVAHomeLoan;
         public bool? EverHadVAHomeLoan { get { return _everHadVAHomeLoan; } set { _everHadVAHomeLoan = value; } }
-        private Value<decimal?> _excessContributionAmount;
+        private DirtyValue<decimal?> _excessContributionAmount;
         public decimal? ExcessContributionAmount { get { return _excessContributionAmount; } set { _excessContributionAmount = value; } }
-        private Value<decimal?> _existingDebtAmount;
+        private DirtyValue<decimal?> _existingDebtAmount;
         public decimal? ExistingDebtAmount { get { return _existingDebtAmount; } set { _existingDebtAmount = value; } }
-        private Value<string> _fHACaseOrderedBy;
+        private DirtyValue<string> _fHACaseOrderedBy;
         public string FHACaseOrderedBy { get { return _fHACaseOrderedBy; } set { _fHACaseOrderedBy = value; } }
-        private Value<string> _fHAManagementCounselType;
+        private DirtyValue<string> _fHAManagementCounselType;
         public string FHAManagementCounselType { get { return _fHAManagementCounselType; } set { _fHAManagementCounselType = value; } }
-        private Value<decimal?> _fHAMaxLoanAmount;
+        private DirtyValue<decimal?> _fHAMaxLoanAmount;
         public decimal? FHAMaxLoanAmount { get { return _fHAMaxLoanAmount; } set { _fHAMaxLoanAmount = value; } }
-        private Value<bool?> _foreclosedProperty;
+        private DirtyValue<bool?> _foreclosedProperty;
         public bool? ForeclosedProperty { get { return _foreclosedProperty; } set { _foreclosedProperty = value; } }
-        private Value<string> _freddieMacCounselType;
+        private DirtyValue<string> _freddieMacCounselType;
         public string FreddieMacCounselType { get { return _freddieMacCounselType; } set { _freddieMacCounselType = value; } }
-        private Value<decimal?> _fundingFeePaidInCash;
+        private DirtyValue<decimal?> _fundingFeePaidInCash;
         public decimal? FundingFeePaidInCash { get { return _fundingFeePaidInCash; } set { _fundingFeePaidInCash = value; } }
-        private Value<decimal?> _giftFundsAmount;
+        private DirtyValue<decimal?> _giftFundsAmount;
         public decimal? GiftFundsAmount { get { return _giftFundsAmount; } set { _giftFundsAmount = value; } }
-        private Value<bool?> _haveReceivedLeadPaintPoisoningInfo;
+        private DirtyValue<bool?> _haveReceivedLeadPaintPoisoningInfo;
         public bool? HaveReceivedLeadPaintPoisoningInfo { get { return _haveReceivedLeadPaintPoisoningInfo; } set { _haveReceivedLeadPaintPoisoningInfo = value; } }
-        private Value<string> _hUD1003AddendumApproved;
+        private DirtyValue<string> _hUD1003AddendumApproved;
         public string HUD1003AddendumApproved { get { return _hUD1003AddendumApproved; } set { _hUD1003AddendumApproved = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _lastRefiDate;
+        private DirtyValue<DateTime?> _lastRefiDate;
         public DateTime? LastRefiDate { get { return _lastRefiDate; } set { _lastRefiDate = value; } }
-        private Value<DateTime?> _lDPGSASearchDate;
+        private DirtyValue<DateTime?> _lDPGSASearchDate;
         public DateTime? LDPGSASearchDate { get { return _lDPGSASearchDate; } set { _lDPGSASearchDate = value; } }
-        private Value<string> _lDPGSASearchedBy;
+        private DirtyValue<string> _lDPGSASearchedBy;
         public string LDPGSASearchedBy { get { return _lDPGSASearchedBy; } set { _lDPGSASearchedBy = value; } }
-        private Value<string> _lenderAddress;
+        private DirtyValue<string> _lenderAddress;
         public string LenderAddress { get { return _lenderAddress; } set { _lenderAddress = value; } }
-        private Value<string> _lenderCity;
+        private DirtyValue<string> _lenderCity;
         public string LenderCity { get { return _lenderCity; } set { _lenderCity = value; } }
-        private Value<string> _lenderName;
+        private DirtyValue<string> _lenderName;
         public string LenderName { get { return _lenderName; } set { _lenderName = value; } }
-        private Value<string> _lenderNMLS;
+        private DirtyValue<string> _lenderNMLS;
         public string LenderNMLS { get { return _lenderNMLS; } set { _lenderNMLS = value; } }
-        private Value<string> _lenderPostalCode;
+        private DirtyValue<string> _lenderPostalCode;
         public string LenderPostalCode { get { return _lenderPostalCode; } set { _lenderPostalCode = value; } }
-        private Value<string> _lenderRepresentativeName;
+        private DirtyValue<string> _lenderRepresentativeName;
         public string LenderRepresentativeName { get { return _lenderRepresentativeName; } set { _lenderRepresentativeName = value; } }
-        private Value<string> _lenderRepresentativePhone;
+        private DirtyValue<string> _lenderRepresentativePhone;
         public string LenderRepresentativePhone { get { return _lenderRepresentativePhone; } set { _lenderRepresentativePhone = value; } }
-        private Value<string> _lenderRepresentativeTitle;
+        private DirtyValue<string> _lenderRepresentativeTitle;
         public string LenderRepresentativeTitle { get { return _lenderRepresentativeTitle; } set { _lenderRepresentativeTitle = value; } }
-        private Value<string> _lenderState;
+        private DirtyValue<string> _lenderState;
         public string LenderState { get { return _lenderState; } set { _lenderState = value; } }
-        private Value<string> _lenderTaxID;
+        private DirtyValue<string> _lenderTaxID;
         public string LenderTaxID { get { return _lenderTaxID; } set { _lenderTaxID = value; } }
-        private Value<string> _loanScoreID;
+        private DirtyValue<string> _loanScoreID;
         public string LoanScoreID { get { return _loanScoreID; } set { _loanScoreID = value; } }
-        private Value<string> _mIAppliedBy;
+        private DirtyValue<string> _mIAppliedBy;
         public string MIAppliedBy { get { return _mIAppliedBy; } set { _mIAppliedBy = value; } }
-        private Value<DateTime?> _mIAppliedDate;
+        private DirtyValue<DateTime?> _mIAppliedDate;
         public DateTime? MIAppliedDate { get { return _mIAppliedDate; } set { _mIAppliedDate = value; } }
-        private Value<DateTime?> _mICRetrivedDate;
+        private DirtyValue<DateTime?> _mICRetrivedDate;
         public DateTime? MICRetrivedDate { get { return _mICRetrivedDate; } set { _mICRetrivedDate = value; } }
-        private Value<decimal?> _minimumDownPayment;
+        private DirtyValue<decimal?> _minimumDownPayment;
         public decimal? MinimumDownPayment { get { return _minimumDownPayment; } set { _minimumDownPayment = value; } }
-        private Value<DateTime?> _mIP1stDueDate;
+        private DirtyValue<DateTime?> _mIP1stDueDate;
         public DateTime? MIP1stDueDate { get { return _mIP1stDueDate; } set { _mIP1stDueDate = value; } }
-        private Value<DateTime?> _mIP1stToInvestor;
+        private DirtyValue<DateTime?> _mIP1stToInvestor;
         public DateTime? MIP1stToInvestor { get { return _mIP1stToInvestor; } set { _mIP1stToInvestor = value; } }
-        private Value<DateTime?> _mIPRemittedDate;
+        private DirtyValue<DateTime?> _mIPRemittedDate;
         public DateTime? MIPRemittedDate { get { return _mIPRemittedDate; } set { _mIPRemittedDate = value; } }
-        private Value<DateTime?> _mIRejectedDate;
+        private DirtyValue<DateTime?> _mIRejectedDate;
         public DateTime? MIRejectedDate { get { return _mIRejectedDate; } set { _mIRejectedDate = value; } }
-        private Value<decimal?> _modifiedInterestRate;
+        private DirtyValue<decimal?> _modifiedInterestRate;
         public decimal? ModifiedInterestRate { get { return _modifiedInterestRate; } set { _modifiedInterestRate = value; } }
-        private Value<decimal?> _modifiedLoanAmount;
+        private DirtyValue<decimal?> _modifiedLoanAmount;
         public decimal? ModifiedLoanAmount { get { return _modifiedLoanAmount; } set { _modifiedLoanAmount = value; } }
-        private Value<decimal?> _modifiedMonthlyPayment;
+        private DirtyValue<decimal?> _modifiedMonthlyPayment;
         public decimal? ModifiedMonthlyPayment { get { return _modifiedMonthlyPayment; } set { _modifiedMonthlyPayment = value; } }
-        private Value<decimal?> _modifiedMonthlyPremium;
+        private DirtyValue<decimal?> _modifiedMonthlyPremium;
         public decimal? ModifiedMonthlyPremium { get { return _modifiedMonthlyPremium; } set { _modifiedMonthlyPremium = value; } }
-        private Value<int?> _modifiedProposedMaturityMonth;
+        private DirtyValue<int?> _modifiedProposedMaturityMonth;
         public int? ModifiedProposedMaturityMonth { get { return _modifiedProposedMaturityMonth; } set { _modifiedProposedMaturityMonth = value; } }
-        private Value<int?> _modifiedProposedMaturityYear;
+        private DirtyValue<int?> _modifiedProposedMaturityYear;
         public int? ModifiedProposedMaturityYear { get { return _modifiedProposedMaturityYear; } set { _modifiedProposedMaturityYear = value; } }
-        private Value<int?> _modifiedTermAnnualPremium;
+        private DirtyValue<int?> _modifiedTermAnnualPremium;
         public int? ModifiedTermAnnualPremium { get { return _modifiedTermAnnualPremium; } set { _modifiedTermAnnualPremium = value; } }
-        private Value<decimal?> _modifiedUpfrontPremium;
+        private DirtyValue<decimal?> _modifiedUpfrontPremium;
         public decimal? ModifiedUpfrontPremium { get { return _modifiedUpfrontPremium; } set { _modifiedUpfrontPremium = value; } }
-        private Value<string> _mortgageeRepresentative;
+        private DirtyValue<string> _mortgageeRepresentative;
         public string MortgageeRepresentative { get { return _mortgageeRepresentative; } set { _mortgageeRepresentative = value; } }
-        private Value<string> _mortgageFinancialInterest;
+        private DirtyValue<string> _mortgageFinancialInterest;
         public string MortgageFinancialInterest { get { return _mortgageFinancialInterest; } set { _mortgageFinancialInterest = value; } }
-        private Value<decimal?> _nonRealtyAndOtherItems;
+        private DirtyValue<decimal?> _nonRealtyAndOtherItems;
         public decimal? NonRealtyAndOtherItems { get { return _nonRealtyAndOtherItems; } set { _nonRealtyAndOtherItems = value; } }
-        private Value<DateTime?> _obtainCAIVRSDate;
+        private DirtyValue<DateTime?> _obtainCAIVRSDate;
         public DateTime? ObtainCAIVRSDate { get { return _obtainCAIVRSDate; } set { _obtainCAIVRSDate = value; } }
-        private Value<string> _occupancy;
+        private DirtyValue<string> _occupancy;
         public string Occupancy { get { return _occupancy; } set { _occupancy = value; } }
-        private Value<string> _oldAgencyCaseIdentifier;
+        private DirtyValue<string> _oldAgencyCaseIdentifier;
         public string OldAgencyCaseIdentifier { get { return _oldAgencyCaseIdentifier; } set { _oldAgencyCaseIdentifier = value; } }
-        private Value<decimal?> _originalMortgageAmount;
+        private DirtyValue<decimal?> _originalMortgageAmount;
         public decimal? OriginalMortgageAmount { get { return _originalMortgageAmount; } set { _originalMortgageAmount = value; } }
-        private Value<decimal?> _otherLiabilitiesMonthlyPayment;
+        private DirtyValue<decimal?> _otherLiabilitiesMonthlyPayment;
         public decimal? OtherLiabilitiesMonthlyPayment { get { return _otherLiabilitiesMonthlyPayment; } set { _otherLiabilitiesMonthlyPayment = value; } }
-        private Value<decimal?> _otherLiabilitiesUnpaidBalance;
+        private DirtyValue<decimal?> _otherLiabilitiesUnpaidBalance;
         public decimal? OtherLiabilitiesUnpaidBalance { get { return _otherLiabilitiesUnpaidBalance; } set { _otherLiabilitiesUnpaidBalance = value; } }
-        private Value<decimal?> _otherMonthlyShelterExpense;
+        private DirtyValue<decimal?> _otherMonthlyShelterExpense;
         public decimal? OtherMonthlyShelterExpense { get { return _otherMonthlyShelterExpense; } set { _otherMonthlyShelterExpense = value; } }
-        private Value<string> _otherTitleDescription;
+        private DirtyValue<string> _otherTitleDescription;
         public string OtherTitleDescription { get { return _otherTitleDescription; } set { _otherTitleDescription = value; } }
-        private Value<bool?> _ownMoreThanFourDwellings;
+        private DirtyValue<bool?> _ownMoreThanFourDwellings;
         public bool? OwnMoreThanFourDwellings { get { return _ownMoreThanFourDwellings; } set { _ownMoreThanFourDwellings = value; } }
-        private Value<bool?> _ownOrSoldOtherRealEstate;
+        private DirtyValue<bool?> _ownOrSoldOtherRealEstate;
         public bool? OwnOrSoldOtherRealEstate { get { return _ownOrSoldOtherRealEstate; } set { _ownOrSoldOtherRealEstate = value; } }
-        private Value<decimal?> _paidAmount;
+        private DirtyValue<decimal?> _paidAmount;
         public decimal? PaidAmount { get { return _paidAmount; } set { _paidAmount = value; } }
-        private Value<int?> _premiumMonths;
+        private DirtyValue<int?> _premiumMonths;
         public int? PremiumMonths { get { return _premiumMonths; } set { _premiumMonths = value; } }
-        private Value<decimal?> _prepaidExpenses;
+        private DirtyValue<decimal?> _prepaidExpenses;
         public decimal? PrepaidExpenses { get { return _prepaidExpenses; } set { _prepaidExpenses = value; } }
-        private Value<DateTime?> _previousPurchaseDate;
+        private DirtyValue<DateTime?> _previousPurchaseDate;
         public DateTime? PreviousPurchaseDate { get { return _previousPurchaseDate; } set { _previousPurchaseDate = value; } }
-        private Value<DateTime?> _priorEndorsementDate;
+        private DirtyValue<DateTime?> _priorEndorsementDate;
         public DateTime? PriorEndorsementDate { get { return _priorEndorsementDate; } set { _priorEndorsementDate = value; } }
-        private Value<int?> _proposedMaturityMonths;
+        private DirtyValue<int?> _proposedMaturityMonths;
         public int? ProposedMaturityMonths { get { return _proposedMaturityMonths; } set { _proposedMaturityMonths = value; } }
-        private Value<int?> _proposedMaturityYears;
+        private DirtyValue<int?> _proposedMaturityYears;
         public int? ProposedMaturityYears { get { return _proposedMaturityYears; } set { _proposedMaturityYears = value; } }
-        private Value<string> _purposeOfLoan;
+        private DirtyValue<string> _purposeOfLoan;
         public string PurposeOfLoan { get { return _purposeOfLoan; } set { _purposeOfLoan = value; } }
-        private Value<string> _refiAuthorizationBy;
+        private DirtyValue<string> _refiAuthorizationBy;
         public string RefiAuthorizationBy { get { return _refiAuthorizationBy; } set { _refiAuthorizationBy = value; } }
-        private Value<DateTime?> _refiAuthorizationDate;
+        private DirtyValue<DateTime?> _refiAuthorizationDate;
         public DateTime? RefiAuthorizationDate { get { return _refiAuthorizationDate; } set { _refiAuthorizationDate = value; } }
-        private Value<decimal?> _salesPrice;
+        private DirtyValue<decimal?> _salesPrice;
         public decimal? SalesPrice { get { return _salesPrice; } set { _salesPrice = value; } }
-        private Value<decimal?> _secondMortgageAmount;
+        private DirtyValue<decimal?> _secondMortgageAmount;
         public decimal? SecondMortgageAmount { get { return _secondMortgageAmount; } set { _secondMortgageAmount = value; } }
-        private Value<decimal?> _sellerPaidClosingCost;
+        private DirtyValue<decimal?> _sellerPaidClosingCost;
         public decimal? SellerPaidClosingCost { get { return _sellerPaidClosingCost; } set { _sellerPaidClosingCost = value; } }
-        private Value<DateTime?> _servingTransferedDate;
+        private DirtyValue<DateTime?> _servingTransferedDate;
         public DateTime? ServingTransferedDate { get { return _servingTransferedDate; } set { _servingTransferedDate = value; } }
-        private Value<decimal?> _specialAssessments;
+        private DirtyValue<decimal?> _specialAssessments;
         public decimal? SpecialAssessments { get { return _specialAssessments; } set { _specialAssessments = value; } }
-        private Value<string> _sponsorAgentAddress;
+        private DirtyValue<string> _sponsorAgentAddress;
         public string SponsorAgentAddress { get { return _sponsorAgentAddress; } set { _sponsorAgentAddress = value; } }
-        private Value<string> _sponsorAgentCity;
+        private DirtyValue<string> _sponsorAgentCity;
         public string SponsorAgentCity { get { return _sponsorAgentCity; } set { _sponsorAgentCity = value; } }
-        private Value<string> _sponsorAgentName;
+        private DirtyValue<string> _sponsorAgentName;
         public string SponsorAgentName { get { return _sponsorAgentName; } set { _sponsorAgentName = value; } }
-        private Value<string> _sponsorAgentNMLS;
+        private DirtyValue<string> _sponsorAgentNMLS;
         public string SponsorAgentNMLS { get { return _sponsorAgentNMLS; } set { _sponsorAgentNMLS = value; } }
-        private Value<string> _sponsorAgentPostalCode;
+        private DirtyValue<string> _sponsorAgentPostalCode;
         public string SponsorAgentPostalCode { get { return _sponsorAgentPostalCode; } set { _sponsorAgentPostalCode = value; } }
-        private Value<string> _sponsorAgentState;
+        private DirtyValue<string> _sponsorAgentState;
         public string SponsorAgentState { get { return _sponsorAgentState; } set { _sponsorAgentState = value; } }
-        private Value<string> _sponsorAgentTaxID;
+        private DirtyValue<string> _sponsorAgentTaxID;
         public string SponsorAgentTaxID { get { return _sponsorAgentTaxID; } set { _sponsorAgentTaxID = value; } }
-        private Value<string> _sponsoredOriginationsName;
+        private DirtyValue<string> _sponsoredOriginationsName;
         public string SponsoredOriginationsName { get { return _sponsoredOriginationsName; } set { _sponsoredOriginationsName = value; } }
-        private Value<string> _sponsoredOriginationsNMLS;
+        private DirtyValue<string> _sponsoredOriginationsNMLS;
         public string SponsoredOriginationsNMLS { get { return _sponsoredOriginationsNMLS; } set { _sponsoredOriginationsNMLS = value; } }
-        private Value<string> _sponsoredOriginationsTaxID;
+        private DirtyValue<string> _sponsoredOriginationsTaxID;
         public string SponsoredOriginationsTaxID { get { return _sponsoredOriginationsTaxID; } set { _sponsoredOriginationsTaxID = value; } }
-        private Value<string> _sponsorID;
+        private DirtyValue<string> _sponsorID;
         public string SponsorID { get { return _sponsorID; } set { _sponsorID = value; } }
-        private Value<string> _titleVestedIn;
+        private DirtyValue<string> _titleVestedIn;
         public string TitleVestedIn { get { return _titleVestedIn; } set { _titleVestedIn = value; } }
-        private Value<bool?> _toBeSold;
+        private DirtyValue<bool?> _toBeSold;
         public bool? ToBeSold { get { return _toBeSold; } set { _toBeSold = value; } }
-        private Value<decimal?> _totalClosingCost;
+        private DirtyValue<decimal?> _totalClosingCost;
         public decimal? TotalClosingCost { get { return _totalClosingCost; } set { _totalClosingCost = value; } }
-        private Value<string> _totalScorecardBy;
+        private DirtyValue<string> _totalScorecardBy;
         public string TotalScorecardBy { get { return _totalScorecardBy; } set { _totalScorecardBy = value; } }
-        private Value<DateTime?> _totalScorecardDate;
+        private DirtyValue<DateTime?> _totalScorecardDate;
         public DateTime? TotalScorecardDate { get { return _totalScorecardDate; } set { _totalScorecardDate = value; } }
-        private Value<DateTime?> _uFMIPRemittanceDueDate;
+        private DirtyValue<DateTime?> _uFMIPRemittanceDueDate;
         public DateTime? UFMIPRemittanceDueDate { get { return _uFMIPRemittanceDueDate; } set { _uFMIPRemittanceDueDate = value; } }
-        private Value<decimal?> _uFMIPRemittedAmount;
+        private DirtyValue<decimal?> _uFMIPRemittedAmount;
         public decimal? UFMIPRemittedAmount { get { return _uFMIPRemittedAmount; } set { _uFMIPRemittedAmount = value; } }
-        private Value<string> _uFMIPRemittedBy;
+        private DirtyValue<string> _uFMIPRemittedBy;
         public string UFMIPRemittedBy { get { return _uFMIPRemittedBy; } set { _uFMIPRemittedBy = value; } }
-        private Value<DateTime?> _uFMIPRemittedDate;
+        private DirtyValue<DateTime?> _uFMIPRemittedDate;
         public DateTime? UFMIPRemittedDate { get { return _uFMIPRemittedDate; } set { _uFMIPRemittedDate = value; } }
-        private Value<string> _uFMIPVerificationCode;
+        private DirtyValue<string> _uFMIPVerificationCode;
         public string UFMIPVerificationCode { get { return _uFMIPVerificationCode; } set { _uFMIPVerificationCode = value; } }
-        private Value<bool?> _useDefaultLenderInfo;
+        private DirtyValue<bool?> _useDefaultLenderInfo;
         public bool? UseDefaultLenderInfo { get { return _useDefaultLenderInfo; } set { _useDefaultLenderInfo = value; } }
-        private Value<bool?> _utilityIncluded;
+        private DirtyValue<bool?> _utilityIncluded;
         public bool? UtilityIncluded { get { return _utilityIncluded; } set { _utilityIncluded = value; } }
-        private Value<DateTime?> _validateAddressDate;
+        private DirtyValue<DateTime?> _validateAddressDate;
         public DateTime? ValidateAddressDate { get { return _validateAddressDate; } set { _validateAddressDate = value; } }
-        private Value<string> _valuation;
+        private DirtyValue<string> _valuation;
         public string Valuation { get { return _valuation; } set { _valuation = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FhaVaLoan.cs
+++ b/src/EncompassRest/Loans/FhaVaLoan.cs
@@ -84,13 +84,14 @@ namespace EncompassRest.Loans
         public string DulyAgentState { get { return _dulyAgentState; } set { _dulyAgentState = value; } }
         private Value<bool?> _dwellingCoveredBy;
         public bool? DwellingCoveredBy { get { return _dwellingCoveredBy; } set { _dwellingCoveredBy = value; } }
-        public EnergyEfficientMortgage Eem { get; set; }
+        private EnergyEfficientMortgage _eem;
+        public EnergyEfficientMortgage Eem { get { var v = _eem; return v ?? Interlocked.CompareExchange(ref _eem, (v = new EnergyEfficientMortgage()), null) ?? v; } set { _eem = value; } }
         private Value<string> _eligibilityAssessment;
         public string EligibilityAssessment { get { return _eligibilityAssessment; } set { _eligibilityAssessment = value; } }
         private Value<decimal?> _energyEfficientMortgageAmount;
         public decimal? EnergyEfficientMortgageAmount { get { return _energyEfficientMortgageAmount; } set { _energyEfficientMortgageAmount = value; } }
-        private Value<List<EnergyEfficientMortgageItem>> _energyEfficientMortgageItems;
-        public List<EnergyEfficientMortgageItem> EnergyEfficientMortgageItems { get { return _energyEfficientMortgageItems; } set { _energyEfficientMortgageItems = value; } }
+        private DirtyList<EnergyEfficientMortgageItem> _energyEfficientMortgageItems;
+        public IList<EnergyEfficientMortgageItem> EnergyEfficientMortgageItems { get { var v = _energyEfficientMortgageItems; return v ?? Interlocked.CompareExchange(ref _energyEfficientMortgageItems, (v = new DirtyList<EnergyEfficientMortgageItem>()), null) ?? v; } set { _energyEfficientMortgageItems = new DirtyList<EnergyEfficientMortgageItem>(value); } }
         private Value<bool?> _everHadVAHomeLoan;
         public bool? EverHadVAHomeLoan { get { return _everHadVAHomeLoan; } set { _everHadVAHomeLoan = value; } }
         private Value<decimal?> _excessContributionAmount;
@@ -330,7 +331,6 @@ namespace EncompassRest.Loans
                     || _dwellingCoveredBy.Dirty
                     || _eligibilityAssessment.Dirty
                     || _energyEfficientMortgageAmount.Dirty
-                    || _energyEfficientMortgageItems.Dirty
                     || _everHadVAHomeLoan.Dirty
                     || _excessContributionAmount.Dirty
                     || _existingDebtAmount.Dirty
@@ -427,7 +427,8 @@ namespace EncompassRest.Loans
                     || _utilityIncluded.Dirty
                     || _validateAddressDate.Dirty
                     || _valuation.Dirty
-                    || Eem?.Dirty == true;
+                    || _eem?.Dirty == true
+                    || _energyEfficientMortgageItems?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -474,7 +475,6 @@ namespace EncompassRest.Loans
                 _dwellingCoveredBy.Dirty = value;
                 _eligibilityAssessment.Dirty = value;
                 _energyEfficientMortgageAmount.Dirty = value;
-                _energyEfficientMortgageItems.Dirty = value;
                 _everHadVAHomeLoan.Dirty = value;
                 _excessContributionAmount.Dirty = value;
                 _existingDebtAmount.Dirty = value;
@@ -571,7 +571,8 @@ namespace EncompassRest.Loans
                 _utilityIncluded.Dirty = value;
                 _validateAddressDate.Dirty = value;
                 _valuation.Dirty = value;
-                if (Eem != null) Eem.Dirty = value;
+                if (_eem != null) _eem.Dirty = value;
+                if (_energyEfficientMortgageItems != null) _energyEfficientMortgageItems.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/FieldLockData.cs
+++ b/src/EncompassRest/Loans/FieldLockData.cs
@@ -8,11 +8,11 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FieldLockData : IDirty
     {
-        private Value<bool?> _lockRemoved;
+        private DirtyValue<bool?> _lockRemoved;
         public bool? LockRemoved { get { return _lockRemoved; } set { _lockRemoved = value; } }
-        private Value<string> _modelPath;
+        private DirtyValue<string> _modelPath;
         public string ModelPath { get { return _modelPath; } set { _modelPath = value; } }
-        private Value<string> _value;
+        private DirtyValue<string> _value;
         public string Value { get { return _value; } set { _value = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Form.cs
+++ b/src/EncompassRest/Loans/Form.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Form : IDirty
     {
-        private Value<int?> _formId;
+        private DirtyValue<int?> _formId;
         public int? FormId { get { return _formId; } set { _formId = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FreddieMac.cs
+++ b/src/EncompassRest/Loans/FreddieMac.cs
@@ -8,163 +8,163 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FreddieMac : IDirty
     {
-        private Value<string> _affordableProduct;
+        private DirtyValue<string> _affordableProduct;
         public string AffordableProduct { get { return _affordableProduct; } set { _affordableProduct = value; } }
-        private Value<decimal?> _alimonyAsIncomeReduction;
+        private DirtyValue<decimal?> _alimonyAsIncomeReduction;
         public decimal? AlimonyAsIncomeReduction { get { return _alimonyAsIncomeReduction; } set { _alimonyAsIncomeReduction = value; } }
-        private Value<decimal?> _allMonthlyPayments;
+        private DirtyValue<decimal?> _allMonthlyPayments;
         public decimal? AllMonthlyPayments { get { return _allMonthlyPayments; } set { _allMonthlyPayments = value; } }
-        private Value<bool?> _allowsNegativeAmortizationIndicator;
+        private DirtyValue<bool?> _allowsNegativeAmortizationIndicator;
         public bool? AllowsNegativeAmortizationIndicator { get { return _allowsNegativeAmortizationIndicator; } set { _allowsNegativeAmortizationIndicator = value; } }
-        private Value<string> _amountOfFinancedMI;
+        private DirtyValue<string> _amountOfFinancedMI;
         public string AmountOfFinancedMI { get { return _amountOfFinancedMI; } set { _amountOfFinancedMI = value; } }
-        private Value<string> _aPNCity;
+        private DirtyValue<string> _aPNCity;
         public string APNCity { get { return _aPNCity; } set { _aPNCity = value; } }
-        private Value<bool?> _armsLengthTransactionIndicator;
+        private DirtyValue<bool?> _armsLengthTransactionIndicator;
         public bool? ArmsLengthTransactionIndicator { get { return _armsLengthTransactionIndicator; } set { _armsLengthTransactionIndicator = value; } }
-        private Value<bool?> _borrowerQualifiesAsVeteranIndicator;
+        private DirtyValue<bool?> _borrowerQualifiesAsVeteranIndicator;
         public bool? BorrowerQualifiesAsVeteranIndicator { get { return _borrowerQualifiesAsVeteranIndicator; } set { _borrowerQualifiesAsVeteranIndicator = value; } }
-        private Value<string> _brokerOriginated;
+        private DirtyValue<string> _brokerOriginated;
         public string BrokerOriginated { get { return _brokerOriginated; } set { _brokerOriginated = value; } }
-        private Value<string> _buydownContributor;
+        private DirtyValue<string> _buydownContributor;
         public string BuydownContributor { get { return _buydownContributor; } set { _buydownContributor = value; } }
-        private Value<string> _condoClass;
+        private DirtyValue<string> _condoClass;
         public string CondoClass { get { return _condoClass; } set { _condoClass = value; } }
-        private Value<decimal?> _convertibleFeeAmount;
+        private DirtyValue<decimal?> _convertibleFeeAmount;
         public decimal? ConvertibleFeeAmount { get { return _convertibleFeeAmount; } set { _convertibleFeeAmount = value; } }
-        private Value<decimal?> _convertibleFeePercent;
+        private DirtyValue<decimal?> _convertibleFeePercent;
         public decimal? ConvertibleFeePercent { get { return _convertibleFeePercent; } set { _convertibleFeePercent = value; } }
-        private Value<decimal?> _convertibleMaxRateAdjPercent;
+        private DirtyValue<decimal?> _convertibleMaxRateAdjPercent;
         public decimal? ConvertibleMaxRateAdjPercent { get { return _convertibleMaxRateAdjPercent; } set { _convertibleMaxRateAdjPercent = value; } }
-        private Value<decimal?> _convertibleMinRateAdjPercent;
+        private DirtyValue<decimal?> _convertibleMinRateAdjPercent;
         public decimal? ConvertibleMinRateAdjPercent { get { return _convertibleMinRateAdjPercent; } set { _convertibleMinRateAdjPercent = value; } }
-        private Value<string> _county;
+        private DirtyValue<string> _county;
         public string County { get { return _county; } set { _county = value; } }
-        private Value<string> _creditReportCompany;
+        private DirtyValue<string> _creditReportCompany;
         public string CreditReportCompany { get { return _creditReportCompany; } set { _creditReportCompany = value; } }
-        private Value<decimal?> _financingConcessions;
+        private DirtyValue<decimal?> _financingConcessions;
         public decimal? FinancingConcessions { get { return _financingConcessions; } set { _financingConcessions = value; } }
-        private Value<string> _freddieFiel11;
+        private DirtyValue<string> _freddieFiel11;
         public string FreddieFiel11 { get { return _freddieFiel11; } set { _freddieFiel11 = value; } }
-        private Value<string> _freddieFiel12;
+        private DirtyValue<string> _freddieFiel12;
         public string FreddieFiel12 { get { return _freddieFiel12; } set { _freddieFiel12 = value; } }
-        private Value<string> _freddieFiel13;
+        private DirtyValue<string> _freddieFiel13;
         public string FreddieFiel13 { get { return _freddieFiel13; } set { _freddieFiel13 = value; } }
-        private Value<string> _freddieFiel14;
+        private DirtyValue<string> _freddieFiel14;
         public string FreddieFiel14 { get { return _freddieFiel14; } set { _freddieFiel14 = value; } }
-        private Value<string> _freddieFiel15;
+        private DirtyValue<string> _freddieFiel15;
         public string FreddieFiel15 { get { return _freddieFiel15; } set { _freddieFiel15 = value; } }
-        private Value<string> _freddieField3;
+        private DirtyValue<string> _freddieField3;
         public string FreddieField3 { get { return _freddieField3; } set { _freddieField3 = value; } }
-        private Value<string> _freddieField7;
+        private DirtyValue<string> _freddieField7;
         public string FreddieField7 { get { return _freddieField7; } set { _freddieField7 = value; } }
-        private Value<string> _hELOCActualBalance;
+        private DirtyValue<string> _hELOCActualBalance;
         public string HELOCActualBalance { get { return _hELOCActualBalance; } set { _hELOCActualBalance = value; } }
-        private Value<string> _hELOCCreditLimit;
+        private DirtyValue<string> _hELOCCreditLimit;
         public string HELOCCreditLimit { get { return _hELOCCreditLimit; } set { _hELOCCreditLimit = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lenderAltPhone;
+        private DirtyValue<string> _lenderAltPhone;
         public string LenderAltPhone { get { return _lenderAltPhone; } set { _lenderAltPhone = value; } }
-        private Value<string> _lenderRegistration;
+        private DirtyValue<string> _lenderRegistration;
         public string LenderRegistration { get { return _lenderRegistration; } set { _lenderRegistration = value; } }
-        private Value<string> _loanProspectorID;
+        private DirtyValue<string> _loanProspectorID;
         public string LoanProspectorID { get { return _loanProspectorID; } set { _loanProspectorID = value; } }
-        private Value<string> _loanToConduitCode;
+        private DirtyValue<string> _loanToConduitCode;
         public string LoanToConduitCode { get { return _loanToConduitCode; } set { _loanToConduitCode = value; } }
-        private Value<string> _longLegalDescription;
+        private DirtyValue<string> _longLegalDescription;
         public string LongLegalDescription { get { return _longLegalDescription; } set { _longLegalDescription = value; } }
-        private Value<string> _lossCoverage;
+        private DirtyValue<string> _lossCoverage;
         public string LossCoverage { get { return _lossCoverage; } set { _lossCoverage = value; } }
-        private Value<string> _lPKeyNumber;
+        private DirtyValue<string> _lPKeyNumber;
         public string LPKeyNumber { get { return _lPKeyNumber; } set { _lPKeyNumber = value; } }
-        private Value<string> _mIRefundOption;
+        private DirtyValue<string> _mIRefundOption;
         public string MIRefundOption { get { return _mIRefundOption; } set { _mIRefundOption = value; } }
-        private Value<string> _mortgageInsuranceCompany;
+        private DirtyValue<string> _mortgageInsuranceCompany;
         public string MortgageInsuranceCompany { get { return _mortgageInsuranceCompany; } set { _mortgageInsuranceCompany = value; } }
-        private Value<decimal?> _netPurchasePrice;
+        private DirtyValue<decimal?> _netPurchasePrice;
         public decimal? NetPurchasePrice { get { return _netPurchasePrice; } set { _netPurchasePrice = value; } }
-        private Value<string> _newConstructionType;
+        private DirtyValue<string> _newConstructionType;
         public string NewConstructionType { get { return _newConstructionType; } set { _newConstructionType = value; } }
-        private Value<string> _noAppraisalMAF;
+        private DirtyValue<string> _noAppraisalMAF;
         public string NoAppraisalMAF { get { return _noAppraisalMAF; } set { _noAppraisalMAF = value; } }
-        private Value<decimal?> _nonOccupantNonHousingDebt;
+        private DirtyValue<decimal?> _nonOccupantNonHousingDebt;
         public decimal? NonOccupantNonHousingDebt { get { return _nonOccupantNonHousingDebt; } set { _nonOccupantNonHousingDebt = value; } }
-        private Value<decimal?> _nonOccupantPresentHE;
+        private DirtyValue<decimal?> _nonOccupantPresentHE;
         public decimal? NonOccupantPresentHE { get { return _nonOccupantPresentHE; } set { _nonOccupantPresentHE = value; } }
-        private Value<bool?> _orderCreditEvaluationIndicator;
+        private DirtyValue<bool?> _orderCreditEvaluationIndicator;
         public bool? OrderCreditEvaluationIndicator { get { return _orderCreditEvaluationIndicator; } set { _orderCreditEvaluationIndicator = value; } }
-        private Value<bool?> _orderMergedCreditReportIndicator;
+        private DirtyValue<bool?> _orderMergedCreditReportIndicator;
         public bool? OrderMergedCreditReportIndicator { get { return _orderMergedCreditReportIndicator; } set { _orderMergedCreditReportIndicator = value; } }
-        private Value<string> _orderMortgageInsurance;
+        private DirtyValue<string> _orderMortgageInsurance;
         public string OrderMortgageInsurance { get { return _orderMortgageInsurance; } set { _orderMortgageInsurance = value; } }
-        private Value<bool?> _orderRiskGradeEvaluationIndicator;
+        private DirtyValue<bool?> _orderRiskGradeEvaluationIndicator;
         public bool? OrderRiskGradeEvaluationIndicator { get { return _orderRiskGradeEvaluationIndicator; } set { _orderRiskGradeEvaluationIndicator = value; } }
-        private Value<decimal?> _originalIntRate;
+        private DirtyValue<decimal?> _originalIntRate;
         public decimal? OriginalIntRate { get { return _originalIntRate; } set { _originalIntRate = value; } }
-        private Value<string> _originateID;
+        private DirtyValue<string> _originateID;
         public string OriginateID { get { return _originateID; } set { _originateID = value; } }
-        private Value<string> _paymentFrequency;
+        private DirtyValue<string> _paymentFrequency;
         public string PaymentFrequency { get { return _paymentFrequency; } set { _paymentFrequency = value; } }
-        private Value<string> _paymentOption;
+        private DirtyValue<string> _paymentOption;
         public string PaymentOption { get { return _paymentOption; } set { _paymentOption = value; } }
-        private Value<decimal?> _personIncomeForSelfEmployment1;
+        private DirtyValue<decimal?> _personIncomeForSelfEmployment1;
         public decimal? PersonIncomeForSelfEmployment1 { get { return _personIncomeForSelfEmployment1; } set { _personIncomeForSelfEmployment1 = value; } }
-        private Value<decimal?> _personIncomeForSelfEmployment2;
+        private DirtyValue<decimal?> _personIncomeForSelfEmployment2;
         public decimal? PersonIncomeForSelfEmployment2 { get { return _personIncomeForSelfEmployment2; } set { _personIncomeForSelfEmployment2 = value; } }
-        private Value<int?> _personPercentOfBusinessOwned1;
+        private DirtyValue<int?> _personPercentOfBusinessOwned1;
         public int? PersonPercentOfBusinessOwned1 { get { return _personPercentOfBusinessOwned1; } set { _personPercentOfBusinessOwned1 = value; } }
-        private Value<int?> _personPercentOfBusinessOwned2;
+        private DirtyValue<int?> _personPercentOfBusinessOwned2;
         public int? PersonPercentOfBusinessOwned2 { get { return _personPercentOfBusinessOwned2; } set { _personPercentOfBusinessOwned2 = value; } }
-        private Value<string> _premiumSource;
+        private DirtyValue<string> _premiumSource;
         public string PremiumSource { get { return _premiumSource; } set { _premiumSource = value; } }
-        private Value<decimal?> _presentHousingExpense;
+        private DirtyValue<decimal?> _presentHousingExpense;
         public decimal? PresentHousingExpense { get { return _presentHousingExpense; } set { _presentHousingExpense = value; } }
-        private Value<string> _processingPoint;
+        private DirtyValue<string> _processingPoint;
         public string ProcessingPoint { get { return _processingPoint; } set { _processingPoint = value; } }
-        private Value<string> _propertyType;
+        private DirtyValue<string> _propertyType;
         public string PropertyType { get { return _propertyType; } set { _propertyType = value; } }
-        private Value<string> _purposeOfLoan;
+        private DirtyValue<string> _purposeOfLoan;
         public string PurposeOfLoan { get { return _purposeOfLoan; } set { _purposeOfLoan = value; } }
-        private Value<string> _renewalOption;
+        private DirtyValue<string> _renewalOption;
         public string RenewalOption { get { return _renewalOption; } set { _renewalOption = value; } }
-        private Value<string> _renewalType;
+        private DirtyValue<string> _renewalType;
         public string RenewalType { get { return _renewalType; } set { _renewalType = value; } }
-        private Value<string> _requiredDocumentType;
+        private DirtyValue<string> _requiredDocumentType;
         public string RequiredDocumentType { get { return _requiredDocumentType; } set { _requiredDocumentType = value; } }
-        private Value<decimal?> _reserves;
+        private DirtyValue<decimal?> _reserves;
         public decimal? Reserves { get { return _reserves; } set { _reserves = value; } }
-        private Value<bool?> _retailLoanIndicator;
+        private DirtyValue<bool?> _retailLoanIndicator;
         public bool? RetailLoanIndicator { get { return _retailLoanIndicator; } set { _retailLoanIndicator = value; } }
-        private Value<string> _riskClass;
+        private DirtyValue<string> _riskClass;
         public string RiskClass { get { return _riskClass; } set { _riskClass = value; } }
-        private Value<string> _riskGradeEvaluationType;
+        private DirtyValue<string> _riskGradeEvaluationType;
         public string RiskGradeEvaluationType { get { return _riskGradeEvaluationType; } set { _riskGradeEvaluationType = value; } }
-        private Value<decimal?> _salesConcessions;
+        private DirtyValue<decimal?> _salesConcessions;
         public decimal? SalesConcessions { get { return _salesConcessions; } set { _salesConcessions = value; } }
-        private Value<string> _secondaryFinancingType;
+        private DirtyValue<string> _secondaryFinancingType;
         public string SecondaryFinancingType { get { return _secondaryFinancingType; } set { _secondaryFinancingType = value; } }
-        private Value<bool?> _secondTrustRefiIndicator;
+        private DirtyValue<bool?> _secondTrustRefiIndicator;
         public bool? SecondTrustRefiIndicator { get { return _secondTrustRefiIndicator; } set { _secondTrustRefiIndicator = value; } }
-        private Value<decimal?> _simulatedPITI;
+        private DirtyValue<decimal?> _simulatedPITI;
         public decimal? SimulatedPITI { get { return _simulatedPITI; } set { _simulatedPITI = value; } }
-        private Value<string> _sizeOfHousehold;
+        private DirtyValue<string> _sizeOfHousehold;
         public string SizeOfHousehold { get { return _sizeOfHousehold; } set { _sizeOfHousehold = value; } }
-        private Value<string> _specialInstruction1;
+        private DirtyValue<string> _specialInstruction1;
         public string SpecialInstruction1 { get { return _specialInstruction1; } set { _specialInstruction1 = value; } }
-        private Value<string> _specialInstruction2;
+        private DirtyValue<string> _specialInstruction2;
         public string SpecialInstruction2 { get { return _specialInstruction2; } set { _specialInstruction2 = value; } }
-        private Value<string> _specialInstruction3;
+        private DirtyValue<string> _specialInstruction3;
         public string SpecialInstruction3 { get { return _specialInstruction3; } set { _specialInstruction3 = value; } }
-        private Value<string> _specialInstruction4;
+        private DirtyValue<string> _specialInstruction4;
         public string SpecialInstruction4 { get { return _specialInstruction4; } set { _specialInstruction4 = value; } }
-        private Value<string> _specialInstruction5;
+        private DirtyValue<string> _specialInstruction5;
         public string SpecialInstruction5 { get { return _specialInstruction5; } set { _specialInstruction5 = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<bool?> _transferLoanToConduitIndicator;
+        private DirtyValue<bool?> _transferLoanToConduitIndicator;
         public bool? TransferLoanToConduitIndicator { get { return _transferLoanToConduitIndicator; } set { _transferLoanToConduitIndicator = value; } }
-        private Value<string> _yearsOfCoverage;
+        private DirtyValue<string> _yearsOfCoverage;
         public string YearsOfCoverage { get { return _yearsOfCoverage; } set { _yearsOfCoverage = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Funding.cs
+++ b/src/EncompassRest/Loans/Funding.cs
@@ -8,47 +8,47 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Funding : IDirty
     {
-        private Value<DateTime?> _collateralSentDate;
+        private DirtyValue<DateTime?> _collateralSentDate;
         public DateTime? CollateralSentDate { get { return _collateralSentDate; } set { _collateralSentDate = value; } }
-        private Value<string> _funderName;
+        private DirtyValue<string> _funderName;
         public string FunderName { get { return _funderName; } set { _funderName = value; } }
-        private Value<string> _funderUrl;
+        private DirtyValue<string> _funderUrl;
         public string FunderUrl { get { return _funderUrl; } set { _funderUrl = value; } }
-        private Value<string> _fundingClearedBy;
+        private DirtyValue<string> _fundingClearedBy;
         public string FundingClearedBy { get { return _fundingClearedBy; } set { _fundingClearedBy = value; } }
-        private Value<DateTime?> _fundingCloseDate;
+        private DirtyValue<DateTime?> _fundingCloseDate;
         public DateTime? FundingCloseDate { get { return _fundingCloseDate; } set { _fundingCloseDate = value; } }
-        private Value<string> _fundingFees;
+        private DirtyValue<string> _fundingFees;
         public string FundingFees { get { return _fundingFees; } set { _fundingFees = value; } }
-        private Value<DateTime?> _fundingOrderDate;
+        private DirtyValue<DateTime?> _fundingOrderDate;
         public DateTime? FundingOrderDate { get { return _fundingOrderDate; } set { _fundingOrderDate = value; } }
-        private Value<string> _fundingType;
+        private DirtyValue<string> _fundingType;
         public string FundingType { get { return _fundingType; } set { _fundingType = value; } }
-        private Value<DateTime?> _fundsReleasedDate;
+        private DirtyValue<DateTime?> _fundsReleasedDate;
         public DateTime? FundsReleasedDate { get { return _fundsReleasedDate; } set { _fundsReleasedDate = value; } }
-        private Value<string> _fundsReleaseNumber;
+        private DirtyValue<string> _fundsReleaseNumber;
         public string FundsReleaseNumber { get { return _fundsReleaseNumber; } set { _fundsReleaseNumber = value; } }
-        private Value<DateTime?> _fundsSentDate;
+        private DirtyValue<DateTime?> _fundsSentDate;
         public DateTime? FundsSentDate { get { return _fundsSentDate; } set { _fundsSentDate = value; } }
-        private Value<string> _fundsWireTo;
+        private DirtyValue<string> _fundsWireTo;
         public string FundsWireTo { get { return _fundsWireTo; } set { _fundsWireTo = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _sentToFunderDate;
+        private DirtyValue<DateTime?> _sentToFunderDate;
         public DateTime? SentToFunderDate { get { return _sentToFunderDate; } set { _sentToFunderDate = value; } }
-        private Value<string> _wiredToAbaNumber;
+        private DirtyValue<string> _wiredToAbaNumber;
         public string WiredToAbaNumber { get { return _wiredToAbaNumber; } set { _wiredToAbaNumber = value; } }
-        private Value<string> _wiredToAccountNumber;
+        private DirtyValue<string> _wiredToAccountNumber;
         public string WiredToAccountNumber { get { return _wiredToAccountNumber; } set { _wiredToAccountNumber = value; } }
-        private Value<string> _wiredToForCreditTo;
+        private DirtyValue<string> _wiredToForCreditTo;
         public string WiredToForCreditTo { get { return _wiredToForCreditTo; } set { _wiredToForCreditTo = value; } }
-        private Value<string> _wiredToForCreditTo1;
+        private DirtyValue<string> _wiredToForCreditTo1;
         public string WiredToForCreditTo1 { get { return _wiredToForCreditTo1; } set { _wiredToForCreditTo1 = value; } }
-        private Value<string> _wiredToForCreditTo2;
+        private DirtyValue<string> _wiredToForCreditTo2;
         public string WiredToForCreditTo2 { get { return _wiredToForCreditTo2; } set { _wiredToForCreditTo2 = value; } }
-        private Value<string> _wiredToForFurtherCreditTo1;
+        private DirtyValue<string> _wiredToForFurtherCreditTo1;
         public string WiredToForFurtherCreditTo1 { get { return _wiredToForFurtherCreditTo1; } set { _wiredToForFurtherCreditTo1 = value; } }
-        private Value<string> _wiredToForFurtherCreditTo2;
+        private DirtyValue<string> _wiredToForFurtherCreditTo2;
         public string WiredToForFurtherCreditTo2 { get { return _wiredToForFurtherCreditTo2; } set { _wiredToForFurtherCreditTo2 = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/FundingFee.cs
+++ b/src/EncompassRest/Loans/FundingFee.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class FundingFee : IDirty
     {
-        private Value<bool?> _balanceChecked;
+        private DirtyValue<bool?> _balanceChecked;
         public bool? BalanceChecked { get { return _balanceChecked; } set { _balanceChecked = value; } }
-        private Value<string> _cdLineId;
+        private DirtyValue<string> _cdLineId;
         public string CdLineId { get { return _cdLineId; } set { _cdLineId = value; } }
-        private Value<string> _feeDescription;
+        private DirtyValue<string> _feeDescription;
         public string FeeDescription { get { return _feeDescription; } set { _feeDescription = value; } }
-        private Value<string> _feeDescription2015;
+        private DirtyValue<string> _feeDescription2015;
         public string FeeDescription2015 { get { return _feeDescription2015; } set { _feeDescription2015 = value; } }
-        private Value<string> _lineId;
+        private DirtyValue<string> _lineId;
         public string LineId { get { return _lineId; } set { _lineId = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
-        private Value<string> _paidBy;
+        private DirtyValue<string> _paidBy;
         public string PaidBy { get { return _paidBy; } set { _paidBy = value; } }
-        private Value<string> _paidTo;
+        private DirtyValue<string> _paidTo;
         public string PaidTo { get { return _paidTo; } set { _paidTo = value; } }
-        private Value<string> _payee;
+        private DirtyValue<string> _payee;
         public string Payee { get { return _payee; } set { _payee = value; } }
-        private Value<string> _pocPaidBy;
+        private DirtyValue<string> _pocPaidBy;
         public string PocPaidBy { get { return _pocPaidBy; } set { _pocPaidBy = value; } }
-        private Value<string> _ptcPaidBy;
+        private DirtyValue<string> _ptcPaidBy;
         public string PtcPaidBy { get { return _ptcPaidBy; } set { _ptcPaidBy = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe.cs
+++ b/src/EncompassRest/Loans/Gfe.cs
@@ -8,43 +8,43 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<decimal?> _agregateAdjustment;
+        private DirtyValue<decimal?> _agregateAdjustment;
         public decimal? AgregateAdjustment { get { return _agregateAdjustment; } set { _agregateAdjustment = value; } }
-        private Value<decimal?> _brokerCommission;
+        private DirtyValue<decimal?> _brokerCommission;
         public decimal? BrokerCommission { get { return _brokerCommission; } set { _brokerCommission = value; } }
-        private Value<string> _brokerLicense;
+        private DirtyValue<string> _brokerLicense;
         public string BrokerLicense { get { return _brokerLicense; } set { _brokerLicense = value; } }
-        private Value<string> _brokerName;
+        private DirtyValue<string> _brokerName;
         public string BrokerName { get { return _brokerName; } set { _brokerName = value; } }
-        private Value<string> _brokerRepresentative;
+        private DirtyValue<string> _brokerRepresentative;
         public string BrokerRepresentative { get { return _brokerRepresentative; } set { _brokerRepresentative = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<decimal?> _compensationFromLenderAmount;
+        private DirtyValue<decimal?> _compensationFromLenderAmount;
         public decimal? CompensationFromLenderAmount { get { return _compensationFromLenderAmount; } set { _compensationFromLenderAmount = value; } }
-        private Value<decimal?> _compensationFromLenderPercentage;
+        private DirtyValue<decimal?> _compensationFromLenderPercentage;
         public decimal? CompensationFromLenderPercentage { get { return _compensationFromLenderPercentage; } set { _compensationFromLenderPercentage = value; } }
-        private Value<decimal?> _compensationFromLenderTotalAmount;
+        private DirtyValue<decimal?> _compensationFromLenderTotalAmount;
         public decimal? CompensationFromLenderTotalAmount { get { return _compensationFromLenderTotalAmount; } set { _compensationFromLenderTotalAmount = value; } }
-        private Value<decimal?> _creditLifeOrDisabilityPremium;
+        private DirtyValue<decimal?> _creditLifeOrDisabilityPremium;
         public decimal? CreditLifeOrDisabilityPremium { get { return _creditLifeOrDisabilityPremium; } set { _creditLifeOrDisabilityPremium = value; } }
-        private Value<decimal?> _creditToBorrowerAmount;
+        private DirtyValue<decimal?> _creditToBorrowerAmount;
         public decimal? CreditToBorrowerAmount { get { return _creditToBorrowerAmount; } set { _creditToBorrowerAmount = value; } }
-        private Value<decimal?> _estimatedCashAtClosing;
+        private DirtyValue<decimal?> _estimatedCashAtClosing;
         public decimal? EstimatedCashAtClosing { get { return _estimatedCashAtClosing; } set { _estimatedCashAtClosing = value; } }
-        private Value<decimal?> _estimatedCashToBorrower;
+        private DirtyValue<decimal?> _estimatedCashToBorrower;
         public decimal? EstimatedCashToBorrower { get { return _estimatedCashToBorrower; } set { _estimatedCashToBorrower = value; } }
-        private Value<DateTime?> _estimatedDueDate;
+        private DirtyValue<DateTime?> _estimatedDueDate;
         public DateTime? EstimatedDueDate { get { return _estimatedDueDate; } set { _estimatedDueDate = value; } }
-        private Value<decimal?> _finalBalloonPayment;
+        private DirtyValue<decimal?> _finalBalloonPayment;
         public decimal? FinalBalloonPayment { get { return _finalBalloonPayment; } set { _finalBalloonPayment = value; } }
-        private Value<decimal?> _firstChangePayment;
+        private DirtyValue<decimal?> _firstChangePayment;
         public decimal? FirstChangePayment { get { return _firstChangePayment; } set { _firstChangePayment = value; } }
-        private Value<decimal?> _firstChangePercent;
+        private DirtyValue<decimal?> _firstChangePercent;
         public decimal? FirstChangePercent { get { return _firstChangePercent; } set { _firstChangePercent = value; } }
-        private Value<decimal?> _fundingAmount;
+        private DirtyValue<decimal?> _fundingAmount;
         public decimal? FundingAmount { get { return _fundingAmount; } set { _fundingAmount = value; } }
         private DirtyList<GfeFee> _gfeFees;
         public IList<GfeFee> GfeFees { get { var v = _gfeFees; return v ?? Interlocked.CompareExchange(ref _gfeFees, (v = new DirtyList<GfeFee>()), null) ?? v; } set { _gfeFees = new DirtyList<GfeFee>(value); } }
@@ -54,113 +54,113 @@ namespace EncompassRest.Loans
         public IList<GfePayment> GfePayments { get { var v = _gfePayments; return v ?? Interlocked.CompareExchange(ref _gfePayments, (v = new DirtyList<GfePayment>()), null) ?? v; } set { _gfePayments = new DirtyList<GfePayment>(value); } }
         private DirtyList<GfePayoff> _gfePayoffs;
         public IList<GfePayoff> GfePayoffs { get { var v = _gfePayoffs; return v ?? Interlocked.CompareExchange(ref _gfePayoffs, (v = new DirtyList<GfePayoff>()), null) ?? v; } set { _gfePayoffs = new DirtyList<GfePayoff>(value); } }
-        private Value<bool?> _gfeProvidedByBrokerIndicator;
+        private DirtyValue<bool?> _gfeProvidedByBrokerIndicator;
         public bool? GfeProvidedByBrokerIndicator { get { return _gfeProvidedByBrokerIndicator; } set { _gfeProvidedByBrokerIndicator = value; } }
-        private Value<bool?> _hasAdditionalCompensationIndicator;
+        private DirtyValue<bool?> _hasAdditionalCompensationIndicator;
         public bool? HasAdditionalCompensationIndicator { get { return _hasAdditionalCompensationIndicator; } set { _hasAdditionalCompensationIndicator = value; } }
-        private Value<bool?> _hasLateChargesIndicator;
+        private DirtyValue<bool?> _hasLateChargesIndicator;
         public bool? HasLateChargesIndicator { get { return _hasLateChargesIndicator; } set { _hasLateChargesIndicator = value; } }
-        private Value<bool?> _hasPrepaymentPenaltyIndicator;
+        private DirtyValue<bool?> _hasPrepaymentPenaltyIndicator;
         public bool? HasPrepaymentPenaltyIndicator { get { return _hasPrepaymentPenaltyIndicator; } set { _hasPrepaymentPenaltyIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _initialFixedOrArmType;
+        private DirtyValue<string> _initialFixedOrArmType;
         public string InitialFixedOrArmType { get { return _initialFixedOrArmType; } set { _initialFixedOrArmType = value; } }
-        private Value<decimal?> _lenderOriginationFee;
+        private DirtyValue<decimal?> _lenderOriginationFee;
         public decimal? LenderOriginationFee { get { return _lenderOriginationFee; } set { _lenderOriginationFee = value; } }
-        private Value<string> _loanFromBrokerControledFundsType;
+        private DirtyValue<string> _loanFromBrokerControledFundsType;
         public string LoanFromBrokerControledFundsType { get { return _loanFromBrokerControledFundsType; } set { _loanFromBrokerControledFundsType = value; } }
-        private Value<bool?> _lockField;
+        private DirtyValue<bool?> _lockField;
         public bool? LockField { get { return _lockField; } set { _lockField = value; } }
-        private Value<decimal?> _maxLifePayment;
+        private DirtyValue<decimal?> _maxLifePayment;
         public decimal? MaxLifePayment { get { return _maxLifePayment; } set { _maxLifePayment = value; } }
-        private Value<int?> _maxPaymentAfterMonth;
+        private DirtyValue<int?> _maxPaymentAfterMonth;
         public int? MaxPaymentAfterMonth { get { return _maxPaymentAfterMonth; } set { _maxPaymentAfterMonth = value; } }
-        private Value<decimal?> _monthlyPaymentAndEscrow;
+        private DirtyValue<decimal?> _monthlyPaymentAndEscrow;
         public decimal? MonthlyPaymentAndEscrow { get { return _monthlyPaymentAndEscrow; } set { _monthlyPaymentAndEscrow = value; } }
-        private Value<decimal?> _mortgageBrokerComissionFee;
+        private DirtyValue<decimal?> _mortgageBrokerComissionFee;
         public decimal? MortgageBrokerComissionFee { get { return _mortgageBrokerComissionFee; } set { _mortgageBrokerComissionFee = value; } }
-        private Value<string> _mortgageBrokerComissionFeePaidToName;
+        private DirtyValue<string> _mortgageBrokerComissionFeePaidToName;
         public string MortgageBrokerComissionFeePaidToName { get { return _mortgageBrokerComissionFeePaidToName; } set { _mortgageBrokerComissionFeePaidToName = value; } }
-        private Value<string> _natureLien1Description;
+        private DirtyValue<string> _natureLien1Description;
         public string NatureLien1Description { get { return _natureLien1Description; } set { _natureLien1Description = value; } }
-        private Value<string> _natureLien1PayoffDescription;
+        private DirtyValue<string> _natureLien1PayoffDescription;
         public string NatureLien1PayoffDescription { get { return _natureLien1PayoffDescription; } set { _natureLien1PayoffDescription = value; } }
-        private Value<string> _natureLien2Description;
+        private DirtyValue<string> _natureLien2Description;
         public string NatureLien2Description { get { return _natureLien2Description; } set { _natureLien2Description = value; } }
-        private Value<string> _natureLien2PayoffDescription;
+        private DirtyValue<string> _natureLien2PayoffDescription;
         public string NatureLien2PayoffDescription { get { return _natureLien2PayoffDescription; } set { _natureLien2PayoffDescription = value; } }
-        private Value<string> _natureLien3Description;
+        private DirtyValue<string> _natureLien3Description;
         public string NatureLien3Description { get { return _natureLien3Description; } set { _natureLien3Description = value; } }
-        private Value<string> _natureLien3PayoffDescription;
+        private DirtyValue<string> _natureLien3PayoffDescription;
         public string NatureLien3PayoffDescription { get { return _natureLien3PayoffDescription; } set { _natureLien3PayoffDescription = value; } }
-        private Value<bool?> _paymentOfPrincipleIndicator;
+        private DirtyValue<bool?> _paymentOfPrincipleIndicator;
         public bool? PaymentOfPrincipleIndicator { get { return _paymentOfPrincipleIndicator; } set { _paymentOfPrincipleIndicator = value; } }
-        private Value<string> _paymentOfPrincipleType;
+        private DirtyValue<string> _paymentOfPrincipleType;
         public string PaymentOfPrincipleType { get { return _paymentOfPrincipleType; } set { _paymentOfPrincipleType = value; } }
-        private Value<int?> _penaltyNotToExceedMonths;
+        private DirtyValue<int?> _penaltyNotToExceedMonths;
         public int? PenaltyNotToExceedMonths { get { return _penaltyNotToExceedMonths; } set { _penaltyNotToExceedMonths = value; } }
-        private Value<string> _pocPaid1;
+        private DirtyValue<string> _pocPaid1;
         public string PocPaid1 { get { return _pocPaid1; } set { _pocPaid1 = value; } }
-        private Value<string> _pocPaid2;
+        private DirtyValue<string> _pocPaid2;
         public string PocPaid2 { get { return _pocPaid2; } set { _pocPaid2 = value; } }
-        private Value<string> _pocPaid3;
+        private DirtyValue<string> _pocPaid3;
         public string PocPaid3 { get { return _pocPaid3; } set { _pocPaid3 = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _prepaymentOtherDescription;
+        private DirtyValue<string> _prepaymentOtherDescription;
         public string PrepaymentOtherDescription { get { return _prepaymentOtherDescription; } set { _prepaymentOtherDescription = value; } }
-        private Value<bool?> _prepaymentOtherTypeIndicator;
+        private DirtyValue<bool?> _prepaymentOtherTypeIndicator;
         public bool? PrepaymentOtherTypeIndicator { get { return _prepaymentOtherTypeIndicator; } set { _prepaymentOtherTypeIndicator = value; } }
-        private Value<decimal?> _prepaymentPenaltyAmount;
+        private DirtyValue<decimal?> _prepaymentPenaltyAmount;
         public decimal? PrepaymentPenaltyAmount { get { return _prepaymentPenaltyAmount; } set { _prepaymentPenaltyAmount = value; } }
-        private Value<bool?> _prepaymentPenaltyIndicator;
+        private DirtyValue<bool?> _prepaymentPenaltyIndicator;
         public bool? PrepaymentPenaltyIndicator { get { return _prepaymentPenaltyIndicator; } set { _prepaymentPenaltyIndicator = value; } }
-        private Value<int?> _prepaymentPenaltyPeriod;
+        private DirtyValue<int?> _prepaymentPenaltyPeriod;
         public int? PrepaymentPenaltyPeriod { get { return _prepaymentPenaltyPeriod; } set { _prepaymentPenaltyPeriod = value; } }
-        private Value<decimal?> _principalAmount;
+        private DirtyValue<decimal?> _principalAmount;
         public decimal? PrincipalAmount { get { return _principalAmount; } set { _principalAmount = value; } }
-        private Value<decimal?> _purchasePayOff;
+        private DirtyValue<decimal?> _purchasePayOff;
         public decimal? PurchasePayOff { get { return _purchasePayOff; } set { _purchasePayOff = value; } }
-        private Value<decimal?> _re882AdditionalCompensation;
+        private DirtyValue<decimal?> _re882AdditionalCompensation;
         public decimal? Re882AdditionalCompensation { get { return _re882AdditionalCompensation; } set { _re882AdditionalCompensation = value; } }
-        private Value<decimal?> _receivedFromLenderAmount;
+        private DirtyValue<decimal?> _receivedFromLenderAmount;
         public decimal? ReceivedFromLenderAmount { get { return _receivedFromLenderAmount; } set { _receivedFromLenderAmount = value; } }
-        private Value<string> _representativeLicense;
+        private DirtyValue<string> _representativeLicense;
         public string RepresentativeLicense { get { return _representativeLicense; } set { _representativeLicense = value; } }
-        private Value<bool?> _sourcesDeemedReliableIndicator;
+        private DirtyValue<bool?> _sourcesDeemedReliableIndicator;
         public bool? SourcesDeemedReliableIndicator { get { return _sourcesDeemedReliableIndicator; } set { _sourcesDeemedReliableIndicator = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<decimal?> _subtotalOfAllDeductions;
+        private DirtyValue<decimal?> _subtotalOfAllDeductions;
         public decimal? SubtotalOfAllDeductions { get { return _subtotalOfAllDeductions; } set { _subtotalOfAllDeductions = value; } }
-        private Value<decimal?> _totalBrokerCompensationAmount;
+        private DirtyValue<decimal?> _totalBrokerCompensationAmount;
         public decimal? TotalBrokerCompensationAmount { get { return _totalBrokerCompensationAmount; } set { _totalBrokerCompensationAmount = value; } }
-        private Value<decimal?> _totalClosingCostWithDiscount;
+        private DirtyValue<decimal?> _totalClosingCostWithDiscount;
         public decimal? TotalClosingCostWithDiscount { get { return _totalClosingCostWithDiscount; } set { _totalClosingCostWithDiscount = value; } }
-        private Value<decimal?> _totalCostsExpenses;
+        private DirtyValue<decimal?> _totalCostsExpenses;
         public decimal? TotalCostsExpenses { get { return _totalCostsExpenses; } set { _totalCostsExpenses = value; } }
-        private Value<decimal?> _totalMaximumCostsExpenses;
+        private DirtyValue<decimal?> _totalMaximumCostsExpenses;
         public decimal? TotalMaximumCostsExpenses { get { return _totalMaximumCostsExpenses; } set { _totalMaximumCostsExpenses = value; } }
-        private Value<decimal?> _totalOfInitialFees;
+        private DirtyValue<decimal?> _totalOfInitialFees;
         public decimal? TotalOfInitialFees { get { return _totalOfInitialFees; } set { _totalOfInitialFees = value; } }
-        private Value<decimal?> _totalPrepaidClosingCost;
+        private DirtyValue<decimal?> _totalPrepaidClosingCost;
         public decimal? TotalPrepaidClosingCost { get { return _totalPrepaidClosingCost; } set { _totalPrepaidClosingCost = value; } }
-        private Value<decimal?> _totalSettlementCharges;
+        private DirtyValue<decimal?> _totalSettlementCharges;
         public decimal? TotalSettlementCharges { get { return _totalSettlementCharges; } set { _totalSettlementCharges = value; } }
-        private Value<decimal?> _totalTaxAndInsurance;
+        private DirtyValue<decimal?> _totalTaxAndInsurance;
         public decimal? TotalTaxAndInsurance { get { return _totalTaxAndInsurance; } set { _totalTaxAndInsurance = value; } }
-        private Value<decimal?> _yearlyFloodInsurance;
+        private DirtyValue<decimal?> _yearlyFloodInsurance;
         public decimal? YearlyFloodInsurance { get { return _yearlyFloodInsurance; } set { _yearlyFloodInsurance = value; } }
-        private Value<decimal?> _yearlyInsurance;
+        private DirtyValue<decimal?> _yearlyInsurance;
         public decimal? YearlyInsurance { get { return _yearlyInsurance; } set { _yearlyInsurance = value; } }
-        private Value<decimal?> _yearlyMortgageInsurance;
+        private DirtyValue<decimal?> _yearlyMortgageInsurance;
         public decimal? YearlyMortgageInsurance { get { return _yearlyMortgageInsurance; } set { _yearlyMortgageInsurance = value; } }
-        private Value<decimal?> _yearlyOtherInsurance;
+        private DirtyValue<decimal?> _yearlyOtherInsurance;
         public decimal? YearlyOtherInsurance { get { return _yearlyOtherInsurance; } set { _yearlyOtherInsurance = value; } }
-        private Value<string> _yearlyOtherInsuranceDescription;
+        private DirtyValue<string> _yearlyOtherInsuranceDescription;
         public string YearlyOtherInsuranceDescription { get { return _yearlyOtherInsuranceDescription; } set { _yearlyOtherInsuranceDescription = value; } }
-        private Value<decimal?> _yearlyTax;
+        private DirtyValue<decimal?> _yearlyTax;
         public decimal? YearlyTax { get { return _yearlyTax; } set { _yearlyTax = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe.cs
+++ b/src/EncompassRest/Loans/Gfe.cs
@@ -46,14 +46,14 @@ namespace EncompassRest.Loans
         public decimal? FirstChangePercent { get { return _firstChangePercent; } set { _firstChangePercent = value; } }
         private Value<decimal?> _fundingAmount;
         public decimal? FundingAmount { get { return _fundingAmount; } set { _fundingAmount = value; } }
-        private Value<List<GfeFee>> _gfeFees;
-        public List<GfeFee> GfeFees { get { return _gfeFees; } set { _gfeFees = value; } }
-        private Value<List<GfeLien>> _gfeLiens;
-        public List<GfeLien> GfeLiens { get { return _gfeLiens; } set { _gfeLiens = value; } }
-        private Value<List<GfePayment>> _gfePayments;
-        public List<GfePayment> GfePayments { get { return _gfePayments; } set { _gfePayments = value; } }
-        private Value<List<GfePayoff>> _gfePayoffs;
-        public List<GfePayoff> GfePayoffs { get { return _gfePayoffs; } set { _gfePayoffs = value; } }
+        private DirtyList<GfeFee> _gfeFees;
+        public IList<GfeFee> GfeFees { get { var v = _gfeFees; return v ?? Interlocked.CompareExchange(ref _gfeFees, (v = new DirtyList<GfeFee>()), null) ?? v; } set { _gfeFees = new DirtyList<GfeFee>(value); } }
+        private DirtyList<GfeLien> _gfeLiens;
+        public IList<GfeLien> GfeLiens { get { var v = _gfeLiens; return v ?? Interlocked.CompareExchange(ref _gfeLiens, (v = new DirtyList<GfeLien>()), null) ?? v; } set { _gfeLiens = new DirtyList<GfeLien>(value); } }
+        private DirtyList<GfePayment> _gfePayments;
+        public IList<GfePayment> GfePayments { get { var v = _gfePayments; return v ?? Interlocked.CompareExchange(ref _gfePayments, (v = new DirtyList<GfePayment>()), null) ?? v; } set { _gfePayments = new DirtyList<GfePayment>(value); } }
+        private DirtyList<GfePayoff> _gfePayoffs;
+        public IList<GfePayoff> GfePayoffs { get { var v = _gfePayoffs; return v ?? Interlocked.CompareExchange(ref _gfePayoffs, (v = new DirtyList<GfePayoff>()), null) ?? v; } set { _gfePayoffs = new DirtyList<GfePayoff>(value); } }
         private Value<bool?> _gfeProvidedByBrokerIndicator;
         public bool? GfeProvidedByBrokerIndicator { get { return _gfeProvidedByBrokerIndicator; } set { _gfeProvidedByBrokerIndicator = value; } }
         private Value<bool?> _hasAdditionalCompensationIndicator;
@@ -188,10 +188,6 @@ namespace EncompassRest.Loans
                     || _firstChangePayment.Dirty
                     || _firstChangePercent.Dirty
                     || _fundingAmount.Dirty
-                    || _gfeFees.Dirty
-                    || _gfeLiens.Dirty
-                    || _gfePayments.Dirty
-                    || _gfePayoffs.Dirty
                     || _gfeProvidedByBrokerIndicator.Dirty
                     || _hasAdditionalCompensationIndicator.Dirty
                     || _hasLateChargesIndicator.Dirty
@@ -245,7 +241,11 @@ namespace EncompassRest.Loans
                     || _yearlyMortgageInsurance.Dirty
                     || _yearlyOtherInsurance.Dirty
                     || _yearlyOtherInsuranceDescription.Dirty
-                    || _yearlyTax.Dirty;
+                    || _yearlyTax.Dirty
+                    || _gfeFees?.Dirty == true
+                    || _gfeLiens?.Dirty == true
+                    || _gfePayments?.Dirty == true
+                    || _gfePayoffs?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -271,10 +271,6 @@ namespace EncompassRest.Loans
                 _firstChangePayment.Dirty = value;
                 _firstChangePercent.Dirty = value;
                 _fundingAmount.Dirty = value;
-                _gfeFees.Dirty = value;
-                _gfeLiens.Dirty = value;
-                _gfePayments.Dirty = value;
-                _gfePayoffs.Dirty = value;
                 _gfeProvidedByBrokerIndicator.Dirty = value;
                 _hasAdditionalCompensationIndicator.Dirty = value;
                 _hasLateChargesIndicator.Dirty = value;
@@ -329,6 +325,10 @@ namespace EncompassRest.Loans
                 _yearlyOtherInsurance.Dirty = value;
                 _yearlyOtherInsuranceDescription.Dirty = value;
                 _yearlyTax.Dirty = value;
+                if (_gfeFees != null) _gfeFees.Dirty = value;
+                if (_gfeLiens != null) _gfeLiens.Dirty = value;
+                if (_gfePayments != null) _gfePayments.Dirty = value;
+                if (_gfePayoffs != null) _gfePayoffs.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Gfe2010.cs
+++ b/src/EncompassRest/Loans/Gfe2010.cs
@@ -8,435 +8,435 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010 : IDirty
     {
-        private Value<decimal?> _adjustedOriginationCharges;
+        private DirtyValue<decimal?> _adjustedOriginationCharges;
         public decimal? AdjustedOriginationCharges { get { return _adjustedOriginationCharges; } set { _adjustedOriginationCharges = value; } }
-        private Value<decimal?> _allOtherServiceAmount;
+        private DirtyValue<decimal?> _allOtherServiceAmount;
         public decimal? AllOtherServiceAmount { get { return _allOtherServiceAmount; } set { _allOtherServiceAmount = value; } }
-        private Value<decimal?> _applicationFees;
+        private DirtyValue<decimal?> _applicationFees;
         public decimal? ApplicationFees { get { return _applicationFees; } set { _applicationFees = value; } }
-        private Value<bool?> _borrowerSelectIndicator10;
+        private DirtyValue<bool?> _borrowerSelectIndicator10;
         public bool? BorrowerSelectIndicator10 { get { return _borrowerSelectIndicator10; } set { _borrowerSelectIndicator10 = value; } }
-        private Value<bool?> _borrowerSelectIndicator11;
+        private DirtyValue<bool?> _borrowerSelectIndicator11;
         public bool? BorrowerSelectIndicator11 { get { return _borrowerSelectIndicator11; } set { _borrowerSelectIndicator11 = value; } }
-        private Value<bool?> _borrowerSelectIndicator12;
+        private DirtyValue<bool?> _borrowerSelectIndicator12;
         public bool? BorrowerSelectIndicator12 { get { return _borrowerSelectIndicator12; } set { _borrowerSelectIndicator12 = value; } }
-        private Value<bool?> _borrowerSelectIndicator13;
+        private DirtyValue<bool?> _borrowerSelectIndicator13;
         public bool? BorrowerSelectIndicator13 { get { return _borrowerSelectIndicator13; } set { _borrowerSelectIndicator13 = value; } }
-        private Value<bool?> _borrowerSelectIndicator14;
+        private DirtyValue<bool?> _borrowerSelectIndicator14;
         public bool? BorrowerSelectIndicator14 { get { return _borrowerSelectIndicator14; } set { _borrowerSelectIndicator14 = value; } }
-        private Value<bool?> _borrowerSelectIndicator15;
+        private DirtyValue<bool?> _borrowerSelectIndicator15;
         public bool? BorrowerSelectIndicator15 { get { return _borrowerSelectIndicator15; } set { _borrowerSelectIndicator15 = value; } }
-        private Value<bool?> _borrowerSelectIndicator16;
+        private DirtyValue<bool?> _borrowerSelectIndicator16;
         public bool? BorrowerSelectIndicator16 { get { return _borrowerSelectIndicator16; } set { _borrowerSelectIndicator16 = value; } }
-        private Value<bool?> _borrowerSelectIndicator17;
+        private DirtyValue<bool?> _borrowerSelectIndicator17;
         public bool? BorrowerSelectIndicator17 { get { return _borrowerSelectIndicator17; } set { _borrowerSelectIndicator17 = value; } }
-        private Value<bool?> _borrowerSelectIndicator18;
+        private DirtyValue<bool?> _borrowerSelectIndicator18;
         public bool? BorrowerSelectIndicator18 { get { return _borrowerSelectIndicator18; } set { _borrowerSelectIndicator18 = value; } }
-        private Value<bool?> _borrowerSelectIndicator19;
+        private DirtyValue<bool?> _borrowerSelectIndicator19;
         public bool? BorrowerSelectIndicator19 { get { return _borrowerSelectIndicator19; } set { _borrowerSelectIndicator19 = value; } }
-        private Value<bool?> _borrowerSelectIndicator2;
+        private DirtyValue<bool?> _borrowerSelectIndicator2;
         public bool? BorrowerSelectIndicator2 { get { return _borrowerSelectIndicator2; } set { _borrowerSelectIndicator2 = value; } }
-        private Value<bool?> _borrowerSelectIndicator20;
+        private DirtyValue<bool?> _borrowerSelectIndicator20;
         public bool? BorrowerSelectIndicator20 { get { return _borrowerSelectIndicator20; } set { _borrowerSelectIndicator20 = value; } }
-        private Value<bool?> _borrowerSelectIndicator3;
+        private DirtyValue<bool?> _borrowerSelectIndicator3;
         public bool? BorrowerSelectIndicator3 { get { return _borrowerSelectIndicator3; } set { _borrowerSelectIndicator3 = value; } }
-        private Value<bool?> _borrowerSelectIndicator4;
+        private DirtyValue<bool?> _borrowerSelectIndicator4;
         public bool? BorrowerSelectIndicator4 { get { return _borrowerSelectIndicator4; } set { _borrowerSelectIndicator4 = value; } }
-        private Value<bool?> _borrowerSelectIndicator5;
+        private DirtyValue<bool?> _borrowerSelectIndicator5;
         public bool? BorrowerSelectIndicator5 { get { return _borrowerSelectIndicator5; } set { _borrowerSelectIndicator5 = value; } }
-        private Value<bool?> _borrowerSelectIndicator6;
+        private DirtyValue<bool?> _borrowerSelectIndicator6;
         public bool? BorrowerSelectIndicator6 { get { return _borrowerSelectIndicator6; } set { _borrowerSelectIndicator6 = value; } }
-        private Value<bool?> _borrowerSelectIndicator7;
+        private DirtyValue<bool?> _borrowerSelectIndicator7;
         public bool? BorrowerSelectIndicator7 { get { return _borrowerSelectIndicator7; } set { _borrowerSelectIndicator7 = value; } }
-        private Value<bool?> _borrowerSelectIndicator8;
+        private DirtyValue<bool?> _borrowerSelectIndicator8;
         public bool? BorrowerSelectIndicator8 { get { return _borrowerSelectIndicator8; } set { _borrowerSelectIndicator8 = value; } }
-        private Value<bool?> _borrowerSelectIndicator9;
+        private DirtyValue<bool?> _borrowerSelectIndicator9;
         public bool? BorrowerSelectIndicator9 { get { return _borrowerSelectIndicator9; } set { _borrowerSelectIndicator9 = value; } }
-        private Value<decimal?> _brokerAdditionalFees;
+        private DirtyValue<decimal?> _brokerAdditionalFees;
         public decimal? BrokerAdditionalFees { get { return _brokerAdditionalFees; } set { _brokerAdditionalFees = value; } }
-        private Value<decimal?> _brokerFees;
+        private DirtyValue<decimal?> _brokerFees;
         public decimal? BrokerFees { get { return _brokerFees; } set { _brokerFees = value; } }
-        private Value<decimal?> _brokerFeesPercentage;
+        private DirtyValue<decimal?> _brokerFeesPercentage;
         public decimal? BrokerFeesPercentage { get { return _brokerFeesPercentage; } set { _brokerFeesPercentage = value; } }
-        private Value<decimal?> _chargeAmount;
+        private DirtyValue<decimal?> _chargeAmount;
         public decimal? ChargeAmount { get { return _chargeAmount; } set { _chargeAmount = value; } }
-        private Value<decimal?> _chargeAmountForPrint;
+        private DirtyValue<decimal?> _chargeAmountForPrint;
         public decimal? ChargeAmountForPrint { get { return _chargeAmountForPrint; } set { _chargeAmountForPrint = value; } }
-        private Value<bool?> _copyFromGfeIndicator1;
+        private DirtyValue<bool?> _copyFromGfeIndicator1;
         public bool? CopyFromGfeIndicator1 { get { return _copyFromGfeIndicator1; } set { _copyFromGfeIndicator1 = value; } }
-        private Value<bool?> _copyFromGfeIndicator10;
+        private DirtyValue<bool?> _copyFromGfeIndicator10;
         public bool? CopyFromGfeIndicator10 { get { return _copyFromGfeIndicator10; } set { _copyFromGfeIndicator10 = value; } }
-        private Value<bool?> _copyFromGfeIndicator11;
+        private DirtyValue<bool?> _copyFromGfeIndicator11;
         public bool? CopyFromGfeIndicator11 { get { return _copyFromGfeIndicator11; } set { _copyFromGfeIndicator11 = value; } }
-        private Value<bool?> _copyFromGfeIndicator12;
+        private DirtyValue<bool?> _copyFromGfeIndicator12;
         public bool? CopyFromGfeIndicator12 { get { return _copyFromGfeIndicator12; } set { _copyFromGfeIndicator12 = value; } }
-        private Value<bool?> _copyFromGfeIndicator13;
+        private DirtyValue<bool?> _copyFromGfeIndicator13;
         public bool? CopyFromGfeIndicator13 { get { return _copyFromGfeIndicator13; } set { _copyFromGfeIndicator13 = value; } }
-        private Value<bool?> _copyFromGfeIndicator14;
+        private DirtyValue<bool?> _copyFromGfeIndicator14;
         public bool? CopyFromGfeIndicator14 { get { return _copyFromGfeIndicator14; } set { _copyFromGfeIndicator14 = value; } }
-        private Value<bool?> _copyFromGfeIndicator15;
+        private DirtyValue<bool?> _copyFromGfeIndicator15;
         public bool? CopyFromGfeIndicator15 { get { return _copyFromGfeIndicator15; } set { _copyFromGfeIndicator15 = value; } }
-        private Value<bool?> _copyFromGfeIndicator16;
+        private DirtyValue<bool?> _copyFromGfeIndicator16;
         public bool? CopyFromGfeIndicator16 { get { return _copyFromGfeIndicator16; } set { _copyFromGfeIndicator16 = value; } }
-        private Value<bool?> _copyFromGfeIndicator17;
+        private DirtyValue<bool?> _copyFromGfeIndicator17;
         public bool? CopyFromGfeIndicator17 { get { return _copyFromGfeIndicator17; } set { _copyFromGfeIndicator17 = value; } }
-        private Value<bool?> _copyFromGfeIndicator18;
+        private DirtyValue<bool?> _copyFromGfeIndicator18;
         public bool? CopyFromGfeIndicator18 { get { return _copyFromGfeIndicator18; } set { _copyFromGfeIndicator18 = value; } }
-        private Value<bool?> _copyFromGfeIndicator19;
+        private DirtyValue<bool?> _copyFromGfeIndicator19;
         public bool? CopyFromGfeIndicator19 { get { return _copyFromGfeIndicator19; } set { _copyFromGfeIndicator19 = value; } }
-        private Value<bool?> _copyFromGfeIndicator2;
+        private DirtyValue<bool?> _copyFromGfeIndicator2;
         public bool? CopyFromGfeIndicator2 { get { return _copyFromGfeIndicator2; } set { _copyFromGfeIndicator2 = value; } }
-        private Value<bool?> _copyFromGfeIndicator20;
+        private DirtyValue<bool?> _copyFromGfeIndicator20;
         public bool? CopyFromGfeIndicator20 { get { return _copyFromGfeIndicator20; } set { _copyFromGfeIndicator20 = value; } }
-        private Value<bool?> _copyFromGfeIndicator21;
+        private DirtyValue<bool?> _copyFromGfeIndicator21;
         public bool? CopyFromGfeIndicator21 { get { return _copyFromGfeIndicator21; } set { _copyFromGfeIndicator21 = value; } }
-        private Value<bool?> _copyFromGfeIndicator22;
+        private DirtyValue<bool?> _copyFromGfeIndicator22;
         public bool? CopyFromGfeIndicator22 { get { return _copyFromGfeIndicator22; } set { _copyFromGfeIndicator22 = value; } }
-        private Value<bool?> _copyFromGfeIndicator23;
+        private DirtyValue<bool?> _copyFromGfeIndicator23;
         public bool? CopyFromGfeIndicator23 { get { return _copyFromGfeIndicator23; } set { _copyFromGfeIndicator23 = value; } }
-        private Value<bool?> _copyFromGfeIndicator24;
+        private DirtyValue<bool?> _copyFromGfeIndicator24;
         public bool? CopyFromGfeIndicator24 { get { return _copyFromGfeIndicator24; } set { _copyFromGfeIndicator24 = value; } }
-        private Value<bool?> _copyFromGfeIndicator25;
+        private DirtyValue<bool?> _copyFromGfeIndicator25;
         public bool? CopyFromGfeIndicator25 { get { return _copyFromGfeIndicator25; } set { _copyFromGfeIndicator25 = value; } }
-        private Value<bool?> _copyFromGfeIndicator26;
+        private DirtyValue<bool?> _copyFromGfeIndicator26;
         public bool? CopyFromGfeIndicator26 { get { return _copyFromGfeIndicator26; } set { _copyFromGfeIndicator26 = value; } }
-        private Value<bool?> _copyFromGfeIndicator27;
+        private DirtyValue<bool?> _copyFromGfeIndicator27;
         public bool? CopyFromGfeIndicator27 { get { return _copyFromGfeIndicator27; } set { _copyFromGfeIndicator27 = value; } }
-        private Value<bool?> _copyFromGfeIndicator28;
+        private DirtyValue<bool?> _copyFromGfeIndicator28;
         public bool? CopyFromGfeIndicator28 { get { return _copyFromGfeIndicator28; } set { _copyFromGfeIndicator28 = value; } }
-        private Value<bool?> _copyFromGfeIndicator29;
+        private DirtyValue<bool?> _copyFromGfeIndicator29;
         public bool? CopyFromGfeIndicator29 { get { return _copyFromGfeIndicator29; } set { _copyFromGfeIndicator29 = value; } }
-        private Value<bool?> _copyFromGfeIndicator3;
+        private DirtyValue<bool?> _copyFromGfeIndicator3;
         public bool? CopyFromGfeIndicator3 { get { return _copyFromGfeIndicator3; } set { _copyFromGfeIndicator3 = value; } }
-        private Value<bool?> _copyFromGfeIndicator30;
+        private DirtyValue<bool?> _copyFromGfeIndicator30;
         public bool? CopyFromGfeIndicator30 { get { return _copyFromGfeIndicator30; } set { _copyFromGfeIndicator30 = value; } }
-        private Value<bool?> _copyFromGfeIndicator31;
+        private DirtyValue<bool?> _copyFromGfeIndicator31;
         public bool? CopyFromGfeIndicator31 { get { return _copyFromGfeIndicator31; } set { _copyFromGfeIndicator31 = value; } }
-        private Value<bool?> _copyFromGfeIndicator32;
+        private DirtyValue<bool?> _copyFromGfeIndicator32;
         public bool? CopyFromGfeIndicator32 { get { return _copyFromGfeIndicator32; } set { _copyFromGfeIndicator32 = value; } }
-        private Value<bool?> _copyFromGfeIndicator33;
+        private DirtyValue<bool?> _copyFromGfeIndicator33;
         public bool? CopyFromGfeIndicator33 { get { return _copyFromGfeIndicator33; } set { _copyFromGfeIndicator33 = value; } }
-        private Value<bool?> _copyFromGfeIndicator34;
+        private DirtyValue<bool?> _copyFromGfeIndicator34;
         public bool? CopyFromGfeIndicator34 { get { return _copyFromGfeIndicator34; } set { _copyFromGfeIndicator34 = value; } }
-        private Value<bool?> _copyFromGfeIndicator35;
+        private DirtyValue<bool?> _copyFromGfeIndicator35;
         public bool? CopyFromGfeIndicator35 { get { return _copyFromGfeIndicator35; } set { _copyFromGfeIndicator35 = value; } }
-        private Value<bool?> _copyFromGfeIndicator4;
+        private DirtyValue<bool?> _copyFromGfeIndicator4;
         public bool? CopyFromGfeIndicator4 { get { return _copyFromGfeIndicator4; } set { _copyFromGfeIndicator4 = value; } }
-        private Value<bool?> _copyFromGfeIndicator5;
+        private DirtyValue<bool?> _copyFromGfeIndicator5;
         public bool? CopyFromGfeIndicator5 { get { return _copyFromGfeIndicator5; } set { _copyFromGfeIndicator5 = value; } }
-        private Value<bool?> _copyFromGfeIndicator6;
+        private DirtyValue<bool?> _copyFromGfeIndicator6;
         public bool? CopyFromGfeIndicator6 { get { return _copyFromGfeIndicator6; } set { _copyFromGfeIndicator6 = value; } }
-        private Value<bool?> _copyFromGfeIndicator7;
+        private DirtyValue<bool?> _copyFromGfeIndicator7;
         public bool? CopyFromGfeIndicator7 { get { return _copyFromGfeIndicator7; } set { _copyFromGfeIndicator7 = value; } }
-        private Value<bool?> _copyFromGfeIndicator8;
+        private DirtyValue<bool?> _copyFromGfeIndicator8;
         public bool? CopyFromGfeIndicator8 { get { return _copyFromGfeIndicator8; } set { _copyFromGfeIndicator8 = value; } }
-        private Value<bool?> _copyFromGfeIndicator9;
+        private DirtyValue<bool?> _copyFromGfeIndicator9;
         public bool? CopyFromGfeIndicator9 { get { return _copyFromGfeIndicator9; } set { _copyFromGfeIndicator9 = value; } }
-        private Value<decimal?> _creditAmount;
+        private DirtyValue<decimal?> _creditAmount;
         public decimal? CreditAmount { get { return _creditAmount; } set { _creditAmount = value; } }
-        private Value<decimal?> _creditAmountForPrint;
+        private DirtyValue<decimal?> _creditAmountForPrint;
         public decimal? CreditAmountForPrint { get { return _creditAmountForPrint; } set { _creditAmountForPrint = value; } }
-        private Value<string> _creditChargeType;
+        private DirtyValue<string> _creditChargeType;
         public string CreditChargeType { get { return _creditChargeType; } set { _creditChargeType = value; } }
-        private Value<decimal?> _creditOrChange;
+        private DirtyValue<decimal?> _creditOrChange;
         public decimal? CreditOrChange { get { return _creditOrChange; } set { _creditOrChange = value; } }
-        private Value<decimal?> _curedAdjustedOriginationCharges;
+        private DirtyValue<decimal?> _curedAdjustedOriginationCharges;
         public decimal? CuredAdjustedOriginationCharges { get { return _curedAdjustedOriginationCharges; } set { _curedAdjustedOriginationCharges = value; } }
-        private Value<decimal?> _curedCreditOrChange;
+        private DirtyValue<decimal?> _curedCreditOrChange;
         public decimal? CuredCreditOrChange { get { return _curedCreditOrChange; } set { _curedCreditOrChange = value; } }
-        private Value<decimal?> _curedOriginationCharges;
+        private DirtyValue<decimal?> _curedOriginationCharges;
         public decimal? CuredOriginationCharges { get { return _curedOriginationCharges; } set { _curedOriginationCharges = value; } }
-        private Value<decimal?> _curedTotalTransferTaxes;
+        private DirtyValue<decimal?> _curedTotalTransferTaxes;
         public decimal? CuredTotalTransferTaxes { get { return _curedTotalTransferTaxes; } set { _curedTotalTransferTaxes = value; } }
-        private Value<decimal?> _dailyInterestCharges;
+        private DirtyValue<decimal?> _dailyInterestCharges;
         public decimal? DailyInterestCharges { get { return _dailyInterestCharges; } set { _dailyInterestCharges = value; } }
-        private Value<DateTime?> _dateForCharges;
+        private DirtyValue<DateTime?> _dateForCharges;
         public DateTime? DateForCharges { get { return _dateForCharges; } set { _dateForCharges = value; } }
-        private Value<string> _dateForRate;
+        private DirtyValue<string> _dateForRate;
         public string DateForRate { get { return _dateForRate; } set { _dateForRate = value; } }
-        private Value<string> _daysToSettlement;
+        private DirtyValue<string> _daysToSettlement;
         public string DaysToSettlement { get { return _daysToSettlement; } set { _daysToSettlement = value; } }
-        private Value<int?> _durationMonths;
+        private DirtyValue<int?> _durationMonths;
         public int? DurationMonths { get { return _durationMonths; } set { _durationMonths = value; } }
-        private Value<bool?> _escrowChargeAllInsuranceIndicator;
+        private DirtyValue<bool?> _escrowChargeAllInsuranceIndicator;
         public bool? EscrowChargeAllInsuranceIndicator { get { return _escrowChargeAllInsuranceIndicator; } set { _escrowChargeAllInsuranceIndicator = value; } }
-        private Value<bool?> _escrowChargeAllPropertyTaxesIndicator;
+        private DirtyValue<bool?> _escrowChargeAllPropertyTaxesIndicator;
         public bool? EscrowChargeAllPropertyTaxesIndicator { get { return _escrowChargeAllPropertyTaxesIndicator; } set { _escrowChargeAllPropertyTaxesIndicator = value; } }
-        private Value<bool?> _escrowChargeOtherIndicator;
+        private DirtyValue<bool?> _escrowChargeOtherIndicator;
         public bool? EscrowChargeOtherIndicator { get { return _escrowChargeOtherIndicator; } set { _escrowChargeOtherIndicator = value; } }
-        private Value<string> _escrowOtherDescription;
+        private DirtyValue<string> _escrowOtherDescription;
         public string EscrowOtherDescription { get { return _escrowOtherDescription; } set { _escrowOtherDescription = value; } }
-        private Value<decimal?> _financedFeesFromPrepaid;
+        private DirtyValue<decimal?> _financedFeesFromPrepaid;
         public decimal? FinancedFeesFromPrepaid { get { return _financedFeesFromPrepaid; } set { _financedFeesFromPrepaid = value; } }
         private DirtyList<Gfe2010Fee> _gfe2010Fees;
         public IList<Gfe2010Fee> Gfe2010Fees { get { var v = _gfe2010Fees; return v ?? Interlocked.CompareExchange(ref _gfe2010Fees, (v = new DirtyList<Gfe2010Fee>()), null) ?? v; } set { _gfe2010Fees = new DirtyList<Gfe2010Fee>(value); } }
         private DirtyList<Gfe2010WholePoc> _gfe2010WholePocs;
         public IList<Gfe2010WholePoc> Gfe2010WholePocs { get { var v = _gfe2010WholePocs; return v ?? Interlocked.CompareExchange(ref _gfe2010WholePocs, (v = new DirtyList<Gfe2010WholePoc>()), null) ?? v; } set { _gfe2010WholePocs = new DirtyList<Gfe2010WholePoc>(value); } }
-        private Value<decimal?> _gfeGovernmentRecordingCharges;
+        private DirtyValue<decimal?> _gfeGovernmentRecordingCharges;
         public decimal? GfeGovernmentRecordingCharges { get { return _gfeGovernmentRecordingCharges; } set { _gfeGovernmentRecordingCharges = value; } }
-        private Value<decimal?> _hazardInsurance;
+        private DirtyValue<decimal?> _hazardInsurance;
         public decimal? HazardInsurance { get { return _hazardInsurance; } set { _hazardInsurance = value; } }
-        private Value<decimal?> _homeownerInsurance;
+        private DirtyValue<decimal?> _homeownerInsurance;
         public decimal? HomeownerInsurance { get { return _homeownerInsurance; } set { _homeownerInsurance = value; } }
-        private Value<decimal?> _hudGuaranteeFee;
+        private DirtyValue<decimal?> _hudGuaranteeFee;
         public decimal? HudGuaranteeFee { get { return _hudGuaranteeFee; } set { _hudGuaranteeFee = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _includeOriginationPointsCreditType;
+        private DirtyValue<string> _includeOriginationPointsCreditType;
         public string IncludeOriginationPointsCreditType { get { return _includeOriginationPointsCreditType; } set { _includeOriginationPointsCreditType = value; } }
-        private Value<decimal?> _initialLoanAmount;
+        private DirtyValue<decimal?> _initialLoanAmount;
         public decimal? InitialLoanAmount { get { return _initialLoanAmount; } set { _initialLoanAmount = value; } }
-        private Value<decimal?> _initialMonthlyAmount;
+        private DirtyValue<decimal?> _initialMonthlyAmount;
         public decimal? InitialMonthlyAmount { get { return _initialMonthlyAmount; } set { _initialMonthlyAmount = value; } }
-        private Value<bool?> _interestRateRiseIndicator;
+        private DirtyValue<bool?> _interestRateRiseIndicator;
         public bool? InterestRateRiseIndicator { get { return _interestRateRiseIndicator; } set { _interestRateRiseIndicator = value; } }
-        private Value<bool?> _isCDValidForEarliestClosingDate;
+        private DirtyValue<bool?> _isCDValidForEarliestClosingDate;
         public bool? IsCDValidForEarliestClosingDate { get { return _isCDValidForEarliestClosingDate; } set { _isCDValidForEarliestClosingDate = value; } }
-        private Value<decimal?> _line1001Fee;
+        private DirtyValue<decimal?> _line1001Fee;
         public decimal? Line1001Fee { get { return _line1001Fee; } set { _line1001Fee = value; } }
-        private Value<decimal?> _line1002Fee;
+        private DirtyValue<decimal?> _line1002Fee;
         public decimal? Line1002Fee { get { return _line1002Fee; } set { _line1002Fee = value; } }
-        private Value<decimal?> _line1003Fee;
+        private DirtyValue<decimal?> _line1003Fee;
         public decimal? Line1003Fee { get { return _line1003Fee; } set { _line1003Fee = value; } }
-        private Value<decimal?> _line1004Fee;
+        private DirtyValue<decimal?> _line1004Fee;
         public decimal? Line1004Fee { get { return _line1004Fee; } set { _line1004Fee = value; } }
-        private Value<decimal?> _line1005Fee;
+        private DirtyValue<decimal?> _line1005Fee;
         public decimal? Line1005Fee { get { return _line1005Fee; } set { _line1005Fee = value; } }
-        private Value<decimal?> _line1006Fee;
+        private DirtyValue<decimal?> _line1006Fee;
         public decimal? Line1006Fee { get { return _line1006Fee; } set { _line1006Fee = value; } }
-        private Value<decimal?> _line1007Fee;
+        private DirtyValue<decimal?> _line1007Fee;
         public decimal? Line1007Fee { get { return _line1007Fee; } set { _line1007Fee = value; } }
-        private Value<decimal?> _line1008Fee;
+        private DirtyValue<decimal?> _line1008Fee;
         public decimal? Line1008Fee { get { return _line1008Fee; } set { _line1008Fee = value; } }
-        private Value<decimal?> _line1009Fee;
+        private DirtyValue<decimal?> _line1009Fee;
         public decimal? Line1009Fee { get { return _line1009Fee; } set { _line1009Fee = value; } }
-        private Value<decimal?> _line801BrokerCompensationAdditionalAmount;
+        private DirtyValue<decimal?> _line801BrokerCompensationAdditionalAmount;
         public decimal? Line801BrokerCompensationAdditionalAmount { get { return _line801BrokerCompensationAdditionalAmount; } set { _line801BrokerCompensationAdditionalAmount = value; } }
-        private Value<decimal?> _line801BrokerCompensationFees;
+        private DirtyValue<decimal?> _line801BrokerCompensationFees;
         public decimal? Line801BrokerCompensationFees { get { return _line801BrokerCompensationFees; } set { _line801BrokerCompensationFees = value; } }
-        private Value<decimal?> _line801BrokerCompensationRate;
+        private DirtyValue<decimal?> _line801BrokerCompensationRate;
         public decimal? Line801BrokerCompensationRate { get { return _line801BrokerCompensationRate; } set { _line801BrokerCompensationRate = value; } }
-        private Value<decimal?> _line808Fee;
+        private DirtyValue<decimal?> _line808Fee;
         public decimal? Line808Fee { get { return _line808Fee; } set { _line808Fee = value; } }
-        private Value<decimal?> _line809Fee;
+        private DirtyValue<decimal?> _line809Fee;
         public decimal? Line809Fee { get { return _line809Fee; } set { _line809Fee = value; } }
-        private Value<decimal?> _line810Fee;
+        private DirtyValue<decimal?> _line810Fee;
         public decimal? Line810Fee { get { return _line810Fee; } set { _line810Fee = value; } }
-        private Value<decimal?> _line811Fee;
+        private DirtyValue<decimal?> _line811Fee;
         public decimal? Line811Fee { get { return _line811Fee; } set { _line811Fee = value; } }
-        private Value<decimal?> _line812Fee;
+        private DirtyValue<decimal?> _line812Fee;
         public decimal? Line812Fee { get { return _line812Fee; } set { _line812Fee = value; } }
-        private Value<decimal?> _line813Fee;
+        private DirtyValue<decimal?> _line813Fee;
         public decimal? Line813Fee { get { return _line813Fee; } set { _line813Fee = value; } }
-        private Value<decimal?> _line814Fee;
+        private DirtyValue<decimal?> _line814Fee;
         public decimal? Line814Fee { get { return _line814Fee; } set { _line814Fee = value; } }
-        private Value<decimal?> _line815Fee;
+        private DirtyValue<decimal?> _line815Fee;
         public decimal? Line815Fee { get { return _line815Fee; } set { _line815Fee = value; } }
-        private Value<decimal?> _line816Fee;
+        private DirtyValue<decimal?> _line816Fee;
         public decimal? Line816Fee { get { return _line816Fee; } set { _line816Fee = value; } }
-        private Value<decimal?> _line817Fee;
+        private DirtyValue<decimal?> _line817Fee;
         public decimal? Line817Fee { get { return _line817Fee; } set { _line817Fee = value; } }
-        private Value<decimal?> _line818Fee;
+        private DirtyValue<decimal?> _line818Fee;
         public decimal? Line818Fee { get { return _line818Fee; } set { _line818Fee = value; } }
-        private Value<decimal?> _line819Fee;
+        private DirtyValue<decimal?> _line819Fee;
         public decimal? Line819Fee { get { return _line819Fee; } set { _line819Fee = value; } }
-        private Value<decimal?> _line820Fee;
+        private DirtyValue<decimal?> _line820Fee;
         public decimal? Line820Fee { get { return _line820Fee; } set { _line820Fee = value; } }
-        private Value<decimal?> _line821Fee;
+        private DirtyValue<decimal?> _line821Fee;
         public decimal? Line821Fee { get { return _line821Fee; } set { _line821Fee = value; } }
-        private Value<decimal?> _line822Fee;
+        private DirtyValue<decimal?> _line822Fee;
         public decimal? Line822Fee { get { return _line822Fee; } set { _line822Fee = value; } }
-        private Value<decimal?> _line823Fee;
+        private DirtyValue<decimal?> _line823Fee;
         public decimal? Line823Fee { get { return _line823Fee; } set { _line823Fee = value; } }
-        private Value<decimal?> _line824Fee;
+        private DirtyValue<decimal?> _line824Fee;
         public decimal? Line824Fee { get { return _line824Fee; } set { _line824Fee = value; } }
-        private Value<decimal?> _line825Fee;
+        private DirtyValue<decimal?> _line825Fee;
         public decimal? Line825Fee { get { return _line825Fee; } set { _line825Fee = value; } }
-        private Value<decimal?> _line826Fee;
+        private DirtyValue<decimal?> _line826Fee;
         public decimal? Line826Fee { get { return _line826Fee; } set { _line826Fee = value; } }
-        private Value<decimal?> _line827Fee;
+        private DirtyValue<decimal?> _line827Fee;
         public decimal? Line827Fee { get { return _line827Fee; } set { _line827Fee = value; } }
-        private Value<decimal?> _line828Fee;
+        private DirtyValue<decimal?> _line828Fee;
         public decimal? Line828Fee { get { return _line828Fee; } set { _line828Fee = value; } }
-        private Value<decimal?> _line829Fee;
+        private DirtyValue<decimal?> _line829Fee;
         public decimal? Line829Fee { get { return _line829Fee; } set { _line829Fee = value; } }
-        private Value<decimal?> _line830Fee;
+        private DirtyValue<decimal?> _line830Fee;
         public decimal? Line830Fee { get { return _line830Fee; } set { _line830Fee = value; } }
-        private Value<decimal?> _line831Fee;
+        private DirtyValue<decimal?> _line831Fee;
         public decimal? Line831Fee { get { return _line831Fee; } set { _line831Fee = value; } }
-        private Value<decimal?> _line832Fee;
+        private DirtyValue<decimal?> _line832Fee;
         public decimal? Line832Fee { get { return _line832Fee; } set { _line832Fee = value; } }
-        private Value<decimal?> _line833Fee;
+        private DirtyValue<decimal?> _line833Fee;
         public decimal? Line833Fee { get { return _line833Fee; } set { _line833Fee = value; } }
-        private Value<bool?> _loanBalanceRiseIndicator;
+        private DirtyValue<bool?> _loanBalanceRiseIndicator;
         public bool? LoanBalanceRiseIndicator { get { return _loanBalanceRiseIndicator; } set { _loanBalanceRiseIndicator = value; } }
-        private Value<decimal?> _loanOriginationFees;
+        private DirtyValue<decimal?> _loanOriginationFees;
         public decimal? LoanOriginationFees { get { return _loanOriginationFees; } set { _loanOriginationFees = value; } }
-        private Value<decimal?> _loanOriginationPercentage;
+        private DirtyValue<decimal?> _loanOriginationPercentage;
         public decimal? LoanOriginationPercentage { get { return _loanOriginationPercentage; } set { _loanOriginationPercentage = value; } }
-        private Value<string> _loanOriginatorName;
+        private DirtyValue<string> _loanOriginatorName;
         public string LoanOriginatorName { get { return _loanOriginatorName; } set { _loanOriginatorName = value; } }
-        private Value<decimal?> _lowerInterestInitialInterestRate;
+        private DirtyValue<decimal?> _lowerInterestInitialInterestRate;
         public decimal? LowerInterestInitialInterestRate { get { return _lowerInterestInitialInterestRate; } set { _lowerInterestInitialInterestRate = value; } }
-        private Value<decimal?> _lowerInterestInitialMonthlyAmountOwed;
+        private DirtyValue<decimal?> _lowerInterestInitialMonthlyAmountOwed;
         public decimal? LowerInterestInitialMonthlyAmountOwed { get { return _lowerInterestInitialMonthlyAmountOwed; } set { _lowerInterestInitialMonthlyAmountOwed = value; } }
-        private Value<decimal?> _lowerInterestMonthlyPaymentReduced;
+        private DirtyValue<decimal?> _lowerInterestMonthlyPaymentReduced;
         public decimal? LowerInterestMonthlyPaymentReduced { get { return _lowerInterestMonthlyPaymentReduced; } set { _lowerInterestMonthlyPaymentReduced = value; } }
-        private Value<decimal?> _lowerInterestServiceChargeIncreasedAmount;
+        private DirtyValue<decimal?> _lowerInterestServiceChargeIncreasedAmount;
         public decimal? LowerInterestServiceChargeIncreasedAmount { get { return _lowerInterestServiceChargeIncreasedAmount; } set { _lowerInterestServiceChargeIncreasedAmount = value; } }
-        private Value<decimal?> _lowerInterestTotalSettlementCharges;
+        private DirtyValue<decimal?> _lowerInterestTotalSettlementCharges;
         public decimal? LowerInterestTotalSettlementCharges { get { return _lowerInterestTotalSettlementCharges; } set { _lowerInterestTotalSettlementCharges = value; } }
-        private Value<decimal?> _lowerSettlementInitialInterestRate;
+        private DirtyValue<decimal?> _lowerSettlementInitialInterestRate;
         public decimal? LowerSettlementInitialInterestRate { get { return _lowerSettlementInitialInterestRate; } set { _lowerSettlementInitialInterestRate = value; } }
-        private Value<decimal?> _lowerSettlementInitialMonthlyAmountOwed;
+        private DirtyValue<decimal?> _lowerSettlementInitialMonthlyAmountOwed;
         public decimal? LowerSettlementInitialMonthlyAmountOwed { get { return _lowerSettlementInitialMonthlyAmountOwed; } set { _lowerSettlementInitialMonthlyAmountOwed = value; } }
-        private Value<decimal?> _lowerSettlementMonthlyPaymentIncreased;
+        private DirtyValue<decimal?> _lowerSettlementMonthlyPaymentIncreased;
         public decimal? LowerSettlementMonthlyPaymentIncreased { get { return _lowerSettlementMonthlyPaymentIncreased; } set { _lowerSettlementMonthlyPaymentIncreased = value; } }
-        private Value<decimal?> _lowerSettlementServiceChargeReducedAmount;
+        private DirtyValue<decimal?> _lowerSettlementServiceChargeReducedAmount;
         public decimal? LowerSettlementServiceChargeReducedAmount { get { return _lowerSettlementServiceChargeReducedAmount; } set { _lowerSettlementServiceChargeReducedAmount = value; } }
-        private Value<decimal?> _lowerSettlementTotalSettlementCharges;
+        private DirtyValue<decimal?> _lowerSettlementTotalSettlementCharges;
         public decimal? LowerSettlementTotalSettlementCharges { get { return _lowerSettlementTotalSettlementCharges; } set { _lowerSettlementTotalSettlementCharges = value; } }
-        private Value<decimal?> _maximumLoanBalance;
+        private DirtyValue<decimal?> _maximumLoanBalance;
         public decimal? MaximumLoanBalance { get { return _maximumLoanBalance; } set { _maximumLoanBalance = value; } }
-        private Value<decimal?> _maximumOwedMonthlyPayment;
+        private DirtyValue<decimal?> _maximumOwedMonthlyPayment;
         public decimal? MaximumOwedMonthlyPayment { get { return _maximumOwedMonthlyPayment; } set { _maximumOwedMonthlyPayment = value; } }
-        private Value<decimal?> _maxLifeInterestCapPercent;
+        private DirtyValue<decimal?> _maxLifeInterestCapPercent;
         public decimal? MaxLifeInterestCapPercent { get { return _maxLifeInterestCapPercent; } set { _maxLifeInterestCapPercent = value; } }
-        private Value<int?> _monthlyPaymentFirstIncreaseDate;
+        private DirtyValue<int?> _monthlyPaymentFirstIncreaseDate;
         public int? MonthlyPaymentFirstIncreaseDate { get { return _monthlyPaymentFirstIncreaseDate; } set { _monthlyPaymentFirstIncreaseDate = value; } }
-        private Value<bool?> _monthlyPaymentRiseIndicator;
+        private DirtyValue<bool?> _monthlyPaymentRiseIndicator;
         public bool? MonthlyPaymentRiseIndicator { get { return _monthlyPaymentRiseIndicator; } set { _monthlyPaymentRiseIndicator = value; } }
-        private Value<decimal?> _mortgageInsurancePremium;
+        private DirtyValue<decimal?> _mortgageInsurancePremium;
         public decimal? MortgageInsurancePremium { get { return _mortgageInsurancePremium; } set { _mortgageInsurancePremium = value; } }
-        private Value<string> _mustLockRateDays;
+        private DirtyValue<string> _mustLockRateDays;
         public string MustLockRateDays { get { return _mustLockRateDays; } set { _mustLockRateDays = value; } }
-        private Value<decimal?> _newHudSection1100Line1104BorPaidAmount;
+        private DirtyValue<decimal?> _newHudSection1100Line1104BorPaidAmount;
         public decimal? NewHudSection1100Line1104BorPaidAmount { get { return _newHudSection1100Line1104BorPaidAmount; } set { _newHudSection1100Line1104BorPaidAmount = value; } }
-        private Value<decimal?> _newHudSection1100Line1104SelPaidAmount;
+        private DirtyValue<decimal?> _newHudSection1100Line1104SelPaidAmount;
         public decimal? NewHudSection1100Line1104SelPaidAmount { get { return _newHudSection1100Line1104SelPaidAmount; } set { _newHudSection1100Line1104SelPaidAmount = value; } }
-        private Value<decimal?> _newHudSection1100Line1107BorPaidAmount;
+        private DirtyValue<decimal?> _newHudSection1100Line1107BorPaidAmount;
         public decimal? NewHudSection1100Line1107BorPaidAmount { get { return _newHudSection1100Line1107BorPaidAmount; } set { _newHudSection1100Line1107BorPaidAmount = value; } }
-        private Value<decimal?> _newHudSection1100Line1108BorPaidAmount;
+        private DirtyValue<decimal?> _newHudSection1100Line1108BorPaidAmount;
         public decimal? NewHudSection1100Line1108BorPaidAmount { get { return _newHudSection1100Line1108BorPaidAmount; } set { _newHudSection1100Line1108BorPaidAmount = value; } }
-        private Value<decimal?> _originationCharges;
+        private DirtyValue<decimal?> _originationCharges;
         public decimal? OriginationCharges { get { return _originationCharges; } set { _originationCharges = value; } }
-        private Value<decimal?> _originationCreditYsp;
+        private DirtyValue<decimal?> _originationCreditYsp;
         public decimal? OriginationCreditYsp { get { return _originationCreditYsp; } set { _originationCreditYsp = value; } }
-        private Value<decimal?> _originationCreditYspAdditional;
+        private DirtyValue<decimal?> _originationCreditYspAdditional;
         public decimal? OriginationCreditYspAdditional { get { return _originationCreditYspAdditional; } set { _originationCreditYspAdditional = value; } }
-        private Value<decimal?> _originationPoints;
+        private DirtyValue<decimal?> _originationPoints;
         public decimal? OriginationPoints { get { return _originationPoints; } set { _originationPoints = value; } }
-        private Value<decimal?> _originationPointsAdditional;
+        private DirtyValue<decimal?> _originationPointsAdditional;
         public decimal? OriginationPointsAdditional { get { return _originationPointsAdditional; } set { _originationPointsAdditional = value; } }
-        private Value<decimal?> _originationPointsPercentage;
+        private DirtyValue<decimal?> _originationPointsPercentage;
         public decimal? OriginationPointsPercentage { get { return _originationPointsPercentage; } set { _originationPointsPercentage = value; } }
-        private Value<NA<decimal>?> _ownerTitleInsuranceAmount;
+        private DirtyValue<NA<decimal>?> _ownerTitleInsuranceAmount;
         public NA<decimal>? OwnerTitleInsuranceAmount { get { return _ownerTitleInsuranceAmount; } set { _ownerTitleInsuranceAmount = value; } }
-        private Value<bool?> _printNAInLockRateDays;
+        private DirtyValue<bool?> _printNAInLockRateDays;
         public bool? PrintNAInLockRateDays { get { return _printNAInLockRateDays; } set { _printNAInLockRateDays = value; } }
-        private Value<bool?> _printShoppingChartIndicator;
+        private DirtyValue<bool?> _printShoppingChartIndicator;
         public bool? PrintShoppingChartIndicator { get { return _printShoppingChartIndicator; } set { _printShoppingChartIndicator = value; } }
-        private Value<decimal?> _processingFees;
+        private DirtyValue<decimal?> _processingFees;
         public decimal? ProcessingFees { get { return _processingFees; } set { _processingFees = value; } }
-        private Value<decimal?> _requiredAppraisalFee;
+        private DirtyValue<decimal?> _requiredAppraisalFee;
         public decimal? RequiredAppraisalFee { get { return _requiredAppraisalFee; } set { _requiredAppraisalFee = value; } }
-        private Value<decimal?> _requiredCreditReportFee;
+        private DirtyValue<decimal?> _requiredCreditReportFee;
         public decimal? RequiredCreditReportFee { get { return _requiredCreditReportFee; } set { _requiredCreditReportFee = value; } }
-        private Value<decimal?> _requiredFloodCertificationFee;
+        private DirtyValue<decimal?> _requiredFloodCertificationFee;
         public decimal? RequiredFloodCertificationFee { get { return _requiredFloodCertificationFee; } set { _requiredFloodCertificationFee = value; } }
-        private Value<decimal?> _requiredServicesAmount;
+        private DirtyValue<decimal?> _requiredServicesAmount;
         public decimal? RequiredServicesAmount { get { return _requiredServicesAmount; } set { _requiredServicesAmount = value; } }
-        private Value<decimal?> _requiredTaxServiceFee;
+        private DirtyValue<decimal?> _requiredTaxServiceFee;
         public decimal? RequiredTaxServiceFee { get { return _requiredTaxServiceFee; } set { _requiredTaxServiceFee = value; } }
-        private Value<decimal?> _section1000TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section1000TotalBorrowerPaidAmount;
         public decimal? Section1000TotalBorrowerPaidAmount { get { return _section1000TotalBorrowerPaidAmount; } set { _section1000TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section1000TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section1000TotalOtherPaidAmount;
         public decimal? Section1000TotalOtherPaidAmount { get { return _section1000TotalOtherPaidAmount; } set { _section1000TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section1000TotalPaidAmount;
+        private DirtyValue<decimal?> _section1000TotalPaidAmount;
         public decimal? Section1000TotalPaidAmount { get { return _section1000TotalPaidAmount; } set { _section1000TotalPaidAmount = value; } }
-        private Value<decimal?> _section1000TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section1000TotalSellerPaidAmount;
         public decimal? Section1000TotalSellerPaidAmount { get { return _section1000TotalSellerPaidAmount; } set { _section1000TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section1100TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section1100TotalBorrowerPaidAmount;
         public decimal? Section1100TotalBorrowerPaidAmount { get { return _section1100TotalBorrowerPaidAmount; } set { _section1100TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section1100TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section1100TotalOtherPaidAmount;
         public decimal? Section1100TotalOtherPaidAmount { get { return _section1100TotalOtherPaidAmount; } set { _section1100TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section1100TotalPaidAmount;
+        private DirtyValue<decimal?> _section1100TotalPaidAmount;
         public decimal? Section1100TotalPaidAmount { get { return _section1100TotalPaidAmount; } set { _section1100TotalPaidAmount = value; } }
-        private Value<decimal?> _section1100TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section1100TotalSellerPaidAmount;
         public decimal? Section1100TotalSellerPaidAmount { get { return _section1100TotalSellerPaidAmount; } set { _section1100TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section1200TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section1200TotalBorrowerPaidAmount;
         public decimal? Section1200TotalBorrowerPaidAmount { get { return _section1200TotalBorrowerPaidAmount; } set { _section1200TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section1200TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section1200TotalOtherPaidAmount;
         public decimal? Section1200TotalOtherPaidAmount { get { return _section1200TotalOtherPaidAmount; } set { _section1200TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section1200TotalPaidAmount;
+        private DirtyValue<decimal?> _section1200TotalPaidAmount;
         public decimal? Section1200TotalPaidAmount { get { return _section1200TotalPaidAmount; } set { _section1200TotalPaidAmount = value; } }
-        private Value<decimal?> _section1200TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section1200TotalSellerPaidAmount;
         public decimal? Section1200TotalSellerPaidAmount { get { return _section1200TotalSellerPaidAmount; } set { _section1200TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section1300TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section1300TotalBorrowerPaidAmount;
         public decimal? Section1300TotalBorrowerPaidAmount { get { return _section1300TotalBorrowerPaidAmount; } set { _section1300TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section1300TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section1300TotalOtherPaidAmount;
         public decimal? Section1300TotalOtherPaidAmount { get { return _section1300TotalOtherPaidAmount; } set { _section1300TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section1300TotalPaidAmount;
+        private DirtyValue<decimal?> _section1300TotalPaidAmount;
         public decimal? Section1300TotalPaidAmount { get { return _section1300TotalPaidAmount; } set { _section1300TotalPaidAmount = value; } }
-        private Value<decimal?> _section1300TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section1300TotalSellerPaidAmount;
         public decimal? Section1300TotalSellerPaidAmount { get { return _section1300TotalSellerPaidAmount; } set { _section1300TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section1400TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section1400TotalBorrowerPaidAmount;
         public decimal? Section1400TotalBorrowerPaidAmount { get { return _section1400TotalBorrowerPaidAmount; } set { _section1400TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section1400TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section1400TotalOtherPaidAmount;
         public decimal? Section1400TotalOtherPaidAmount { get { return _section1400TotalOtherPaidAmount; } set { _section1400TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section1400TotalPaidAmount;
+        private DirtyValue<decimal?> _section1400TotalPaidAmount;
         public decimal? Section1400TotalPaidAmount { get { return _section1400TotalPaidAmount; } set { _section1400TotalPaidAmount = value; } }
-        private Value<decimal?> _section1400TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section1400TotalSellerPaidAmount;
         public decimal? Section1400TotalSellerPaidAmount { get { return _section1400TotalSellerPaidAmount; } set { _section1400TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section700TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section700TotalBorrowerPaidAmount;
         public decimal? Section700TotalBorrowerPaidAmount { get { return _section700TotalBorrowerPaidAmount; } set { _section700TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section700TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section700TotalOtherPaidAmount;
         public decimal? Section700TotalOtherPaidAmount { get { return _section700TotalOtherPaidAmount; } set { _section700TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section700TotalPaidAmount;
+        private DirtyValue<decimal?> _section700TotalPaidAmount;
         public decimal? Section700TotalPaidAmount { get { return _section700TotalPaidAmount; } set { _section700TotalPaidAmount = value; } }
-        private Value<decimal?> _section700TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section700TotalSellerPaidAmount;
         public decimal? Section700TotalSellerPaidAmount { get { return _section700TotalSellerPaidAmount; } set { _section700TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section800TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section800TotalBorrowerPaidAmount;
         public decimal? Section800TotalBorrowerPaidAmount { get { return _section800TotalBorrowerPaidAmount; } set { _section800TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section800TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section800TotalOtherPaidAmount;
         public decimal? Section800TotalOtherPaidAmount { get { return _section800TotalOtherPaidAmount; } set { _section800TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section800TotalPaidAmount;
+        private DirtyValue<decimal?> _section800TotalPaidAmount;
         public decimal? Section800TotalPaidAmount { get { return _section800TotalPaidAmount; } set { _section800TotalPaidAmount = value; } }
-        private Value<decimal?> _section800TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section800TotalSellerPaidAmount;
         public decimal? Section800TotalSellerPaidAmount { get { return _section800TotalSellerPaidAmount; } set { _section800TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _section900TotalBorrowerPaidAmount;
+        private DirtyValue<decimal?> _section900TotalBorrowerPaidAmount;
         public decimal? Section900TotalBorrowerPaidAmount { get { return _section900TotalBorrowerPaidAmount; } set { _section900TotalBorrowerPaidAmount = value; } }
-        private Value<decimal?> _section900TotalOtherPaidAmount;
+        private DirtyValue<decimal?> _section900TotalOtherPaidAmount;
         public decimal? Section900TotalOtherPaidAmount { get { return _section900TotalOtherPaidAmount; } set { _section900TotalOtherPaidAmount = value; } }
-        private Value<decimal?> _section900TotalPaidAmount;
+        private DirtyValue<decimal?> _section900TotalPaidAmount;
         public decimal? Section900TotalPaidAmount { get { return _section900TotalPaidAmount; } set { _section900TotalPaidAmount = value; } }
-        private Value<decimal?> _section900TotalSellerPaidAmount;
+        private DirtyValue<decimal?> _section900TotalSellerPaidAmount;
         public decimal? Section900TotalSellerPaidAmount { get { return _section900TotalSellerPaidAmount; } set { _section900TotalSellerPaidAmount = value; } }
-        private Value<decimal?> _shopRequiredServicesAmount;
+        private DirtyValue<decimal?> _shopRequiredServicesAmount;
         public decimal? ShopRequiredServicesAmount { get { return _shopRequiredServicesAmount; } set { _shopRequiredServicesAmount = value; } }
-        private Value<decimal?> _subsequentCapPercent;
+        private DirtyValue<decimal?> _subsequentCapPercent;
         public decimal? SubsequentCapPercent { get { return _subsequentCapPercent; } set { _subsequentCapPercent = value; } }
-        private Value<int?> _subsequentRateAdjustmentMonths;
+        private DirtyValue<int?> _subsequentRateAdjustmentMonths;
         public int? SubsequentRateAdjustmentMonths { get { return _subsequentRateAdjustmentMonths; } set { _subsequentRateAdjustmentMonths = value; } }
-        private Value<bool?> _tableFundedIndicator;
+        private DirtyValue<bool?> _tableFundedIndicator;
         public bool? TableFundedIndicator { get { return _tableFundedIndicator; } set { _tableFundedIndicator = value; } }
-        private Value<string> _timeForRate;
+        private DirtyValue<string> _timeForRate;
         public string TimeForRate { get { return _timeForRate; } set { _timeForRate = value; } }
-        private Value<decimal?> _titleServiceAmount;
+        private DirtyValue<decimal?> _titleServiceAmount;
         public decimal? TitleServiceAmount { get { return _titleServiceAmount; } set { _titleServiceAmount = value; } }
-        private Value<decimal?> _totalBelow10;
+        private DirtyValue<decimal?> _totalBelow10;
         public decimal? TotalBelow10 { get { return _totalBelow10; } set { _totalBelow10 = value; } }
-        private Value<decimal?> _totalOfFinancedFees;
+        private DirtyValue<decimal?> _totalOfFinancedFees;
         public decimal? TotalOfFinancedFees { get { return _totalOfFinancedFees; } set { _totalOfFinancedFees = value; } }
-        private Value<decimal?> _totalSettlementCharges;
+        private DirtyValue<decimal?> _totalSettlementCharges;
         public decimal? TotalSettlementCharges { get { return _totalSettlementCharges; } set { _totalSettlementCharges = value; } }
-        private Value<decimal?> _totalTransferTaxes;
+        private DirtyValue<decimal?> _totalTransferTaxes;
         public decimal? TotalTransferTaxes { get { return _totalTransferTaxes; } set { _totalTransferTaxes = value; } }
-        private Value<decimal?> _transferTaxes;
+        private DirtyValue<decimal?> _transferTaxes;
         public decimal? TransferTaxes { get { return _transferTaxes; } set { _transferTaxes = value; } }
-        private Value<decimal?> _underwritingFees;
+        private DirtyValue<decimal?> _underwritingFees;
         public decimal? UnderwritingFees { get { return _underwritingFees; } set { _underwritingFees = value; } }
-        private Value<bool?> _useLOCompTool;
+        private DirtyValue<bool?> _useLOCompTool;
         public bool? UseLOCompTool { get { return _useLOCompTool; } set { _useLOCompTool = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe2010.cs
+++ b/src/EncompassRest/Loans/Gfe2010.cs
@@ -168,10 +168,10 @@ namespace EncompassRest.Loans
         public string EscrowOtherDescription { get { return _escrowOtherDescription; } set { _escrowOtherDescription = value; } }
         private Value<decimal?> _financedFeesFromPrepaid;
         public decimal? FinancedFeesFromPrepaid { get { return _financedFeesFromPrepaid; } set { _financedFeesFromPrepaid = value; } }
-        private Value<List<Gfe2010Fee>> _gfe2010Fees;
-        public List<Gfe2010Fee> Gfe2010Fees { get { return _gfe2010Fees; } set { _gfe2010Fees = value; } }
-        private Value<List<Gfe2010WholePoc>> _gfe2010WholePocs;
-        public List<Gfe2010WholePoc> Gfe2010WholePocs { get { return _gfe2010WholePocs; } set { _gfe2010WholePocs = value; } }
+        private DirtyList<Gfe2010Fee> _gfe2010Fees;
+        public IList<Gfe2010Fee> Gfe2010Fees { get { var v = _gfe2010Fees; return v ?? Interlocked.CompareExchange(ref _gfe2010Fees, (v = new DirtyList<Gfe2010Fee>()), null) ?? v; } set { _gfe2010Fees = new DirtyList<Gfe2010Fee>(value); } }
+        private DirtyList<Gfe2010WholePoc> _gfe2010WholePocs;
+        public IList<Gfe2010WholePoc> Gfe2010WholePocs { get { var v = _gfe2010WholePocs; return v ?? Interlocked.CompareExchange(ref _gfe2010WholePocs, (v = new DirtyList<Gfe2010WholePoc>()), null) ?? v; } set { _gfe2010WholePocs = new DirtyList<Gfe2010WholePoc>(value); } }
         private Value<decimal?> _gfeGovernmentRecordingCharges;
         public decimal? GfeGovernmentRecordingCharges { get { return _gfeGovernmentRecordingCharges; } set { _gfeGovernmentRecordingCharges = value; } }
         private Value<decimal?> _hazardInsurance;
@@ -525,8 +525,6 @@ namespace EncompassRest.Loans
                     || _escrowChargeOtherIndicator.Dirty
                     || _escrowOtherDescription.Dirty
                     || _financedFeesFromPrepaid.Dirty
-                    || _gfe2010Fees.Dirty
-                    || _gfe2010WholePocs.Dirty
                     || _gfeGovernmentRecordingCharges.Dirty
                     || _hazardInsurance.Dirty
                     || _homeownerInsurance.Dirty
@@ -659,7 +657,9 @@ namespace EncompassRest.Loans
                     || _totalTransferTaxes.Dirty
                     || _transferTaxes.Dirty
                     || _underwritingFees.Dirty
-                    || _useLOCompTool.Dirty;
+                    || _useLOCompTool.Dirty
+                    || _gfe2010Fees?.Dirty == true
+                    || _gfe2010WholePocs?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -746,8 +746,6 @@ namespace EncompassRest.Loans
                 _escrowChargeOtherIndicator.Dirty = value;
                 _escrowOtherDescription.Dirty = value;
                 _financedFeesFromPrepaid.Dirty = value;
-                _gfe2010Fees.Dirty = value;
-                _gfe2010WholePocs.Dirty = value;
                 _gfeGovernmentRecordingCharges.Dirty = value;
                 _hazardInsurance.Dirty = value;
                 _homeownerInsurance.Dirty = value;
@@ -881,6 +879,8 @@ namespace EncompassRest.Loans
                 _transferTaxes.Dirty = value;
                 _underwritingFees.Dirty = value;
                 _useLOCompTool.Dirty = value;
+                if (_gfe2010Fees != null) _gfe2010Fees.Dirty = value;
+                if (_gfe2010WholePocs != null) _gfe2010WholePocs.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Gfe2010Fee.cs
+++ b/src/EncompassRest/Loans/Gfe2010Fee.cs
@@ -8,123 +8,123 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010Fee : IDirty
     {
-        private Value<decimal?> _additionalAmount;
+        private DirtyValue<decimal?> _additionalAmount;
         public decimal? AdditionalAmount { get { return _additionalAmount; } set { _additionalAmount = value; } }
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<bool?> _aprIndicator;
+        private DirtyValue<bool?> _aprIndicator;
         public bool? AprIndicator { get { return _aprIndicator; } set { _aprIndicator = value; } }
-        private Value<decimal?> _borPaidAmount;
+        private DirtyValue<decimal?> _borPaidAmount;
         public decimal? BorPaidAmount { get { return _borPaidAmount; } set { _borPaidAmount = value; } }
-        private Value<decimal?> _borrowerAmountPaid2015;
+        private DirtyValue<decimal?> _borrowerAmountPaid2015;
         public decimal? BorrowerAmountPaid2015 { get { return _borrowerAmountPaid2015; } set { _borrowerAmountPaid2015 = value; } }
-        private Value<bool?> _borrowerCanShopForIndicator2015;
+        private DirtyValue<bool?> _borrowerCanShopForIndicator2015;
         public bool? BorrowerCanShopForIndicator2015 { get { return _borrowerCanShopForIndicator2015; } set { _borrowerCanShopForIndicator2015 = value; } }
-        private Value<bool?> _borrowerDidShopForIndicator2015;
+        private DirtyValue<bool?> _borrowerDidShopForIndicator2015;
         public bool? BorrowerDidShopForIndicator2015 { get { return _borrowerDidShopForIndicator2015; } set { _borrowerDidShopForIndicator2015 = value; } }
-        private Value<decimal?> _borrowerFinanced2015;
+        private DirtyValue<decimal?> _borrowerFinanced2015;
         public decimal? BorrowerFinanced2015 { get { return _borrowerFinanced2015; } set { _borrowerFinanced2015 = value; } }
-        private Value<decimal?> _borrowerPAC2015;
+        private DirtyValue<decimal?> _borrowerPAC2015;
         public decimal? BorrowerPAC2015 { get { return _borrowerPAC2015; } set { _borrowerPAC2015 = value; } }
-        private Value<decimal?> _borrowerPOC2015;
+        private DirtyValue<decimal?> _borrowerPOC2015;
         public decimal? BorrowerPOC2015 { get { return _borrowerPOC2015; } set { _borrowerPOC2015 = value; } }
-        private Value<decimal?> _borrowerPTC2015;
+        private DirtyValue<decimal?> _borrowerPTC2015;
         public decimal? BorrowerPTC2015 { get { return _borrowerPTC2015; } set { _borrowerPTC2015 = value; } }
-        private Value<bool?> _borrowerSelectIndicator;
+        private DirtyValue<bool?> _borrowerSelectIndicator;
         public bool? BorrowerSelectIndicator { get { return _borrowerSelectIndicator; } set { _borrowerSelectIndicator = value; } }
-        private Value<decimal?> _brokerAmountPaid2015;
+        private DirtyValue<decimal?> _brokerAmountPaid2015;
         public decimal? BrokerAmountPaid2015 { get { return _brokerAmountPaid2015; } set { _brokerAmountPaid2015 = value; } }
-        private Value<decimal?> _brokerPAC2015;
+        private DirtyValue<decimal?> _brokerPAC2015;
         public decimal? BrokerPAC2015 { get { return _brokerPAC2015; } set { _brokerPAC2015 = value; } }
-        private Value<decimal?> _brokerPOC2015;
+        private DirtyValue<decimal?> _brokerPOC2015;
         public decimal? BrokerPOC2015 { get { return _brokerPOC2015; } set { _brokerPOC2015 = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<bool?> _escrowedIndicator2015;
+        private DirtyValue<bool?> _escrowedIndicator2015;
         public bool? EscrowedIndicator2015 { get { return _escrowedIndicator2015; } set { _escrowedIndicator2015 = value; } }
-        private Value<bool?> _financedIndicator;
+        private DirtyValue<bool?> _financedIndicator;
         public bool? FinancedIndicator { get { return _financedIndicator; } set { _financedIndicator = value; } }
-        private Value<int?> _gfe2010FeeIndex;
+        private DirtyValue<int?> _gfe2010FeeIndex;
         public int? Gfe2010FeeIndex { get { return _gfe2010FeeIndex; } set { _gfe2010FeeIndex = value; } }
-        private Value<string> _gfe2010FeeParentType;
+        private DirtyValue<string> _gfe2010FeeParentType;
         public string Gfe2010FeeParentType { get { return _gfe2010FeeParentType; } set { _gfe2010FeeParentType = value; } }
-        private Value<string> _gfe2010FeeType;
+        private DirtyValue<string> _gfe2010FeeType;
         public string Gfe2010FeeType { get { return _gfe2010FeeType; } set { _gfe2010FeeType = value; } }
-        private Value<decimal?> _gfeAmount;
+        private DirtyValue<decimal?> _gfeAmount;
         public decimal? GfeAmount { get { return _gfeAmount; } set { _gfeAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _insuranceIndicator2015;
+        private DirtyValue<bool?> _insuranceIndicator2015;
         public bool? InsuranceIndicator2015 { get { return _insuranceIndicator2015; } set { _insuranceIndicator2015 = value; } }
-        private Value<decimal?> _lastDisclosedClosingDisclosure2015;
+        private DirtyValue<decimal?> _lastDisclosedClosingDisclosure2015;
         public decimal? LastDisclosedClosingDisclosure2015 { get { return _lastDisclosedClosingDisclosure2015; } set { _lastDisclosedClosingDisclosure2015 = value; } }
-        private Value<int?> _lastDisclosedLoanEstimate2015;
+        private DirtyValue<int?> _lastDisclosedLoanEstimate2015;
         public int? LastDisclosedLoanEstimate2015 { get { return _lastDisclosedLoanEstimate2015; } set { _lastDisclosedLoanEstimate2015 = value; } }
-        private Value<decimal?> _lenderAmountPaid2015;
+        private DirtyValue<decimal?> _lenderAmountPaid2015;
         public decimal? LenderAmountPaid2015 { get { return _lenderAmountPaid2015; } set { _lenderAmountPaid2015 = value; } }
-        private Value<decimal?> _lenderPAC2015;
+        private DirtyValue<decimal?> _lenderPAC2015;
         public decimal? LenderPAC2015 { get { return _lenderPAC2015; } set { _lenderPAC2015 = value; } }
-        private Value<decimal?> _lenderPOC2015;
+        private DirtyValue<decimal?> _lenderPOC2015;
         public decimal? LenderPOC2015 { get { return _lenderPOC2015; } set { _lenderPOC2015 = value; } }
-        private Value<decimal?> _monthlyPayment;
+        private DirtyValue<decimal?> _monthlyPayment;
         public decimal? MonthlyPayment { get { return _monthlyPayment; } set { _monthlyPayment = value; } }
-        private Value<int?> _numberOfMonths;
+        private DirtyValue<int?> _numberOfMonths;
         public int? NumberOfMonths { get { return _numberOfMonths; } set { _numberOfMonths = value; } }
-        private Value<bool?> _optionalIndicator2015;
+        private DirtyValue<bool?> _optionalIndicator2015;
         public bool? OptionalIndicator2015 { get { return _optionalIndicator2015; } set { _optionalIndicator2015 = value; } }
-        private Value<decimal?> _otherAmountPaid2015;
+        private DirtyValue<decimal?> _otherAmountPaid2015;
         public decimal? OtherAmountPaid2015 { get { return _otherAmountPaid2015; } set { _otherAmountPaid2015 = value; } }
-        private Value<decimal?> _otherPAC2015;
+        private DirtyValue<decimal?> _otherPAC2015;
         public decimal? OtherPAC2015 { get { return _otherPAC2015; } set { _otherPAC2015 = value; } }
-        private Value<decimal?> _otherPOC2015;
+        private DirtyValue<decimal?> _otherPOC2015;
         public decimal? OtherPOC2015 { get { return _otherPOC2015; } set { _otherPOC2015 = value; } }
-        private Value<string> _paidByType;
+        private DirtyValue<string> _paidByType;
         public string PaidByType { get { return _paidByType; } set { _paidByType = value; } }
-        private Value<string> _paidToName;
+        private DirtyValue<string> _paidToName;
         public string PaidToName { get { return _paidToName; } set { _paidToName = value; } }
-        private Value<bool?> _pocPtcIndicator;
+        private DirtyValue<bool?> _pocPtcIndicator;
         public bool? PocPtcIndicator { get { return _pocPtcIndicator; } set { _pocPtcIndicator = value; } }
-        private Value<bool?> _propertyIndicator2015;
+        private DirtyValue<bool?> _propertyIndicator2015;
         public bool? PropertyIndicator2015 { get { return _propertyIndicator2015; } set { _propertyIndicator2015 = value; } }
-        private Value<string> _ptbType;
+        private DirtyValue<string> _ptbType;
         public string PtbType { get { return _ptbType; } set { _ptbType = value; } }
-        private Value<decimal?> _rate;
+        private DirtyValue<decimal?> _rate;
         public decimal? Rate { get { return _rate; } set { _rate = value; } }
-        private Value<decimal?> _retainedAmount2015;
+        private DirtyValue<decimal?> _retainedAmount2015;
         public decimal? RetainedAmount2015 { get { return _retainedAmount2015; } set { _retainedAmount2015 = value; } }
-        private Value<decimal?> _sec32PointsAndFees2015;
+        private DirtyValue<decimal?> _sec32PointsAndFees2015;
         public decimal? Sec32PointsAndFees2015 { get { return _sec32PointsAndFees2015; } set { _sec32PointsAndFees2015 = value; } }
-        private Value<decimal?> _sellerAmountPaid2015;
+        private DirtyValue<decimal?> _sellerAmountPaid2015;
         public decimal? SellerAmountPaid2015 { get { return _sellerAmountPaid2015; } set { _sellerAmountPaid2015 = value; } }
-        private Value<bool?> _sellerCreditIndicator2015;
+        private DirtyValue<bool?> _sellerCreditIndicator2015;
         public bool? SellerCreditIndicator2015 { get { return _sellerCreditIndicator2015; } set { _sellerCreditIndicator2015 = value; } }
-        private Value<decimal?> _sellerObligatedAmount2015;
+        private DirtyValue<decimal?> _sellerObligatedAmount2015;
         public decimal? SellerObligatedAmount2015 { get { return _sellerObligatedAmount2015; } set { _sellerObligatedAmount2015 = value; } }
-        private Value<bool?> _sellerObligatedIndicator2015;
+        private DirtyValue<bool?> _sellerObligatedIndicator2015;
         public bool? SellerObligatedIndicator2015 { get { return _sellerObligatedIndicator2015; } set { _sellerObligatedIndicator2015 = value; } }
-        private Value<decimal?> _sellerPAC2015;
+        private DirtyValue<decimal?> _sellerPAC2015;
         public decimal? SellerPAC2015 { get { return _sellerPAC2015; } set { _sellerPAC2015 = value; } }
-        private Value<decimal?> _sellerPOC2015;
+        private DirtyValue<decimal?> _sellerPOC2015;
         public decimal? SellerPOC2015 { get { return _sellerPOC2015; } set { _sellerPOC2015 = value; } }
-        private Value<decimal?> _selPaidAmount;
+        private DirtyValue<decimal?> _selPaidAmount;
         public decimal? SelPaidAmount { get { return _selPaidAmount; } set { _selPaidAmount = value; } }
-        private Value<bool?> _simultaneousIssuanceIndicator2015;
+        private DirtyValue<bool?> _simultaneousIssuanceIndicator2015;
         public bool? SimultaneousIssuanceIndicator2015 { get { return _simultaneousIssuanceIndicator2015; } set { _simultaneousIssuanceIndicator2015 = value; } }
-        private Value<bool?> _taxesIndicator2015;
+        private DirtyValue<bool?> _taxesIndicator2015;
         public bool? TaxesIndicator2015 { get { return _taxesIndicator2015; } set { _taxesIndicator2015 = value; } }
-        private Value<bool?> _titleServiceSelectIndicator;
+        private DirtyValue<bool?> _titleServiceSelectIndicator;
         public bool? TitleServiceSelectIndicator { get { return _titleServiceSelectIndicator; } set { _titleServiceSelectIndicator = value; } }
-        private Value<decimal?> _totalFeeAmount2015;
+        private DirtyValue<decimal?> _totalFeeAmount2015;
         public decimal? TotalFeeAmount2015 { get { return _totalFeeAmount2015; } set { _totalFeeAmount2015 = value; } }
-        private Value<decimal?> _totalFeePercentage2015;
+        private DirtyValue<decimal?> _totalFeePercentage2015;
         public decimal? TotalFeePercentage2015 { get { return _totalFeePercentage2015; } set { _totalFeePercentage2015 = value; } }
-        private Value<decimal?> _totalPaidByBLO2015;
+        private DirtyValue<decimal?> _totalPaidByBLO2015;
         public decimal? TotalPaidByBLO2015 { get { return _totalPaidByBLO2015; } set { _totalPaidByBLO2015 = value; } }
-        private Value<decimal?> _undiscountedInsurance2015;
+        private DirtyValue<decimal?> _undiscountedInsurance2015;
         public decimal? UndiscountedInsurance2015 { get { return _undiscountedInsurance2015; } set { _undiscountedInsurance2015 = value; } }
-        private Value<decimal?> _wholePoc;
+        private DirtyValue<decimal?> _wholePoc;
         public decimal? WholePoc { get { return _wholePoc; } set { _wholePoc = value; } }
-        private Value<string> _wholePocPaidByType;
+        private DirtyValue<string> _wholePocPaidByType;
         public string WholePocPaidByType { get { return _wholePocPaidByType; } set { _wholePocPaidByType = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe2010FwbcFwsc.cs
+++ b/src/EncompassRest/Loans/Gfe2010FwbcFwsc.cs
@@ -8,17 +8,17 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010FwbcFwsc : IDirty
     {
-        private Value<string> _fwbc;
+        private DirtyValue<string> _fwbc;
         public string Fwbc { get { return _fwbc; } set { _fwbc = value; } }
-        private Value<string> _fwsc;
+        private DirtyValue<string> _fwsc;
         public string Fwsc { get { return _fwsc; } set { _fwsc = value; } }
-        private Value<int?> _gfe2010FwbcFwscIndex;
+        private DirtyValue<int?> _gfe2010FwbcFwscIndex;
         public int? Gfe2010FwbcFwscIndex { get { return _gfe2010FwbcFwscIndex; } set { _gfe2010FwbcFwscIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lineLetter;
+        private DirtyValue<string> _lineLetter;
         public string LineLetter { get { return _lineLetter; } set { _lineLetter = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe2010GfeCharge.cs
+++ b/src/EncompassRest/Loans/Gfe2010GfeCharge.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010GfeCharge : IDirty
     {
-        private Value<bool?> _chargeBelow10Indicator;
+        private DirtyValue<bool?> _chargeBelow10Indicator;
         public bool? ChargeBelow10Indicator { get { return _chargeBelow10Indicator; } set { _chargeBelow10Indicator = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<int?> _gfe2010GfeChargeIndex;
+        private DirtyValue<int?> _gfe2010GfeChargeIndex;
         public int? Gfe2010GfeChargeIndex { get { return _gfe2010GfeChargeIndex; } set { _gfe2010GfeChargeIndex = value; } }
-        private Value<decimal?> _gfeCharge;
+        private DirtyValue<decimal?> _gfeCharge;
         public decimal? GfeCharge { get { return _gfeCharge; } set { _gfeCharge = value; } }
-        private Value<decimal?> _hudCharge;
+        private DirtyValue<decimal?> _hudCharge;
         public decimal? HudCharge { get { return _hudCharge; } set { _hudCharge = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _line;
+        private DirtyValue<string> _line;
         public string Line { get { return _line; } set { _line = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe2010Page.cs
+++ b/src/EncompassRest/Loans/Gfe2010Page.cs
@@ -8,183 +8,183 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010Page : IDirty
     {
-        private Value<int?> _balloonPaymentDueInYears;
+        private DirtyValue<int?> _balloonPaymentDueInYears;
         public int? BalloonPaymentDueInYears { get { return _balloonPaymentDueInYears; } set { _balloonPaymentDueInYears = value; } }
-        private Value<string> _brokerCompensationFwbc;
+        private DirtyValue<string> _brokerCompensationFwbc;
         public string BrokerCompensationFwbc { get { return _brokerCompensationFwbc; } set { _brokerCompensationFwbc = value; } }
-        private Value<string> _brokerCompensationFwsc;
+        private DirtyValue<string> _brokerCompensationFwsc;
         public string BrokerCompensationFwsc { get { return _brokerCompensationFwsc; } set { _brokerCompensationFwsc = value; } }
-        private Value<decimal?> _curedGfeTotalTolerance;
+        private DirtyValue<decimal?> _curedGfeTotalTolerance;
         public decimal? CuredGfeTotalTolerance { get { return _curedGfeTotalTolerance; } set { _curedGfeTotalTolerance = value; } }
-        private Value<DateTime?> _firstArmChangeDate;
+        private DirtyValue<DateTime?> _firstArmChangeDate;
         public DateTime? FirstArmChangeDate { get { return _firstArmChangeDate; } set { _firstArmChangeDate = value; } }
         private DirtyList<Gfe2010FwbcFwsc> _gfe2010FwbcFwscs;
         public IList<Gfe2010FwbcFwsc> Gfe2010FwbcFwscs { get { var v = _gfe2010FwbcFwscs; return v ?? Interlocked.CompareExchange(ref _gfe2010FwbcFwscs, (v = new DirtyList<Gfe2010FwbcFwsc>()), null) ?? v; } set { _gfe2010FwbcFwscs = new DirtyList<Gfe2010FwbcFwsc>(value); } }
         private DirtyList<Gfe2010GfeCharge> _gfe2010GfeCharges;
         public IList<Gfe2010GfeCharge> Gfe2010GfeCharges { get { var v = _gfe2010GfeCharges; return v ?? Interlocked.CompareExchange(ref _gfe2010GfeCharges, (v = new DirtyList<Gfe2010GfeCharge>()), null) ?? v; } set { _gfe2010GfeCharges = new DirtyList<Gfe2010GfeCharge>(value); } }
-        private Value<string> _gfeRecordingCharges;
+        private DirtyValue<string> _gfeRecordingCharges;
         public string GfeRecordingCharges { get { return _gfeRecordingCharges; } set { _gfeRecordingCharges = value; } }
-        private Value<decimal?> _gfeTotalTolerance;
+        private DirtyValue<decimal?> _gfeTotalTolerance;
         public decimal? GfeTotalTolerance { get { return _gfeTotalTolerance; } set { _gfeTotalTolerance = value; } }
-        private Value<bool?> _hasEscrowAccountIndicator;
+        private DirtyValue<bool?> _hasEscrowAccountIndicator;
         public bool? HasEscrowAccountIndicator { get { return _hasEscrowAccountIndicator; } set { _hasEscrowAccountIndicator = value; } }
-        private Value<bool?> _hasEscrowCityPropertyTaxesIndicator;
+        private DirtyValue<bool?> _hasEscrowCityPropertyTaxesIndicator;
         public bool? HasEscrowCityPropertyTaxesIndicator { get { return _hasEscrowCityPropertyTaxesIndicator; } set { _hasEscrowCityPropertyTaxesIndicator = value; } }
-        private Value<bool?> _hasEscrowFloodInsurancesIndicator;
+        private DirtyValue<bool?> _hasEscrowFloodInsurancesIndicator;
         public bool? HasEscrowFloodInsurancesIndicator { get { return _hasEscrowFloodInsurancesIndicator; } set { _hasEscrowFloodInsurancesIndicator = value; } }
-        private Value<bool?> _hasEscrowHomeownerInsurancesIndicator;
+        private DirtyValue<bool?> _hasEscrowHomeownerInsurancesIndicator;
         public bool? HasEscrowHomeownerInsurancesIndicator { get { return _hasEscrowHomeownerInsurancesIndicator; } set { _hasEscrowHomeownerInsurancesIndicator = value; } }
-        private Value<bool?> _hasEscrowPropertyTaxesIndicator;
+        private DirtyValue<bool?> _hasEscrowPropertyTaxesIndicator;
         public bool? HasEscrowPropertyTaxesIndicator { get { return _hasEscrowPropertyTaxesIndicator; } set { _hasEscrowPropertyTaxesIndicator = value; } }
-        private Value<bool?> _hasEscrowUserDefinedIndicator1;
+        private DirtyValue<bool?> _hasEscrowUserDefinedIndicator1;
         public bool? HasEscrowUserDefinedIndicator1 { get { return _hasEscrowUserDefinedIndicator1; } set { _hasEscrowUserDefinedIndicator1 = value; } }
-        private Value<bool?> _hasEscrowUserDefinedIndicator2;
+        private DirtyValue<bool?> _hasEscrowUserDefinedIndicator2;
         public bool? HasEscrowUserDefinedIndicator2 { get { return _hasEscrowUserDefinedIndicator2; } set { _hasEscrowUserDefinedIndicator2 = value; } }
-        private Value<bool?> _hasEscrowUserDefinedIndicator3;
+        private DirtyValue<bool?> _hasEscrowUserDefinedIndicator3;
         public bool? HasEscrowUserDefinedIndicator3 { get { return _hasEscrowUserDefinedIndicator3; } set { _hasEscrowUserDefinedIndicator3 = value; } }
-        private Value<bool?> _hasEscrowUserDefinedIndicator4;
+        private DirtyValue<bool?> _hasEscrowUserDefinedIndicator4;
         public bool? HasEscrowUserDefinedIndicator4 { get { return _hasEscrowUserDefinedIndicator4; } set { _hasEscrowUserDefinedIndicator4 = value; } }
-        private Value<decimal?> _highestArmRate;
+        private DirtyValue<decimal?> _highestArmRate;
         public decimal? HighestArmRate { get { return _highestArmRate; } set { _highestArmRate = value; } }
-        private Value<decimal?> _hud1GovernmentRecordingCharge;
+        private DirtyValue<decimal?> _hud1GovernmentRecordingCharge;
         public decimal? Hud1GovernmentRecordingCharge { get { return _hud1GovernmentRecordingCharge; } set { _hud1GovernmentRecordingCharge = value; } }
-        private Value<decimal?> _hud1Pg1SellerPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _hud1Pg1SellerPaidClosingCostsAmount;
         public decimal? Hud1Pg1SellerPaidClosingCostsAmount { get { return _hud1Pg1SellerPaidClosingCostsAmount; } set { _hud1Pg1SellerPaidClosingCostsAmount = value; } }
-        private Value<decimal?> _hud1Pg1TotalSettlementCharges;
+        private DirtyValue<decimal?> _hud1Pg1TotalSettlementCharges;
         public decimal? Hud1Pg1TotalSettlementCharges { get { return _hud1Pg1TotalSettlementCharges; } set { _hud1Pg1TotalSettlementCharges = value; } }
-        private Value<decimal?> _hud1Pg2SellerPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _hud1Pg2SellerPaidClosingCostsAmount;
         public decimal? Hud1Pg2SellerPaidClosingCostsAmount { get { return _hud1Pg2SellerPaidClosingCostsAmount; } set { _hud1Pg2SellerPaidClosingCostsAmount = value; } }
-        private Value<decimal?> _hud1Pg2TotalSettlementCharges;
+        private DirtyValue<decimal?> _hud1Pg2TotalSettlementCharges;
         public decimal? Hud1Pg2TotalSettlementCharges { get { return _hud1Pg2TotalSettlementCharges; } set { _hud1Pg2TotalSettlementCharges = value; } }
-        private Value<decimal?> _hudTotalTolerance;
+        private DirtyValue<decimal?> _hudTotalTolerance;
         public decimal? HudTotalTolerance { get { return _hudTotalTolerance; } set { _hudTotalTolerance = value; } }
-        private Value<decimal?> _hudTotalToleranceIncreasePercent;
+        private DirtyValue<decimal?> _hudTotalToleranceIncreasePercent;
         public decimal? HudTotalToleranceIncreasePercent { get { return _hudTotalToleranceIncreasePercent; } set { _hudTotalToleranceIncreasePercent = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _line1101SellerPaidTotal;
+        private DirtyValue<decimal?> _line1101SellerPaidTotal;
         public decimal? Line1101SellerPaidTotal { get { return _line1101SellerPaidTotal; } set { _line1101SellerPaidTotal = value; } }
-        private Value<decimal?> _line1201SellerPaidTotal;
+        private DirtyValue<decimal?> _line1201SellerPaidTotal;
         public decimal? Line1201SellerPaidTotal { get { return _line1201SellerPaidTotal; } set { _line1201SellerPaidTotal = value; } }
-        private Value<decimal?> _line1301SellerPaidTotal;
+        private DirtyValue<decimal?> _line1301SellerPaidTotal;
         public decimal? Line1301SellerPaidTotal { get { return _line1301SellerPaidTotal; } set { _line1301SellerPaidTotal = value; } }
-        private Value<decimal?> _line801BorrowerPaidTotal;
+        private DirtyValue<decimal?> _line801BorrowerPaidTotal;
         public decimal? Line801BorrowerPaidTotal { get { return _line801BorrowerPaidTotal; } set { _line801BorrowerPaidTotal = value; } }
-        private Value<decimal?> _line801SellerPaidTotal;
+        private DirtyValue<decimal?> _line801SellerPaidTotal;
         public decimal? Line801SellerPaidTotal { get { return _line801SellerPaidTotal; } set { _line801SellerPaidTotal = value; } }
-        private Value<decimal?> _line802BorrowerPaidTotal;
+        private DirtyValue<decimal?> _line802BorrowerPaidTotal;
         public decimal? Line802BorrowerPaidTotal { get { return _line802BorrowerPaidTotal; } set { _line802BorrowerPaidTotal = value; } }
-        private Value<decimal?> _line803BorrowerPaidTotal;
+        private DirtyValue<decimal?> _line803BorrowerPaidTotal;
         public decimal? Line803BorrowerPaidTotal { get { return _line803BorrowerPaidTotal; } set { _line803BorrowerPaidTotal = value; } }
-        private Value<decimal?> _line803SellerPaidTotal;
+        private DirtyValue<decimal?> _line803SellerPaidTotal;
         public decimal? Line803SellerPaidTotal { get { return _line803SellerPaidTotal; } set { _line803SellerPaidTotal = value; } }
-        private Value<bool?> _line818FwbcIndicator;
+        private DirtyValue<bool?> _line818FwbcIndicator;
         public bool? Line818FwbcIndicator { get { return _line818FwbcIndicator; } set { _line818FwbcIndicator = value; } }
-        private Value<bool?> _line818FwscIndicator;
+        private DirtyValue<bool?> _line818FwscIndicator;
         public bool? Line818FwscIndicator { get { return _line818FwscIndicator; } set { _line818FwscIndicator = value; } }
-        private Value<bool?> _line819FwbcIndicator;
+        private DirtyValue<bool?> _line819FwbcIndicator;
         public bool? Line819FwbcIndicator { get { return _line819FwbcIndicator; } set { _line819FwbcIndicator = value; } }
-        private Value<bool?> _line819FwscIndicator;
+        private DirtyValue<bool?> _line819FwscIndicator;
         public bool? Line819FwscIndicator { get { return _line819FwscIndicator; } set { _line819FwscIndicator = value; } }
-        private Value<bool?> _line820FwbcIndicator;
+        private DirtyValue<bool?> _line820FwbcIndicator;
         public bool? Line820FwbcIndicator { get { return _line820FwbcIndicator; } set { _line820FwbcIndicator = value; } }
-        private Value<bool?> _line820FwscIndicator;
+        private DirtyValue<bool?> _line820FwscIndicator;
         public bool? Line820FwscIndicator { get { return _line820FwscIndicator; } set { _line820FwscIndicator = value; } }
-        private Value<bool?> _line821FwbcIndicator;
+        private DirtyValue<bool?> _line821FwbcIndicator;
         public bool? Line821FwbcIndicator { get { return _line821FwbcIndicator; } set { _line821FwbcIndicator = value; } }
-        private Value<bool?> _line821FwscIndicator;
+        private DirtyValue<bool?> _line821FwscIndicator;
         public bool? Line821FwscIndicator { get { return _line821FwscIndicator; } set { _line821FwscIndicator = value; } }
-        private Value<bool?> _line822FwbcIndicator;
+        private DirtyValue<bool?> _line822FwbcIndicator;
         public bool? Line822FwbcIndicator { get { return _line822FwbcIndicator; } set { _line822FwbcIndicator = value; } }
-        private Value<bool?> _line822FwscIndicator;
+        private DirtyValue<bool?> _line822FwscIndicator;
         public bool? Line822FwscIndicator { get { return _line822FwscIndicator; } set { _line822FwscIndicator = value; } }
-        private Value<bool?> _line823FwbcIndicator;
+        private DirtyValue<bool?> _line823FwbcIndicator;
         public bool? Line823FwbcIndicator { get { return _line823FwbcIndicator; } set { _line823FwbcIndicator = value; } }
-        private Value<bool?> _line823FwscIndicator;
+        private DirtyValue<bool?> _line823FwscIndicator;
         public bool? Line823FwscIndicator { get { return _line823FwscIndicator; } set { _line823FwscIndicator = value; } }
-        private Value<bool?> _line824FwbcIndicator;
+        private DirtyValue<bool?> _line824FwbcIndicator;
         public bool? Line824FwbcIndicator { get { return _line824FwbcIndicator; } set { _line824FwbcIndicator = value; } }
-        private Value<bool?> _line824FwscIndicator;
+        private DirtyValue<bool?> _line824FwscIndicator;
         public bool? Line824FwscIndicator { get { return _line824FwscIndicator; } set { _line824FwscIndicator = value; } }
-        private Value<bool?> _line825FwbcIndicator;
+        private DirtyValue<bool?> _line825FwbcIndicator;
         public bool? Line825FwbcIndicator { get { return _line825FwbcIndicator; } set { _line825FwbcIndicator = value; } }
-        private Value<bool?> _line825FwscIndicator;
+        private DirtyValue<bool?> _line825FwscIndicator;
         public bool? Line825FwscIndicator { get { return _line825FwscIndicator; } set { _line825FwscIndicator = value; } }
-        private Value<bool?> _line826FwbcIndicator;
+        private DirtyValue<bool?> _line826FwbcIndicator;
         public bool? Line826FwbcIndicator { get { return _line826FwbcIndicator; } set { _line826FwbcIndicator = value; } }
-        private Value<bool?> _line826FwscIndicator;
+        private DirtyValue<bool?> _line826FwscIndicator;
         public bool? Line826FwscIndicator { get { return _line826FwscIndicator; } set { _line826FwscIndicator = value; } }
-        private Value<bool?> _line827FwbcIndicator;
+        private DirtyValue<bool?> _line827FwbcIndicator;
         public bool? Line827FwbcIndicator { get { return _line827FwbcIndicator; } set { _line827FwbcIndicator = value; } }
-        private Value<bool?> _line827FwscIndicator;
+        private DirtyValue<bool?> _line827FwscIndicator;
         public bool? Line827FwscIndicator { get { return _line827FwscIndicator; } set { _line827FwscIndicator = value; } }
-        private Value<bool?> _line828FwbcIndicator;
+        private DirtyValue<bool?> _line828FwbcIndicator;
         public bool? Line828FwbcIndicator { get { return _line828FwbcIndicator; } set { _line828FwbcIndicator = value; } }
-        private Value<bool?> _line828FwscIndicator;
+        private DirtyValue<bool?> _line828FwscIndicator;
         public bool? Line828FwscIndicator { get { return _line828FwscIndicator; } set { _line828FwscIndicator = value; } }
-        private Value<bool?> _line829FwbcIndicator;
+        private DirtyValue<bool?> _line829FwbcIndicator;
         public bool? Line829FwbcIndicator { get { return _line829FwbcIndicator; } set { _line829FwbcIndicator = value; } }
-        private Value<bool?> _line829FwscIndicator;
+        private DirtyValue<bool?> _line829FwscIndicator;
         public bool? Line829FwscIndicator { get { return _line829FwscIndicator; } set { _line829FwscIndicator = value; } }
-        private Value<bool?> _line830FwbcIndicator;
+        private DirtyValue<bool?> _line830FwbcIndicator;
         public bool? Line830FwbcIndicator { get { return _line830FwbcIndicator; } set { _line830FwbcIndicator = value; } }
-        private Value<bool?> _line830FwscIndicator;
+        private DirtyValue<bool?> _line830FwscIndicator;
         public bool? Line830FwscIndicator { get { return _line830FwscIndicator; } set { _line830FwscIndicator = value; } }
-        private Value<bool?> _line831FwbcIndicator;
+        private DirtyValue<bool?> _line831FwbcIndicator;
         public bool? Line831FwbcIndicator { get { return _line831FwbcIndicator; } set { _line831FwbcIndicator = value; } }
-        private Value<bool?> _line831FwscIndicator;
+        private DirtyValue<bool?> _line831FwscIndicator;
         public bool? Line831FwscIndicator { get { return _line831FwscIndicator; } set { _line831FwscIndicator = value; } }
-        private Value<bool?> _line832FwbcIndicator;
+        private DirtyValue<bool?> _line832FwbcIndicator;
         public bool? Line832FwbcIndicator { get { return _line832FwbcIndicator; } set { _line832FwbcIndicator = value; } }
-        private Value<bool?> _line832FwscIndicator;
+        private DirtyValue<bool?> _line832FwscIndicator;
         public bool? Line832FwscIndicator { get { return _line832FwscIndicator; } set { _line832FwscIndicator = value; } }
-        private Value<bool?> _line833FwbcIndicator;
+        private DirtyValue<bool?> _line833FwbcIndicator;
         public bool? Line833FwbcIndicator { get { return _line833FwbcIndicator; } set { _line833FwbcIndicator = value; } }
-        private Value<bool?> _line833FwscIndicator;
+        private DirtyValue<bool?> _line833FwscIndicator;
         public bool? Line833FwscIndicator { get { return _line833FwscIndicator; } set { _line833FwscIndicator = value; } }
-        private Value<bool?> _lineLFwbcIndicator;
+        private DirtyValue<bool?> _lineLFwbcIndicator;
         public bool? LineLFwbcIndicator { get { return _lineLFwbcIndicator; } set { _lineLFwbcIndicator = value; } }
-        private Value<bool?> _lineLFwscIndicator;
+        private DirtyValue<bool?> _lineLFwscIndicator;
         public bool? LineLFwscIndicator { get { return _lineLFwscIndicator; } set { _lineLFwscIndicator = value; } }
-        private Value<bool?> _lineMFwbcIndicator;
+        private DirtyValue<bool?> _lineMFwbcIndicator;
         public bool? LineMFwbcIndicator { get { return _lineMFwbcIndicator; } set { _lineMFwbcIndicator = value; } }
-        private Value<bool?> _lineMFwscIndicator;
+        private DirtyValue<bool?> _lineMFwscIndicator;
         public bool? LineMFwscIndicator { get { return _lineMFwscIndicator; } set { _lineMFwscIndicator = value; } }
-        private Value<bool?> _lineNFwbcIndicator;
+        private DirtyValue<bool?> _lineNFwbcIndicator;
         public bool? LineNFwbcIndicator { get { return _lineNFwbcIndicator; } set { _lineNFwbcIndicator = value; } }
-        private Value<bool?> _lineNFwscIndicator;
+        private DirtyValue<bool?> _lineNFwscIndicator;
         public bool? LineNFwscIndicator { get { return _lineNFwscIndicator; } set { _lineNFwscIndicator = value; } }
-        private Value<bool?> _lineOFwbcIndicator;
+        private DirtyValue<bool?> _lineOFwbcIndicator;
         public bool? LineOFwbcIndicator { get { return _lineOFwbcIndicator; } set { _lineOFwbcIndicator = value; } }
-        private Value<bool?> _lineOFwscIndicator;
+        private DirtyValue<bool?> _lineOFwscIndicator;
         public bool? LineOFwscIndicator { get { return _lineOFwscIndicator; } set { _lineOFwscIndicator = value; } }
-        private Value<bool?> _linePFwbcIndicator;
+        private DirtyValue<bool?> _linePFwbcIndicator;
         public bool? LinePFwbcIndicator { get { return _linePFwbcIndicator; } set { _linePFwbcIndicator = value; } }
-        private Value<bool?> _linePFwscIndicator;
+        private DirtyValue<bool?> _linePFwscIndicator;
         public bool? LinePFwscIndicator { get { return _linePFwscIndicator; } set { _linePFwscIndicator = value; } }
-        private Value<bool?> _lineQFwbcIndicator;
+        private DirtyValue<bool?> _lineQFwbcIndicator;
         public bool? LineQFwbcIndicator { get { return _lineQFwbcIndicator; } set { _lineQFwbcIndicator = value; } }
-        private Value<bool?> _lineQFwscIndicator;
+        private DirtyValue<bool?> _lineQFwscIndicator;
         public bool? LineQFwscIndicator { get { return _lineQFwscIndicator; } set { _lineQFwscIndicator = value; } }
-        private Value<bool?> _lineRFwbcIndicator;
+        private DirtyValue<bool?> _lineRFwbcIndicator;
         public bool? LineRFwbcIndicator { get { return _lineRFwbcIndicator; } set { _lineRFwbcIndicator = value; } }
-        private Value<bool?> _lineRFwscIndicator;
+        private DirtyValue<bool?> _lineRFwscIndicator;
         public bool? LineRFwscIndicator { get { return _lineRFwscIndicator; } set { _lineRFwscIndicator = value; } }
-        private Value<decimal?> _lowestArmRate;
+        private DirtyValue<decimal?> _lowestArmRate;
         public decimal? LowestArmRate { get { return _lowestArmRate; } set { _lowestArmRate = value; } }
-        private Value<bool?> _monthlyAmountIncludeInterestIndicator;
+        private DirtyValue<bool?> _monthlyAmountIncludeInterestIndicator;
         public bool? MonthlyAmountIncludeInterestIndicator { get { return _monthlyAmountIncludeInterestIndicator; } set { _monthlyAmountIncludeInterestIndicator = value; } }
-        private Value<bool?> _monthlyAmountIncludeMiIndicator;
+        private DirtyValue<bool?> _monthlyAmountIncludeMiIndicator;
         public bool? MonthlyAmountIncludeMiIndicator { get { return _monthlyAmountIncludeMiIndicator; } set { _monthlyAmountIncludeMiIndicator = value; } }
-        private Value<bool?> _monthlyAmountIncludePrincipalIndicator;
+        private DirtyValue<bool?> _monthlyAmountIncludePrincipalIndicator;
         public bool? MonthlyAmountIncludePrincipalIndicator { get { return _monthlyAmountIncludePrincipalIndicator; } set { _monthlyAmountIncludePrincipalIndicator = value; } }
-        private Value<decimal?> _monthlyAmountWithEscrow;
+        private DirtyValue<decimal?> _monthlyAmountWithEscrow;
         public decimal? MonthlyAmountWithEscrow { get { return _monthlyAmountWithEscrow; } set { _monthlyAmountWithEscrow = value; } }
-        private Value<decimal?> _monthlyEscrowPayment;
+        private DirtyValue<decimal?> _monthlyEscrowPayment;
         public decimal? MonthlyEscrowPayment { get { return _monthlyEscrowPayment; } set { _monthlyEscrowPayment = value; } }
-        private Value<decimal?> _prepaidInterest;
+        private DirtyValue<decimal?> _prepaidInterest;
         public decimal? PrepaidInterest { get { return _prepaidInterest; } set { _prepaidInterest = value; } }
-        private Value<decimal?> _totalToleranceIncreaseAmount;
+        private DirtyValue<decimal?> _totalToleranceIncreaseAmount;
         public decimal? TotalToleranceIncreaseAmount { get { return _totalToleranceIncreaseAmount; } set { _totalToleranceIncreaseAmount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe2010Page.cs
+++ b/src/EncompassRest/Loans/Gfe2010Page.cs
@@ -18,10 +18,10 @@ namespace EncompassRest.Loans
         public decimal? CuredGfeTotalTolerance { get { return _curedGfeTotalTolerance; } set { _curedGfeTotalTolerance = value; } }
         private Value<DateTime?> _firstArmChangeDate;
         public DateTime? FirstArmChangeDate { get { return _firstArmChangeDate; } set { _firstArmChangeDate = value; } }
-        private Value<List<Gfe2010FwbcFwsc>> _gfe2010FwbcFwscs;
-        public List<Gfe2010FwbcFwsc> Gfe2010FwbcFwscs { get { return _gfe2010FwbcFwscs; } set { _gfe2010FwbcFwscs = value; } }
-        private Value<List<Gfe2010GfeCharge>> _gfe2010GfeCharges;
-        public List<Gfe2010GfeCharge> Gfe2010GfeCharges { get { return _gfe2010GfeCharges; } set { _gfe2010GfeCharges = value; } }
+        private DirtyList<Gfe2010FwbcFwsc> _gfe2010FwbcFwscs;
+        public IList<Gfe2010FwbcFwsc> Gfe2010FwbcFwscs { get { var v = _gfe2010FwbcFwscs; return v ?? Interlocked.CompareExchange(ref _gfe2010FwbcFwscs, (v = new DirtyList<Gfe2010FwbcFwsc>()), null) ?? v; } set { _gfe2010FwbcFwscs = new DirtyList<Gfe2010FwbcFwsc>(value); } }
+        private DirtyList<Gfe2010GfeCharge> _gfe2010GfeCharges;
+        public IList<Gfe2010GfeCharge> Gfe2010GfeCharges { get { var v = _gfe2010GfeCharges; return v ?? Interlocked.CompareExchange(ref _gfe2010GfeCharges, (v = new DirtyList<Gfe2010GfeCharge>()), null) ?? v; } set { _gfe2010GfeCharges = new DirtyList<Gfe2010GfeCharge>(value); } }
         private Value<string> _gfeRecordingCharges;
         public string GfeRecordingCharges { get { return _gfeRecordingCharges; } set { _gfeRecordingCharges = value; } }
         private Value<decimal?> _gfeTotalTolerance;
@@ -198,8 +198,6 @@ namespace EncompassRest.Loans
                     || _brokerCompensationFwsc.Dirty
                     || _curedGfeTotalTolerance.Dirty
                     || _firstArmChangeDate.Dirty
-                    || _gfe2010FwbcFwscs.Dirty
-                    || _gfe2010GfeCharges.Dirty
                     || _gfeRecordingCharges.Dirty
                     || _gfeTotalTolerance.Dirty
                     || _hasEscrowAccountIndicator.Dirty
@@ -281,7 +279,9 @@ namespace EncompassRest.Loans
                     || _monthlyAmountWithEscrow.Dirty
                     || _monthlyEscrowPayment.Dirty
                     || _prepaidInterest.Dirty
-                    || _totalToleranceIncreaseAmount.Dirty;
+                    || _totalToleranceIncreaseAmount.Dirty
+                    || _gfe2010FwbcFwscs?.Dirty == true
+                    || _gfe2010GfeCharges?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -293,8 +293,6 @@ namespace EncompassRest.Loans
                 _brokerCompensationFwsc.Dirty = value;
                 _curedGfeTotalTolerance.Dirty = value;
                 _firstArmChangeDate.Dirty = value;
-                _gfe2010FwbcFwscs.Dirty = value;
-                _gfe2010GfeCharges.Dirty = value;
                 _gfeRecordingCharges.Dirty = value;
                 _gfeTotalTolerance.Dirty = value;
                 _hasEscrowAccountIndicator.Dirty = value;
@@ -377,6 +375,8 @@ namespace EncompassRest.Loans
                 _monthlyEscrowPayment.Dirty = value;
                 _prepaidInterest.Dirty = value;
                 _totalToleranceIncreaseAmount.Dirty = value;
+                if (_gfe2010FwbcFwscs != null) _gfe2010FwbcFwscs.Dirty = value;
+                if (_gfe2010GfeCharges != null) _gfe2010GfeCharges.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Gfe2010Section.cs
+++ b/src/EncompassRest/Loans/Gfe2010Section.cs
@@ -8,269 +8,269 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010Section : IDirty
     {
-        private Value<bool?> _borrowerSelectIndicator903;
+        private DirtyValue<bool?> _borrowerSelectIndicator903;
         public bool? BorrowerSelectIndicator903 { get { return _borrowerSelectIndicator903; } set { _borrowerSelectIndicator903 = value; } }
-        private Value<bool?> _borrowerSelectIndicator904;
+        private DirtyValue<bool?> _borrowerSelectIndicator904;
         public bool? BorrowerSelectIndicator904 { get { return _borrowerSelectIndicator904; } set { _borrowerSelectIndicator904 = value; } }
-        private Value<bool?> _borrowerSelectIndicator906;
+        private DirtyValue<bool?> _borrowerSelectIndicator906;
         public bool? BorrowerSelectIndicator906 { get { return _borrowerSelectIndicator906; } set { _borrowerSelectIndicator906 = value; } }
-        private Value<bool?> _borrowerSelectIndicator907;
+        private DirtyValue<bool?> _borrowerSelectIndicator907;
         public bool? BorrowerSelectIndicator907 { get { return _borrowerSelectIndicator907; } set { _borrowerSelectIndicator907 = value; } }
-        private Value<bool?> _borrowerSelectIndicator908;
+        private DirtyValue<bool?> _borrowerSelectIndicator908;
         public bool? BorrowerSelectIndicator908 { get { return _borrowerSelectIndicator908; } set { _borrowerSelectIndicator908 = value; } }
-        private Value<bool?> _borrowerSelectIndicator909;
+        private DirtyValue<bool?> _borrowerSelectIndicator909;
         public bool? BorrowerSelectIndicator909 { get { return _borrowerSelectIndicator909; } set { _borrowerSelectIndicator909 = value; } }
-        private Value<bool?> _borrowerSelectIndicator910;
+        private DirtyValue<bool?> _borrowerSelectIndicator910;
         public bool? BorrowerSelectIndicator910 { get { return _borrowerSelectIndicator910; } set { _borrowerSelectIndicator910 = value; } }
-        private Value<decimal?> _hudGfeLine1109;
+        private DirtyValue<decimal?> _hudGfeLine1109;
         public decimal? HudGfeLine1109 { get { return _hudGfeLine1109; } set { _hudGfeLine1109 = value; } }
-        private Value<decimal?> _hudGfeLine1110;
+        private DirtyValue<decimal?> _hudGfeLine1110;
         public decimal? HudGfeLine1110 { get { return _hudGfeLine1110; } set { _hudGfeLine1110 = value; } }
-        private Value<decimal?> _hudGfeLine1111;
+        private DirtyValue<decimal?> _hudGfeLine1111;
         public decimal? HudGfeLine1111 { get { return _hudGfeLine1111; } set { _hudGfeLine1111 = value; } }
-        private Value<decimal?> _hudGfeLine1112;
+        private DirtyValue<decimal?> _hudGfeLine1112;
         public decimal? HudGfeLine1112 { get { return _hudGfeLine1112; } set { _hudGfeLine1112 = value; } }
-        private Value<decimal?> _hudGfeLine1113;
+        private DirtyValue<decimal?> _hudGfeLine1113;
         public decimal? HudGfeLine1113 { get { return _hudGfeLine1113; } set { _hudGfeLine1113 = value; } }
-        private Value<decimal?> _hudGfeLine1114;
+        private DirtyValue<decimal?> _hudGfeLine1114;
         public decimal? HudGfeLine1114 { get { return _hudGfeLine1114; } set { _hudGfeLine1114 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _line1001;
+        private DirtyValue<string> _line1001;
         public string Line1001 { get { return _line1001; } set { _line1001 = value; } }
-        private Value<decimal?> _line1001BorPaidTotal;
+        private DirtyValue<decimal?> _line1001BorPaidTotal;
         public decimal? Line1001BorPaidTotal { get { return _line1001BorPaidTotal; } set { _line1001BorPaidTotal = value; } }
-        private Value<string> _line1002;
+        private DirtyValue<string> _line1002;
         public string Line1002 { get { return _line1002; } set { _line1002 = value; } }
-        private Value<string> _line1003;
+        private DirtyValue<string> _line1003;
         public string Line1003 { get { return _line1003; } set { _line1003 = value; } }
-        private Value<string> _line1004;
+        private DirtyValue<string> _line1004;
         public string Line1004 { get { return _line1004; } set { _line1004 = value; } }
-        private Value<string> _line1005;
+        private DirtyValue<string> _line1005;
         public string Line1005 { get { return _line1005; } set { _line1005 = value; } }
-        private Value<string> _line1006;
+        private DirtyValue<string> _line1006;
         public string Line1006 { get { return _line1006; } set { _line1006 = value; } }
-        private Value<string> _line1007;
+        private DirtyValue<string> _line1007;
         public string Line1007 { get { return _line1007; } set { _line1007 = value; } }
-        private Value<string> _line1008;
+        private DirtyValue<string> _line1008;
         public string Line1008 { get { return _line1008; } set { _line1008 = value; } }
-        private Value<string> _line1009;
+        private DirtyValue<string> _line1009;
         public string Line1009 { get { return _line1009; } set { _line1009 = value; } }
-        private Value<string> _line1010;
+        private DirtyValue<string> _line1010;
         public string Line1010 { get { return _line1010; } set { _line1010 = value; } }
-        private Value<string> _line1011;
+        private DirtyValue<string> _line1011;
         public string Line1011 { get { return _line1011; } set { _line1011 = value; } }
-        private Value<string> _line1101;
+        private DirtyValue<string> _line1101;
         public string Line1101 { get { return _line1101; } set { _line1101 = value; } }
-        private Value<decimal?> _line1101BorPaidTotal;
+        private DirtyValue<decimal?> _line1101BorPaidTotal;
         public decimal? Line1101BorPaidTotal { get { return _line1101BorPaidTotal; } set { _line1101BorPaidTotal = value; } }
-        private Value<decimal?> _line1101SellerPaidAtoF;
+        private DirtyValue<decimal?> _line1101SellerPaidAtoF;
         public decimal? Line1101SellerPaidAtoF { get { return _line1101SellerPaidAtoF; } set { _line1101SellerPaidAtoF = value; } }
-        private Value<string> _line1102;
+        private DirtyValue<string> _line1102;
         public string Line1102 { get { return _line1102; } set { _line1102 = value; } }
-        private Value<string> _line1103;
+        private DirtyValue<string> _line1103;
         public string Line1103 { get { return _line1103; } set { _line1103 = value; } }
-        private Value<decimal?> _line1103PTAAmount;
+        private DirtyValue<decimal?> _line1103PTAAmount;
         public decimal? Line1103PTAAmount { get { return _line1103PTAAmount; } set { _line1103PTAAmount = value; } }
-        private Value<string> _line1104;
+        private DirtyValue<string> _line1104;
         public string Line1104 { get { return _line1104; } set { _line1104 = value; } }
-        private Value<decimal?> _line1104PTAAmount;
+        private DirtyValue<decimal?> _line1104PTAAmount;
         public decimal? Line1104PTAAmount { get { return _line1104PTAAmount; } set { _line1104PTAAmount = value; } }
-        private Value<string> _line1107;
+        private DirtyValue<string> _line1107;
         public string Line1107 { get { return _line1107; } set { _line1107 = value; } }
-        private Value<string> _line1108;
+        private DirtyValue<string> _line1108;
         public string Line1108 { get { return _line1108; } set { _line1108 = value; } }
-        private Value<string> _line1109;
+        private DirtyValue<string> _line1109;
         public string Line1109 { get { return _line1109; } set { _line1109 = value; } }
-        private Value<string> _line1110;
+        private DirtyValue<string> _line1110;
         public string Line1110 { get { return _line1110; } set { _line1110 = value; } }
-        private Value<string> _line1115;
+        private DirtyValue<string> _line1115;
         public string Line1115 { get { return _line1115; } set { _line1115 = value; } }
-        private Value<string> _line1116;
+        private DirtyValue<string> _line1116;
         public string Line1116 { get { return _line1116; } set { _line1116 = value; } }
-        private Value<decimal?> _line1201BorPaidTotal;
+        private DirtyValue<decimal?> _line1201BorPaidTotal;
         public decimal? Line1201BorPaidTotal { get { return _line1201BorPaidTotal; } set { _line1201BorPaidTotal = value; } }
-        private Value<string> _line1209;
+        private DirtyValue<string> _line1209;
         public string Line1209 { get { return _line1209; } set { _line1209 = value; } }
-        private Value<string> _line1210;
+        private DirtyValue<string> _line1210;
         public string Line1210 { get { return _line1210; } set { _line1210 = value; } }
-        private Value<decimal?> _line1301BorPaidTotal;
+        private DirtyValue<decimal?> _line1301BorPaidTotal;
         public decimal? Line1301BorPaidTotal { get { return _line1301BorPaidTotal; } set { _line1301BorPaidTotal = value; } }
-        private Value<string> _line1302;
+        private DirtyValue<string> _line1302;
         public string Line1302 { get { return _line1302; } set { _line1302 = value; } }
-        private Value<string> _line1310;
+        private DirtyValue<string> _line1310;
         public string Line1310 { get { return _line1310; } set { _line1310 = value; } }
-        private Value<string> _line1311;
+        private DirtyValue<string> _line1311;
         public string Line1311 { get { return _line1311; } set { _line1311 = value; } }
-        private Value<string> _line1312;
+        private DirtyValue<string> _line1312;
         public string Line1312 { get { return _line1312; } set { _line1312 = value; } }
-        private Value<string> _line1313;
+        private DirtyValue<string> _line1313;
         public string Line1313 { get { return _line1313; } set { _line1313 = value; } }
-        private Value<string> _line1314;
+        private DirtyValue<string> _line1314;
         public string Line1314 { get { return _line1314; } set { _line1314 = value; } }
-        private Value<string> _line1315;
+        private DirtyValue<string> _line1315;
         public string Line1315 { get { return _line1315; } set { _line1315 = value; } }
-        private Value<string> _line1316;
+        private DirtyValue<string> _line1316;
         public string Line1316 { get { return _line1316; } set { _line1316 = value; } }
-        private Value<string> _line1317;
+        private DirtyValue<string> _line1317;
         public string Line1317 { get { return _line1317; } set { _line1317 = value; } }
-        private Value<string> _line1318;
+        private DirtyValue<string> _line1318;
         public string Line1318 { get { return _line1318; } set { _line1318 = value; } }
-        private Value<string> _line1319;
+        private DirtyValue<string> _line1319;
         public string Line1319 { get { return _line1319; } set { _line1319 = value; } }
-        private Value<string> _line1320;
+        private DirtyValue<string> _line1320;
         public string Line1320 { get { return _line1320; } set { _line1320 = value; } }
-        private Value<string> _line701;
+        private DirtyValue<string> _line701;
         public string Line701 { get { return _line701; } set { _line701 = value; } }
-        private Value<string> _line702;
+        private DirtyValue<string> _line702;
         public string Line702 { get { return _line702; } set { _line702 = value; } }
-        private Value<string> _line703;
+        private DirtyValue<string> _line703;
         public string Line703 { get { return _line703; } set { _line703 = value; } }
-        private Value<string> _line704;
+        private DirtyValue<string> _line704;
         public string Line704 { get { return _line704; } set { _line704 = value; } }
-        private Value<string> _line803x;
+        private DirtyValue<string> _line803x;
         public string Line803x { get { return _line803x; } set { _line803x = value; } }
-        private Value<string> _line807Company;
+        private DirtyValue<string> _line807Company;
         public string Line807Company { get { return _line807Company; } set { _line807Company = value; } }
-        private Value<string> _line808;
+        private DirtyValue<string> _line808;
         public string Line808 { get { return _line808; } set { _line808 = value; } }
-        private Value<string> _line809;
+        private DirtyValue<string> _line809;
         public string Line809 { get { return _line809; } set { _line809 = value; } }
-        private Value<string> _line810;
+        private DirtyValue<string> _line810;
         public string Line810 { get { return _line810; } set { _line810 = value; } }
-        private Value<string> _line811;
+        private DirtyValue<string> _line811;
         public string Line811 { get { return _line811; } set { _line811 = value; } }
-        private Value<string> _line812;
+        private DirtyValue<string> _line812;
         public string Line812 { get { return _line812; } set { _line812 = value; } }
-        private Value<string> _line819;
+        private DirtyValue<string> _line819;
         public string Line819 { get { return _line819; } set { _line819 = value; } }
-        private Value<string> _line820;
+        private DirtyValue<string> _line820;
         public string Line820 { get { return _line820; } set { _line820 = value; } }
-        private Value<string> _line821;
+        private DirtyValue<string> _line821;
         public string Line821 { get { return _line821; } set { _line821 = value; } }
-        private Value<string> _line822;
+        private DirtyValue<string> _line822;
         public string Line822 { get { return _line822; } set { _line822 = value; } }
-        private Value<string> _line823;
+        private DirtyValue<string> _line823;
         public string Line823 { get { return _line823; } set { _line823 = value; } }
-        private Value<string> _line824;
+        private DirtyValue<string> _line824;
         public string Line824 { get { return _line824; } set { _line824 = value; } }
-        private Value<string> _line825;
+        private DirtyValue<string> _line825;
         public string Line825 { get { return _line825; } set { _line825 = value; } }
-        private Value<string> _line826;
+        private DirtyValue<string> _line826;
         public string Line826 { get { return _line826; } set { _line826 = value; } }
-        private Value<string> _line827;
+        private DirtyValue<string> _line827;
         public string Line827 { get { return _line827; } set { _line827 = value; } }
-        private Value<string> _line828;
+        private DirtyValue<string> _line828;
         public string Line828 { get { return _line828; } set { _line828 = value; } }
-        private Value<string> _line829;
+        private DirtyValue<string> _line829;
         public string Line829 { get { return _line829; } set { _line829 = value; } }
-        private Value<string> _line830;
+        private DirtyValue<string> _line830;
         public string Line830 { get { return _line830; } set { _line830 = value; } }
-        private Value<string> _line831;
+        private DirtyValue<string> _line831;
         public string Line831 { get { return _line831; } set { _line831 = value; } }
-        private Value<string> _line832;
+        private DirtyValue<string> _line832;
         public string Line832 { get { return _line832; } set { _line832 = value; } }
-        private Value<string> _line833;
+        private DirtyValue<string> _line833;
         public string Line833 { get { return _line833; } set { _line833 = value; } }
-        private Value<string> _line834;
+        private DirtyValue<string> _line834;
         public string Line834 { get { return _line834; } set { _line834 = value; } }
-        private Value<string> _line835;
+        private DirtyValue<string> _line835;
         public string Line835 { get { return _line835; } set { _line835 = value; } }
-        private Value<string> _line904;
+        private DirtyValue<string> _line904;
         public string Line904 { get { return _line904; } set { _line904 = value; } }
-        private Value<string> _line909;
+        private DirtyValue<string> _line909;
         public string Line909 { get { return _line909; } set { _line909 = value; } }
-        private Value<string> _line910;
+        private DirtyValue<string> _line910;
         public string Line910 { get { return _line910; } set { _line910 = value; } }
-        private Value<string> _line911;
+        private DirtyValue<string> _line911;
         public string Line911 { get { return _line911; } set { _line911 = value; } }
-        private Value<string> _line912;
+        private DirtyValue<string> _line912;
         public string Line912 { get { return _line912; } set { _line912 = value; } }
-        private Value<bool?> _loanTermTableCustomized;
+        private DirtyValue<bool?> _loanTermTableCustomized;
         public bool? LoanTermTableCustomized { get { return _loanTermTableCustomized; } set { _loanTermTableCustomized = value; } }
-        private Value<bool?> _loCompensationItemizeFeesIndicator;
+        private DirtyValue<bool?> _loCompensationItemizeFeesIndicator;
         public bool? LoCompensationItemizeFeesIndicator { get { return _loCompensationItemizeFeesIndicator; } set { _loCompensationItemizeFeesIndicator = value; } }
-        private Value<decimal?> _loCompensationLenderTotalPaidOriginatorAmount;
+        private DirtyValue<decimal?> _loCompensationLenderTotalPaidOriginatorAmount;
         public decimal? LoCompensationLenderTotalPaidOriginatorAmount { get { return _loCompensationLenderTotalPaidOriginatorAmount; } set { _loCompensationLenderTotalPaidOriginatorAmount = value; } }
-        private Value<decimal?> _loCompensationLenderTotalPaidOriginatorAmountForGFE;
+        private DirtyValue<decimal?> _loCompensationLenderTotalPaidOriginatorAmountForGFE;
         public decimal? LoCompensationLenderTotalPaidOriginatorAmountForGFE { get { return _loCompensationLenderTotalPaidOriginatorAmountForGFE; } set { _loCompensationLenderTotalPaidOriginatorAmountForGFE = value; } }
-        private Value<decimal?> _loCompensationLenderTotalPaidOriginatorAmountForLOTool;
+        private DirtyValue<decimal?> _loCompensationLenderTotalPaidOriginatorAmountForLOTool;
         public decimal? LoCompensationLenderTotalPaidOriginatorAmountForLOTool { get { return _loCompensationLenderTotalPaidOriginatorAmountForLOTool; } set { _loCompensationLenderTotalPaidOriginatorAmountForLOTool = value; } }
-        private Value<decimal?> _loCompensationNewHudLenderTotalPaidOriginatorAmount;
+        private DirtyValue<decimal?> _loCompensationNewHudLenderTotalPaidOriginatorAmount;
         public decimal? LoCompensationNewHudLenderTotalPaidOriginatorAmount { get { return _loCompensationNewHudLenderTotalPaidOriginatorAmount; } set { _loCompensationNewHudLenderTotalPaidOriginatorAmount = value; } }
-        private Value<decimal?> _loCompensationNewHudTotalBorrowerPaidDiscountPointAmount;
+        private DirtyValue<decimal?> _loCompensationNewHudTotalBorrowerPaidDiscountPointAmount;
         public decimal? LoCompensationNewHudTotalBorrowerPaidDiscountPointAmount { get { return _loCompensationNewHudTotalBorrowerPaidDiscountPointAmount; } set { _loCompensationNewHudTotalBorrowerPaidDiscountPointAmount = value; } }
-        private Value<decimal?> _loCompensationNewHudTotalLoCompensationAmount;
+        private DirtyValue<decimal?> _loCompensationNewHudTotalLoCompensationAmount;
         public decimal? LoCompensationNewHudTotalLoCompensationAmount { get { return _loCompensationNewHudTotalLoCompensationAmount; } set { _loCompensationNewHudTotalLoCompensationAmount = value; } }
-        private Value<decimal?> _loCompensationTotalBorrowerPaidDiscountPointAmount4;
+        private DirtyValue<decimal?> _loCompensationTotalBorrowerPaidDiscountPointAmount4;
         public decimal? LoCompensationTotalBorrowerPaidDiscountPointAmount4 { get { return _loCompensationTotalBorrowerPaidDiscountPointAmount4; } set { _loCompensationTotalBorrowerPaidDiscountPointAmount4 = value; } }
-        private Value<decimal?> _loCompensationTotalLoCompensationAmount;
+        private DirtyValue<decimal?> _loCompensationTotalLoCompensationAmount;
         public decimal? LoCompensationTotalLoCompensationAmount { get { return _loCompensationTotalLoCompensationAmount; } set { _loCompensationTotalLoCompensationAmount = value; } }
-        private Value<decimal?> _loCompensationTotalSellerPaidDiscountPointAmount4;
+        private DirtyValue<decimal?> _loCompensationTotalSellerPaidDiscountPointAmount4;
         public decimal? LoCompensationTotalSellerPaidDiscountPointAmount4 { get { return _loCompensationTotalSellerPaidDiscountPointAmount4; } set { _loCompensationTotalSellerPaidDiscountPointAmount4 = value; } }
-        private Value<bool?> _loCompensationUseLoCompensationToolIndicator;
+        private DirtyValue<bool?> _loCompensationUseLoCompensationToolIndicator;
         public bool? LoCompensationUseLoCompensationToolIndicator { get { return _loCompensationUseLoCompensationToolIndicator; } set { _loCompensationUseLoCompensationToolIndicator = value; } }
-        private Value<string> _projectedPaymentTableColumns;
+        private DirtyValue<string> _projectedPaymentTableColumns;
         public string ProjectedPaymentTableColumns { get { return _projectedPaymentTableColumns; } set { _projectedPaymentTableColumns = value; } }
-        private Value<bool?> _projectedPaymentTableCustomized;
+        private DirtyValue<bool?> _projectedPaymentTableCustomized;
         public bool? ProjectedPaymentTableCustomized { get { return _projectedPaymentTableCustomized; } set { _projectedPaymentTableCustomized = value; } }
-        private Value<string> _projectedPaymentTableType;
+        private DirtyValue<string> _projectedPaymentTableType;
         public string ProjectedPaymentTableType { get { return _projectedPaymentTableType; } set { _projectedPaymentTableType = value; } }
-        private Value<decimal?> _section1000AggregateAdjust;
+        private DirtyValue<decimal?> _section1000AggregateAdjust;
         public decimal? Section1000AggregateAdjust { get { return _section1000AggregateAdjust; } set { _section1000AggregateAdjust = value; } }
-        private Value<bool?> _section1000HudGuaranteeFeeAprIndicator;
+        private DirtyValue<bool?> _section1000HudGuaranteeFeeAprIndicator;
         public bool? Section1000HudGuaranteeFeeAprIndicator { get { return _section1000HudGuaranteeFeeAprIndicator; } set { _section1000HudGuaranteeFeeAprIndicator = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator1;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator1;
         public bool? Section1100BorrowerSelectIndicator1 { get { return _section1100BorrowerSelectIndicator1; } set { _section1100BorrowerSelectIndicator1 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator10;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator10;
         public bool? Section1100BorrowerSelectIndicator10 { get { return _section1100BorrowerSelectIndicator10; } set { _section1100BorrowerSelectIndicator10 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator2;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator2;
         public bool? Section1100BorrowerSelectIndicator2 { get { return _section1100BorrowerSelectIndicator2; } set { _section1100BorrowerSelectIndicator2 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator3;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator3;
         public bool? Section1100BorrowerSelectIndicator3 { get { return _section1100BorrowerSelectIndicator3; } set { _section1100BorrowerSelectIndicator3 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator4;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator4;
         public bool? Section1100BorrowerSelectIndicator4 { get { return _section1100BorrowerSelectIndicator4; } set { _section1100BorrowerSelectIndicator4 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator5;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator5;
         public bool? Section1100BorrowerSelectIndicator5 { get { return _section1100BorrowerSelectIndicator5; } set { _section1100BorrowerSelectIndicator5 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator6;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator6;
         public bool? Section1100BorrowerSelectIndicator6 { get { return _section1100BorrowerSelectIndicator6; } set { _section1100BorrowerSelectIndicator6 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator7;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator7;
         public bool? Section1100BorrowerSelectIndicator7 { get { return _section1100BorrowerSelectIndicator7; } set { _section1100BorrowerSelectIndicator7 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator8;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator8;
         public bool? Section1100BorrowerSelectIndicator8 { get { return _section1100BorrowerSelectIndicator8; } set { _section1100BorrowerSelectIndicator8 = value; } }
-        private Value<bool?> _section1100BorrowerSelectIndicator9;
+        private DirtyValue<bool?> _section1100BorrowerSelectIndicator9;
         public bool? Section1100BorrowerSelectIndicator9 { get { return _section1100BorrowerSelectIndicator9; } set { _section1100BorrowerSelectIndicator9 = value; } }
-        private Value<bool?> _section1100ItemizeFeesIndicator;
+        private DirtyValue<bool?> _section1100ItemizeFeesIndicator;
         public bool? Section1100ItemizeFeesIndicator { get { return _section1100ItemizeFeesIndicator; } set { _section1100ItemizeFeesIndicator = value; } }
-        private Value<decimal?> _section1200TotalTransferTaxes;
+        private DirtyValue<decimal?> _section1200TotalTransferTaxes;
         public decimal? Section1200TotalTransferTaxes { get { return _section1200TotalTransferTaxes; } set { _section1200TotalTransferTaxes = value; } }
-        private Value<bool?> _section800BonaFideIndicator;
+        private DirtyValue<bool?> _section800BonaFideIndicator;
         public bool? Section800BonaFideIndicator { get { return _section800BonaFideIndicator; } set { _section800BonaFideIndicator = value; } }
-        private Value<decimal?> _section800BorrowerPaidInitialDiscountPointAmount;
+        private DirtyValue<decimal?> _section800BorrowerPaidInitialDiscountPointAmount;
         public decimal? Section800BorrowerPaidInitialDiscountPointAmount { get { return _section800BorrowerPaidInitialDiscountPointAmount; } set { _section800BorrowerPaidInitialDiscountPointAmount = value; } }
-        private Value<decimal?> _section800ChargeAmount;
+        private DirtyValue<decimal?> _section800ChargeAmount;
         public decimal? Section800ChargeAmount { get { return _section800ChargeAmount; } set { _section800ChargeAmount = value; } }
-        private Value<string> _section800CreditChargeType;
+        private DirtyValue<string> _section800CreditChargeType;
         public string Section800CreditChargeType { get { return _section800CreditChargeType; } set { _section800CreditChargeType = value; } }
-        private Value<string> _section800IncludeOriginationPointsCreditType;
+        private DirtyValue<string> _section800IncludeOriginationPointsCreditType;
         public string Section800IncludeOriginationPointsCreditType { get { return _section800IncludeOriginationPointsCreditType; } set { _section800IncludeOriginationPointsCreditType = value; } }
-        private Value<decimal?> _section800InitialDiscountPoint;
+        private DirtyValue<decimal?> _section800InitialDiscountPoint;
         public decimal? Section800InitialDiscountPoint { get { return _section800InitialDiscountPoint; } set { _section800InitialDiscountPoint = value; } }
-        private Value<decimal?> _section800InitialDiscountPointAdditionalAmount;
+        private DirtyValue<decimal?> _section800InitialDiscountPointAdditionalAmount;
         public decimal? Section800InitialDiscountPointAdditionalAmount { get { return _section800InitialDiscountPointAdditionalAmount; } set { _section800InitialDiscountPointAdditionalAmount = value; } }
-        private Value<decimal?> _section800InitialDiscountRate;
+        private DirtyValue<decimal?> _section800InitialDiscountRate;
         public decimal? Section800InitialDiscountRate { get { return _section800InitialDiscountRate; } set { _section800InitialDiscountRate = value; } }
-        private Value<bool?> _section800ItemizeFeesIndicator;
+        private DirtyValue<bool?> _section800ItemizeFeesIndicator;
         public bool? Section800ItemizeFeesIndicator { get { return _section800ItemizeFeesIndicator; } set { _section800ItemizeFeesIndicator = value; } }
-        private Value<decimal?> _section800SelChargeAmount;
+        private DirtyValue<decimal?> _section800SelChargeAmount;
         public decimal? Section800SelChargeAmount { get { return _section800SelChargeAmount; } set { _section800SelChargeAmount = value; } }
-        private Value<decimal?> _section800TotalTransferTaxes;
+        private DirtyValue<decimal?> _section800TotalTransferTaxes;
         public decimal? Section800TotalTransferTaxes { get { return _section800TotalTransferTaxes; } set { _section800TotalTransferTaxes = value; } }
-        private Value<decimal?> _section900HomeownerInsurance;
+        private DirtyValue<decimal?> _section900HomeownerInsurance;
         public decimal? Section900HomeownerInsurance { get { return _section900HomeownerInsurance; } set { _section900HomeownerInsurance = value; } }
-        private Value<decimal?> _section900HudGfeVaFundingFee;
+        private DirtyValue<decimal?> _section900HudGfeVaFundingFee;
         public decimal? Section900HudGfeVaFundingFee { get { return _section900HudGfeVaFundingFee; } set { _section900HudGfeVaFundingFee = value; } }
-        private Value<bool?> _useActualPaymentChange;
+        private DirtyValue<bool?> _useActualPaymentChange;
         public bool? UseActualPaymentChange { get { return _useActualPaymentChange; } set { _useActualPaymentChange = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Gfe2010WholePoc.cs
+++ b/src/EncompassRest/Loans/Gfe2010WholePoc.cs
@@ -8,15 +8,15 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Gfe2010WholePoc : IDirty
     {
-        private Value<int?> _gfe2010WholePocIndex;
+        private DirtyValue<int?> _gfe2010WholePocIndex;
         public int? Gfe2010WholePocIndex { get { return _gfe2010WholePocIndex; } set { _gfe2010WholePocIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
-        private Value<decimal?> _wholePoc;
+        private DirtyValue<decimal?> _wholePoc;
         public decimal? WholePoc { get { return _wholePoc; } set { _wholePoc = value; } }
-        private Value<string> _wholePocPaidByType;
+        private DirtyValue<string> _wholePocPaidByType;
         public string WholePocPaidByType { get { return _wholePocPaidByType; } set { _wholePocPaidByType = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/GfeFee.cs
+++ b/src/EncompassRest/Loans/GfeFee.cs
@@ -8,21 +8,21 @@ namespace EncompassRest.Loans
 {
     public sealed partial class GfeFee : IDirty
     {
-        private Value<string> _amountDescription;
+        private DirtyValue<string> _amountDescription;
         public string AmountDescription { get { return _amountDescription; } set { _amountDescription = value; } }
-        private Value<decimal?> _brokerAmount;
+        private DirtyValue<decimal?> _brokerAmount;
         public decimal? BrokerAmount { get { return _brokerAmount; } set { _brokerAmount = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<int?> _gfeFeeIndex;
+        private DirtyValue<int?> _gfeFeeIndex;
         public int? GfeFeeIndex { get { return _gfeFeeIndex; } set { _gfeFeeIndex = value; } }
-        private Value<string> _gfeFeeType;
+        private DirtyValue<string> _gfeFeeType;
         public string GfeFeeType { get { return _gfeFeeType; } set { _gfeFeeType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _otherAmount;
+        private DirtyValue<decimal?> _otherAmount;
         public decimal? OtherAmount { get { return _otherAmount; } set { _otherAmount = value; } }
-        private Value<string> _rate;
+        private DirtyValue<string> _rate;
         public string Rate { get { return _rate; } set { _rate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/GfeLien.cs
+++ b/src/EncompassRest/Loans/GfeLien.cs
@@ -8,17 +8,17 @@ namespace EncompassRest.Loans
 {
     public sealed partial class GfeLien : IDirty
     {
-        private Value<decimal?> _amountOwing;
+        private DirtyValue<decimal?> _amountOwing;
         public decimal? AmountOwing { get { return _amountOwing; } set { _amountOwing = value; } }
-        private Value<int?> _gfeLienIndex;
+        private DirtyValue<int?> _gfeLienIndex;
         public int? GfeLienIndex { get { return _gfeLienIndex; } set { _gfeLienIndex = value; } }
-        private Value<string> _gfeLienType;
+        private DirtyValue<string> _gfeLienType;
         public string GfeLienType { get { return _gfeLienType; } set { _gfeLienType = value; } }
-        private Value<string> _holderName;
+        private DirtyValue<string> _holderName;
         public string HolderName { get { return _holderName; } set { _holderName = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _priority;
+        private DirtyValue<string> _priority;
         public string Priority { get { return _priority; } set { _priority = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/GfePayment.cs
+++ b/src/EncompassRest/Loans/GfePayment.cs
@@ -8,45 +8,45 @@ namespace EncompassRest.Loans
 {
     public sealed partial class GfePayment : IDirty
     {
-        private Value<decimal?> _fixedRate;
+        private DirtyValue<decimal?> _fixedRate;
         public decimal? FixedRate { get { return _fixedRate; } set { _fixedRate = value; } }
-        private Value<int?> _gfePaymentIndex;
+        private DirtyValue<int?> _gfePaymentIndex;
         public int? GfePaymentIndex { get { return _gfePaymentIndex; } set { _gfePaymentIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _indexRate;
+        private DirtyValue<decimal?> _indexRate;
         public decimal? IndexRate { get { return _indexRate; } set { _indexRate = value; } }
-        private Value<string> _isBalanceReduced;
+        private DirtyValue<string> _isBalanceReduced;
         public string IsBalanceReduced { get { return _isBalanceReduced; } set { _isBalanceReduced = value; } }
-        private Value<string> _loanTypeExplanation;
+        private DirtyValue<string> _loanTypeExplanation;
         public string LoanTypeExplanation { get { return _loanTypeExplanation; } set { _loanTypeExplanation = value; } }
-        private Value<decimal?> _marginRate;
+        private DirtyValue<decimal?> _marginRate;
         public decimal? MarginRate { get { return _marginRate; } set { _marginRate = value; } }
-        private Value<decimal?> _maximumDifference;
+        private DirtyValue<decimal?> _maximumDifference;
         public decimal? MaximumDifference { get { return _maximumDifference; } set { _maximumDifference = value; } }
-        private Value<decimal?> _maximumRate;
+        private DirtyValue<decimal?> _maximumRate;
         public decimal? MaximumRate { get { return _maximumRate; } set { _maximumRate = value; } }
-        private Value<decimal?> _minimumDifference;
+        private DirtyValue<decimal?> _minimumDifference;
         public decimal? MinimumDifference { get { return _minimumDifference; } set { _minimumDifference = value; } }
-        private Value<decimal?> _minimumMonthlyPayment;
+        private DirtyValue<decimal?> _minimumMonthlyPayment;
         public decimal? MinimumMonthlyPayment { get { return _minimumMonthlyPayment; } set { _minimumMonthlyPayment = value; } }
-        private Value<decimal?> _monthlyPaymentYear1;
+        private DirtyValue<decimal?> _monthlyPaymentYear1;
         public decimal? MonthlyPaymentYear1 { get { return _monthlyPaymentYear1; } set { _monthlyPaymentYear1 = value; } }
-        private Value<decimal?> _monthlyPaymentYear6;
+        private DirtyValue<decimal?> _monthlyPaymentYear6;
         public decimal? MonthlyPaymentYear6 { get { return _monthlyPaymentYear6; } set { _monthlyPaymentYear6 = value; } }
-        private Value<decimal?> _monthlyPaymentYear6Change;
+        private DirtyValue<decimal?> _monthlyPaymentYear6Change;
         public decimal? MonthlyPaymentYear6Change { get { return _monthlyPaymentYear6Change; } set { _monthlyPaymentYear6Change = value; } }
-        private Value<decimal?> _monthlyPaymentYear6MaxChange;
+        private DirtyValue<decimal?> _monthlyPaymentYear6MaxChange;
         public decimal? MonthlyPaymentYear6MaxChange { get { return _monthlyPaymentYear6MaxChange; } set { _monthlyPaymentYear6MaxChange = value; } }
-        private Value<bool?> _notOfferedIndicator;
+        private DirtyValue<bool?> _notOfferedIndicator;
         public bool? NotOfferedIndicator { get { return _notOfferedIndicator; } set { _notOfferedIndicator = value; } }
-        private Value<decimal?> _owedAfter5Years;
+        private DirtyValue<decimal?> _owedAfter5Years;
         public decimal? OwedAfter5Years { get { return _owedAfter5Years; } set { _owedAfter5Years = value; } }
-        private Value<decimal?> _rateInMonth2;
+        private DirtyValue<decimal?> _rateInMonth2;
         public decimal? RateInMonth2 { get { return _rateInMonth2; } set { _rateInMonth2 = value; } }
-        private Value<decimal?> _reducedLoanBalance;
+        private DirtyValue<decimal?> _reducedLoanBalance;
         public decimal? ReducedLoanBalance { get { return _reducedLoanBalance; } set { _reducedLoanBalance = value; } }
-        private Value<string> _reducedStatus;
+        private DirtyValue<string> _reducedStatus;
         public string ReducedStatus { get { return _reducedStatus; } set { _reducedStatus = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/GfePayoff.cs
+++ b/src/EncompassRest/Loans/GfePayoff.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class GfePayoff : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<int?> _gfePayoffIndex;
+        private DirtyValue<int?> _gfePayoffIndex;
         public int? GfePayoffIndex { get { return _gfePayoffIndex; } set { _gfePayoffIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/HelocRepaymentDrawPeriod.cs
+++ b/src/EncompassRest/Loans/HelocRepaymentDrawPeriod.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class HelocRepaymentDrawPeriod : IDirty
     {
-        private Value<decimal?> _apr;
+        private DirtyValue<decimal?> _apr;
         public decimal? Apr { get { return _apr; } set { _apr = value; } }
-        private Value<bool?> _drawIndicator;
+        private DirtyValue<bool?> _drawIndicator;
         public bool? DrawIndicator { get { return _drawIndicator; } set { _drawIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _indexRatePercent;
+        private DirtyValue<decimal?> _indexRatePercent;
         public decimal? IndexRatePercent { get { return _indexRatePercent; } set { _indexRatePercent = value; } }
-        private Value<decimal?> _marginRatePercent;
+        private DirtyValue<decimal?> _marginRatePercent;
         public decimal? MarginRatePercent { get { return _marginRatePercent; } set { _marginRatePercent = value; } }
-        private Value<decimal?> _minimumMonthlyPaymentAmount;
+        private DirtyValue<decimal?> _minimumMonthlyPaymentAmount;
         public decimal? MinimumMonthlyPaymentAmount { get { return _minimumMonthlyPaymentAmount; } set { _minimumMonthlyPaymentAmount = value; } }
-        private Value<int?> _year;
+        private DirtyValue<int?> _year;
         public int? Year { get { return _year; } set { _year = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hmda.cs
+++ b/src/EncompassRest/Loans/Hmda.cs
@@ -8,189 +8,189 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hmda : IDirty
     {
-        private Value<string> _actionTaken;
+        private DirtyValue<string> _actionTaken;
         public string ActionTaken { get { return _actionTaken; } set { _actionTaken = value; } }
-        private Value<string> _applicationDate;
+        private DirtyValue<string> _applicationDate;
         public string ApplicationDate { get { return _applicationDate; } set { _applicationDate = value; } }
-        private Value<string> _aUS1;
+        private DirtyValue<string> _aUS1;
         public string AUS1 { get { return _aUS1; } set { _aUS1 = value; } }
-        private Value<string> _aUS2;
+        private DirtyValue<string> _aUS2;
         public string AUS2 { get { return _aUS2; } set { _aUS2 = value; } }
-        private Value<string> _aUS3;
+        private DirtyValue<string> _aUS3;
         public string AUS3 { get { return _aUS3; } set { _aUS3 = value; } }
-        private Value<string> _aUS4;
+        private DirtyValue<string> _aUS4;
         public string AUS4 { get { return _aUS4; } set { _aUS4 = value; } }
-        private Value<string> _aUS5;
+        private DirtyValue<string> _aUS5;
         public string AUS5 { get { return _aUS5; } set { _aUS5 = value; } }
-        private Value<string> _aUSRecommendation1;
+        private DirtyValue<string> _aUSRecommendation1;
         public string AUSRecommendation1 { get { return _aUSRecommendation1; } set { _aUSRecommendation1 = value; } }
-        private Value<string> _aUSRecommendation2;
+        private DirtyValue<string> _aUSRecommendation2;
         public string AUSRecommendation2 { get { return _aUSRecommendation2; } set { _aUSRecommendation2 = value; } }
-        private Value<string> _aUSRecommendation3;
+        private DirtyValue<string> _aUSRecommendation3;
         public string AUSRecommendation3 { get { return _aUSRecommendation3; } set { _aUSRecommendation3 = value; } }
-        private Value<string> _aUSRecommendation4;
+        private DirtyValue<string> _aUSRecommendation4;
         public string AUSRecommendation4 { get { return _aUSRecommendation4; } set { _aUSRecommendation4 = value; } }
-        private Value<string> _aUSRecommendation5;
+        private DirtyValue<string> _aUSRecommendation5;
         public string AUSRecommendation5 { get { return _aUSRecommendation5; } set { _aUSRecommendation5 = value; } }
-        private Value<string> _businessOrCommercialPurpose;
+        private DirtyValue<string> _businessOrCommercialPurpose;
         public string BusinessOrCommercialPurpose { get { return _businessOrCommercialPurpose; } set { _businessOrCommercialPurpose = value; } }
-        private Value<string> _censusTrack;
+        private DirtyValue<string> _censusTrack;
         public string CensusTrack { get { return _censusTrack; } set { _censusTrack = value; } }
-        private Value<NA<decimal>?> _cLTV;
+        private DirtyValue<NA<decimal>?> _cLTV;
         public NA<decimal>? CLTV { get { return _cLTV; } set { _cLTV = value; } }
-        private Value<string> _contactEmailAddress;
+        private DirtyValue<string> _contactEmailAddress;
         public string ContactEmailAddress { get { return _contactEmailAddress; } set { _contactEmailAddress = value; } }
-        private Value<string> _contactFaxNumber;
+        private DirtyValue<string> _contactFaxNumber;
         public string ContactFaxNumber { get { return _contactFaxNumber; } set { _contactFaxNumber = value; } }
-        private Value<string> _contactName;
+        private DirtyValue<string> _contactName;
         public string ContactName { get { return _contactName; } set { _contactName = value; } }
-        private Value<string> _contactOfficeCity;
+        private DirtyValue<string> _contactOfficeCity;
         public string ContactOfficeCity { get { return _contactOfficeCity; } set { _contactOfficeCity = value; } }
-        private Value<string> _contactOfficeState;
+        private DirtyValue<string> _contactOfficeState;
         public string ContactOfficeState { get { return _contactOfficeState; } set { _contactOfficeState = value; } }
-        private Value<string> _contactOfficeStreetAddress;
+        private DirtyValue<string> _contactOfficeStreetAddress;
         public string ContactOfficeStreetAddress { get { return _contactOfficeStreetAddress; } set { _contactOfficeStreetAddress = value; } }
-        private Value<string> _contactOfficeZIPCode;
+        private DirtyValue<string> _contactOfficeZIPCode;
         public string ContactOfficeZIPCode { get { return _contactOfficeZIPCode; } set { _contactOfficeZIPCode = value; } }
-        private Value<string> _contactPhoneNumber;
+        private DirtyValue<string> _contactPhoneNumber;
         public string ContactPhoneNumber { get { return _contactPhoneNumber; } set { _contactPhoneNumber = value; } }
-        private Value<string> _countyCode;
+        private DirtyValue<string> _countyCode;
         public string CountyCode { get { return _countyCode; } set { _countyCode = value; } }
-        private Value<NA<decimal>?> _debtToIncomeRatio;
+        private DirtyValue<NA<decimal>?> _debtToIncomeRatio;
         public NA<decimal>? DebtToIncomeRatio { get { return _debtToIncomeRatio; } set { _debtToIncomeRatio = value; } }
-        private Value<string> _denialReason1;
+        private DirtyValue<string> _denialReason1;
         public string DenialReason1 { get { return _denialReason1; } set { _denialReason1 = value; } }
-        private Value<string> _denialReason2;
+        private DirtyValue<string> _denialReason2;
         public string DenialReason2 { get { return _denialReason2; } set { _denialReason2 = value; } }
-        private Value<string> _denialReason3;
+        private DirtyValue<string> _denialReason3;
         public string DenialReason3 { get { return _denialReason3; } set { _denialReason3 = value; } }
-        private Value<string> _denialReason4;
+        private DirtyValue<string> _denialReason4;
         public string DenialReason4 { get { return _denialReason4; } set { _denialReason4 = value; } }
-        private Value<NA<decimal>?> _discountPoints;
+        private DirtyValue<NA<decimal>?> _discountPoints;
         public NA<decimal>? DiscountPoints { get { return _discountPoints; } set { _discountPoints = value; } }
-        private Value<bool?> _excludeLoanFromHMDAReportIndicator;
+        private DirtyValue<bool?> _excludeLoanFromHMDAReportIndicator;
         public bool? ExcludeLoanFromHMDAReportIndicator { get { return _excludeLoanFromHMDAReportIndicator; } set { _excludeLoanFromHMDAReportIndicator = value; } }
-        private Value<string> _federalAgency;
+        private DirtyValue<string> _federalAgency;
         public string FederalAgency { get { return _federalAgency; } set { _federalAgency = value; } }
-        private Value<string> _federalTaxpayerIdNumber;
+        private DirtyValue<string> _federalTaxpayerIdNumber;
         public string FederalTaxpayerIdNumber { get { return _federalTaxpayerIdNumber; } set { _federalTaxpayerIdNumber = value; } }
-        private Value<string> _financialInstitutionName;
+        private DirtyValue<string> _financialInstitutionName;
         public string FinancialInstitutionName { get { return _financialInstitutionName; } set { _financialInstitutionName = value; } }
-        private Value<bool?> _hmdaCltvIndicator;
+        private DirtyValue<bool?> _hmdaCltvIndicator;
         public bool? HmdaCltvIndicator { get { return _hmdaCltvIndicator; } set { _hmdaCltvIndicator = value; } }
-        private Value<bool?> _hmdaDtiIndicator;
+        private DirtyValue<bool?> _hmdaDtiIndicator;
         public bool? HmdaDtiIndicator { get { return _hmdaDtiIndicator; } set { _hmdaDtiIndicator = value; } }
-        private Value<bool?> _hmdaIncomeIndicator;
+        private DirtyValue<bool?> _hmdaIncomeIndicator;
         public bool? HmdaIncomeIndicator { get { return _hmdaIncomeIndicator; } set { _hmdaIncomeIndicator = value; } }
-        private Value<string> _hmdaPropertyAddress;
+        private DirtyValue<string> _hmdaPropertyAddress;
         public string HmdaPropertyAddress { get { return _hmdaPropertyAddress; } set { _hmdaPropertyAddress = value; } }
-        private Value<string> _hmdaPropertyCity;
+        private DirtyValue<string> _hmdaPropertyCity;
         public string HmdaPropertyCity { get { return _hmdaPropertyCity; } set { _hmdaPropertyCity = value; } }
-        private Value<string> _hmdaPropertyState;
+        private DirtyValue<string> _hmdaPropertyState;
         public string HmdaPropertyState { get { return _hmdaPropertyState; } set { _hmdaPropertyState = value; } }
-        private Value<string> _hmdaPropertyZipCode;
+        private DirtyValue<string> _hmdaPropertyZipCode;
         public string HmdaPropertyZipCode { get { return _hmdaPropertyZipCode; } set { _hmdaPropertyZipCode = value; } }
-        private Value<bool?> _hmdaSyncAddressIndicator;
+        private DirtyValue<bool?> _hmdaSyncAddressIndicator;
         public bool? HmdaSyncAddressIndicator { get { return _hmdaSyncAddressIndicator; } set { _hmdaSyncAddressIndicator = value; } }
-        private Value<string> _hOEPAStatus;
+        private DirtyValue<string> _hOEPAStatus;
         public string HOEPAStatus { get { return _hOEPAStatus; } set { _hOEPAStatus = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<NA<decimal>?> _income;
+        private DirtyValue<NA<decimal>?> _income;
         public NA<decimal>? Income { get { return _income; } set { _income = value; } }
-        private Value<string> _initiallyPayableToYourInstitution;
+        private DirtyValue<string> _initiallyPayableToYourInstitution;
         public string InitiallyPayableToYourInstitution { get { return _initiallyPayableToYourInstitution; } set { _initiallyPayableToYourInstitution = value; } }
-        private Value<NA<decimal>?> _interestRate;
+        private DirtyValue<NA<decimal>?> _interestRate;
         public NA<decimal>? InterestRate { get { return _interestRate; } set { _interestRate = value; } }
-        private Value<string> _introRatePeriod;
+        private DirtyValue<string> _introRatePeriod;
         public string IntroRatePeriod { get { return _introRatePeriod; } set { _introRatePeriod = value; } }
-        private Value<string> _legalEntityIdentifier;
+        private DirtyValue<string> _legalEntityIdentifier;
         public string LegalEntityIdentifier { get { return _legalEntityIdentifier; } set { _legalEntityIdentifier = value; } }
-        private Value<NA<decimal>?> _lenderCredits;
+        private DirtyValue<NA<decimal>?> _lenderCredits;
         public NA<decimal>? LenderCredits { get { return _lenderCredits; } set { _lenderCredits = value; } }
-        private Value<string> _lienStatus;
+        private DirtyValue<string> _lienStatus;
         public string LienStatus { get { return _lienStatus; } set { _lienStatus = value; } }
-        private Value<decimal?> _loanAmount;
+        private DirtyValue<decimal?> _loanAmount;
         public decimal? LoanAmount { get { return _loanAmount; } set { _loanAmount = value; } }
-        private Value<string> _loanPurpose;
+        private DirtyValue<string> _loanPurpose;
         public string LoanPurpose { get { return _loanPurpose; } set { _loanPurpose = value; } }
-        private Value<string> _loanTerm;
+        private DirtyValue<string> _loanTerm;
         public string LoanTerm { get { return _loanTerm; } set { _loanTerm = value; } }
-        private Value<string> _loanType;
+        private DirtyValue<string> _loanType;
         public string LoanType { get { return _loanType; } set { _loanType = value; } }
-        private Value<string> _manufacturedHomeLandPropertyInterest;
+        private DirtyValue<string> _manufacturedHomeLandPropertyInterest;
         public string ManufacturedHomeLandPropertyInterest { get { return _manufacturedHomeLandPropertyInterest; } set { _manufacturedHomeLandPropertyInterest = value; } }
-        private Value<string> _manufacturedSecuredProperyType;
+        private DirtyValue<string> _manufacturedSecuredProperyType;
         public string ManufacturedSecuredProperyType { get { return _manufacturedSecuredProperyType; } set { _manufacturedSecuredProperyType = value; } }
-        private Value<string> _mSANumber;
+        private DirtyValue<string> _mSANumber;
         public string MSANumber { get { return _mSANumber; } set { _mSANumber = value; } }
-        private Value<string> _multifamilyNoUnits;
+        private DirtyValue<string> _multifamilyNoUnits;
         public string MultifamilyNoUnits { get { return _multifamilyNoUnits; } set { _multifamilyNoUnits = value; } }
-        private Value<string> _nMLSLoanOriginatorID;
+        private DirtyValue<string> _nMLSLoanOriginatorID;
         public string NMLSLoanOriginatorID { get { return _nMLSLoanOriginatorID; } set { _nMLSLoanOriginatorID = value; } }
-        private Value<string> _openEndLineOfCredit;
+        private DirtyValue<string> _openEndLineOfCredit;
         public string OpenEndLineOfCredit { get { return _openEndLineOfCredit; } set { _openEndLineOfCredit = value; } }
-        private Value<string> _originationCharges;
+        private DirtyValue<string> _originationCharges;
         public string OriginationCharges { get { return _originationCharges; } set { _originationCharges = value; } }
-        private Value<string> _otherAUS;
+        private DirtyValue<string> _otherAUS;
         public string OtherAUS { get { return _otherAUS; } set { _otherAUS = value; } }
-        private Value<string> _otherAUSRecommendations;
+        private DirtyValue<string> _otherAUSRecommendations;
         public string OtherAUSRecommendations { get { return _otherAUSRecommendations; } set { _otherAUSRecommendations = value; } }
-        private Value<string> _otherDenialReason;
+        private DirtyValue<string> _otherDenialReason;
         public string OtherDenialReason { get { return _otherDenialReason; } set { _otherDenialReason = value; } }
-        private Value<string> _otherNonAmortization;
+        private DirtyValue<string> _otherNonAmortization;
         public string OtherNonAmortization { get { return _otherNonAmortization; } set { _otherNonAmortization = value; } }
-        private Value<string> _parentAddress;
+        private DirtyValue<string> _parentAddress;
         public string ParentAddress { get { return _parentAddress; } set { _parentAddress = value; } }
-        private Value<string> _parentCity;
+        private DirtyValue<string> _parentCity;
         public string ParentCity { get { return _parentCity; } set { _parentCity = value; } }
-        private Value<string> _parentName;
+        private DirtyValue<string> _parentName;
         public string ParentName { get { return _parentName; } set { _parentName = value; } }
-        private Value<string> _parentState;
+        private DirtyValue<string> _parentState;
         public string ParentState { get { return _parentState; } set { _parentState = value; } }
-        private Value<string> _parentZip;
+        private DirtyValue<string> _parentZip;
         public string ParentZip { get { return _parentZip; } set { _parentZip = value; } }
-        private Value<string> _preapprovals;
+        private DirtyValue<string> _preapprovals;
         public string Preapprovals { get { return _preapprovals; } set { _preapprovals = value; } }
-        private Value<string> _prepaymentPenaltyPeriod;
+        private DirtyValue<string> _prepaymentPenaltyPeriod;
         public string PrepaymentPenaltyPeriod { get { return _prepaymentPenaltyPeriod; } set { _prepaymentPenaltyPeriod = value; } }
-        private Value<string> _propertyType;
+        private DirtyValue<string> _propertyType;
         public string PropertyType { get { return _propertyType; } set { _propertyType = value; } }
-        private Value<NA<decimal>?> _propertyValue;
+        private DirtyValue<NA<decimal>?> _propertyValue;
         public NA<decimal>? PropertyValue { get { return _propertyValue; } set { _propertyValue = value; } }
-        private Value<string> _qMStatus;
+        private DirtyValue<string> _qMStatus;
         public string QMStatus { get { return _qMStatus; } set { _qMStatus = value; } }
-        private Value<NA<decimal>?> _rateSpread;
+        private DirtyValue<NA<decimal>?> _rateSpread;
         public NA<decimal>? RateSpread { get { return _rateSpread; } set { _rateSpread = value; } }
-        private Value<int?> _reportingYear;
+        private DirtyValue<int?> _reportingYear;
         public int? ReportingYear { get { return _reportingYear; } set { _reportingYear = value; } }
-        private Value<bool?> _reportPurposeOfLoanIndicator;
+        private DirtyValue<bool?> _reportPurposeOfLoanIndicator;
         public bool? ReportPurposeOfLoanIndicator { get { return _reportPurposeOfLoanIndicator; } set { _reportPurposeOfLoanIndicator = value; } }
-        private Value<string> _repurchasedActionDate;
+        private DirtyValue<string> _repurchasedActionDate;
         public string RepurchasedActionDate { get { return _repurchasedActionDate; } set { _repurchasedActionDate = value; } }
-        private Value<string> _repurchasedActionTaken;
+        private DirtyValue<string> _repurchasedActionTaken;
         public string RepurchasedActionTaken { get { return _repurchasedActionTaken; } set { _repurchasedActionTaken = value; } }
-        private Value<decimal?> _repurchasedLoanAmount;
+        private DirtyValue<decimal?> _repurchasedLoanAmount;
         public decimal? RepurchasedLoanAmount { get { return _repurchasedLoanAmount; } set { _repurchasedLoanAmount = value; } }
-        private Value<int?> _repurchasedReportingYear;
+        private DirtyValue<int?> _repurchasedReportingYear;
         public int? RepurchasedReportingYear { get { return _repurchasedReportingYear; } set { _repurchasedReportingYear = value; } }
-        private Value<string> _repurchasedTypeOfPurchaser;
+        private DirtyValue<string> _repurchasedTypeOfPurchaser;
         public string RepurchasedTypeOfPurchaser { get { return _repurchasedTypeOfPurchaser; } set { _repurchasedTypeOfPurchaser = value; } }
-        private Value<string> _respondentID;
+        private DirtyValue<string> _respondentID;
         public string RespondentID { get { return _respondentID; } set { _respondentID = value; } }
-        private Value<string> _reverseMortgage;
+        private DirtyValue<string> _reverseMortgage;
         public string ReverseMortgage { get { return _reverseMortgage; } set { _reverseMortgage = value; } }
-        private Value<string> _stateCode;
+        private DirtyValue<string> _stateCode;
         public string StateCode { get { return _stateCode; } set { _stateCode = value; } }
-        private Value<string> _submissionOfApplication;
+        private DirtyValue<string> _submissionOfApplication;
         public string SubmissionOfApplication { get { return _submissionOfApplication; } set { _submissionOfApplication = value; } }
-        private Value<string> _totalLoanCosts;
+        private DirtyValue<string> _totalLoanCosts;
         public string TotalLoanCosts { get { return _totalLoanCosts; } set { _totalLoanCosts = value; } }
-        private Value<string> _totalPointsAndFees;
+        private DirtyValue<string> _totalPointsAndFees;
         public string TotalPointsAndFees { get { return _totalPointsAndFees; } set { _totalPointsAndFees = value; } }
-        private Value<string> _typeOfPurchaser;
+        private DirtyValue<string> _typeOfPurchaser;
         public string TypeOfPurchaser { get { return _typeOfPurchaser; } set { _typeOfPurchaser = value; } }
-        private Value<string> _universalLoanId;
+        private DirtyValue<string> _universalLoanId;
         public string UniversalLoanId { get { return _universalLoanId; } set { _universalLoanId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hmda.cs
+++ b/src/EncompassRest/Loans/Hmda.cs
@@ -76,6 +76,12 @@ namespace EncompassRest.Loans
         public string FederalTaxpayerIdNumber { get { return _federalTaxpayerIdNumber; } set { _federalTaxpayerIdNumber = value; } }
         private Value<string> _financialInstitutionName;
         public string FinancialInstitutionName { get { return _financialInstitutionName; } set { _financialInstitutionName = value; } }
+        private Value<bool?> _hmdaCltvIndicator;
+        public bool? HmdaCltvIndicator { get { return _hmdaCltvIndicator; } set { _hmdaCltvIndicator = value; } }
+        private Value<bool?> _hmdaDtiIndicator;
+        public bool? HmdaDtiIndicator { get { return _hmdaDtiIndicator; } set { _hmdaDtiIndicator = value; } }
+        private Value<bool?> _hmdaIncomeIndicator;
+        public bool? HmdaIncomeIndicator { get { return _hmdaIncomeIndicator; } set { _hmdaIncomeIndicator = value; } }
         private Value<string> _hmdaPropertyAddress;
         public string HmdaPropertyAddress { get { return _hmdaPropertyAddress; } set { _hmdaPropertyAddress = value; } }
         private Value<string> _hmdaPropertyCity;
@@ -227,6 +233,9 @@ namespace EncompassRest.Loans
                     || _federalAgency.Dirty
                     || _federalTaxpayerIdNumber.Dirty
                     || _financialInstitutionName.Dirty
+                    || _hmdaCltvIndicator.Dirty
+                    || _hmdaDtiIndicator.Dirty
+                    || _hmdaIncomeIndicator.Dirty
                     || _hmdaPropertyAddress.Dirty
                     || _hmdaPropertyCity.Dirty
                     || _hmdaPropertyState.Dirty
@@ -322,6 +331,9 @@ namespace EncompassRest.Loans
                 _federalAgency.Dirty = value;
                 _federalTaxpayerIdNumber.Dirty = value;
                 _financialInstitutionName.Dirty = value;
+                _hmdaCltvIndicator.Dirty = value;
+                _hmdaDtiIndicator.Dirty = value;
+                _hmdaIncomeIndicator.Dirty = value;
                 _hmdaPropertyAddress.Dirty = value;
                 _hmdaPropertyCity.Dirty = value;
                 _hmdaPropertyState.Dirty = value;

--- a/src/EncompassRest/Loans/HomeCounselingProvider.cs
+++ b/src/EncompassRest/Loans/HomeCounselingProvider.cs
@@ -8,47 +8,47 @@ namespace EncompassRest.Loans
 {
     public sealed partial class HomeCounselingProvider : IDirty
     {
-        private Value<string> _agencyAddress;
+        private DirtyValue<string> _agencyAddress;
         public string AgencyAddress { get { return _agencyAddress; } set { _agencyAddress = value; } }
-        private Value<string> _agencyAddressCity;
+        private DirtyValue<string> _agencyAddressCity;
         public string AgencyAddressCity { get { return _agencyAddressCity; } set { _agencyAddressCity = value; } }
-        private Value<string> _agencyAddressPostalCode;
+        private DirtyValue<string> _agencyAddressPostalCode;
         public string AgencyAddressPostalCode { get { return _agencyAddressPostalCode; } set { _agencyAddressPostalCode = value; } }
-        private Value<string> _agencyAddressState;
+        private DirtyValue<string> _agencyAddressState;
         public string AgencyAddressState { get { return _agencyAddressState; } set { _agencyAddressState = value; } }
-        private Value<string> _agencyAffiliationDescription;
+        private DirtyValue<string> _agencyAffiliationDescription;
         public string AgencyAffiliationDescription { get { return _agencyAffiliationDescription; } set { _agencyAffiliationDescription = value; } }
-        private Value<bool?> _agencyAffiliationIndicator;
+        private DirtyValue<bool?> _agencyAffiliationIndicator;
         public bool? AgencyAffiliationIndicator { get { return _agencyAffiliationIndicator; } set { _agencyAffiliationIndicator = value; } }
-        private Value<string> _agencyEmail;
+        private DirtyValue<string> _agencyEmail;
         public string AgencyEmail { get { return _agencyEmail; } set { _agencyEmail = value; } }
-        private Value<string> _agencyFax;
+        private DirtyValue<string> _agencyFax;
         public string AgencyFax { get { return _agencyFax; } set { _agencyFax = value; } }
-        private Value<string> _agencyId;
+        private DirtyValue<string> _agencyId;
         public string AgencyId { get { return _agencyId; } set { _agencyId = value; } }
-        private Value<string> _agencyName;
+        private DirtyValue<string> _agencyName;
         public string AgencyName { get { return _agencyName; } set { _agencyName = value; } }
-        private Value<string> _agencyPhoneDirect;
+        private DirtyValue<string> _agencyPhoneDirect;
         public string AgencyPhoneDirect { get { return _agencyPhoneDirect; } set { _agencyPhoneDirect = value; } }
-        private Value<string> _agencyPhoneTollFree;
+        private DirtyValue<string> _agencyPhoneTollFree;
         public string AgencyPhoneTollFree { get { return _agencyPhoneTollFree; } set { _agencyPhoneTollFree = value; } }
-        private Value<string> _agencySource;
+        private DirtyValue<string> _agencySource;
         public string AgencySource { get { return _agencySource; } set { _agencySource = value; } }
-        private Value<string> _agencyWebAddress;
+        private DirtyValue<string> _agencyWebAddress;
         public string AgencyWebAddress { get { return _agencyWebAddress; } set { _agencyWebAddress = value; } }
-        private Value<string> _counselingServicesProvided;
+        private DirtyValue<string> _counselingServicesProvided;
         public string CounselingServicesProvided { get { return _counselingServicesProvided; } set { _counselingServicesProvided = value; } }
-        private Value<decimal?> _distanceMiles;
+        private DirtyValue<decimal?> _distanceMiles;
         public decimal? DistanceMiles { get { return _distanceMiles; } set { _distanceMiles = value; } }
-        private Value<string> _homeCounselingProviderId;
+        private DirtyValue<string> _homeCounselingProviderId;
         public string HomeCounselingProviderId { get { return _homeCounselingProviderId; } set { _homeCounselingProviderId = value; } }
-        private Value<int?> _homeCounselingProviderIndex;
+        private DirtyValue<int?> _homeCounselingProviderIndex;
         public int? HomeCounselingProviderIndex { get { return _homeCounselingProviderIndex; } set { _homeCounselingProviderIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _languagesSupported;
+        private DirtyValue<string> _languagesSupported;
         public string LanguagesSupported { get { return _languagesSupported; } set { _languagesSupported = value; } }
-        private Value<bool?> _selectedIndicator;
+        private DirtyValue<bool?> _selectedIndicator;
         public bool? SelectedIndicator { get { return _selectedIndicator; } set { _selectedIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/HtmlEmailLog.cs
+++ b/src/EncompassRest/Loans/HtmlEmailLog.cs
@@ -10,35 +10,35 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _body;
+        private DirtyValue<string> _body;
         public string Body { get { return _body; } set { _body = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _creator;
+        private DirtyValue<string> _creator;
         public string Creator { get { return _creator; } set { _creator = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _recipient;
+        private DirtyValue<string> _recipient;
         public string Recipient { get { return _recipient; } set { _recipient = value; } }
-        private Value<string> _sender;
+        private DirtyValue<string> _sender;
         public string Sender { get { return _sender; } set { _sender = value; } }
-        private Value<string> _subject;
+        private DirtyValue<string> _subject;
         public string Subject { get { return _subject; } set { _subject = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/HtmlEmailLog.cs
+++ b/src/EncompassRest/Loans/HtmlEmailLog.cs
@@ -8,12 +8,12 @@ namespace EncompassRest.Loans
 {
     public sealed partial class HtmlEmailLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _body;
         public string Body { get { return _body; } set { _body = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _creator;
@@ -47,9 +47,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _body.Dirty
-                    || _commentList.Dirty
+                var dirty = _body.Dirty
                     || _comments.Dirty
                     || _creator.Dirty
                     || _dateUtc.Dirty
@@ -62,16 +60,16 @@ namespace EncompassRest.Loans
                     || _recipient.Dirty
                     || _sender.Dirty
                     || _subject.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
                 _body.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _creator.Dirty = value;
                 _dateUtc.Dirty = value;
@@ -85,6 +83,8 @@ namespace EncompassRest.Loans
                 _sender.Dirty = value;
                 _subject.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Hud1Es.cs
+++ b/src/EncompassRest/Loans/Hud1Es.cs
@@ -94,20 +94,20 @@ namespace EncompassRest.Loans
         public int? FloodInsDisbCushion { get { return _floodInsDisbCushion; } set { _floodInsDisbCushion = value; } }
         private Value<int?> _hazInsDisbCushion;
         public int? HazInsDisbCushion { get { return _hazInsDisbCushion; } set { _hazInsDisbCushion = value; } }
-        private Value<List<Hud1EsDate>> _hud1EsDates;
-        public List<Hud1EsDate> Hud1EsDates { get { return _hud1EsDates; } set { _hud1EsDates = value; } }
-        private Value<List<Hud1EsDueDate>> _hud1EsDueDates;
-        public List<Hud1EsDueDate> Hud1EsDueDates { get { return _hud1EsDueDates; } set { _hud1EsDueDates = value; } }
-        private Value<List<Hud1EsItemize>> _hud1EsItemizes;
-        public List<Hud1EsItemize> Hud1EsItemizes { get { return _hud1EsItemizes; } set { _hud1EsItemizes = value; } }
+        private DirtyList<Hud1EsDate> _hud1EsDates;
+        public IList<Hud1EsDate> Hud1EsDates { get { var v = _hud1EsDates; return v ?? Interlocked.CompareExchange(ref _hud1EsDates, (v = new DirtyList<Hud1EsDate>()), null) ?? v; } set { _hud1EsDates = new DirtyList<Hud1EsDate>(value); } }
+        private DirtyList<Hud1EsDueDate> _hud1EsDueDates;
+        public IList<Hud1EsDueDate> Hud1EsDueDates { get { var v = _hud1EsDueDates; return v ?? Interlocked.CompareExchange(ref _hud1EsDueDates, (v = new DirtyList<Hud1EsDueDate>()), null) ?? v; } set { _hud1EsDueDates = new DirtyList<Hud1EsDueDate>(value); } }
+        private DirtyList<Hud1EsItemize> _hud1EsItemizes;
+        public IList<Hud1EsItemize> Hud1EsItemizes { get { var v = _hud1EsItemizes; return v ?? Interlocked.CompareExchange(ref _hud1EsItemizes, (v = new DirtyList<Hud1EsItemize>()), null) ?? v; } set { _hud1EsItemizes = new DirtyList<Hud1EsItemize>(value); } }
         private Value<int?> _hud1EsItemizesTotalLines;
         public int? Hud1EsItemizesTotalLines { get { return _hud1EsItemizesTotalLines; } set { _hud1EsItemizesTotalLines = value; } }
         private Value<bool?> _hud1EsItemizesUseItemizeEscrowIndicator;
         public bool? Hud1EsItemizesUseItemizeEscrowIndicator { get { return _hud1EsItemizesUseItemizeEscrowIndicator; } set { _hud1EsItemizesUseItemizeEscrowIndicator = value; } }
-        private Value<List<Hud1EsPayTo>> _hud1EsPayTos;
-        public List<Hud1EsPayTo> Hud1EsPayTos { get { return _hud1EsPayTos; } set { _hud1EsPayTos = value; } }
-        private Value<List<Hud1EsSetup>> _hud1EsSetups;
-        public List<Hud1EsSetup> Hud1EsSetups { get { return _hud1EsSetups; } set { _hud1EsSetups = value; } }
+        private DirtyList<Hud1EsPayTo> _hud1EsPayTos;
+        public IList<Hud1EsPayTo> Hud1EsPayTos { get { var v = _hud1EsPayTos; return v ?? Interlocked.CompareExchange(ref _hud1EsPayTos, (v = new DirtyList<Hud1EsPayTo>()), null) ?? v; } set { _hud1EsPayTos = new DirtyList<Hud1EsPayTo>(value); } }
+        private DirtyList<Hud1EsSetup> _hud1EsSetups;
+        public IList<Hud1EsSetup> Hud1EsSetups { get { var v = _hud1EsSetups; return v ?? Interlocked.CompareExchange(ref _hud1EsSetups, (v = new DirtyList<Hud1EsSetup>()), null) ?? v; } set { _hud1EsSetups = new DirtyList<Hud1EsSetup>(value); } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private Value<bool?> _mtgInsCushionTerminationIndicator;
@@ -230,13 +230,8 @@ namespace EncompassRest.Loans
                     || _escrowPaymentYearly.Dirty
                     || _floodInsDisbCushion.Dirty
                     || _hazInsDisbCushion.Dirty
-                    || _hud1EsDates.Dirty
-                    || _hud1EsDueDates.Dirty
-                    || _hud1EsItemizes.Dirty
                     || _hud1EsItemizesTotalLines.Dirty
                     || _hud1EsItemizesUseItemizeEscrowIndicator.Dirty
-                    || _hud1EsPayTos.Dirty
-                    || _hud1EsSetups.Dirty
                     || _id.Dirty
                     || _mtgInsCushionTerminationIndicator.Dirty
                     || _mtgInsDisbCushion.Dirty
@@ -272,7 +267,12 @@ namespace EncompassRest.Loans
                     || _userDefinedCushion2.Dirty
                     || _userDefinedCushion3.Dirty
                     || _yearlyMortgageInsurance.Dirty
-                    || _yearlyUsdaFee.Dirty;
+                    || _yearlyUsdaFee.Dirty
+                    || _hud1EsDates?.Dirty == true
+                    || _hud1EsDueDates?.Dirty == true
+                    || _hud1EsItemizes?.Dirty == true
+                    || _hud1EsPayTos?.Dirty == true
+                    || _hud1EsSetups?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -322,13 +322,8 @@ namespace EncompassRest.Loans
                 _escrowPaymentYearly.Dirty = value;
                 _floodInsDisbCushion.Dirty = value;
                 _hazInsDisbCushion.Dirty = value;
-                _hud1EsDates.Dirty = value;
-                _hud1EsDueDates.Dirty = value;
-                _hud1EsItemizes.Dirty = value;
                 _hud1EsItemizesTotalLines.Dirty = value;
                 _hud1EsItemizesUseItemizeEscrowIndicator.Dirty = value;
-                _hud1EsPayTos.Dirty = value;
-                _hud1EsSetups.Dirty = value;
                 _id.Dirty = value;
                 _mtgInsCushionTerminationIndicator.Dirty = value;
                 _mtgInsDisbCushion.Dirty = value;
@@ -365,6 +360,11 @@ namespace EncompassRest.Loans
                 _userDefinedCushion3.Dirty = value;
                 _yearlyMortgageInsurance.Dirty = value;
                 _yearlyUsdaFee.Dirty = value;
+                if (_hud1EsDates != null) _hud1EsDates.Dirty = value;
+                if (_hud1EsDueDates != null) _hud1EsDueDates.Dirty = value;
+                if (_hud1EsItemizes != null) _hud1EsItemizes.Dirty = value;
+                if (_hud1EsPayTos != null) _hud1EsPayTos.Dirty = value;
+                if (_hud1EsSetups != null) _hud1EsSetups.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Hud1Es.cs
+++ b/src/EncompassRest/Loans/Hud1Es.cs
@@ -8,91 +8,91 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hud1Es : IDirty
     {
-        private Value<decimal?> _annualCityTax;
+        private DirtyValue<decimal?> _annualCityTax;
         public decimal? AnnualCityTax { get { return _annualCityTax; } set { _annualCityTax = value; } }
-        private Value<int?> _annualFeeCushion;
+        private DirtyValue<int?> _annualFeeCushion;
         public int? AnnualFeeCushion { get { return _annualFeeCushion; } set { _annualFeeCushion = value; } }
-        private Value<decimal?> _annualFloodInsurance;
+        private DirtyValue<decimal?> _annualFloodInsurance;
         public decimal? AnnualFloodInsurance { get { return _annualFloodInsurance; } set { _annualFloodInsurance = value; } }
-        private Value<decimal?> _annualHazardInsurance;
+        private DirtyValue<decimal?> _annualHazardInsurance;
         public decimal? AnnualHazardInsurance { get { return _annualHazardInsurance; } set { _annualHazardInsurance = value; } }
-        private Value<decimal?> _annualMortgageInsurance;
+        private DirtyValue<decimal?> _annualMortgageInsurance;
         public decimal? AnnualMortgageInsurance { get { return _annualMortgageInsurance; } set { _annualMortgageInsurance = value; } }
-        private Value<decimal?> _annualTax;
+        private DirtyValue<decimal?> _annualTax;
         public decimal? AnnualTax { get { return _annualTax; } set { _annualTax = value; } }
-        private Value<decimal?> _annualUserEscrow1;
+        private DirtyValue<decimal?> _annualUserEscrow1;
         public decimal? AnnualUserEscrow1 { get { return _annualUserEscrow1; } set { _annualUserEscrow1 = value; } }
-        private Value<decimal?> _annualUserEscrow2;
+        private DirtyValue<decimal?> _annualUserEscrow2;
         public decimal? AnnualUserEscrow2 { get { return _annualUserEscrow2; } set { _annualUserEscrow2 = value; } }
-        private Value<decimal?> _annualUserEscrow3;
+        private DirtyValue<decimal?> _annualUserEscrow3;
         public decimal? AnnualUserEscrow3 { get { return _annualUserEscrow3; } set { _annualUserEscrow3 = value; } }
-        private Value<decimal?> _biweeklyCityPropertyTaxes;
+        private DirtyValue<decimal?> _biweeklyCityPropertyTaxes;
         public decimal? BiweeklyCityPropertyTaxes { get { return _biweeklyCityPropertyTaxes; } set { _biweeklyCityPropertyTaxes = value; } }
-        private Value<decimal?> _biweeklyCountyTaxes;
+        private DirtyValue<decimal?> _biweeklyCountyTaxes;
         public decimal? BiweeklyCountyTaxes { get { return _biweeklyCountyTaxes; } set { _biweeklyCountyTaxes = value; } }
-        private Value<decimal?> _biweeklyFloodInsurance;
+        private DirtyValue<decimal?> _biweeklyFloodInsurance;
         public decimal? BiweeklyFloodInsurance { get { return _biweeklyFloodInsurance; } set { _biweeklyFloodInsurance = value; } }
-        private Value<decimal?> _biweeklyHazardInsurance;
+        private DirtyValue<decimal?> _biweeklyHazardInsurance;
         public decimal? BiweeklyHazardInsurance { get { return _biweeklyHazardInsurance; } set { _biweeklyHazardInsurance = value; } }
-        private Value<decimal?> _biweeklyMortgageInsurance;
+        private DirtyValue<decimal?> _biweeklyMortgageInsurance;
         public decimal? BiweeklyMortgageInsurance { get { return _biweeklyMortgageInsurance; } set { _biweeklyMortgageInsurance = value; } }
-        private Value<decimal?> _biweeklyPITI;
+        private DirtyValue<decimal?> _biweeklyPITI;
         public decimal? BiweeklyPITI { get { return _biweeklyPITI; } set { _biweeklyPITI = value; } }
-        private Value<decimal?> _biweeklyTotalBiweeklyPayment;
+        private DirtyValue<decimal?> _biweeklyTotalBiweeklyPayment;
         public decimal? BiweeklyTotalBiweeklyPayment { get { return _biweeklyTotalBiweeklyPayment; } set { _biweeklyTotalBiweeklyPayment = value; } }
-        private Value<decimal?> _biweeklyTotalBiweeklyPaymentToEscrow;
+        private DirtyValue<decimal?> _biweeklyTotalBiweeklyPaymentToEscrow;
         public decimal? BiweeklyTotalBiweeklyPaymentToEscrow { get { return _biweeklyTotalBiweeklyPaymentToEscrow; } set { _biweeklyTotalBiweeklyPaymentToEscrow = value; } }
-        private Value<decimal?> _biweeklyUSDAFee;
+        private DirtyValue<decimal?> _biweeklyUSDAFee;
         public decimal? BiweeklyUSDAFee { get { return _biweeklyUSDAFee; } set { _biweeklyUSDAFee = value; } }
-        private Value<decimal?> _biweeklyUserDefinedEscrowFee1;
+        private DirtyValue<decimal?> _biweeklyUserDefinedEscrowFee1;
         public decimal? BiweeklyUserDefinedEscrowFee1 { get { return _biweeklyUserDefinedEscrowFee1; } set { _biweeklyUserDefinedEscrowFee1 = value; } }
-        private Value<decimal?> _biweeklyUserDefinedEscrowFee2;
+        private DirtyValue<decimal?> _biweeklyUserDefinedEscrowFee2;
         public decimal? BiweeklyUserDefinedEscrowFee2 { get { return _biweeklyUserDefinedEscrowFee2; } set { _biweeklyUserDefinedEscrowFee2 = value; } }
-        private Value<decimal?> _biweeklyUserDefinedEscrowFee3;
+        private DirtyValue<decimal?> _biweeklyUserDefinedEscrowFee3;
         public decimal? BiweeklyUserDefinedEscrowFee3 { get { return _biweeklyUserDefinedEscrowFee3; } set { _biweeklyUserDefinedEscrowFee3 = value; } }
-        private Value<string> _cityPropertyTaxAddress;
+        private DirtyValue<string> _cityPropertyTaxAddress;
         public string CityPropertyTaxAddress { get { return _cityPropertyTaxAddress; } set { _cityPropertyTaxAddress = value; } }
-        private Value<decimal?> _cityPropertyTaxAmountLastPay;
+        private DirtyValue<decimal?> _cityPropertyTaxAmountLastPay;
         public decimal? CityPropertyTaxAmountLastPay { get { return _cityPropertyTaxAmountLastPay; } set { _cityPropertyTaxAmountLastPay = value; } }
-        private Value<decimal?> _cityPropertyTaxAmountNextDue;
+        private DirtyValue<decimal?> _cityPropertyTaxAmountNextDue;
         public decimal? CityPropertyTaxAmountNextDue { get { return _cityPropertyTaxAmountNextDue; } set { _cityPropertyTaxAmountNextDue = value; } }
-        private Value<string> _cityPropertyTaxCity;
+        private DirtyValue<string> _cityPropertyTaxCity;
         public string CityPropertyTaxCity { get { return _cityPropertyTaxCity; } set { _cityPropertyTaxCity = value; } }
-        private Value<string> _cityPropertyTaxContactName;
+        private DirtyValue<string> _cityPropertyTaxContactName;
         public string CityPropertyTaxContactName { get { return _cityPropertyTaxContactName; } set { _cityPropertyTaxContactName = value; } }
-        private Value<DateTime?> _cityPropertyTaxDatePaid;
+        private DirtyValue<DateTime?> _cityPropertyTaxDatePaid;
         public DateTime? CityPropertyTaxDatePaid { get { return _cityPropertyTaxDatePaid; } set { _cityPropertyTaxDatePaid = value; } }
-        private Value<DateTime?> _cityPropertyTaxDelinquentDate;
+        private DirtyValue<DateTime?> _cityPropertyTaxDelinquentDate;
         public DateTime? CityPropertyTaxDelinquentDate { get { return _cityPropertyTaxDelinquentDate; } set { _cityPropertyTaxDelinquentDate = value; } }
-        private Value<string> _cityPropertyTaxEmail;
+        private DirtyValue<string> _cityPropertyTaxEmail;
         public string CityPropertyTaxEmail { get { return _cityPropertyTaxEmail; } set { _cityPropertyTaxEmail = value; } }
-        private Value<string> _cityPropertyTaxFax;
+        private DirtyValue<string> _cityPropertyTaxFax;
         public string CityPropertyTaxFax { get { return _cityPropertyTaxFax; } set { _cityPropertyTaxFax = value; } }
-        private Value<string> _cityPropertyTaxName;
+        private DirtyValue<string> _cityPropertyTaxName;
         public string CityPropertyTaxName { get { return _cityPropertyTaxName; } set { _cityPropertyTaxName = value; } }
-        private Value<DateTime?> _cityPropertyTaxNextDueDate;
+        private DirtyValue<DateTime?> _cityPropertyTaxNextDueDate;
         public DateTime? CityPropertyTaxNextDueDate { get { return _cityPropertyTaxNextDueDate; } set { _cityPropertyTaxNextDueDate = value; } }
-        private Value<string> _cityPropertyTaxPaymentSchedule;
+        private DirtyValue<string> _cityPropertyTaxPaymentSchedule;
         public string CityPropertyTaxPaymentSchedule { get { return _cityPropertyTaxPaymentSchedule; } set { _cityPropertyTaxPaymentSchedule = value; } }
-        private Value<string> _cityPropertyTaxPhone;
+        private DirtyValue<string> _cityPropertyTaxPhone;
         public string CityPropertyTaxPhone { get { return _cityPropertyTaxPhone; } set { _cityPropertyTaxPhone = value; } }
-        private Value<string> _cityPropertyTaxPostalCode;
+        private DirtyValue<string> _cityPropertyTaxPostalCode;
         public string CityPropertyTaxPostalCode { get { return _cityPropertyTaxPostalCode; } set { _cityPropertyTaxPostalCode = value; } }
-        private Value<string> _cityPropertyTaxState;
+        private DirtyValue<string> _cityPropertyTaxState;
         public string CityPropertyTaxState { get { return _cityPropertyTaxState; } set { _cityPropertyTaxState = value; } }
-        private Value<decimal?> _endingBalance;
+        private DirtyValue<decimal?> _endingBalance;
         public decimal? EndingBalance { get { return _endingBalance; } set { _endingBalance = value; } }
-        private Value<DateTime?> _escrowFirstPaymentDate;
+        private DirtyValue<DateTime?> _escrowFirstPaymentDate;
         public DateTime? EscrowFirstPaymentDate { get { return _escrowFirstPaymentDate; } set { _escrowFirstPaymentDate = value; } }
-        private Value<string> _escrowFirstPaymentDateType;
+        private DirtyValue<string> _escrowFirstPaymentDateType;
         public string EscrowFirstPaymentDateType { get { return _escrowFirstPaymentDateType; } set { _escrowFirstPaymentDateType = value; } }
-        private Value<decimal?> _escrowPayment;
+        private DirtyValue<decimal?> _escrowPayment;
         public decimal? EscrowPayment { get { return _escrowPayment; } set { _escrowPayment = value; } }
-        private Value<decimal?> _escrowPaymentYearly;
+        private DirtyValue<decimal?> _escrowPaymentYearly;
         public decimal? EscrowPaymentYearly { get { return _escrowPaymentYearly; } set { _escrowPaymentYearly = value; } }
-        private Value<int?> _floodInsDisbCushion;
+        private DirtyValue<int?> _floodInsDisbCushion;
         public int? FloodInsDisbCushion { get { return _floodInsDisbCushion; } set { _floodInsDisbCushion = value; } }
-        private Value<int?> _hazInsDisbCushion;
+        private DirtyValue<int?> _hazInsDisbCushion;
         public int? HazInsDisbCushion { get { return _hazInsDisbCushion; } set { _hazInsDisbCushion = value; } }
         private DirtyList<Hud1EsDate> _hud1EsDates;
         public IList<Hud1EsDate> Hud1EsDates { get { var v = _hud1EsDates; return v ?? Interlocked.CompareExchange(ref _hud1EsDates, (v = new DirtyList<Hud1EsDate>()), null) ?? v; } set { _hud1EsDates = new DirtyList<Hud1EsDate>(value); } }
@@ -100,85 +100,85 @@ namespace EncompassRest.Loans
         public IList<Hud1EsDueDate> Hud1EsDueDates { get { var v = _hud1EsDueDates; return v ?? Interlocked.CompareExchange(ref _hud1EsDueDates, (v = new DirtyList<Hud1EsDueDate>()), null) ?? v; } set { _hud1EsDueDates = new DirtyList<Hud1EsDueDate>(value); } }
         private DirtyList<Hud1EsItemize> _hud1EsItemizes;
         public IList<Hud1EsItemize> Hud1EsItemizes { get { var v = _hud1EsItemizes; return v ?? Interlocked.CompareExchange(ref _hud1EsItemizes, (v = new DirtyList<Hud1EsItemize>()), null) ?? v; } set { _hud1EsItemizes = new DirtyList<Hud1EsItemize>(value); } }
-        private Value<int?> _hud1EsItemizesTotalLines;
+        private DirtyValue<int?> _hud1EsItemizesTotalLines;
         public int? Hud1EsItemizesTotalLines { get { return _hud1EsItemizesTotalLines; } set { _hud1EsItemizesTotalLines = value; } }
-        private Value<bool?> _hud1EsItemizesUseItemizeEscrowIndicator;
+        private DirtyValue<bool?> _hud1EsItemizesUseItemizeEscrowIndicator;
         public bool? Hud1EsItemizesUseItemizeEscrowIndicator { get { return _hud1EsItemizesUseItemizeEscrowIndicator; } set { _hud1EsItemizesUseItemizeEscrowIndicator = value; } }
         private DirtyList<Hud1EsPayTo> _hud1EsPayTos;
         public IList<Hud1EsPayTo> Hud1EsPayTos { get { var v = _hud1EsPayTos; return v ?? Interlocked.CompareExchange(ref _hud1EsPayTos, (v = new DirtyList<Hud1EsPayTo>()), null) ?? v; } set { _hud1EsPayTos = new DirtyList<Hud1EsPayTo>(value); } }
         private DirtyList<Hud1EsSetup> _hud1EsSetups;
         public IList<Hud1EsSetup> Hud1EsSetups { get { var v = _hud1EsSetups; return v ?? Interlocked.CompareExchange(ref _hud1EsSetups, (v = new DirtyList<Hud1EsSetup>()), null) ?? v; } set { _hud1EsSetups = new DirtyList<Hud1EsSetup>(value); } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _mtgInsCushionTerminationIndicator;
+        private DirtyValue<bool?> _mtgInsCushionTerminationIndicator;
         public bool? MtgInsCushionTerminationIndicator { get { return _mtgInsCushionTerminationIndicator; } set { _mtgInsCushionTerminationIndicator = value; } }
-        private Value<int?> _mtgInsDisbCushion;
+        private DirtyValue<int?> _mtgInsDisbCushion;
         public int? MtgInsDisbCushion { get { return _mtgInsDisbCushion; } set { _mtgInsDisbCushion = value; } }
-        private Value<decimal?> _nonEscrowCostsYearly;
+        private DirtyValue<decimal?> _nonEscrowCostsYearly;
         public decimal? NonEscrowCostsYearly { get { return _nonEscrowCostsYearly; } set { _nonEscrowCostsYearly = value; } }
-        private Value<string> _realEstateTaxAddress;
+        private DirtyValue<string> _realEstateTaxAddress;
         public string RealEstateTaxAddress { get { return _realEstateTaxAddress; } set { _realEstateTaxAddress = value; } }
-        private Value<decimal?> _realEstateTaxAmountLastPay;
+        private DirtyValue<decimal?> _realEstateTaxAmountLastPay;
         public decimal? RealEstateTaxAmountLastPay { get { return _realEstateTaxAmountLastPay; } set { _realEstateTaxAmountLastPay = value; } }
-        private Value<decimal?> _realEstateTaxAmountNextDue;
+        private DirtyValue<decimal?> _realEstateTaxAmountNextDue;
         public decimal? RealEstateTaxAmountNextDue { get { return _realEstateTaxAmountNextDue; } set { _realEstateTaxAmountNextDue = value; } }
-        private Value<string> _realEstateTaxCity;
+        private DirtyValue<string> _realEstateTaxCity;
         public string RealEstateTaxCity { get { return _realEstateTaxCity; } set { _realEstateTaxCity = value; } }
-        private Value<string> _realEstateTaxContactName;
+        private DirtyValue<string> _realEstateTaxContactName;
         public string RealEstateTaxContactName { get { return _realEstateTaxContactName; } set { _realEstateTaxContactName = value; } }
-        private Value<DateTime?> _realEstateTaxDatePaid;
+        private DirtyValue<DateTime?> _realEstateTaxDatePaid;
         public DateTime? RealEstateTaxDatePaid { get { return _realEstateTaxDatePaid; } set { _realEstateTaxDatePaid = value; } }
-        private Value<DateTime?> _realEstateTaxDelinquentDate;
+        private DirtyValue<DateTime?> _realEstateTaxDelinquentDate;
         public DateTime? RealEstateTaxDelinquentDate { get { return _realEstateTaxDelinquentDate; } set { _realEstateTaxDelinquentDate = value; } }
-        private Value<string> _realEstateTaxEmail;
+        private DirtyValue<string> _realEstateTaxEmail;
         public string RealEstateTaxEmail { get { return _realEstateTaxEmail; } set { _realEstateTaxEmail = value; } }
-        private Value<string> _realEstateTaxFax;
+        private DirtyValue<string> _realEstateTaxFax;
         public string RealEstateTaxFax { get { return _realEstateTaxFax; } set { _realEstateTaxFax = value; } }
-        private Value<string> _realEstateTaxName;
+        private DirtyValue<string> _realEstateTaxName;
         public string RealEstateTaxName { get { return _realEstateTaxName; } set { _realEstateTaxName = value; } }
-        private Value<DateTime?> _realEstateTaxNextDueDate;
+        private DirtyValue<DateTime?> _realEstateTaxNextDueDate;
         public DateTime? RealEstateTaxNextDueDate { get { return _realEstateTaxNextDueDate; } set { _realEstateTaxNextDueDate = value; } }
-        private Value<string> _realEstateTaxPaymentSchedule;
+        private DirtyValue<string> _realEstateTaxPaymentSchedule;
         public string RealEstateTaxPaymentSchedule { get { return _realEstateTaxPaymentSchedule; } set { _realEstateTaxPaymentSchedule = value; } }
-        private Value<string> _realEstateTaxPhone;
+        private DirtyValue<string> _realEstateTaxPhone;
         public string RealEstateTaxPhone { get { return _realEstateTaxPhone; } set { _realEstateTaxPhone = value; } }
-        private Value<string> _realEstateTaxPostalCode;
+        private DirtyValue<string> _realEstateTaxPostalCode;
         public string RealEstateTaxPostalCode { get { return _realEstateTaxPostalCode; } set { _realEstateTaxPostalCode = value; } }
-        private Value<string> _realEstateTaxState;
+        private DirtyValue<string> _realEstateTaxState;
         public string RealEstateTaxState { get { return _realEstateTaxState; } set { _realEstateTaxState = value; } }
-        private Value<int?> _schoolTaxesCushion;
+        private DirtyValue<int?> _schoolTaxesCushion;
         public int? SchoolTaxesCushion { get { return _schoolTaxesCushion; } set { _schoolTaxesCushion = value; } }
-        private Value<string> _servicerAddress;
+        private DirtyValue<string> _servicerAddress;
         public string ServicerAddress { get { return _servicerAddress; } set { _servicerAddress = value; } }
-        private Value<string> _servicerCity;
+        private DirtyValue<string> _servicerCity;
         public string ServicerCity { get { return _servicerCity; } set { _servicerCity = value; } }
-        private Value<string> _servicerContactName;
+        private DirtyValue<string> _servicerContactName;
         public string ServicerContactName { get { return _servicerContactName; } set { _servicerContactName = value; } }
-        private Value<string> _servicerPhone;
+        private DirtyValue<string> _servicerPhone;
         public string ServicerPhone { get { return _servicerPhone; } set { _servicerPhone = value; } }
-        private Value<string> _servicerPostalCode;
+        private DirtyValue<string> _servicerPostalCode;
         public string ServicerPostalCode { get { return _servicerPostalCode; } set { _servicerPostalCode = value; } }
-        private Value<string> _servicerState;
+        private DirtyValue<string> _servicerState;
         public string ServicerState { get { return _servicerState; } set { _servicerState = value; } }
-        private Value<decimal?> _singleLineAnalysis;
+        private DirtyValue<decimal?> _singleLineAnalysis;
         public decimal? SingleLineAnalysis { get { return _singleLineAnalysis; } set { _singleLineAnalysis = value; } }
-        private Value<decimal?> _startingBalance;
+        private DirtyValue<decimal?> _startingBalance;
         public decimal? StartingBalance { get { return _startingBalance; } set { _startingBalance = value; } }
-        private Value<int?> _taxDisbCushion;
+        private DirtyValue<int?> _taxDisbCushion;
         public int? TaxDisbCushion { get { return _taxDisbCushion; } set { _taxDisbCushion = value; } }
-        private Value<decimal?> _totalEscrowReserves;
+        private DirtyValue<decimal?> _totalEscrowReserves;
         public decimal? TotalEscrowReserves { get { return _totalEscrowReserves; } set { _totalEscrowReserves = value; } }
-        private Value<decimal?> _usdaAnnualFee;
+        private DirtyValue<decimal?> _usdaAnnualFee;
         public decimal? UsdaAnnualFee { get { return _usdaAnnualFee; } set { _usdaAnnualFee = value; } }
-        private Value<int?> _userDefinedCushion1;
+        private DirtyValue<int?> _userDefinedCushion1;
         public int? UserDefinedCushion1 { get { return _userDefinedCushion1; } set { _userDefinedCushion1 = value; } }
-        private Value<int?> _userDefinedCushion2;
+        private DirtyValue<int?> _userDefinedCushion2;
         public int? UserDefinedCushion2 { get { return _userDefinedCushion2; } set { _userDefinedCushion2 = value; } }
-        private Value<int?> _userDefinedCushion3;
+        private DirtyValue<int?> _userDefinedCushion3;
         public int? UserDefinedCushion3 { get { return _userDefinedCushion3; } set { _userDefinedCushion3 = value; } }
-        private Value<decimal?> _yearlyMortgageInsurance;
+        private DirtyValue<decimal?> _yearlyMortgageInsurance;
         public decimal? YearlyMortgageInsurance { get { return _yearlyMortgageInsurance; } set { _yearlyMortgageInsurance = value; } }
-        private Value<decimal?> _yearlyUsdaFee;
+        private DirtyValue<decimal?> _yearlyUsdaFee;
         public decimal? YearlyUsdaFee { get { return _yearlyUsdaFee; } set { _yearlyUsdaFee = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hud1EsDate.cs
+++ b/src/EncompassRest/Loans/Hud1EsDate.cs
@@ -8,33 +8,33 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hud1EsDate : IDirty
     {
-        private Value<decimal?> _aggrMthDisb;
+        private DirtyValue<decimal?> _aggrMthDisb;
         public decimal? AggrMthDisb { get { return _aggrMthDisb; } set { _aggrMthDisb = value; } }
-        private Value<decimal?> _annualFee;
+        private DirtyValue<decimal?> _annualFee;
         public decimal? AnnualFee { get { return _annualFee; } set { _annualFee = value; } }
-        private Value<decimal?> _balance;
+        private DirtyValue<decimal?> _balance;
         public decimal? Balance { get { return _balance; } set { _balance = value; } }
-        private Value<string> _date;
+        private DirtyValue<string> _date;
         public string Date { get { return _date; } set { _date = value; } }
-        private Value<decimal?> _floodInsDisb;
+        private DirtyValue<decimal?> _floodInsDisb;
         public decimal? FloodInsDisb { get { return _floodInsDisb; } set { _floodInsDisb = value; } }
-        private Value<decimal?> _hazInsDisb;
+        private DirtyValue<decimal?> _hazInsDisb;
         public decimal? HazInsDisb { get { return _hazInsDisb; } set { _hazInsDisb = value; } }
-        private Value<int?> _hud1EsDateIndex;
+        private DirtyValue<int?> _hud1EsDateIndex;
         public int? Hud1EsDateIndex { get { return _hud1EsDateIndex; } set { _hud1EsDateIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _mtgInsDisb;
+        private DirtyValue<decimal?> _mtgInsDisb;
         public decimal? MtgInsDisb { get { return _mtgInsDisb; } set { _mtgInsDisb = value; } }
-        private Value<decimal?> _schoolTaxes;
+        private DirtyValue<decimal?> _schoolTaxes;
         public decimal? SchoolTaxes { get { return _schoolTaxes; } set { _schoolTaxes = value; } }
-        private Value<decimal?> _taxDisb;
+        private DirtyValue<decimal?> _taxDisb;
         public decimal? TaxDisb { get { return _taxDisb; } set { _taxDisb = value; } }
-        private Value<decimal?> _userDefined1;
+        private DirtyValue<decimal?> _userDefined1;
         public decimal? UserDefined1 { get { return _userDefined1; } set { _userDefined1 = value; } }
-        private Value<decimal?> _userDefined2;
+        private DirtyValue<decimal?> _userDefined2;
         public decimal? UserDefined2 { get { return _userDefined2; } set { _userDefined2 = value; } }
-        private Value<decimal?> _userDefined3;
+        private DirtyValue<decimal?> _userDefined3;
         public decimal? UserDefined3 { get { return _userDefined3; } set { _userDefined3 = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hud1EsDueDate.cs
+++ b/src/EncompassRest/Loans/Hud1EsDueDate.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hud1EsDueDate : IDirty
     {
-        private Value<DateTime?> _annualFee;
+        private DirtyValue<DateTime?> _annualFee;
         public DateTime? AnnualFee { get { return _annualFee; } set { _annualFee = value; } }
-        private Value<DateTime?> _floodInsDisb;
+        private DirtyValue<DateTime?> _floodInsDisb;
         public DateTime? FloodInsDisb { get { return _floodInsDisb; } set { _floodInsDisb = value; } }
-        private Value<DateTime?> _hazInsDisb;
+        private DirtyValue<DateTime?> _hazInsDisb;
         public DateTime? HazInsDisb { get { return _hazInsDisb; } set { _hazInsDisb = value; } }
-        private Value<int?> _hud1EsDueDateIndex;
+        private DirtyValue<int?> _hud1EsDueDateIndex;
         public int? Hud1EsDueDateIndex { get { return _hud1EsDueDateIndex; } set { _hud1EsDueDateIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _mtgInsDisb;
+        private DirtyValue<DateTime?> _mtgInsDisb;
         public DateTime? MtgInsDisb { get { return _mtgInsDisb; } set { _mtgInsDisb = value; } }
-        private Value<DateTime?> _schoolTaxes;
+        private DirtyValue<DateTime?> _schoolTaxes;
         public DateTime? SchoolTaxes { get { return _schoolTaxes; } set { _schoolTaxes = value; } }
-        private Value<DateTime?> _taxDisb;
+        private DirtyValue<DateTime?> _taxDisb;
         public DateTime? TaxDisb { get { return _taxDisb; } set { _taxDisb = value; } }
-        private Value<DateTime?> _userDefined1;
+        private DirtyValue<DateTime?> _userDefined1;
         public DateTime? UserDefined1 { get { return _userDefined1; } set { _userDefined1 = value; } }
-        private Value<DateTime?> _userDefined2;
+        private DirtyValue<DateTime?> _userDefined2;
         public DateTime? UserDefined2 { get { return _userDefined2; } set { _userDefined2 = value; } }
-        private Value<DateTime?> _userDefined3;
+        private DirtyValue<DateTime?> _userDefined3;
         public DateTime? UserDefined3 { get { return _userDefined3; } set { _userDefined3 = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hud1EsItemize.cs
+++ b/src/EncompassRest/Loans/Hud1EsItemize.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hud1EsItemize : IDirty
     {
-        private Value<string> _date;
+        private DirtyValue<string> _date;
         public string Date { get { return _date; } set { _date = value; } }
-        private Value<decimal?> _escrowPaymentBalance;
+        private DirtyValue<decimal?> _escrowPaymentBalance;
         public decimal? EscrowPaymentBalance { get { return _escrowPaymentBalance; } set { _escrowPaymentBalance = value; } }
-        private Value<string> _escrowPaymentDescription;
+        private DirtyValue<string> _escrowPaymentDescription;
         public string EscrowPaymentDescription { get { return _escrowPaymentDescription; } set { _escrowPaymentDescription = value; } }
-        private Value<decimal?> _escrowPaymentFrom;
+        private DirtyValue<decimal?> _escrowPaymentFrom;
         public decimal? EscrowPaymentFrom { get { return _escrowPaymentFrom; } set { _escrowPaymentFrom = value; } }
-        private Value<decimal?> _escrowPaymentTo;
+        private DirtyValue<decimal?> _escrowPaymentTo;
         public decimal? EscrowPaymentTo { get { return _escrowPaymentTo; } set { _escrowPaymentTo = value; } }
-        private Value<int?> _hud1EsItemizeIndex;
+        private DirtyValue<int?> _hud1EsItemizeIndex;
         public int? Hud1EsItemizeIndex { get { return _hud1EsItemizeIndex; } set { _hud1EsItemizeIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hud1EsPayTo.cs
+++ b/src/EncompassRest/Loans/Hud1EsPayTo.cs
@@ -8,53 +8,53 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hud1EsPayTo : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<decimal?> _amountLastPay;
+        private DirtyValue<decimal?> _amountLastPay;
         public decimal? AmountLastPay { get { return _amountLastPay; } set { _amountLastPay = value; } }
-        private Value<decimal?> _amountNextDue;
+        private DirtyValue<decimal?> _amountNextDue;
         public decimal? AmountNextDue { get { return _amountNextDue; } set { _amountNextDue = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _contactName;
+        private DirtyValue<string> _contactName;
         public string ContactName { get { return _contactName; } set { _contactName = value; } }
-        private Value<decimal?> _coverageAmount;
+        private DirtyValue<decimal?> _coverageAmount;
         public decimal? CoverageAmount { get { return _coverageAmount; } set { _coverageAmount = value; } }
-        private Value<DateTime?> _datePaid;
+        private DirtyValue<DateTime?> _datePaid;
         public DateTime? DatePaid { get { return _datePaid; } set { _datePaid = value; } }
-        private Value<DateTime?> _delinquentDate;
+        private DirtyValue<DateTime?> _delinquentDate;
         public DateTime? DelinquentDate { get { return _delinquentDate; } set { _delinquentDate = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<string> _feeType;
+        private DirtyValue<string> _feeType;
         public string FeeType { get { return _feeType; } set { _feeType = value; } }
-        private Value<int?> _hud1EsPayToIndex;
+        private DirtyValue<int?> _hud1EsPayToIndex;
         public int? Hud1EsPayToIndex { get { return _hud1EsPayToIndex; } set { _hud1EsPayToIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _maxDeductibleAmount;
+        private DirtyValue<decimal?> _maxDeductibleAmount;
         public decimal? MaxDeductibleAmount { get { return _maxDeductibleAmount; } set { _maxDeductibleAmount = value; } }
-        private Value<decimal?> _maxDeductiblePercentage;
+        private DirtyValue<decimal?> _maxDeductiblePercentage;
         public decimal? MaxDeductiblePercentage { get { return _maxDeductiblePercentage; } set { _maxDeductiblePercentage = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<DateTime?> _nextDueDate;
+        private DirtyValue<DateTime?> _nextDueDate;
         public DateTime? NextDueDate { get { return _nextDueDate; } set { _nextDueDate = value; } }
-        private Value<string> _paymentSchedule;
+        private DirtyValue<string> _paymentSchedule;
         public string PaymentSchedule { get { return _paymentSchedule; } set { _paymentSchedule = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _policyNumber;
+        private DirtyValue<string> _policyNumber;
         public string PolicyNumber { get { return _policyNumber; } set { _policyNumber = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<decimal?> _premium;
+        private DirtyValue<decimal?> _premium;
         public decimal? Premium { get { return _premium; } set { _premium = value; } }
-        private Value<DateTime?> _renewalDate;
+        private DirtyValue<DateTime?> _renewalDate;
         public DateTime? RenewalDate { get { return _renewalDate; } set { _renewalDate = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Hud1EsSetup.cs
+++ b/src/EncompassRest/Loans/Hud1EsSetup.cs
@@ -8,47 +8,47 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Hud1EsSetup : IDirty
     {
-        private Value<bool?> _annualFeePrepaid;
+        private DirtyValue<bool?> _annualFeePrepaid;
         public bool? AnnualFeePrepaid { get { return _annualFeePrepaid; } set { _annualFeePrepaid = value; } }
-        private Value<int?> _annualFees;
+        private DirtyValue<int?> _annualFees;
         public int? AnnualFees { get { return _annualFees; } set { _annualFees = value; } }
-        private Value<string> _date;
+        private DirtyValue<string> _date;
         public string Date { get { return _date; } set { _date = value; } }
-        private Value<int?> _floodInsDisb;
+        private DirtyValue<int?> _floodInsDisb;
         public int? FloodInsDisb { get { return _floodInsDisb; } set { _floodInsDisb = value; } }
-        private Value<bool?> _floodInsPrepaid;
+        private DirtyValue<bool?> _floodInsPrepaid;
         public bool? FloodInsPrepaid { get { return _floodInsPrepaid; } set { _floodInsPrepaid = value; } }
-        private Value<int?> _hazInsDisb;
+        private DirtyValue<int?> _hazInsDisb;
         public int? HazInsDisb { get { return _hazInsDisb; } set { _hazInsDisb = value; } }
-        private Value<bool?> _hazInsPrepaid;
+        private DirtyValue<bool?> _hazInsPrepaid;
         public bool? HazInsPrepaid { get { return _hazInsPrepaid; } set { _hazInsPrepaid = value; } }
-        private Value<int?> _hud1EsSetupIndex;
+        private DirtyValue<int?> _hud1EsSetupIndex;
         public int? Hud1EsSetupIndex { get { return _hud1EsSetupIndex; } set { _hud1EsSetupIndex = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _mtgInsDisb;
+        private DirtyValue<int?> _mtgInsDisb;
         public int? MtgInsDisb { get { return _mtgInsDisb; } set { _mtgInsDisb = value; } }
-        private Value<bool?> _mtgInsPrepaid;
+        private DirtyValue<bool?> _mtgInsPrepaid;
         public bool? MtgInsPrepaid { get { return _mtgInsPrepaid; } set { _mtgInsPrepaid = value; } }
-        private Value<int?> _schoolTaxes;
+        private DirtyValue<int?> _schoolTaxes;
         public int? SchoolTaxes { get { return _schoolTaxes; } set { _schoolTaxes = value; } }
-        private Value<bool?> _schoolTaxesPrepaid;
+        private DirtyValue<bool?> _schoolTaxesPrepaid;
         public bool? SchoolTaxesPrepaid { get { return _schoolTaxesPrepaid; } set { _schoolTaxesPrepaid = value; } }
-        private Value<int?> _taxDisb;
+        private DirtyValue<int?> _taxDisb;
         public int? TaxDisb { get { return _taxDisb; } set { _taxDisb = value; } }
-        private Value<bool?> _taxPrepaid;
+        private DirtyValue<bool?> _taxPrepaid;
         public bool? TaxPrepaid { get { return _taxPrepaid; } set { _taxPrepaid = value; } }
-        private Value<int?> _userDefined1;
+        private DirtyValue<int?> _userDefined1;
         public int? UserDefined1 { get { return _userDefined1; } set { _userDefined1 = value; } }
-        private Value<int?> _userDefined2;
+        private DirtyValue<int?> _userDefined2;
         public int? UserDefined2 { get { return _userDefined2; } set { _userDefined2 = value; } }
-        private Value<int?> _userDefined3;
+        private DirtyValue<int?> _userDefined3;
         public int? UserDefined3 { get { return _userDefined3; } set { _userDefined3 = value; } }
-        private Value<bool?> _userDefinedPrepaid1;
+        private DirtyValue<bool?> _userDefinedPrepaid1;
         public bool? UserDefinedPrepaid1 { get { return _userDefinedPrepaid1; } set { _userDefinedPrepaid1 = value; } }
-        private Value<bool?> _userDefinedPrepaid2;
+        private DirtyValue<bool?> _userDefinedPrepaid2;
         public bool? UserDefinedPrepaid2 { get { return _userDefinedPrepaid2; } set { _userDefinedPrepaid2 = value; } }
-        private Value<bool?> _userDefinedPrepaid3;
+        private DirtyValue<bool?> _userDefinedPrepaid3;
         public bool? UserDefinedPrepaid3 { get { return _userDefinedPrepaid3; } set { _userDefinedPrepaid3 = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/HudLoanData.cs
+++ b/src/EncompassRest/Loans/HudLoanData.cs
@@ -254,8 +254,8 @@ namespace EncompassRest.Loans
         public string RiskClass { get { return _riskClass; } set { _riskClass = value; } }
         private Value<bool?> _scoredByTotal;
         public bool? ScoredByTotal { get { return _scoredByTotal; } set { _scoredByTotal = value; } }
-        private Value<List<SecondaryFinancingProvider>> _secondaryFinancingProviders;
-        public List<SecondaryFinancingProvider> SecondaryFinancingProviders { get { return _secondaryFinancingProviders; } set { _secondaryFinancingProviders = value; } }
+        private DirtyList<SecondaryFinancingProvider> _secondaryFinancingProviders;
+        public IList<SecondaryFinancingProvider> SecondaryFinancingProviders { get { var v = _secondaryFinancingProviders; return v ?? Interlocked.CompareExchange(ref _secondaryFinancingProviders, (v = new DirtyList<SecondaryFinancingProvider>()), null) ?? v; } set { _secondaryFinancingProviders = new DirtyList<SecondaryFinancingProvider>(value); } }
         private Value<decimal?> _sellerContributionRate;
         public decimal? SellerContributionRate { get { return _sellerContributionRate; } set { _sellerContributionRate = value; } }
         private Value<bool?> _simpleRefinance;
@@ -454,7 +454,6 @@ namespace EncompassRest.Loans
                     || _residencyType.Dirty
                     || _riskClass.Dirty
                     || _scoredByTotal.Dirty
-                    || _secondaryFinancingProviders.Dirty
                     || _sellerContributionRate.Dirty
                     || _simpleRefinance.Dirty
                     || _statutoryInvestment.Dirty
@@ -488,7 +487,8 @@ namespace EncompassRest.Loans
                     || _unpaidPrincipalBalanceOfAnyJuniorLiens.Dirty
                     || _unpaidPrincipalBalanceOfPurchaseJuniorLiens.Dirty
                     || _valueEstablished.Dirty
-                    || _windEnergySystemActualCost.Dirty;
+                    || _windEnergySystemActualCost.Dirty
+                    || _secondaryFinancingProviders?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -618,7 +618,6 @@ namespace EncompassRest.Loans
                 _residencyType.Dirty = value;
                 _riskClass.Dirty = value;
                 _scoredByTotal.Dirty = value;
-                _secondaryFinancingProviders.Dirty = value;
                 _sellerContributionRate.Dirty = value;
                 _simpleRefinance.Dirty = value;
                 _statutoryInvestment.Dirty = value;
@@ -653,6 +652,7 @@ namespace EncompassRest.Loans
                 _unpaidPrincipalBalanceOfPurchaseJuniorLiens.Dirty = value;
                 _valueEstablished.Dirty = value;
                 _windEnergySystemActualCost.Dirty = value;
+                if (_secondaryFinancingProviders != null) _secondaryFinancingProviders.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/HudLoanData.cs
+++ b/src/EncompassRest/Loans/HudLoanData.cs
@@ -8,321 +8,321 @@ namespace EncompassRest.Loans
 {
     public sealed partial class HudLoanData : IDirty
     {
-        private Value<decimal?> _actualCashInvRequired;
+        private DirtyValue<decimal?> _actualCashInvRequired;
         public decimal? ActualCashInvRequired { get { return _actualCashInvRequired; } set { _actualCashInvRequired = value; } }
-        private Value<decimal?> _adjustedMaxMtgAmount;
+        private DirtyValue<decimal?> _adjustedMaxMtgAmount;
         public decimal? AdjustedMaxMtgAmount { get { return _adjustedMaxMtgAmount; } set { _adjustedMaxMtgAmount = value; } }
-        private Value<decimal?> _afterImprovedValue;
+        private DirtyValue<decimal?> _afterImprovedValue;
         public decimal? AfterImprovedValue { get { return _afterImprovedValue; } set { _afterImprovedValue = value; } }
-        private Value<decimal?> _afterImprovedValueAfter20Percent;
+        private DirtyValue<decimal?> _afterImprovedValueAfter20Percent;
         public decimal? AfterImprovedValueAfter20Percent { get { return _afterImprovedValueAfter20Percent; } set { _afterImprovedValueAfter20Percent = value; } }
-        private Value<decimal?> _allowableEnergyImprovements;
+        private DirtyValue<decimal?> _allowableEnergyImprovements;
         public decimal? AllowableEnergyImprovements { get { return _allowableEnergyImprovements; } set { _allowableEnergyImprovements = value; } }
-        private Value<decimal?> _appropriateLTVFactor;
+        private DirtyValue<decimal?> _appropriateLTVFactor;
         public decimal? AppropriateLTVFactor { get { return _appropriateLTVFactor; } set { _appropriateLTVFactor = value; } }
-        private Value<decimal?> _architecturalEngineeringFee;
+        private DirtyValue<decimal?> _architecturalEngineeringFee;
         public decimal? ArchitecturalEngineeringFee { get { return _architecturalEngineeringFee; } set { _architecturalEngineeringFee = value; } }
-        private Value<decimal?> _asIsValue;
+        private DirtyValue<decimal?> _asIsValue;
         public decimal? AsIsValue { get { return _asIsValue; } set { _asIsValue = value; } }
-        private Value<decimal?> _baseMortgageAmountFrom3COr3D;
+        private DirtyValue<decimal?> _baseMortgageAmountFrom3COr3D;
         public decimal? BaseMortgageAmountFrom3COr3D { get { return _baseMortgageAmountFrom3COr3D; } set { _baseMortgageAmountFrom3COr3D = value; } }
-        private Value<string> _borrowerAcknowledgement;
+        private DirtyValue<string> _borrowerAcknowledgement;
         public string BorrowerAcknowledgement { get { return _borrowerAcknowledgement; } set { _borrowerAcknowledgement = value; } }
-        private Value<decimal?> _borrowerEstimatedProfit1;
+        private DirtyValue<decimal?> _borrowerEstimatedProfit1;
         public decimal? BorrowerEstimatedProfit1 { get { return _borrowerEstimatedProfit1; } set { _borrowerEstimatedProfit1 = value; } }
-        private Value<decimal?> _borrowerEstimatedProfit2;
+        private DirtyValue<decimal?> _borrowerEstimatedProfit2;
         public decimal? BorrowerEstimatedProfit2 { get { return _borrowerEstimatedProfit2; } set { _borrowerEstimatedProfit2 = value; } }
-        private Value<decimal?> _borrowerPaidClosingCosts;
+        private DirtyValue<decimal?> _borrowerPaidClosingCosts;
         public decimal? BorrowerPaidClosingCosts { get { return _borrowerPaidClosingCosts; } set { _borrowerPaidClosingCosts = value; } }
-        private Value<decimal?> _borrowerRequiredInvestment;
+        private DirtyValue<decimal?> _borrowerRequiredInvestment;
         public decimal? BorrowerRequiredInvestment { get { return _borrowerRequiredInvestment; } set { _borrowerRequiredInvestment = value; } }
-        private Value<decimal?> _borrowersOwnFundsforContingencyReserves;
+        private DirtyValue<decimal?> _borrowersOwnFundsforContingencyReserves;
         public decimal? BorrowersOwnFundsforContingencyReserves { get { return _borrowersOwnFundsforContingencyReserves; } set { _borrowersOwnFundsforContingencyReserves = value; } }
-        private Value<bool?> _buildingOnOwnLand;
+        private DirtyValue<bool?> _buildingOnOwnLand;
         public bool? BuildingOnOwnLand { get { return _buildingOnOwnLand; } set { _buildingOnOwnLand = value; } }
-        private Value<DateTime?> _caseAssignedDate;
+        private DirtyValue<DateTime?> _caseAssignedDate;
         public DateTime? CaseAssignedDate { get { return _caseAssignedDate; } set { _caseAssignedDate = value; } }
-        private Value<decimal?> _caseLTV;
+        private DirtyValue<decimal?> _caseLTV;
         public decimal? CaseLTV { get { return _caseLTV; } set { _caseLTV = value; } }
-        private Value<decimal?> _childSupportBalance;
+        private DirtyValue<decimal?> _childSupportBalance;
         public decimal? ChildSupportBalance { get { return _childSupportBalance; } set { _childSupportBalance = value; } }
-        private Value<string> _cHUMSForAppraisal;
+        private DirtyValue<string> _cHUMSForAppraisal;
         public string CHUMSForAppraisal { get { return _cHUMSForAppraisal; } set { _cHUMSForAppraisal = value; } }
-        private Value<decimal?> _commitmentMaximumMortgageAmount;
+        private DirtyValue<decimal?> _commitmentMaximumMortgageAmount;
         public decimal? CommitmentMaximumMortgageAmount { get { return _commitmentMaximumMortgageAmount; } set { _commitmentMaximumMortgageAmount = value; } }
-        private Value<string> _commitmentStage;
+        private DirtyValue<string> _commitmentStage;
         public string CommitmentStage { get { return _commitmentStage; } set { _commitmentStage = value; } }
-        private Value<decimal?> _constructionRepairsRehabilitationCosts;
+        private DirtyValue<decimal?> _constructionRepairsRehabilitationCosts;
         public decimal? ConstructionRepairsRehabilitationCosts { get { return _constructionRepairsRehabilitationCosts; } set { _constructionRepairsRehabilitationCosts = value; } }
-        private Value<decimal?> _contingencyReserveCostsAmount;
+        private DirtyValue<decimal?> _contingencyReserveCostsAmount;
         public decimal? ContingencyReserveCostsAmount { get { return _contingencyReserveCostsAmount; } set { _contingencyReserveCostsAmount = value; } }
-        private Value<decimal?> _contingencyReserveCostsPercent;
+        private DirtyValue<decimal?> _contingencyReserveCostsPercent;
         public decimal? ContingencyReserveCostsPercent { get { return _contingencyReserveCostsPercent; } set { _contingencyReserveCostsPercent = value; } }
-        private Value<decimal?> _contractSalesPrice;
+        private DirtyValue<decimal?> _contractSalesPrice;
         public decimal? ContractSalesPrice { get { return _contractSalesPrice; } set { _contractSalesPrice = value; } }
-        private Value<string> _criteriaForAppropriateLTVFactor;
+        private DirtyValue<string> _criteriaForAppropriateLTVFactor;
         public string CriteriaForAppropriateLTVFactor { get { return _criteriaForAppropriateLTVFactor; } set { _criteriaForAppropriateLTVFactor = value; } }
-        private Value<string> _dealerContractorAddress;
+        private DirtyValue<string> _dealerContractorAddress;
         public string DealerContractorAddress { get { return _dealerContractorAddress; } set { _dealerContractorAddress = value; } }
-        private Value<string> _dealerContractorCity;
+        private DirtyValue<string> _dealerContractorCity;
         public string DealerContractorCity { get { return _dealerContractorCity; } set { _dealerContractorCity = value; } }
-        private Value<string> _dealerContractorName;
+        private DirtyValue<string> _dealerContractorName;
         public string DealerContractorName { get { return _dealerContractorName; } set { _dealerContractorName = value; } }
-        private Value<string> _dealerContractorPostalCode;
+        private DirtyValue<string> _dealerContractorPostalCode;
         public string DealerContractorPostalCode { get { return _dealerContractorPostalCode; } set { _dealerContractorPostalCode = value; } }
-        private Value<string> _dealerContractorState;
+        private DirtyValue<string> _dealerContractorState;
         public string DealerContractorState { get { return _dealerContractorState; } set { _dealerContractorState = value; } }
-        private Value<decimal?> _discountPointsAmount;
+        private DirtyValue<decimal?> _discountPointsAmount;
         public decimal? DiscountPointsAmount { get { return _discountPointsAmount; } set { _discountPointsAmount = value; } }
-        private Value<decimal?> _discountPointsPercent;
+        private DirtyValue<decimal?> _discountPointsPercent;
         public decimal? DiscountPointsPercent { get { return _discountPointsPercent; } set { _discountPointsPercent = value; } }
-        private Value<bool?> _eEMIndicator;
+        private DirtyValue<bool?> _eEMIndicator;
         public bool? EEMIndicator { get { return _eEMIndicator; } set { _eEMIndicator = value; } }
-        private Value<decimal?> _energyEfficientMortgageAmount;
+        private DirtyValue<decimal?> _energyEfficientMortgageAmount;
         public decimal? EnergyEfficientMortgageAmount { get { return _energyEfficientMortgageAmount; } set { _energyEfficientMortgageAmount = value; } }
-        private Value<string> _escrowCommitment;
+        private DirtyValue<string> _escrowCommitment;
         public string EscrowCommitment { get { return _escrowCommitment; } set { _escrowCommitment = value; } }
-        private Value<decimal?> _escrowShortages;
+        private DirtyValue<decimal?> _escrowShortages;
         public decimal? EscrowShortages { get { return _escrowShortages; } set { _escrowShortages = value; } }
-        private Value<decimal?> _existing203KDebtTotal;
+        private DirtyValue<decimal?> _existing203KDebtTotal;
         public decimal? Existing203KDebtTotal { get { return _existing203KDebtTotal; } set { _existing203KDebtTotal = value; } }
-        private Value<bool?> _existingDebt;
+        private DirtyValue<bool?> _existingDebt;
         public bool? ExistingDebt { get { return _existingDebt; } set { _existingDebt = value; } }
-        private Value<decimal?> _existingDebtPlusRehabCosts;
+        private DirtyValue<decimal?> _existingDebtPlusRehabCosts;
         public decimal? ExistingDebtPlusRehabCosts { get { return _existingDebtPlusRehabCosts; } set { _existingDebtPlusRehabCosts = value; } }
-        private Value<decimal?> _existingDebtPlusRehabCostsPlusNewLoanFees;
+        private DirtyValue<decimal?> _existingDebtPlusRehabCostsPlusNewLoanFees;
         public decimal? ExistingDebtPlusRehabCostsPlusNewLoanFees { get { return _existingDebtPlusRehabCostsPlusNewLoanFees; } set { _existingDebtPlusRehabCostsPlusNewLoanFees = value; } }
-        private Value<decimal?> _feasibilityStudyWhenNecessary;
+        private DirtyValue<decimal?> _feasibilityStudyWhenNecessary;
         public decimal? FeasibilityStudyWhenNecessary { get { return _feasibilityStudyWhenNecessary; } set { _feasibilityStudyWhenNecessary = value; } }
-        private Value<decimal?> _feesAssociatedWithNewLoan;
+        private DirtyValue<decimal?> _feesAssociatedWithNewLoan;
         public decimal? FeesAssociatedWithNewLoan { get { return _feesAssociatedWithNewLoan; } set { _feesAssociatedWithNewLoan = value; } }
-        private Value<decimal?> _fHA203kB10SubTotal;
+        private DirtyValue<decimal?> _fHA203kB10SubTotal;
         public decimal? FHA203kB10SubTotal { get { return _fHA203kB10SubTotal; } set { _fHA203kB10SubTotal = value; } }
-        private Value<string> _fHA203kRemarks;
+        private DirtyValue<string> _fHA203kRemarks;
         public string FHA203kRemarks { get { return _fHA203kRemarks; } set { _fHA203kRemarks = value; } }
-        private Value<string> _fHAStreamlineType;
+        private DirtyValue<string> _fHAStreamlineType;
         public string FHAStreamlineType { get { return _fHAStreamlineType; } set { _fHAStreamlineType = value; } }
-        private Value<decimal?> _finalBaseMortgageAmount;
+        private DirtyValue<decimal?> _finalBaseMortgageAmount;
         public decimal? FinalBaseMortgageAmount { get { return _finalBaseMortgageAmount; } set { _finalBaseMortgageAmount = value; } }
-        private Value<decimal?> _financeableMortgageFeesIfCharged;
+        private DirtyValue<decimal?> _financeableMortgageFeesIfCharged;
         public decimal? FinanceableMortgageFeesIfCharged { get { return _financeableMortgageFeesIfCharged; } set { _financeableMortgageFeesIfCharged = value; } }
-        private Value<bool?> _haveOtherPendingApplicationForFHA;
+        private DirtyValue<bool?> _haveOtherPendingApplicationForFHA;
         public bool? HaveOtherPendingApplicationForFHA { get { return _haveOtherPendingApplicationForFHA; } set { _haveOtherPendingApplicationForFHA = value; } }
-        private Value<bool?> _hUDOwned;
+        private DirtyValue<bool?> _hUDOwned;
         public bool? HUDOwned { get { return _hUDOwned; } set { _hUDOwned = value; } }
-        private Value<bool?> _hUDREOIndicator;
+        private DirtyValue<bool?> _hUDREOIndicator;
         public bool? HUDREOIndicator { get { return _hUDREOIndicator; } set { _hUDREOIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _independentConsultantFee;
+        private DirtyValue<decimal?> _independentConsultantFee;
         public decimal? IndependentConsultantFee { get { return _independentConsultantFee; } set { _independentConsultantFee = value; } }
-        private Value<decimal?> _initialBaseMortgageAmountPlusEEMImprovementAmount;
+        private DirtyValue<decimal?> _initialBaseMortgageAmountPlusEEMImprovementAmount;
         public decimal? InitialBaseMortgageAmountPlusEEMImprovementAmount { get { return _initialBaseMortgageAmountPlusEEMImprovementAmount; } set { _initialBaseMortgageAmountPlusEEMImprovementAmount = value; } }
-        private Value<decimal?> _initialDrawAtClosingArchitecturalorEngineeringFees;
+        private DirtyValue<decimal?> _initialDrawAtClosingArchitecturalorEngineeringFees;
         public decimal? InitialDrawAtClosingArchitecturalorEngineeringFees { get { return _initialDrawAtClosingArchitecturalorEngineeringFees; } set { _initialDrawAtClosingArchitecturalorEngineeringFees = value; } }
-        private Value<decimal?> _initialDrawAtClosingConsultantFees;
+        private DirtyValue<decimal?> _initialDrawAtClosingConsultantFees;
         public decimal? InitialDrawAtClosingConsultantFees { get { return _initialDrawAtClosingConsultantFees; } set { _initialDrawAtClosingConsultantFees = value; } }
-        private Value<decimal?> _initialDrawAtClosingPermitFees;
+        private DirtyValue<decimal?> _initialDrawAtClosingPermitFees;
         public decimal? InitialDrawAtClosingPermitFees { get { return _initialDrawAtClosingPermitFees; } set { _initialDrawAtClosingPermitFees = value; } }
-        private Value<decimal?> _initialDrawAtClosingTotal;
+        private DirtyValue<decimal?> _initialDrawAtClosingTotal;
         public decimal? InitialDrawAtClosingTotal { get { return _initialDrawAtClosingTotal; } set { _initialDrawAtClosingTotal = value; } }
-        private Value<decimal?> _inspectionFeeAmount;
+        private DirtyValue<decimal?> _inspectionFeeAmount;
         public decimal? InspectionFeeAmount { get { return _inspectionFeeAmount; } set { _inspectionFeeAmount = value; } }
-        private Value<decimal?> _inspectionFeesDuringRehabilitation;
+        private DirtyValue<decimal?> _inspectionFeesDuringRehabilitation;
         public decimal? InspectionFeesDuringRehabilitation { get { return _inspectionFeesDuringRehabilitation; } set { _inspectionFeesDuringRehabilitation = value; } }
-        private Value<int?> _inspectionFeeTimes;
+        private DirtyValue<int?> _inspectionFeeTimes;
         public int? InspectionFeeTimes { get { return _inspectionFeeTimes; } set { _inspectionFeeTimes = value; } }
-        private Value<decimal?> _interestDueonExistingMortgage;
+        private DirtyValue<decimal?> _interestDueonExistingMortgage;
         public decimal? InterestDueonExistingMortgage { get { return _interestDueonExistingMortgage; } set { _interestDueonExistingMortgage = value; } }
-        private Value<decimal?> _lateCharges;
+        private DirtyValue<decimal?> _lateCharges;
         public decimal? LateCharges { get { return _lateCharges; } set { _lateCharges = value; } }
-        private Value<bool?> _lDPGSAForBorrower;
+        private DirtyValue<bool?> _lDPGSAForBorrower;
         public bool? LDPGSAForBorrower { get { return _lDPGSAForBorrower; } set { _lDPGSAForBorrower = value; } }
-        private Value<bool?> _lDPGSAForCoBorrower;
+        private DirtyValue<bool?> _lDPGSAForCoBorrower;
         public bool? LDPGSAForCoBorrower { get { return _lDPGSAForCoBorrower; } set { _lDPGSAForCoBorrower = value; } }
-        private Value<bool?> _leasedFromSomeoneElse;
+        private DirtyValue<bool?> _leasedFromSomeoneElse;
         public bool? LeasedFromSomeoneElse { get { return _leasedFromSomeoneElse; } set { _leasedFromSomeoneElse = value; } }
-        private Value<DateTime?> _leaseExpiradionDate;
+        private DirtyValue<DateTime?> _leaseExpiradionDate;
         public DateTime? LeaseExpiradionDate { get { return _leaseExpiradionDate; } set { _leaseExpiradionDate = value; } }
-        private Value<decimal?> _leaseMonthlyPayment;
+        private DirtyValue<decimal?> _leaseMonthlyPayment;
         public decimal? LeaseMonthlyPayment { get { return _leaseMonthlyPayment; } set { _leaseMonthlyPayment = value; } }
-        private Value<decimal?> _lessAllowableDownpayment;
+        private DirtyValue<decimal?> _lessAllowableDownpayment;
         public decimal? LessAllowableDownpayment { get { return _lessAllowableDownpayment; } set { _lessAllowableDownpayment = value; } }
-        private Value<decimal?> _lesserOf3AOr3B;
+        private DirtyValue<decimal?> _lesserOf3AOr3B;
         public decimal? LesserOf3AOr3B { get { return _lesserOf3AOr3B; } set { _lesserOf3AOr3B = value; } }
-        private Value<decimal?> _lesserOf3AOr3BMultiply3F;
+        private DirtyValue<decimal?> _lesserOf3AOr3BMultiply3F;
         public decimal? LesserOf3AOr3BMultiply3F { get { return _lesserOf3AOr3BMultiply3F; } set { _lesserOf3AOr3BMultiply3F = value; } }
-        private Value<decimal?> _lesserOfMaximumFinanceableSolarOrWindEnergyAmount;
+        private DirtyValue<decimal?> _lesserOfMaximumFinanceableSolarOrWindEnergyAmount;
         public decimal? LesserOfMaximumFinanceableSolarOrWindEnergyAmount { get { return _lesserOfMaximumFinanceableSolarOrWindEnergyAmount; } set { _lesserOfMaximumFinanceableSolarOrWindEnergyAmount = value; } }
-        private Value<decimal?> _lesserOfSalesPrice;
+        private DirtyValue<decimal?> _lesserOfSalesPrice;
         public decimal? LesserOfSalesPrice { get { return _lesserOfSalesPrice; } set { _lesserOfSalesPrice = value; } }
-        private Value<decimal?> _lesserOfSumAmount;
+        private DirtyValue<decimal?> _lesserOfSumAmount;
         public decimal? LesserOfSumAmount { get { return _lesserOfSumAmount; } set { _lesserOfSumAmount = value; } }
-        private Value<decimal?> _lesserOfSumAsIs;
+        private DirtyValue<decimal?> _lesserOfSumAsIs;
         public decimal? LesserOfSumAsIs { get { return _lesserOfSumAsIs; } set { _lesserOfSumAsIs = value; } }
-        private Value<decimal?> _lesserOfSumPercent;
+        private DirtyValue<decimal?> _lesserOfSumPercent;
         public decimal? LesserOfSumPercent { get { return _lesserOfSumPercent; } set { _lesserOfSumPercent = value; } }
-        private Value<decimal?> _lessLeadBasedPaintCredit;
+        private DirtyValue<decimal?> _lessLeadBasedPaintCredit;
         public decimal? LessLeadBasedPaintCredit { get { return _lessLeadBasedPaintCredit; } set { _lessLeadBasedPaintCredit = value; } }
-        private Value<bool?> _limitedProgram;
+        private DirtyValue<bool?> _limitedProgram;
         public bool? LimitedProgram { get { return _limitedProgram; } set { _limitedProgram = value; } }
-        private Value<bool?> _loanFor203KIndicator;
+        private DirtyValue<bool?> _loanFor203KIndicator;
         public bool? LoanFor203KIndicator { get { return _loanFor203KIndicator; } set { _loanFor203KIndicator = value; } }
-        private Value<string> _loanPurpose;
+        private DirtyValue<string> _loanPurpose;
         public string LoanPurpose { get { return _loanPurpose; } set { _loanPurpose = value; } }
-        private Value<decimal?> _materialCostsOrderedPrepaidByBorrowerContractor;
+        private DirtyValue<decimal?> _materialCostsOrderedPrepaidByBorrowerContractor;
         public decimal? MaterialCostsOrderedPrepaidByBorrowerContractor { get { return _materialCostsOrderedPrepaidByBorrowerContractor; } set { _materialCostsOrderedPrepaidByBorrowerContractor = value; } }
-        private Value<decimal?> _materialCostsOrderedPrepaidByBorrowerContractorAfter50Percent;
+        private DirtyValue<decimal?> _materialCostsOrderedPrepaidByBorrowerContractorAfter50Percent;
         public decimal? MaterialCostsOrderedPrepaidByBorrowerContractorAfter50Percent { get { return _materialCostsOrderedPrepaidByBorrowerContractorAfter50Percent; } set { _materialCostsOrderedPrepaidByBorrowerContractorAfter50Percent = value; } }
-        private Value<decimal?> _maximumMortgageWithUFMIP;
+        private DirtyValue<decimal?> _maximumMortgageWithUFMIP;
         public decimal? MaximumMortgageWithUFMIP { get { return _maximumMortgageWithUFMIP; } set { _maximumMortgageWithUFMIP = value; } }
-        private Value<decimal?> _mIPDueOnExistingMortgage;
+        private DirtyValue<decimal?> _mIPDueOnExistingMortgage;
         public decimal? MIPDueOnExistingMortgage { get { return _mIPDueOnExistingMortgage; } set { _mIPDueOnExistingMortgage = value; } }
-        private Value<decimal?> _mIPLTV;
+        private DirtyValue<decimal?> _mIPLTV;
         public decimal? MIPLTV { get { return _mIPLTV; } set { _mIPLTV = value; } }
-        private Value<bool?> _mtgOrDeedOfTrusOnProperty;
+        private DirtyValue<bool?> _mtgOrDeedOfTrusOnProperty;
         public bool? MtgOrDeedOfTrusOnProperty { get { return _mtgOrDeedOfTrusOnProperty; } set { _mtgOrDeedOfTrusOnProperty = value; } }
-        private Value<decimal?> _mtgPaymentEscrowedAmount;
+        private DirtyValue<decimal?> _mtgPaymentEscrowedAmount;
         public decimal? MtgPaymentEscrowedAmount { get { return _mtgPaymentEscrowedAmount; } set { _mtgPaymentEscrowedAmount = value; } }
-        private Value<int?> _mtgPaymentEscrowedTimes;
+        private DirtyValue<int?> _mtgPaymentEscrowedTimes;
         public int? MtgPaymentEscrowedTimes { get { return _mtgPaymentEscrowedTimes; } set { _mtgPaymentEscrowedTimes = value; } }
-        private Value<decimal?> _nationwideMortgageLimit;
+        private DirtyValue<decimal?> _nationwideMortgageLimit;
         public decimal? NationwideMortgageLimit { get { return _nationwideMortgageLimit; } set { _nationwideMortgageLimit = value; } }
-        private Value<decimal?> _nationwideMortgageLimitAfter120Percent;
+        private DirtyValue<decimal?> _nationwideMortgageLimitAfter120Percent;
         public decimal? NationwideMortgageLimitAfter120Percent { get { return _nationwideMortgageLimitAfter120Percent; } set { _nationwideMortgageLimitAfter120Percent = value; } }
-        private Value<bool?> _newResidential;
+        private DirtyValue<bool?> _newResidential;
         public bool? NewResidential { get { return _newResidential; } set { _newResidential = value; } }
-        private Value<string> _nonresidentialTypeOfUse;
+        private DirtyValue<string> _nonresidentialTypeOfUse;
         public string NonresidentialTypeOfUse { get { return _nonresidentialTypeOfUse; } set { _nonresidentialTypeOfUse = value; } }
-        private Value<int?> _numberOfHistoricUnits;
+        private DirtyValue<int?> _numberOfHistoricUnits;
         public int? NumberOfHistoricUnits { get { return _numberOfHistoricUnits; } set { _numberOfHistoricUnits = value; } }
-        private Value<int?> _numberOfMultifamilyUnits;
+        private DirtyValue<int?> _numberOfMultifamilyUnits;
         public int? NumberOfMultifamilyUnits { get { return _numberOfMultifamilyUnits; } set { _numberOfMultifamilyUnits = value; } }
-        private Value<string> _otherDescription;
+        private DirtyValue<string> _otherDescription;
         public string OtherDescription { get { return _otherDescription; } set { _otherDescription = value; } }
-        private Value<bool?> _ownedByBorrower;
+        private DirtyValue<bool?> _ownedByBorrower;
         public bool? OwnedByBorrower { get { return _ownedByBorrower; } set { _ownedByBorrower = value; } }
-        private Value<decimal?> _percentAfterImprovedValue;
+        private DirtyValue<decimal?> _percentAfterImprovedValue;
         public decimal? PercentAfterImprovedValue { get { return _percentAfterImprovedValue; } set { _percentAfterImprovedValue = value; } }
-        private Value<decimal?> _permitsAndOtherFee;
+        private DirtyValue<decimal?> _permitsAndOtherFee;
         public decimal? PermitsAndOtherFee { get { return _permitsAndOtherFee; } set { _permitsAndOtherFee = value; } }
-        private Value<decimal?> _planReviewerFeeAddition;
+        private DirtyValue<decimal?> _planReviewerFeeAddition;
         public decimal? PlanReviewerFeeAddition { get { return _planReviewerFeeAddition; } set { _planReviewerFeeAddition = value; } }
-        private Value<decimal?> _planReviewerFeeAmount;
+        private DirtyValue<decimal?> _planReviewerFeeAmount;
         public decimal? PlanReviewerFeeAmount { get { return _planReviewerFeeAmount; } set { _planReviewerFeeAmount = value; } }
-        private Value<int?> _planReviewerFeeMiles;
+        private DirtyValue<int?> _planReviewerFeeMiles;
         public int? PlanReviewerFeeMiles { get { return _planReviewerFeeMiles; } set { _planReviewerFeeMiles = value; } }
-        private Value<decimal?> _prepaymentPenalties;
+        private DirtyValue<decimal?> _prepaymentPenalties;
         public decimal? PrepaymentPenalties { get { return _prepaymentPenalties; } set { _prepaymentPenalties = value; } }
-        private Value<string> _propertyOwnerAddress;
+        private DirtyValue<string> _propertyOwnerAddress;
         public string PropertyOwnerAddress { get { return _propertyOwnerAddress; } set { _propertyOwnerAddress = value; } }
-        private Value<string> _propertyOwnerCity;
+        private DirtyValue<string> _propertyOwnerCity;
         public string PropertyOwnerCity { get { return _propertyOwnerCity; } set { _propertyOwnerCity = value; } }
-        private Value<string> _propertyOwnerName;
+        private DirtyValue<string> _propertyOwnerName;
         public string PropertyOwnerName { get { return _propertyOwnerName; } set { _propertyOwnerName = value; } }
-        private Value<string> _propertyOwnerPostalCode;
+        private DirtyValue<string> _propertyOwnerPostalCode;
         public string PropertyOwnerPostalCode { get { return _propertyOwnerPostalCode; } set { _propertyOwnerPostalCode = value; } }
-        private Value<string> _propertyOwnerState;
+        private DirtyValue<string> _propertyOwnerState;
         public string PropertyOwnerState { get { return _propertyOwnerState; } set { _propertyOwnerState = value; } }
-        private Value<string> _propertyToBeImproved;
+        private DirtyValue<string> _propertyToBeImproved;
         public string PropertyToBeImproved { get { return _propertyToBeImproved; } set { _propertyToBeImproved = value; } }
-        private Value<string> _propertyType;
+        private DirtyValue<string> _propertyType;
         public string PropertyType { get { return _propertyType; } set { _propertyType = value; } }
-        private Value<DateTime?> _purchaseDate;
+        private DirtyValue<DateTime?> _purchaseDate;
         public DateTime? PurchaseDate { get { return _purchaseDate; } set { _purchaseDate = value; } }
-        private Value<bool?> _purchasedOnContract;
+        private DirtyValue<bool?> _purchasedOnContract;
         public bool? PurchasedOnContract { get { return _purchasedOnContract; } set { _purchasedOnContract = value; } }
-        private Value<decimal?> _purchaseMaximumMortgageAmount;
+        private DirtyValue<decimal?> _purchaseMaximumMortgageAmount;
         public decimal? PurchaseMaximumMortgageAmount { get { return _purchaseMaximumMortgageAmount; } set { _purchaseMaximumMortgageAmount = value; } }
-        private Value<decimal?> _purchaseMaximumMortgagePercent;
+        private DirtyValue<decimal?> _purchaseMaximumMortgagePercent;
         public decimal? PurchaseMaximumMortgagePercent { get { return _purchaseMaximumMortgagePercent; } set { _purchaseMaximumMortgagePercent = value; } }
-        private Value<decimal?> _purchasePriceLessInducementToPurchase;
+        private DirtyValue<decimal?> _purchasePriceLessInducementToPurchase;
         public decimal? PurchasePriceLessInducementToPurchase { get { return _purchasePriceLessInducementToPurchase; } set { _purchasePriceLessInducementToPurchase = value; } }
-        private Value<decimal?> _refinanceMaximumMortgageAmount;
+        private DirtyValue<decimal?> _refinanceMaximumMortgageAmount;
         public decimal? RefinanceMaximumMortgageAmount { get { return _refinanceMaximumMortgageAmount; } set { _refinanceMaximumMortgageAmount = value; } }
-        private Value<bool?> _refinancingATitleILoan;
+        private DirtyValue<bool?> _refinancingATitleILoan;
         public bool? RefinancingATitleILoan { get { return _refinancingATitleILoan; } set { _refinancingATitleILoan = value; } }
-        private Value<decimal?> _rehabilitationEscrowAccount;
+        private DirtyValue<decimal?> _rehabilitationEscrowAccount;
         public decimal? RehabilitationEscrowAccount { get { return _rehabilitationEscrowAccount; } set { _rehabilitationEscrowAccount = value; } }
-        private Value<decimal?> _rehabilitationEscrowAmountBalanceForFutureDraws;
+        private DirtyValue<decimal?> _rehabilitationEscrowAmountBalanceForFutureDraws;
         public decimal? RehabilitationEscrowAmountBalanceForFutureDraws { get { return _rehabilitationEscrowAmountBalanceForFutureDraws; } set { _rehabilitationEscrowAmountBalanceForFutureDraws = value; } }
-        private Value<decimal?> _rentalCashFlowBalance;
+        private DirtyValue<decimal?> _rentalCashFlowBalance;
         public decimal? RentalCashFlowBalance { get { return _rentalCashFlowBalance; } set { _rentalCashFlowBalance = value; } }
-        private Value<string> _residencyType;
+        private DirtyValue<string> _residencyType;
         public string ResidencyType { get { return _residencyType; } set { _residencyType = value; } }
-        private Value<string> _riskClass;
+        private DirtyValue<string> _riskClass;
         public string RiskClass { get { return _riskClass; } set { _riskClass = value; } }
-        private Value<bool?> _scoredByTotal;
+        private DirtyValue<bool?> _scoredByTotal;
         public bool? ScoredByTotal { get { return _scoredByTotal; } set { _scoredByTotal = value; } }
         private DirtyList<SecondaryFinancingProvider> _secondaryFinancingProviders;
         public IList<SecondaryFinancingProvider> SecondaryFinancingProviders { get { var v = _secondaryFinancingProviders; return v ?? Interlocked.CompareExchange(ref _secondaryFinancingProviders, (v = new DirtyList<SecondaryFinancingProvider>()), null) ?? v; } set { _secondaryFinancingProviders = new DirtyList<SecondaryFinancingProvider>(value); } }
-        private Value<decimal?> _sellerContributionRate;
+        private DirtyValue<decimal?> _sellerContributionRate;
         public decimal? SellerContributionRate { get { return _sellerContributionRate; } set { _sellerContributionRate = value; } }
-        private Value<bool?> _simpleRefinance;
+        private DirtyValue<bool?> _simpleRefinance;
         public bool? SimpleRefinance { get { return _simpleRefinance; } set { _simpleRefinance = value; } }
-        private Value<decimal?> _statutoryInvestment;
+        private DirtyValue<decimal?> _statutoryInvestment;
         public decimal? StatutoryInvestment { get { return _statutoryInvestment; } set { _statutoryInvestment = value; } }
-        private Value<decimal?> _step2EPlusStep1E;
+        private DirtyValue<decimal?> _step2EPlusStep1E;
         public decimal? Step2EPlusStep1E { get { return _step2EPlusStep1E; } set { _step2EPlusStep1E = value; } }
-        private Value<bool?> _streamlined;
+        private DirtyValue<bool?> _streamlined;
         public bool? Streamlined { get { return _streamlined; } set { _streamlined = value; } }
-        private Value<decimal?> _subTotalForEscrowAccount;
+        private DirtyValue<decimal?> _subTotalForEscrowAccount;
         public decimal? SubTotalForEscrowAccount { get { return _subTotalForEscrowAccount; } set { _subTotalForEscrowAccount = value; } }
-        private Value<decimal?> _subTotalForReleaseAtClosing;
+        private DirtyValue<decimal?> _subTotalForReleaseAtClosing;
         public decimal? SubTotalForReleaseAtClosing { get { return _subTotalForReleaseAtClosing; } set { _subTotalForReleaseAtClosing = value; } }
-        private Value<decimal?> _sumForInvestor;
+        private DirtyValue<decimal?> _sumForInvestor;
         public decimal? SumForInvestor { get { return _sumForInvestor; } set { _sumForInvestor = value; } }
-        private Value<decimal?> _sumForOwnerOccupied;
+        private DirtyValue<decimal?> _sumForOwnerOccupied;
         public decimal? SumForOwnerOccupied { get { return _sumForOwnerOccupied; } set { _sumForOwnerOccupied = value; } }
-        private Value<decimal?> _sumOfExistingDebt;
+        private DirtyValue<decimal?> _sumOfExistingDebt;
         public decimal? SumOfExistingDebt { get { return _sumOfExistingDebt; } set { _sumOfExistingDebt = value; } }
-        private Value<decimal?> _suplementalOriginationFee;
+        private DirtyValue<decimal?> _suplementalOriginationFee;
         public decimal? SuplementalOriginationFee { get { return _suplementalOriginationFee; } set { _suplementalOriginationFee = value; } }
-        private Value<decimal?> _title1LoanBalance;
+        private DirtyValue<decimal?> _title1LoanBalance;
         public decimal? Title1LoanBalance { get { return _title1LoanBalance; } set { _title1LoanBalance = value; } }
-        private Value<string> _title1LoanNumber;
+        private DirtyValue<string> _title1LoanNumber;
         public string Title1LoanNumber { get { return _title1LoanNumber; } set { _title1LoanNumber = value; } }
-        private Value<string> _title1LoanWithWhom;
+        private DirtyValue<string> _title1LoanWithWhom;
         public string Title1LoanWithWhom { get { return _title1LoanWithWhom; } set { _title1LoanWithWhom = value; } }
-        private Value<decimal?> _titleUpdateFeeAmount;
+        private DirtyValue<decimal?> _titleUpdateFeeAmount;
         public decimal? TitleUpdateFeeAmount { get { return _titleUpdateFeeAmount; } set { _titleUpdateFeeAmount = value; } }
-        private Value<decimal?> _titleUpdateFees;
+        private DirtyValue<decimal?> _titleUpdateFees;
         public decimal? TitleUpdateFees { get { return _titleUpdateFees; } set { _titleUpdateFees = value; } }
-        private Value<int?> _titleUpdateFeeTimes;
+        private DirtyValue<int?> _titleUpdateFeeTimes;
         public int? TitleUpdateFeeTimes { get { return _titleUpdateFeeTimes; } set { _titleUpdateFeeTimes = value; } }
-        private Value<decimal?> _totalCostsOfRepairsInA6;
+        private DirtyValue<decimal?> _totalCostsOfRepairsInA6;
         public decimal? TotalCostsOfRepairsInA6 { get { return _totalCostsOfRepairsInA6; } set { _totalCostsOfRepairsInA6 = value; } }
-        private Value<decimal?> _totalEscrowCommitment;
+        private DirtyValue<decimal?> _totalEscrowCommitment;
         public decimal? TotalEscrowCommitment { get { return _totalEscrowCommitment; } set { _totalEscrowCommitment = value; } }
-        private Value<decimal?> _totalEscrowedFunds;
+        private DirtyValue<decimal?> _totalEscrowedFunds;
         public decimal? TotalEscrowedFunds { get { return _totalEscrowedFunds; } set { _totalEscrowedFunds = value; } }
-        private Value<decimal?> _totalFixedUnpaidBalance;
+        private DirtyValue<decimal?> _totalFixedUnpaidBalance;
         public decimal? TotalFixedUnpaidBalance { get { return _totalFixedUnpaidBalance; } set { _totalFixedUnpaidBalance = value; } }
-        private Value<decimal?> _totalForBorrowerEstimatedProfit;
+        private DirtyValue<decimal?> _totalForBorrowerEstimatedProfit;
         public decimal? TotalForBorrowerEstimatedProfit { get { return _totalForBorrowerEstimatedProfit; } set { _totalForBorrowerEstimatedProfit = value; } }
-        private Value<decimal?> _totalForInspectionAndTitleFee;
+        private DirtyValue<decimal?> _totalForInspectionAndTitleFee;
         public decimal? TotalForInspectionAndTitleFee { get { return _totalForInspectionAndTitleFee; } set { _totalForInspectionAndTitleFee = value; } }
-        private Value<decimal?> _totalForLesserOfSumAsIs;
+        private DirtyValue<decimal?> _totalForLesserOfSumAsIs;
         public decimal? TotalForLesserOfSumAsIs { get { return _totalForLesserOfSumAsIs; } set { _totalForLesserOfSumAsIs = value; } }
-        private Value<decimal?> _totalForMtgPaymentEscrowed;
+        private DirtyValue<decimal?> _totalForMtgPaymentEscrowed;
         public decimal? TotalForMtgPaymentEscrowed { get { return _totalForMtgPaymentEscrowed; } set { _totalForMtgPaymentEscrowed = value; } }
-        private Value<decimal?> _totalForPlanReviewerFee;
+        private DirtyValue<decimal?> _totalForPlanReviewerFee;
         public decimal? TotalForPlanReviewerFee { get { return _totalForPlanReviewerFee; } set { _totalForPlanReviewerFee = value; } }
-        private Value<decimal?> _totalForRehabilitationCost;
+        private DirtyValue<decimal?> _totalForRehabilitationCost;
         public decimal? TotalForRehabilitationCost { get { return _totalForRehabilitationCost; } set { _totalForRehabilitationCost = value; } }
-        private Value<decimal?> _totalRehabilitationCosts;
+        private DirtyValue<decimal?> _totalRehabilitationCosts;
         public decimal? TotalRehabilitationCosts { get { return _totalRehabilitationCosts; } set { _totalRehabilitationCosts = value; } }
-        private Value<decimal?> _totalRehabilitationCostsFeesReserves;
+        private DirtyValue<decimal?> _totalRehabilitationCostsFeesReserves;
         public decimal? TotalRehabilitationCostsFeesReserves { get { return _totalRehabilitationCostsFeesReserves; } set { _totalRehabilitationCostsFeesReserves = value; } }
-        private Value<decimal?> _unpaidPrincipalBalanceFirstLien;
+        private DirtyValue<decimal?> _unpaidPrincipalBalanceFirstLien;
         public decimal? UnpaidPrincipalBalanceFirstLien { get { return _unpaidPrincipalBalanceFirstLien; } set { _unpaidPrincipalBalanceFirstLien = value; } }
-        private Value<decimal?> _unpaidPrincipalBalanceOfAnyJuniorLiens;
+        private DirtyValue<decimal?> _unpaidPrincipalBalanceOfAnyJuniorLiens;
         public decimal? UnpaidPrincipalBalanceOfAnyJuniorLiens { get { return _unpaidPrincipalBalanceOfAnyJuniorLiens; } set { _unpaidPrincipalBalanceOfAnyJuniorLiens = value; } }
-        private Value<decimal?> _unpaidPrincipalBalanceOfPurchaseJuniorLiens;
+        private DirtyValue<decimal?> _unpaidPrincipalBalanceOfPurchaseJuniorLiens;
         public decimal? UnpaidPrincipalBalanceOfPurchaseJuniorLiens { get { return _unpaidPrincipalBalanceOfPurchaseJuniorLiens; } set { _unpaidPrincipalBalanceOfPurchaseJuniorLiens = value; } }
-        private Value<decimal?> _valueEstablished;
+        private DirtyValue<decimal?> _valueEstablished;
         public decimal? ValueEstablished { get { return _valueEstablished; } set { _valueEstablished = value; } }
-        private Value<decimal?> _windEnergySystemActualCost;
+        private DirtyValue<decimal?> _windEnergySystemActualCost;
         public decimal? WindEnergySystemActualCost { get { return _windEnergySystemActualCost; } set { _windEnergySystemActualCost = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Income.cs
+++ b/src/EncompassRest/Loans/Income.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Income : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<bool?> _currentIndicator;
+        private DirtyValue<bool?> _currentIndicator;
         public bool? CurrentIndicator { get { return _currentIndicator; } set { _currentIndicator = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _incomeType;
+        private DirtyValue<string> _incomeType;
         public string IncomeType { get { return _incomeType; } set { _incomeType = value; } }
-        private Value<int?> _otherIncomeIndex;
+        private DirtyValue<int?> _otherIncomeIndex;
         public int? OtherIncomeIndex { get { return _otherIncomeIndex; } set { _otherIncomeIndex = value; } }
-        private Value<string> _owner;
+        private DirtyValue<string> _owner;
         public string Owner { get { return _owner; } set { _owner = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/InterimServicing.cs
+++ b/src/EncompassRest/Loans/InterimServicing.cs
@@ -8,307 +8,307 @@ namespace EncompassRest.Loans
 {
     public sealed partial class InterimServicing : IDirty
     {
-        private Value<decimal?> _beginningBalance;
+        private DirtyValue<decimal?> _beginningBalance;
         public decimal? BeginningBalance { get { return _beginningBalance; } set { _beginningBalance = value; } }
-        private Value<string> _borrCellPhoneNumber;
+        private DirtyValue<string> _borrCellPhoneNumber;
         public string BorrCellPhoneNumber { get { return _borrCellPhoneNumber; } set { _borrCellPhoneNumber = value; } }
-        private Value<string> _borrHomeEmail;
+        private DirtyValue<string> _borrHomeEmail;
         public string BorrHomeEmail { get { return _borrHomeEmail; } set { _borrHomeEmail = value; } }
-        private Value<string> _borrHomePhoneNumber;
+        private DirtyValue<string> _borrHomePhoneNumber;
         public string BorrHomePhoneNumber { get { return _borrHomePhoneNumber; } set { _borrHomePhoneNumber = value; } }
-        private Value<string> _borrowerFirstName;
+        private DirtyValue<string> _borrowerFirstName;
         public string BorrowerFirstName { get { return _borrowerFirstName; } set { _borrowerFirstName = value; } }
-        private Value<string> _borrowerLastName;
+        private DirtyValue<string> _borrowerLastName;
         public string BorrowerLastName { get { return _borrowerLastName; } set { _borrowerLastName = value; } }
-        private Value<string> _borrWorkPhoneNumber;
+        private DirtyValue<string> _borrWorkPhoneNumber;
         public string BorrWorkPhoneNumber { get { return _borrWorkPhoneNumber; } set { _borrWorkPhoneNumber = value; } }
-        private Value<string> _calcTriggered;
+        private DirtyValue<string> _calcTriggered;
         public string CalcTriggered { get { return _calcTriggered; } set { _calcTriggered = value; } }
-        private Value<decimal?> _cityInsurance;
+        private DirtyValue<decimal?> _cityInsurance;
         public decimal? CityInsurance { get { return _cityInsurance; } set { _cityInsurance = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<decimal?> _currentPrincipalBalance;
+        private DirtyValue<decimal?> _currentPrincipalBalance;
         public decimal? CurrentPrincipalBalance { get { return _currentPrincipalBalance; } set { _currentPrincipalBalance = value; } }
-        private Value<decimal?> _escrowBalance;
+        private DirtyValue<decimal?> _escrowBalance;
         public decimal? EscrowBalance { get { return _escrowBalance; } set { _escrowBalance = value; } }
         private DirtyList<EscrowDisbursementTransaction> _escrowDisbursementTransactions;
         public IList<EscrowDisbursementTransaction> EscrowDisbursementTransactions { get { var v = _escrowDisbursementTransactions; return v ?? Interlocked.CompareExchange(ref _escrowDisbursementTransactions, (v = new DirtyList<EscrowDisbursementTransaction>()), null) ?? v; } set { _escrowDisbursementTransactions = new DirtyList<EscrowDisbursementTransaction>(value); } }
         private DirtyList<EscrowInterestTransaction> _escrowInterestTransactions;
         public IList<EscrowInterestTransaction> EscrowInterestTransactions { get { var v = _escrowInterestTransactions; return v ?? Interlocked.CompareExchange(ref _escrowInterestTransactions, (v = new DirtyList<EscrowInterestTransaction>()), null) ?? v; } set { _escrowInterestTransactions = new DirtyList<EscrowInterestTransaction>(value); } }
-        private Value<decimal?> _floodInsurance;
+        private DirtyValue<decimal?> _floodInsurance;
         public decimal? FloodInsurance { get { return _floodInsurance; } set { _floodInsurance = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private DirtyList<InterimServicingTransaction> _interimServicingTransactions;
         public IList<InterimServicingTransaction> InterimServicingTransactions { get { var v = _interimServicingTransactions; return v ?? Interlocked.CompareExchange(ref _interimServicingTransactions, (v = new DirtyList<InterimServicingTransaction>()), null) ?? v; } set { _interimServicingTransactions = new DirtyList<InterimServicingTransaction>(value); } }
-        private Value<decimal?> _lastPaymentAdditionalEscrow;
+        private DirtyValue<decimal?> _lastPaymentAdditionalEscrow;
         public decimal? LastPaymentAdditionalEscrow { get { return _lastPaymentAdditionalEscrow; } set { _lastPaymentAdditionalEscrow = value; } }
-        private Value<decimal?> _lastPaymentAdditionalPrincipal;
+        private DirtyValue<decimal?> _lastPaymentAdditionalPrincipal;
         public decimal? LastPaymentAdditionalPrincipal { get { return _lastPaymentAdditionalPrincipal; } set { _lastPaymentAdditionalPrincipal = value; } }
-        private Value<decimal?> _lastPaymentBuydownSubsidyAmount;
+        private DirtyValue<decimal?> _lastPaymentBuydownSubsidyAmount;
         public decimal? LastPaymentBuydownSubsidyAmount { get { return _lastPaymentBuydownSubsidyAmount; } set { _lastPaymentBuydownSubsidyAmount = value; } }
-        private Value<decimal?> _lastPaymentEscrowAmount;
+        private DirtyValue<decimal?> _lastPaymentEscrowAmount;
         public decimal? LastPaymentEscrowAmount { get { return _lastPaymentEscrowAmount; } set { _lastPaymentEscrowAmount = value; } }
-        private Value<decimal?> _lastPaymentEscrowCityPropertyTax;
+        private DirtyValue<decimal?> _lastPaymentEscrowCityPropertyTax;
         public decimal? LastPaymentEscrowCityPropertyTax { get { return _lastPaymentEscrowCityPropertyTax; } set { _lastPaymentEscrowCityPropertyTax = value; } }
-        private Value<decimal?> _lastPaymentEscrowFloodInsurance;
+        private DirtyValue<decimal?> _lastPaymentEscrowFloodInsurance;
         public decimal? LastPaymentEscrowFloodInsurance { get { return _lastPaymentEscrowFloodInsurance; } set { _lastPaymentEscrowFloodInsurance = value; } }
-        private Value<decimal?> _lastPaymentEscrowHazardInsurance;
+        private DirtyValue<decimal?> _lastPaymentEscrowHazardInsurance;
         public decimal? LastPaymentEscrowHazardInsurance { get { return _lastPaymentEscrowHazardInsurance; } set { _lastPaymentEscrowHazardInsurance = value; } }
-        private Value<decimal?> _lastPaymentEscrowMortgageInsurance;
+        private DirtyValue<decimal?> _lastPaymentEscrowMortgageInsurance;
         public decimal? LastPaymentEscrowMortgageInsurance { get { return _lastPaymentEscrowMortgageInsurance; } set { _lastPaymentEscrowMortgageInsurance = value; } }
-        private Value<decimal?> _lastPaymentEscrowOther1;
+        private DirtyValue<decimal?> _lastPaymentEscrowOther1;
         public decimal? LastPaymentEscrowOther1 { get { return _lastPaymentEscrowOther1; } set { _lastPaymentEscrowOther1 = value; } }
-        private Value<decimal?> _lastPaymentEscrowOther2;
+        private DirtyValue<decimal?> _lastPaymentEscrowOther2;
         public decimal? LastPaymentEscrowOther2 { get { return _lastPaymentEscrowOther2; } set { _lastPaymentEscrowOther2 = value; } }
-        private Value<decimal?> _lastPaymentEscrowOther3;
+        private DirtyValue<decimal?> _lastPaymentEscrowOther3;
         public decimal? LastPaymentEscrowOther3 { get { return _lastPaymentEscrowOther3; } set { _lastPaymentEscrowOther3 = value; } }
-        private Value<decimal?> _lastPaymentEscrowTax;
+        private DirtyValue<decimal?> _lastPaymentEscrowTax;
         public decimal? LastPaymentEscrowTax { get { return _lastPaymentEscrowTax; } set { _lastPaymentEscrowTax = value; } }
-        private Value<decimal?> _lastPaymentEscrowUSDAMonthlyPremium;
+        private DirtyValue<decimal?> _lastPaymentEscrowUSDAMonthlyPremium;
         public decimal? LastPaymentEscrowUSDAMonthlyPremium { get { return _lastPaymentEscrowUSDAMonthlyPremium; } set { _lastPaymentEscrowUSDAMonthlyPremium = value; } }
-        private Value<string> _lastPaymentGuid;
+        private DirtyValue<string> _lastPaymentGuid;
         public string LastPaymentGuid { get { return _lastPaymentGuid; } set { _lastPaymentGuid = value; } }
-        private Value<decimal?> _lastPaymentInterest;
+        private DirtyValue<decimal?> _lastPaymentInterest;
         public decimal? LastPaymentInterest { get { return _lastPaymentInterest; } set { _lastPaymentInterest = value; } }
-        private Value<decimal?> _lastPaymentLateFee;
+        private DirtyValue<decimal?> _lastPaymentLateFee;
         public decimal? LastPaymentLateFee { get { return _lastPaymentLateFee; } set { _lastPaymentLateFee = value; } }
-        private Value<decimal?> _lastPaymentMiscFee;
+        private DirtyValue<decimal?> _lastPaymentMiscFee;
         public decimal? LastPaymentMiscFee { get { return _lastPaymentMiscFee; } set { _lastPaymentMiscFee = value; } }
-        private Value<int?> _lastPaymentNumber;
+        private DirtyValue<int?> _lastPaymentNumber;
         public int? LastPaymentNumber { get { return _lastPaymentNumber; } set { _lastPaymentNumber = value; } }
-        private Value<decimal?> _lastPaymentPrincipal;
+        private DirtyValue<decimal?> _lastPaymentPrincipal;
         public decimal? LastPaymentPrincipal { get { return _lastPaymentPrincipal; } set { _lastPaymentPrincipal = value; } }
-        private Value<decimal?> _lastPaymentPrincipalAndInterest;
+        private DirtyValue<decimal?> _lastPaymentPrincipalAndInterest;
         public decimal? LastPaymentPrincipalAndInterest { get { return _lastPaymentPrincipalAndInterest; } set { _lastPaymentPrincipalAndInterest = value; } }
-        private Value<DateTime?> _lastPaymentReceivedDate;
+        private DirtyValue<DateTime?> _lastPaymentReceivedDate;
         public DateTime? LastPaymentReceivedDate { get { return _lastPaymentReceivedDate; } set { _lastPaymentReceivedDate = value; } }
-        private Value<DateTime?> _lastPaymentStatementDate;
+        private DirtyValue<DateTime?> _lastPaymentStatementDate;
         public DateTime? LastPaymentStatementDate { get { return _lastPaymentStatementDate; } set { _lastPaymentStatementDate = value; } }
-        private Value<decimal?> _lastPaymentTotalAmountReceived;
+        private DirtyValue<decimal?> _lastPaymentTotalAmountReceived;
         public decimal? LastPaymentTotalAmountReceived { get { return _lastPaymentTotalAmountReceived; } set { _lastPaymentTotalAmountReceived = value; } }
         private SchedulePaymentTransaction _lastScheduledPayment;
         public SchedulePaymentTransaction LastScheduledPayment { get { var v = _lastScheduledPayment; return v ?? Interlocked.CompareExchange(ref _lastScheduledPayment, (v = new SchedulePaymentTransaction()), null) ?? v; } set { _lastScheduledPayment = value; } }
-        private Value<DateTime?> _lastStatementPrintedDate;
+        private DirtyValue<DateTime?> _lastStatementPrintedDate;
         public DateTime? LastStatementPrintedDate { get { return _lastStatementPrintedDate; } set { _lastStatementPrintedDate = value; } }
-        private Value<string> _loanSnapshotXml;
+        private DirtyValue<string> _loanSnapshotXml;
         public string LoanSnapshotXml { get { return _loanSnapshotXml; } set { _loanSnapshotXml = value; } }
-        private Value<string> _mailingCity;
+        private DirtyValue<string> _mailingCity;
         public string MailingCity { get { return _mailingCity; } set { _mailingCity = value; } }
-        private Value<string> _mailingPostalCode;
+        private DirtyValue<string> _mailingPostalCode;
         public string MailingPostalCode { get { return _mailingPostalCode; } set { _mailingPostalCode = value; } }
-        private Value<string> _mailingState;
+        private DirtyValue<string> _mailingState;
         public string MailingState { get { return _mailingState; } set { _mailingState = value; } }
-        private Value<string> _mailingStreetAddress;
+        private DirtyValue<string> _mailingStreetAddress;
         public string MailingStreetAddress { get { return _mailingStreetAddress; } set { _mailingStreetAddress = value; } }
-        private Value<string> _mortgageAccount;
+        private DirtyValue<string> _mortgageAccount;
         public string MortgageAccount { get { return _mortgageAccount; } set { _mortgageAccount = value; } }
-        private Value<decimal?> _nextEscrowTotalFloodInsurance;
+        private DirtyValue<decimal?> _nextEscrowTotalFloodInsurance;
         public decimal? NextEscrowTotalFloodInsurance { get { return _nextEscrowTotalFloodInsurance; } set { _nextEscrowTotalFloodInsurance = value; } }
-        private Value<DateTime?> _nextEscrowTotalFloodInsuranceDueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalFloodInsuranceDueDate;
         public DateTime? NextEscrowTotalFloodInsuranceDueDate { get { return _nextEscrowTotalFloodInsuranceDueDate; } set { _nextEscrowTotalFloodInsuranceDueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalHazardInsurance;
+        private DirtyValue<decimal?> _nextEscrowTotalHazardInsurance;
         public decimal? NextEscrowTotalHazardInsurance { get { return _nextEscrowTotalHazardInsurance; } set { _nextEscrowTotalHazardInsurance = value; } }
-        private Value<DateTime?> _nextEscrowTotalHazardInsuranceDueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalHazardInsuranceDueDate;
         public DateTime? NextEscrowTotalHazardInsuranceDueDate { get { return _nextEscrowTotalHazardInsuranceDueDate; } set { _nextEscrowTotalHazardInsuranceDueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalMortgageInsurance;
+        private DirtyValue<decimal?> _nextEscrowTotalMortgageInsurance;
         public decimal? NextEscrowTotalMortgageInsurance { get { return _nextEscrowTotalMortgageInsurance; } set { _nextEscrowTotalMortgageInsurance = value; } }
-        private Value<DateTime?> _nextEscrowTotalMortgageInsuranceDueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalMortgageInsuranceDueDate;
         public DateTime? NextEscrowTotalMortgageInsuranceDueDate { get { return _nextEscrowTotalMortgageInsuranceDueDate; } set { _nextEscrowTotalMortgageInsuranceDueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalOtherTax1;
+        private DirtyValue<decimal?> _nextEscrowTotalOtherTax1;
         public decimal? NextEscrowTotalOtherTax1 { get { return _nextEscrowTotalOtherTax1; } set { _nextEscrowTotalOtherTax1 = value; } }
-        private Value<DateTime?> _nextEscrowTotalOtherTax1DueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalOtherTax1DueDate;
         public DateTime? NextEscrowTotalOtherTax1DueDate { get { return _nextEscrowTotalOtherTax1DueDate; } set { _nextEscrowTotalOtherTax1DueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalOtherTax2;
+        private DirtyValue<decimal?> _nextEscrowTotalOtherTax2;
         public decimal? NextEscrowTotalOtherTax2 { get { return _nextEscrowTotalOtherTax2; } set { _nextEscrowTotalOtherTax2 = value; } }
-        private Value<DateTime?> _nextEscrowTotalOtherTax2DueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalOtherTax2DueDate;
         public DateTime? NextEscrowTotalOtherTax2DueDate { get { return _nextEscrowTotalOtherTax2DueDate; } set { _nextEscrowTotalOtherTax2DueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalOtherTax3;
+        private DirtyValue<decimal?> _nextEscrowTotalOtherTax3;
         public decimal? NextEscrowTotalOtherTax3 { get { return _nextEscrowTotalOtherTax3; } set { _nextEscrowTotalOtherTax3 = value; } }
-        private Value<DateTime?> _nextEscrowTotalOtherTax3DueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalOtherTax3DueDate;
         public DateTime? NextEscrowTotalOtherTax3DueDate { get { return _nextEscrowTotalOtherTax3DueDate; } set { _nextEscrowTotalOtherTax3DueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalPropertyTax;
+        private DirtyValue<decimal?> _nextEscrowTotalPropertyTax;
         public decimal? NextEscrowTotalPropertyTax { get { return _nextEscrowTotalPropertyTax; } set { _nextEscrowTotalPropertyTax = value; } }
-        private Value<DateTime?> _nextEscrowTotalPropertyTaxDueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalPropertyTaxDueDate;
         public DateTime? NextEscrowTotalPropertyTaxDueDate { get { return _nextEscrowTotalPropertyTaxDueDate; } set { _nextEscrowTotalPropertyTaxDueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalTax;
+        private DirtyValue<decimal?> _nextEscrowTotalTax;
         public decimal? NextEscrowTotalTax { get { return _nextEscrowTotalTax; } set { _nextEscrowTotalTax = value; } }
-        private Value<DateTime?> _nextEscrowTotalTaxDueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalTaxDueDate;
         public DateTime? NextEscrowTotalTaxDueDate { get { return _nextEscrowTotalTaxDueDate; } set { _nextEscrowTotalTaxDueDate = value; } }
-        private Value<decimal?> _nextEscrowTotalUsdaMonthlyPremium;
+        private DirtyValue<decimal?> _nextEscrowTotalUsdaMonthlyPremium;
         public decimal? NextEscrowTotalUsdaMonthlyPremium { get { return _nextEscrowTotalUsdaMonthlyPremium; } set { _nextEscrowTotalUsdaMonthlyPremium = value; } }
-        private Value<DateTime?> _nextEscrowTotalUsdaMonthlyPremiumDueDate;
+        private DirtyValue<DateTime?> _nextEscrowTotalUsdaMonthlyPremiumDueDate;
         public DateTime? NextEscrowTotalUsdaMonthlyPremiumDueDate { get { return _nextEscrowTotalUsdaMonthlyPremiumDueDate; } set { _nextEscrowTotalUsdaMonthlyPremiumDueDate = value; } }
-        private Value<decimal?> _nextPaymentBuydownSubsidyAmount;
+        private DirtyValue<decimal?> _nextPaymentBuydownSubsidyAmount;
         public decimal? NextPaymentBuydownSubsidyAmount { get { return _nextPaymentBuydownSubsidyAmount; } set { _nextPaymentBuydownSubsidyAmount = value; } }
-        private Value<decimal?> _nextPaymentEscrowAmount;
+        private DirtyValue<decimal?> _nextPaymentEscrowAmount;
         public decimal? NextPaymentEscrowAmount { get { return _nextPaymentEscrowAmount; } set { _nextPaymentEscrowAmount = value; } }
-        private Value<decimal?> _nextPaymentEscrowCityPropertyTax;
+        private DirtyValue<decimal?> _nextPaymentEscrowCityPropertyTax;
         public decimal? NextPaymentEscrowCityPropertyTax { get { return _nextPaymentEscrowCityPropertyTax; } set { _nextPaymentEscrowCityPropertyTax = value; } }
-        private Value<decimal?> _nextPaymentEscrowFloodInsurance;
+        private DirtyValue<decimal?> _nextPaymentEscrowFloodInsurance;
         public decimal? NextPaymentEscrowFloodInsurance { get { return _nextPaymentEscrowFloodInsurance; } set { _nextPaymentEscrowFloodInsurance = value; } }
-        private Value<decimal?> _nextPaymentEscrowHazardInsurance;
+        private DirtyValue<decimal?> _nextPaymentEscrowHazardInsurance;
         public decimal? NextPaymentEscrowHazardInsurance { get { return _nextPaymentEscrowHazardInsurance; } set { _nextPaymentEscrowHazardInsurance = value; } }
-        private Value<decimal?> _nextPaymentEscrowMortgageInsurance;
+        private DirtyValue<decimal?> _nextPaymentEscrowMortgageInsurance;
         public decimal? NextPaymentEscrowMortgageInsurance { get { return _nextPaymentEscrowMortgageInsurance; } set { _nextPaymentEscrowMortgageInsurance = value; } }
-        private Value<decimal?> _nextPaymentEscrowOther1;
+        private DirtyValue<decimal?> _nextPaymentEscrowOther1;
         public decimal? NextPaymentEscrowOther1 { get { return _nextPaymentEscrowOther1; } set { _nextPaymentEscrowOther1 = value; } }
-        private Value<decimal?> _nextPaymentEscrowOther2;
+        private DirtyValue<decimal?> _nextPaymentEscrowOther2;
         public decimal? NextPaymentEscrowOther2 { get { return _nextPaymentEscrowOther2; } set { _nextPaymentEscrowOther2 = value; } }
-        private Value<decimal?> _nextPaymentEscrowOther3;
+        private DirtyValue<decimal?> _nextPaymentEscrowOther3;
         public decimal? NextPaymentEscrowOther3 { get { return _nextPaymentEscrowOther3; } set { _nextPaymentEscrowOther3 = value; } }
-        private Value<decimal?> _nextPaymentEscrowTax;
+        private DirtyValue<decimal?> _nextPaymentEscrowTax;
         public decimal? NextPaymentEscrowTax { get { return _nextPaymentEscrowTax; } set { _nextPaymentEscrowTax = value; } }
-        private Value<decimal?> _nextPaymentEscrowUSDAMonthlyPremium;
+        private DirtyValue<decimal?> _nextPaymentEscrowUSDAMonthlyPremium;
         public decimal? NextPaymentEscrowUSDAMonthlyPremium { get { return _nextPaymentEscrowUSDAMonthlyPremium; } set { _nextPaymentEscrowUSDAMonthlyPremium = value; } }
-        private Value<decimal?> _nextPaymentIndexCurrentValuePercent;
+        private DirtyValue<decimal?> _nextPaymentIndexCurrentValuePercent;
         public decimal? NextPaymentIndexCurrentValuePercent { get { return _nextPaymentIndexCurrentValuePercent; } set { _nextPaymentIndexCurrentValuePercent = value; } }
-        private Value<decimal?> _nextPaymentInterest;
+        private DirtyValue<decimal?> _nextPaymentInterest;
         public decimal? NextPaymentInterest { get { return _nextPaymentInterest; } set { _nextPaymentInterest = value; } }
-        private Value<decimal?> _nextPaymentLateFee;
+        private DirtyValue<decimal?> _nextPaymentLateFee;
         public decimal? NextPaymentLateFee { get { return _nextPaymentLateFee; } set { _nextPaymentLateFee = value; } }
-        private Value<DateTime?> _nextPaymentLatePaymentDate;
+        private DirtyValue<DateTime?> _nextPaymentLatePaymentDate;
         public DateTime? NextPaymentLatePaymentDate { get { return _nextPaymentLatePaymentDate; } set { _nextPaymentLatePaymentDate = value; } }
-        private Value<decimal?> _nextPaymentMiscFee;
+        private DirtyValue<decimal?> _nextPaymentMiscFee;
         public decimal? NextPaymentMiscFee { get { return _nextPaymentMiscFee; } set { _nextPaymentMiscFee = value; } }
-        private Value<decimal?> _nextPaymentPastDueAmount;
+        private DirtyValue<decimal?> _nextPaymentPastDueAmount;
         public decimal? NextPaymentPastDueAmount { get { return _nextPaymentPastDueAmount; } set { _nextPaymentPastDueAmount = value; } }
-        private Value<DateTime?> _nextPaymentPaymentDueDate;
+        private DirtyValue<DateTime?> _nextPaymentPaymentDueDate;
         public DateTime? NextPaymentPaymentDueDate { get { return _nextPaymentPaymentDueDate; } set { _nextPaymentPaymentDueDate = value; } }
-        private Value<DateTime?> _nextPaymentPaymentIndexDate;
+        private DirtyValue<DateTime?> _nextPaymentPaymentIndexDate;
         public DateTime? NextPaymentPaymentIndexDate { get { return _nextPaymentPaymentIndexDate; } set { _nextPaymentPaymentIndexDate = value; } }
-        private Value<decimal?> _nextPaymentPrincipal;
+        private DirtyValue<decimal?> _nextPaymentPrincipal;
         public decimal? NextPaymentPrincipal { get { return _nextPaymentPrincipal; } set { _nextPaymentPrincipal = value; } }
-        private Value<decimal?> _nextPaymentPrincipalAndInterest;
+        private DirtyValue<decimal?> _nextPaymentPrincipalAndInterest;
         public decimal? NextPaymentPrincipalAndInterest { get { return _nextPaymentPrincipalAndInterest; } set { _nextPaymentPrincipalAndInterest = value; } }
-        private Value<decimal?> _nextPaymentRequestedInterestRatePercent;
+        private DirtyValue<decimal?> _nextPaymentRequestedInterestRatePercent;
         public decimal? NextPaymentRequestedInterestRatePercent { get { return _nextPaymentRequestedInterestRatePercent; } set { _nextPaymentRequestedInterestRatePercent = value; } }
-        private Value<DateTime?> _nextPaymentStatementDueDate;
+        private DirtyValue<DateTime?> _nextPaymentStatementDueDate;
         public DateTime? NextPaymentStatementDueDate { get { return _nextPaymentStatementDueDate; } set { _nextPaymentStatementDueDate = value; } }
-        private Value<decimal?> _nextPaymentTotalAmountDue;
+        private DirtyValue<decimal?> _nextPaymentTotalAmountDue;
         public decimal? NextPaymentTotalAmountDue { get { return _nextPaymentTotalAmountDue; } set { _nextPaymentTotalAmountDue = value; } }
-        private Value<decimal?> _nextPaymentTotalAmountWithLateFee;
+        private DirtyValue<decimal?> _nextPaymentTotalAmountWithLateFee;
         public decimal? NextPaymentTotalAmountWithLateFee { get { return _nextPaymentTotalAmountWithLateFee; } set { _nextPaymentTotalAmountWithLateFee = value; } }
-        private Value<decimal?> _nextPaymentUnpaidLateFee;
+        private DirtyValue<decimal?> _nextPaymentUnpaidLateFee;
         public decimal? NextPaymentUnpaidLateFee { get { return _nextPaymentUnpaidLateFee; } set { _nextPaymentUnpaidLateFee = value; } }
         private SchedulePaymentTransaction _nextScheduledPayment;
         public SchedulePaymentTransaction NextScheduledPayment { get { var v = _nextScheduledPayment; return v ?? Interlocked.CompareExchange(ref _nextScheduledPayment, (v = new SchedulePaymentTransaction()), null) ?? v; } set { _nextScheduledPayment = value; } }
-        private Value<int?> _numberOfDisbursement;
+        private DirtyValue<int?> _numberOfDisbursement;
         public int? NumberOfDisbursement { get { return _numberOfDisbursement; } set { _numberOfDisbursement = value; } }
         private DirtyList<OtherTransaction> _otherTransactions;
         public IList<OtherTransaction> OtherTransactions { get { var v = _otherTransactions; return v ?? Interlocked.CompareExchange(ref _otherTransactions, (v = new DirtyList<OtherTransaction>()), null) ?? v; } set { _otherTransactions = new DirtyList<OtherTransaction>(value); } }
-        private Value<DateTime?> _paymentDueDatePrinted;
+        private DirtyValue<DateTime?> _paymentDueDatePrinted;
         public DateTime? PaymentDueDatePrinted { get { return _paymentDueDatePrinted; } set { _paymentDueDatePrinted = value; } }
         private DirtyList<PaymentReversalTransaction> _paymentReversalTransactions;
         public IList<PaymentReversalTransaction> PaymentReversalTransactions { get { var v = _paymentReversalTransactions; return v ?? Interlocked.CompareExchange(ref _paymentReversalTransactions, (v = new DirtyList<PaymentReversalTransaction>()), null) ?? v; } set { _paymentReversalTransactions = new DirtyList<PaymentReversalTransaction>(value); } }
         private DirtyList<PaymentTransaction> _paymentTransactions;
         public IList<PaymentTransaction> PaymentTransactions { get { var v = _paymentTransactions; return v ?? Interlocked.CompareExchange(ref _paymentTransactions, (v = new DirtyList<PaymentTransaction>()), null) ?? v; } set { _paymentTransactions = new DirtyList<PaymentTransaction>(value); } }
-        private Value<string> _printedByUserId;
+        private DirtyValue<string> _printedByUserId;
         public string PrintedByUserId { get { return _printedByUserId; } set { _printedByUserId = value; } }
-        private Value<string> _printedByUserName;
+        private DirtyValue<string> _printedByUserName;
         public string PrintedByUserName { get { return _printedByUserName; } set { _printedByUserName = value; } }
-        private Value<decimal?> _purchasedPrincipal;
+        private DirtyValue<decimal?> _purchasedPrincipal;
         public decimal? PurchasedPrincipal { get { return _purchasedPrincipal; } set { _purchasedPrincipal = value; } }
         private DirtyList<SchedulePaymentTransaction> _scheduledPayments;
         public IList<SchedulePaymentTransaction> ScheduledPayments { get { var v = _scheduledPayments; return v ?? Interlocked.CompareExchange(ref _scheduledPayments, (v = new DirtyList<SchedulePaymentTransaction>()), null) ?? v; } set { _scheduledPayments = new DirtyList<SchedulePaymentTransaction>(value); } }
         private DirtyList<SchedulePaymentTransaction> _schedulePaymentTransactions;
         public IList<SchedulePaymentTransaction> SchedulePaymentTransactions { get { var v = _schedulePaymentTransactions; return v ?? Interlocked.CompareExchange(ref _schedulePaymentTransactions, (v = new DirtyList<SchedulePaymentTransaction>()), null) ?? v; } set { _schedulePaymentTransactions = new DirtyList<SchedulePaymentTransaction>(value); } }
-        private Value<string> _servicerLoanNumber;
+        private DirtyValue<string> _servicerLoanNumber;
         public string ServicerLoanNumber { get { return _servicerLoanNumber; } set { _servicerLoanNumber = value; } }
-        private Value<string> _servicingStatus;
+        private DirtyValue<string> _servicingStatus;
         public string ServicingStatus { get { return _servicingStatus; } set { _servicingStatus = value; } }
-        private Value<DateTime?> _servicingTransferDate;
+        private DirtyValue<DateTime?> _servicingTransferDate;
         public DateTime? ServicingTransferDate { get { return _servicingTransferDate; } set { _servicingTransferDate = value; } }
-        private Value<string> _subServicer;
+        private DirtyValue<string> _subServicer;
         public string SubServicer { get { return _subServicer; } set { _subServicer = value; } }
-        private Value<string> _subServicerLoanNumber;
+        private DirtyValue<string> _subServicerLoanNumber;
         public string SubServicerLoanNumber { get { return _subServicerLoanNumber; } set { _subServicerLoanNumber = value; } }
-        private Value<decimal?> _totalAdditionalEscrow;
+        private DirtyValue<decimal?> _totalAdditionalEscrow;
         public decimal? TotalAdditionalEscrow { get { return _totalAdditionalEscrow; } set { _totalAdditionalEscrow = value; } }
-        private Value<decimal?> _totalAdditionalEscrowYearToDate;
+        private DirtyValue<decimal?> _totalAdditionalEscrowYearToDate;
         public decimal? TotalAdditionalEscrowYearToDate { get { return _totalAdditionalEscrowYearToDate; } set { _totalAdditionalEscrowYearToDate = value; } }
-        private Value<decimal?> _totalAdditionalPrincipal;
+        private DirtyValue<decimal?> _totalAdditionalPrincipal;
         public decimal? TotalAdditionalPrincipal { get { return _totalAdditionalPrincipal; } set { _totalAdditionalPrincipal = value; } }
-        private Value<decimal?> _totalAdditionalPrincipalYearToDate;
+        private DirtyValue<decimal?> _totalAdditionalPrincipalYearToDate;
         public decimal? TotalAdditionalPrincipalYearToDate { get { return _totalAdditionalPrincipalYearToDate; } set { _totalAdditionalPrincipalYearToDate = value; } }
-        private Value<decimal?> _totalAmountDisbursed;
+        private DirtyValue<decimal?> _totalAmountDisbursed;
         public decimal? TotalAmountDisbursed { get { return _totalAmountDisbursed; } set { _totalAmountDisbursed = value; } }
-        private Value<decimal?> _totalBuydownSubsidyAmount;
+        private DirtyValue<decimal?> _totalBuydownSubsidyAmount;
         public decimal? TotalBuydownSubsidyAmount { get { return _totalBuydownSubsidyAmount; } set { _totalBuydownSubsidyAmount = value; } }
-        private Value<decimal?> _totalBuydownSubsidyAmountYearToDate;
+        private DirtyValue<decimal?> _totalBuydownSubsidyAmountYearToDate;
         public decimal? TotalBuydownSubsidyAmountYearToDate { get { return _totalBuydownSubsidyAmountYearToDate; } set { _totalBuydownSubsidyAmountYearToDate = value; } }
-        private Value<decimal?> _totalEscrow;
+        private DirtyValue<decimal?> _totalEscrow;
         public decimal? TotalEscrow { get { return _totalEscrow; } set { _totalEscrow = value; } }
-        private Value<decimal?> _totalEscrowYearToDate;
+        private DirtyValue<decimal?> _totalEscrowYearToDate;
         public decimal? TotalEscrowYearToDate { get { return _totalEscrowYearToDate; } set { _totalEscrowYearToDate = value; } }
-        private Value<decimal?> _totalHazardInsurance;
+        private DirtyValue<decimal?> _totalHazardInsurance;
         public decimal? TotalHazardInsurance { get { return _totalHazardInsurance; } set { _totalHazardInsurance = value; } }
-        private Value<decimal?> _totalInterest;
+        private DirtyValue<decimal?> _totalInterest;
         public decimal? TotalInterest { get { return _totalInterest; } set { _totalInterest = value; } }
-        private Value<decimal?> _totalInterestYearToDate;
+        private DirtyValue<decimal?> _totalInterestYearToDate;
         public decimal? TotalInterestYearToDate { get { return _totalInterestYearToDate; } set { _totalInterestYearToDate = value; } }
-        private Value<decimal?> _totalLateFee;
+        private DirtyValue<decimal?> _totalLateFee;
         public decimal? TotalLateFee { get { return _totalLateFee; } set { _totalLateFee = value; } }
-        private Value<decimal?> _totalLateFeeYearToDate;
+        private DirtyValue<decimal?> _totalLateFeeYearToDate;
         public decimal? TotalLateFeeYearToDate { get { return _totalLateFeeYearToDate; } set { _totalLateFeeYearToDate = value; } }
-        private Value<decimal?> _totalMiscFee;
+        private DirtyValue<decimal?> _totalMiscFee;
         public decimal? TotalMiscFee { get { return _totalMiscFee; } set { _totalMiscFee = value; } }
-        private Value<decimal?> _totalMiscFeeYearToDate;
+        private DirtyValue<decimal?> _totalMiscFeeYearToDate;
         public decimal? TotalMiscFeeYearToDate { get { return _totalMiscFeeYearToDate; } set { _totalMiscFeeYearToDate = value; } }
-        private Value<decimal?> _totalMortgageInsurance;
+        private DirtyValue<decimal?> _totalMortgageInsurance;
         public decimal? TotalMortgageInsurance { get { return _totalMortgageInsurance; } set { _totalMortgageInsurance = value; } }
-        private Value<int?> _totalNumberOfLatePayment;
+        private DirtyValue<int?> _totalNumberOfLatePayment;
         public int? TotalNumberOfLatePayment { get { return _totalNumberOfLatePayment; } set { _totalNumberOfLatePayment = value; } }
-        private Value<int?> _totalNumberOfPayment;
+        private DirtyValue<int?> _totalNumberOfPayment;
         public int? TotalNumberOfPayment { get { return _totalNumberOfPayment; } set { _totalNumberOfPayment = value; } }
-        private Value<decimal?> _totalOtherTaxes;
+        private DirtyValue<decimal?> _totalOtherTaxes;
         public decimal? TotalOtherTaxes { get { return _totalOtherTaxes; } set { _totalOtherTaxes = value; } }
-        private Value<decimal?> _totalPAndI;
+        private DirtyValue<decimal?> _totalPAndI;
         public decimal? TotalPAndI { get { return _totalPAndI; } set { _totalPAndI = value; } }
-        private Value<decimal?> _totalPAndIYearToDate;
+        private DirtyValue<decimal?> _totalPAndIYearToDate;
         public decimal? TotalPAndIYearToDate { get { return _totalPAndIYearToDate; } set { _totalPAndIYearToDate = value; } }
-        private Value<decimal?> _totalPaymentCollected;
+        private DirtyValue<decimal?> _totalPaymentCollected;
         public decimal? TotalPaymentCollected { get { return _totalPaymentCollected; } set { _totalPaymentCollected = value; } }
-        private Value<decimal?> _totalPaymentCollectedYearToDate;
+        private DirtyValue<decimal?> _totalPaymentCollectedYearToDate;
         public decimal? TotalPaymentCollectedYearToDate { get { return _totalPaymentCollectedYearToDate; } set { _totalPaymentCollectedYearToDate = value; } }
-        private Value<decimal?> _totalPrincipal;
+        private DirtyValue<decimal?> _totalPrincipal;
         public decimal? TotalPrincipal { get { return _totalPrincipal; } set { _totalPrincipal = value; } }
-        private Value<decimal?> _totalPrincipalYearToDate;
+        private DirtyValue<decimal?> _totalPrincipalYearToDate;
         public decimal? TotalPrincipalYearToDate { get { return _totalPrincipalYearToDate; } set { _totalPrincipalYearToDate = value; } }
-        private Value<decimal?> _totalTaxes;
+        private DirtyValue<decimal?> _totalTaxes;
         public decimal? TotalTaxes { get { return _totalTaxes; } set { _totalTaxes = value; } }
-        private Value<decimal?> _totalUsdaMonthlyPremium;
+        private DirtyValue<decimal?> _totalUsdaMonthlyPremium;
         public decimal? TotalUsdaMonthlyPremium { get { return _totalUsdaMonthlyPremium; } set { _totalUsdaMonthlyPremium = value; } }
-        private Value<decimal?> _unpaidBuydownSubsidyAmount;
+        private DirtyValue<decimal?> _unpaidBuydownSubsidyAmount;
         public decimal? UnpaidBuydownSubsidyAmount { get { return _unpaidBuydownSubsidyAmount; } set { _unpaidBuydownSubsidyAmount = value; } }
-        private Value<decimal?> _unpaidEscrow;
+        private DirtyValue<decimal?> _unpaidEscrow;
         public decimal? UnpaidEscrow { get { return _unpaidEscrow; } set { _unpaidEscrow = value; } }
-        private Value<decimal?> _unpaidEscrowCityPropertyTax;
+        private DirtyValue<decimal?> _unpaidEscrowCityPropertyTax;
         public decimal? UnpaidEscrowCityPropertyTax { get { return _unpaidEscrowCityPropertyTax; } set { _unpaidEscrowCityPropertyTax = value; } }
-        private Value<decimal?> _unpaidEscrowFloodInsurance;
+        private DirtyValue<decimal?> _unpaidEscrowFloodInsurance;
         public decimal? UnpaidEscrowFloodInsurance { get { return _unpaidEscrowFloodInsurance; } set { _unpaidEscrowFloodInsurance = value; } }
-        private Value<decimal?> _unpaidEscrowHazardInsurance;
+        private DirtyValue<decimal?> _unpaidEscrowHazardInsurance;
         public decimal? UnpaidEscrowHazardInsurance { get { return _unpaidEscrowHazardInsurance; } set { _unpaidEscrowHazardInsurance = value; } }
-        private Value<decimal?> _unpaidEscrowMortgageInsurance;
+        private DirtyValue<decimal?> _unpaidEscrowMortgageInsurance;
         public decimal? UnpaidEscrowMortgageInsurance { get { return _unpaidEscrowMortgageInsurance; } set { _unpaidEscrowMortgageInsurance = value; } }
-        private Value<decimal?> _unpaidEscrowOther1;
+        private DirtyValue<decimal?> _unpaidEscrowOther1;
         public decimal? UnpaidEscrowOther1 { get { return _unpaidEscrowOther1; } set { _unpaidEscrowOther1 = value; } }
-        private Value<decimal?> _unpaidEscrowOther2;
+        private DirtyValue<decimal?> _unpaidEscrowOther2;
         public decimal? UnpaidEscrowOther2 { get { return _unpaidEscrowOther2; } set { _unpaidEscrowOther2 = value; } }
-        private Value<decimal?> _unpaidEscrowOther3;
+        private DirtyValue<decimal?> _unpaidEscrowOther3;
         public decimal? UnpaidEscrowOther3 { get { return _unpaidEscrowOther3; } set { _unpaidEscrowOther3 = value; } }
-        private Value<decimal?> _unpaidEscrowTax;
+        private DirtyValue<decimal?> _unpaidEscrowTax;
         public decimal? UnpaidEscrowTax { get { return _unpaidEscrowTax; } set { _unpaidEscrowTax = value; } }
-        private Value<decimal?> _unpaidEscrowUSDAMonthlyPremium;
+        private DirtyValue<decimal?> _unpaidEscrowUSDAMonthlyPremium;
         public decimal? UnpaidEscrowUSDAMonthlyPremium { get { return _unpaidEscrowUSDAMonthlyPremium; } set { _unpaidEscrowUSDAMonthlyPremium = value; } }
-        private Value<decimal?> _unpaidInterest;
+        private DirtyValue<decimal?> _unpaidInterest;
         public decimal? UnpaidInterest { get { return _unpaidInterest; } set { _unpaidInterest = value; } }
-        private Value<decimal?> _unpaidLateFee;
+        private DirtyValue<decimal?> _unpaidLateFee;
         public decimal? UnpaidLateFee { get { return _unpaidLateFee; } set { _unpaidLateFee = value; } }
-        private Value<decimal?> _unpaidMiscrFee;
+        private DirtyValue<decimal?> _unpaidMiscrFee;
         public decimal? UnpaidMiscrFee { get { return _unpaidMiscrFee; } set { _unpaidMiscrFee = value; } }
-        private Value<decimal?> _unpaidPrincipal;
+        private DirtyValue<decimal?> _unpaidPrincipal;
         public decimal? UnpaidPrincipal { get { return _unpaidPrincipal; } set { _unpaidPrincipal = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/InterimServicing.cs
+++ b/src/EncompassRest/Loans/InterimServicing.cs
@@ -32,16 +32,16 @@ namespace EncompassRest.Loans
         public decimal? CurrentPrincipalBalance { get { return _currentPrincipalBalance; } set { _currentPrincipalBalance = value; } }
         private Value<decimal?> _escrowBalance;
         public decimal? EscrowBalance { get { return _escrowBalance; } set { _escrowBalance = value; } }
-        private Value<List<EscrowDisbursementTransaction>> _escrowDisbursementTransactions;
-        public List<EscrowDisbursementTransaction> EscrowDisbursementTransactions { get { return _escrowDisbursementTransactions; } set { _escrowDisbursementTransactions = value; } }
-        private Value<List<EscrowInterestTransaction>> _escrowInterestTransactions;
-        public List<EscrowInterestTransaction> EscrowInterestTransactions { get { return _escrowInterestTransactions; } set { _escrowInterestTransactions = value; } }
+        private DirtyList<EscrowDisbursementTransaction> _escrowDisbursementTransactions;
+        public IList<EscrowDisbursementTransaction> EscrowDisbursementTransactions { get { var v = _escrowDisbursementTransactions; return v ?? Interlocked.CompareExchange(ref _escrowDisbursementTransactions, (v = new DirtyList<EscrowDisbursementTransaction>()), null) ?? v; } set { _escrowDisbursementTransactions = new DirtyList<EscrowDisbursementTransaction>(value); } }
+        private DirtyList<EscrowInterestTransaction> _escrowInterestTransactions;
+        public IList<EscrowInterestTransaction> EscrowInterestTransactions { get { var v = _escrowInterestTransactions; return v ?? Interlocked.CompareExchange(ref _escrowInterestTransactions, (v = new DirtyList<EscrowInterestTransaction>()), null) ?? v; } set { _escrowInterestTransactions = new DirtyList<EscrowInterestTransaction>(value); } }
         private Value<decimal?> _floodInsurance;
         public decimal? FloodInsurance { get { return _floodInsurance; } set { _floodInsurance = value; } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<List<InterimServicingTransaction>> _interimServicingTransactions;
-        public List<InterimServicingTransaction> InterimServicingTransactions { get { return _interimServicingTransactions; } set { _interimServicingTransactions = value; } }
+        private DirtyList<InterimServicingTransaction> _interimServicingTransactions;
+        public IList<InterimServicingTransaction> InterimServicingTransactions { get { var v = _interimServicingTransactions; return v ?? Interlocked.CompareExchange(ref _interimServicingTransactions, (v = new DirtyList<InterimServicingTransaction>()), null) ?? v; } set { _interimServicingTransactions = new DirtyList<InterimServicingTransaction>(value); } }
         private Value<decimal?> _lastPaymentAdditionalEscrow;
         public decimal? LastPaymentAdditionalEscrow { get { return _lastPaymentAdditionalEscrow; } set { _lastPaymentAdditionalEscrow = value; } }
         private Value<decimal?> _lastPaymentAdditionalPrincipal;
@@ -88,7 +88,8 @@ namespace EncompassRest.Loans
         public DateTime? LastPaymentStatementDate { get { return _lastPaymentStatementDate; } set { _lastPaymentStatementDate = value; } }
         private Value<decimal?> _lastPaymentTotalAmountReceived;
         public decimal? LastPaymentTotalAmountReceived { get { return _lastPaymentTotalAmountReceived; } set { _lastPaymentTotalAmountReceived = value; } }
-        public SchedulePaymentTransaction LastScheduledPayment { get; set; }
+        private SchedulePaymentTransaction _lastScheduledPayment;
+        public SchedulePaymentTransaction LastScheduledPayment { get { var v = _lastScheduledPayment; return v ?? Interlocked.CompareExchange(ref _lastScheduledPayment, (v = new SchedulePaymentTransaction()), null) ?? v; } set { _lastScheduledPayment = value; } }
         private Value<DateTime?> _lastStatementPrintedDate;
         public DateTime? LastStatementPrintedDate { get { return _lastStatementPrintedDate; } set { _lastStatementPrintedDate = value; } }
         private Value<string> _loanSnapshotXml;
@@ -191,27 +192,28 @@ namespace EncompassRest.Loans
         public decimal? NextPaymentTotalAmountWithLateFee { get { return _nextPaymentTotalAmountWithLateFee; } set { _nextPaymentTotalAmountWithLateFee = value; } }
         private Value<decimal?> _nextPaymentUnpaidLateFee;
         public decimal? NextPaymentUnpaidLateFee { get { return _nextPaymentUnpaidLateFee; } set { _nextPaymentUnpaidLateFee = value; } }
-        public SchedulePaymentTransaction NextScheduledPayment { get; set; }
+        private SchedulePaymentTransaction _nextScheduledPayment;
+        public SchedulePaymentTransaction NextScheduledPayment { get { var v = _nextScheduledPayment; return v ?? Interlocked.CompareExchange(ref _nextScheduledPayment, (v = new SchedulePaymentTransaction()), null) ?? v; } set { _nextScheduledPayment = value; } }
         private Value<int?> _numberOfDisbursement;
         public int? NumberOfDisbursement { get { return _numberOfDisbursement; } set { _numberOfDisbursement = value; } }
-        private Value<List<OtherTransaction>> _otherTransactions;
-        public List<OtherTransaction> OtherTransactions { get { return _otherTransactions; } set { _otherTransactions = value; } }
+        private DirtyList<OtherTransaction> _otherTransactions;
+        public IList<OtherTransaction> OtherTransactions { get { var v = _otherTransactions; return v ?? Interlocked.CompareExchange(ref _otherTransactions, (v = new DirtyList<OtherTransaction>()), null) ?? v; } set { _otherTransactions = new DirtyList<OtherTransaction>(value); } }
         private Value<DateTime?> _paymentDueDatePrinted;
         public DateTime? PaymentDueDatePrinted { get { return _paymentDueDatePrinted; } set { _paymentDueDatePrinted = value; } }
-        private Value<List<PaymentReversalTransaction>> _paymentReversalTransactions;
-        public List<PaymentReversalTransaction> PaymentReversalTransactions { get { return _paymentReversalTransactions; } set { _paymentReversalTransactions = value; } }
-        private Value<List<PaymentTransaction>> _paymentTransactions;
-        public List<PaymentTransaction> PaymentTransactions { get { return _paymentTransactions; } set { _paymentTransactions = value; } }
+        private DirtyList<PaymentReversalTransaction> _paymentReversalTransactions;
+        public IList<PaymentReversalTransaction> PaymentReversalTransactions { get { var v = _paymentReversalTransactions; return v ?? Interlocked.CompareExchange(ref _paymentReversalTransactions, (v = new DirtyList<PaymentReversalTransaction>()), null) ?? v; } set { _paymentReversalTransactions = new DirtyList<PaymentReversalTransaction>(value); } }
+        private DirtyList<PaymentTransaction> _paymentTransactions;
+        public IList<PaymentTransaction> PaymentTransactions { get { var v = _paymentTransactions; return v ?? Interlocked.CompareExchange(ref _paymentTransactions, (v = new DirtyList<PaymentTransaction>()), null) ?? v; } set { _paymentTransactions = new DirtyList<PaymentTransaction>(value); } }
         private Value<string> _printedByUserId;
         public string PrintedByUserId { get { return _printedByUserId; } set { _printedByUserId = value; } }
         private Value<string> _printedByUserName;
         public string PrintedByUserName { get { return _printedByUserName; } set { _printedByUserName = value; } }
         private Value<decimal?> _purchasedPrincipal;
         public decimal? PurchasedPrincipal { get { return _purchasedPrincipal; } set { _purchasedPrincipal = value; } }
-        private Value<List<SchedulePaymentTransaction>> _scheduledPayments;
-        public List<SchedulePaymentTransaction> ScheduledPayments { get { return _scheduledPayments; } set { _scheduledPayments = value; } }
-        private Value<List<SchedulePaymentTransaction>> _schedulePaymentTransactions;
-        public List<SchedulePaymentTransaction> SchedulePaymentTransactions { get { return _schedulePaymentTransactions; } set { _schedulePaymentTransactions = value; } }
+        private DirtyList<SchedulePaymentTransaction> _scheduledPayments;
+        public IList<SchedulePaymentTransaction> ScheduledPayments { get { var v = _scheduledPayments; return v ?? Interlocked.CompareExchange(ref _scheduledPayments, (v = new DirtyList<SchedulePaymentTransaction>()), null) ?? v; } set { _scheduledPayments = new DirtyList<SchedulePaymentTransaction>(value); } }
+        private DirtyList<SchedulePaymentTransaction> _schedulePaymentTransactions;
+        public IList<SchedulePaymentTransaction> SchedulePaymentTransactions { get { var v = _schedulePaymentTransactions; return v ?? Interlocked.CompareExchange(ref _schedulePaymentTransactions, (v = new DirtyList<SchedulePaymentTransaction>()), null) ?? v; } set { _schedulePaymentTransactions = new DirtyList<SchedulePaymentTransaction>(value); } }
         private Value<string> _servicerLoanNumber;
         public string ServicerLoanNumber { get { return _servicerLoanNumber; } set { _servicerLoanNumber = value; } }
         private Value<string> _servicingStatus;
@@ -327,11 +329,8 @@ namespace EncompassRest.Loans
                     || _comments.Dirty
                     || _currentPrincipalBalance.Dirty
                     || _escrowBalance.Dirty
-                    || _escrowDisbursementTransactions.Dirty
-                    || _escrowInterestTransactions.Dirty
                     || _floodInsurance.Dirty
                     || _id.Dirty
-                    || _interimServicingTransactions.Dirty
                     || _lastPaymentAdditionalEscrow.Dirty
                     || _lastPaymentAdditionalPrincipal.Dirty
                     || _lastPaymentBuydownSubsidyAmount.Dirty
@@ -407,15 +406,10 @@ namespace EncompassRest.Loans
                     || _nextPaymentTotalAmountWithLateFee.Dirty
                     || _nextPaymentUnpaidLateFee.Dirty
                     || _numberOfDisbursement.Dirty
-                    || _otherTransactions.Dirty
                     || _paymentDueDatePrinted.Dirty
-                    || _paymentReversalTransactions.Dirty
-                    || _paymentTransactions.Dirty
                     || _printedByUserId.Dirty
                     || _printedByUserName.Dirty
                     || _purchasedPrincipal.Dirty
-                    || _scheduledPayments.Dirty
-                    || _schedulePaymentTransactions.Dirty
                     || _servicerLoanNumber.Dirty
                     || _servicingStatus.Dirty
                     || _servicingTransferDate.Dirty
@@ -464,8 +458,16 @@ namespace EncompassRest.Loans
                     || _unpaidLateFee.Dirty
                     || _unpaidMiscrFee.Dirty
                     || _unpaidPrincipal.Dirty
-                    || LastScheduledPayment?.Dirty == true
-                    || NextScheduledPayment?.Dirty == true;
+                    || _escrowDisbursementTransactions?.Dirty == true
+                    || _escrowInterestTransactions?.Dirty == true
+                    || _interimServicingTransactions?.Dirty == true
+                    || _lastScheduledPayment?.Dirty == true
+                    || _nextScheduledPayment?.Dirty == true
+                    || _otherTransactions?.Dirty == true
+                    || _paymentReversalTransactions?.Dirty == true
+                    || _paymentTransactions?.Dirty == true
+                    || _scheduledPayments?.Dirty == true
+                    || _schedulePaymentTransactions?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -484,11 +486,8 @@ namespace EncompassRest.Loans
                 _comments.Dirty = value;
                 _currentPrincipalBalance.Dirty = value;
                 _escrowBalance.Dirty = value;
-                _escrowDisbursementTransactions.Dirty = value;
-                _escrowInterestTransactions.Dirty = value;
                 _floodInsurance.Dirty = value;
                 _id.Dirty = value;
-                _interimServicingTransactions.Dirty = value;
                 _lastPaymentAdditionalEscrow.Dirty = value;
                 _lastPaymentAdditionalPrincipal.Dirty = value;
                 _lastPaymentBuydownSubsidyAmount.Dirty = value;
@@ -564,15 +563,10 @@ namespace EncompassRest.Loans
                 _nextPaymentTotalAmountWithLateFee.Dirty = value;
                 _nextPaymentUnpaidLateFee.Dirty = value;
                 _numberOfDisbursement.Dirty = value;
-                _otherTransactions.Dirty = value;
                 _paymentDueDatePrinted.Dirty = value;
-                _paymentReversalTransactions.Dirty = value;
-                _paymentTransactions.Dirty = value;
                 _printedByUserId.Dirty = value;
                 _printedByUserName.Dirty = value;
                 _purchasedPrincipal.Dirty = value;
-                _scheduledPayments.Dirty = value;
-                _schedulePaymentTransactions.Dirty = value;
                 _servicerLoanNumber.Dirty = value;
                 _servicingStatus.Dirty = value;
                 _servicingTransferDate.Dirty = value;
@@ -621,8 +615,16 @@ namespace EncompassRest.Loans
                 _unpaidLateFee.Dirty = value;
                 _unpaidMiscrFee.Dirty = value;
                 _unpaidPrincipal.Dirty = value;
-                if (LastScheduledPayment != null) LastScheduledPayment.Dirty = value;
-                if (NextScheduledPayment != null) NextScheduledPayment.Dirty = value;
+                if (_escrowDisbursementTransactions != null) _escrowDisbursementTransactions.Dirty = value;
+                if (_escrowInterestTransactions != null) _escrowInterestTransactions.Dirty = value;
+                if (_interimServicingTransactions != null) _interimServicingTransactions.Dirty = value;
+                if (_lastScheduledPayment != null) _lastScheduledPayment.Dirty = value;
+                if (_nextScheduledPayment != null) _nextScheduledPayment.Dirty = value;
+                if (_otherTransactions != null) _otherTransactions.Dirty = value;
+                if (_paymentReversalTransactions != null) _paymentReversalTransactions.Dirty = value;
+                if (_paymentTransactions != null) _paymentTransactions.Dirty = value;
+                if (_scheduledPayments != null) _scheduledPayments.Dirty = value;
+                if (_schedulePaymentTransactions != null) _schedulePaymentTransactions.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/InterimServicingTransaction.cs
+++ b/src/EncompassRest/Loans/InterimServicingTransaction.cs
@@ -8,31 +8,31 @@ namespace EncompassRest.Loans
 {
     public sealed partial class InterimServicingTransaction : IDirty
     {
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Liability.cs
+++ b/src/EncompassRest/Loans/Liability.cs
@@ -8,119 +8,119 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Liability : IDirty
     {
-        private Value<string> _accountIdentifier;
+        private DirtyValue<string> _accountIdentifier;
         public string AccountIdentifier { get { return _accountIdentifier; } set { _accountIdentifier = value; } }
-        private Value<bool?> _accountIndicator;
+        private DirtyValue<bool?> _accountIndicator;
         public bool? AccountIndicator { get { return _accountIndicator; } set { _accountIndicator = value; } }
-        private Value<string> _attention;
+        private DirtyValue<string> _attention;
         public string Attention { get { return _attention; } set { _attention = value; } }
-        private Value<DateTime?> _date;
+        private DirtyValue<DateTime?> _date;
         public DateTime? Date { get { return _date; } set { _date = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _descriptionOfPurpose;
+        private DirtyValue<string> _descriptionOfPurpose;
         public string DescriptionOfPurpose { get { return _descriptionOfPurpose; } set { _descriptionOfPurpose = value; } }
-        private Value<bool?> _entityDeleted;
+        private DirtyValue<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
-        private Value<bool?> _exclusionIndicator;
+        private DirtyValue<bool?> _exclusionIndicator;
         public bool? ExclusionIndicator { get { return _exclusionIndicator; } set { _exclusionIndicator = value; } }
-        private Value<string> _holderAddressCity;
+        private DirtyValue<string> _holderAddressCity;
         public string HolderAddressCity { get { return _holderAddressCity; } set { _holderAddressCity = value; } }
-        private Value<string> _holderAddressPostalCode;
+        private DirtyValue<string> _holderAddressPostalCode;
         public string HolderAddressPostalCode { get { return _holderAddressPostalCode; } set { _holderAddressPostalCode = value; } }
-        private Value<string> _holderAddressState;
+        private DirtyValue<string> _holderAddressState;
         public string HolderAddressState { get { return _holderAddressState; } set { _holderAddressState = value; } }
-        private Value<string> _holderAddressStreetLine1;
+        private DirtyValue<string> _holderAddressStreetLine1;
         public string HolderAddressStreetLine1 { get { return _holderAddressStreetLine1; } set { _holderAddressStreetLine1 = value; } }
-        private Value<string> _holderComments;
+        private DirtyValue<string> _holderComments;
         public string HolderComments { get { return _holderComments; } set { _holderComments = value; } }
-        private Value<string> _holderEmail;
+        private DirtyValue<string> _holderEmail;
         public string HolderEmail { get { return _holderEmail; } set { _holderEmail = value; } }
-        private Value<string> _holderFax;
+        private DirtyValue<string> _holderFax;
         public string HolderFax { get { return _holderFax; } set { _holderFax = value; } }
-        private Value<string> _holderName;
+        private DirtyValue<string> _holderName;
         public string HolderName { get { return _holderName; } set { _holderName = value; } }
-        private Value<string> _holderPhone;
+        private DirtyValue<string> _holderPhone;
         public string HolderPhone { get { return _holderPhone; } set { _holderPhone = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isDebtNotSecuredToSubjectPropertyIndicator;
+        private DirtyValue<bool?> _isDebtNotSecuredToSubjectPropertyIndicator;
         public bool? IsDebtNotSecuredToSubjectPropertyIndicator { get { return _isDebtNotSecuredToSubjectPropertyIndicator; } set { _isDebtNotSecuredToSubjectPropertyIndicator = value; } }
-        private Value<int?> _lates12Month120Day;
+        private DirtyValue<int?> _lates12Month120Day;
         public int? Lates12Month120Day { get { return _lates12Month120Day; } set { _lates12Month120Day = value; } }
-        private Value<int?> _lates12Month150Day;
+        private DirtyValue<int?> _lates12Month150Day;
         public int? Lates12Month150Day { get { return _lates12Month150Day; } set { _lates12Month150Day = value; } }
-        private Value<int?> _lates12Month30Day;
+        private DirtyValue<int?> _lates12Month30Day;
         public int? Lates12Month30Day { get { return _lates12Month30Day; } set { _lates12Month30Day = value; } }
-        private Value<int?> _lates12Month60Day;
+        private DirtyValue<int?> _lates12Month60Day;
         public int? Lates12Month60Day { get { return _lates12Month60Day; } set { _lates12Month60Day = value; } }
-        private Value<int?> _lates12Month90Day;
+        private DirtyValue<int?> _lates12Month90Day;
         public int? Lates12Month90Day { get { return _lates12Month90Day; } set { _lates12Month90Day = value; } }
-        private Value<int?> _lates24Month120Day;
+        private DirtyValue<int?> _lates24Month120Day;
         public int? Lates24Month120Day { get { return _lates24Month120Day; } set { _lates24Month120Day = value; } }
-        private Value<int?> _lates24Month150Day;
+        private DirtyValue<int?> _lates24Month150Day;
         public int? Lates24Month150Day { get { return _lates24Month150Day; } set { _lates24Month150Day = value; } }
-        private Value<int?> _lates24Month30Day;
+        private DirtyValue<int?> _lates24Month30Day;
         public int? Lates24Month30Day { get { return _lates24Month30Day; } set { _lates24Month30Day = value; } }
-        private Value<int?> _lates24Month60Day;
+        private DirtyValue<int?> _lates24Month60Day;
         public int? Lates24Month60Day { get { return _lates24Month60Day; } set { _lates24Month60Day = value; } }
-        private Value<int?> _lates24Month90Day;
+        private DirtyValue<int?> _lates24Month90Day;
         public int? Lates24Month90Day { get { return _lates24Month90Day; } set { _lates24Month90Day = value; } }
-        private Value<int?> _lates25Month120Day;
+        private DirtyValue<int?> _lates25Month120Day;
         public int? Lates25Month120Day { get { return _lates25Month120Day; } set { _lates25Month120Day = value; } }
-        private Value<int?> _lates25Month150Day;
+        private DirtyValue<int?> _lates25Month150Day;
         public int? Lates25Month150Day { get { return _lates25Month150Day; } set { _lates25Month150Day = value; } }
-        private Value<int?> _lates25Month30Day;
+        private DirtyValue<int?> _lates25Month30Day;
         public int? Lates25Month30Day { get { return _lates25Month30Day; } set { _lates25Month30Day = value; } }
-        private Value<int?> _lates25Month60Day;
+        private DirtyValue<int?> _lates25Month60Day;
         public int? Lates25Month60Day { get { return _lates25Month60Day; } set { _lates25Month60Day = value; } }
-        private Value<int?> _lates25Month90Day;
+        private DirtyValue<int?> _lates25Month90Day;
         public int? Lates25Month90Day { get { return _lates25Month90Day; } set { _lates25Month90Day = value; } }
-        private Value<int?> _liabilityIndex;
+        private DirtyValue<int?> _liabilityIndex;
         public int? LiabilityIndex { get { return _liabilityIndex; } set { _liabilityIndex = value; } }
-        private Value<string> _liabilityType;
+        private DirtyValue<string> _liabilityType;
         public string LiabilityType { get { return _liabilityType; } set { _liabilityType = value; } }
-        private Value<decimal?> _monthlyPaymentAmount;
+        private DirtyValue<decimal?> _monthlyPaymentAmount;
         public decimal? MonthlyPaymentAmount { get { return _monthlyPaymentAmount; } set { _monthlyPaymentAmount = value; } }
-        private Value<int?> _monthsToExclude;
+        private DirtyValue<int?> _monthsToExclude;
         public int? MonthsToExclude { get { return _monthsToExclude; } set { _monthsToExclude = value; } }
-        private Value<string> _nameInAccount;
+        private DirtyValue<string> _nameInAccount;
         public string NameInAccount { get { return _nameInAccount; } set { _nameInAccount = value; } }
-        private Value<bool?> _noLinkToDocTrackIndicator;
+        private DirtyValue<bool?> _noLinkToDocTrackIndicator;
         public bool? NoLinkToDocTrackIndicator { get { return _noLinkToDocTrackIndicator; } set { _noLinkToDocTrackIndicator = value; } }
-        private Value<string> _owner;
+        private DirtyValue<string> _owner;
         public string Owner { get { return _owner; } set { _owner = value; } }
-        private Value<bool?> _payoffIncludedIndicator;
+        private DirtyValue<bool?> _payoffIncludedIndicator;
         public bool? PayoffIncludedIndicator { get { return _payoffIncludedIndicator; } set { _payoffIncludedIndicator = value; } }
-        private Value<bool?> _payoffStatusIndicator;
+        private DirtyValue<bool?> _payoffStatusIndicator;
         public bool? PayoffStatusIndicator { get { return _payoffStatusIndicator; } set { _payoffStatusIndicator = value; } }
-        private Value<decimal?> _prepaymentPenaltyAmount;
+        private DirtyValue<decimal?> _prepaymentPenaltyAmount;
         public decimal? PrepaymentPenaltyAmount { get { return _prepaymentPenaltyAmount; } set { _prepaymentPenaltyAmount = value; } }
-        private Value<bool?> _printAttachmentIndicator;
+        private DirtyValue<bool?> _printAttachmentIndicator;
         public bool? PrintAttachmentIndicator { get { return _printAttachmentIndicator; } set { _printAttachmentIndicator = value; } }
-        private Value<bool?> _printUserNameIndicator;
+        private DirtyValue<bool?> _printUserNameIndicator;
         public bool? PrintUserNameIndicator { get { return _printUserNameIndicator; } set { _printUserNameIndicator = value; } }
-        private Value<int?> _remainingTermMonths;
+        private DirtyValue<int?> _remainingTermMonths;
         public int? RemainingTermMonths { get { return _remainingTermMonths; } set { _remainingTermMonths = value; } }
-        private Value<string> _reoId;
+        private DirtyValue<string> _reoId;
         public string ReoId { get { return _reoId; } set { _reoId = value; } }
-        private Value<string> _requestId;
+        private DirtyValue<string> _requestId;
         public string RequestId { get { return _requestId; } set { _requestId = value; } }
-        private Value<bool?> _subjectLoanResubordinationIndicator;
+        private DirtyValue<bool?> _subjectLoanResubordinationIndicator;
         public bool? SubjectLoanResubordinationIndicator { get { return _subjectLoanResubordinationIndicator; } set { _subjectLoanResubordinationIndicator = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _titleFax;
+        private DirtyValue<string> _titleFax;
         public string TitleFax { get { return _titleFax; } set { _titleFax = value; } }
-        private Value<string> _titlePhone;
+        private DirtyValue<string> _titlePhone;
         public string TitlePhone { get { return _titlePhone; } set { _titlePhone = value; } }
-        private Value<decimal?> _toBePaidOffAmount;
+        private DirtyValue<decimal?> _toBePaidOffAmount;
         public decimal? ToBePaidOffAmount { get { return _toBePaidOffAmount; } set { _toBePaidOffAmount = value; } }
-        private Value<string> _uCDPayoffType;
+        private DirtyValue<string> _uCDPayoffType;
         public string UCDPayoffType { get { return _uCDPayoffType; } set { _uCDPayoffType = value; } }
-        private Value<decimal?> _unpaidBalanceAmount;
+        private DirtyValue<decimal?> _unpaidBalanceAmount;
         public decimal? UnpaidBalanceAmount { get { return _unpaidBalanceAmount; } set { _unpaidBalanceAmount = value; } }
-        private Value<int?> _volIndex;
+        private DirtyValue<int?> _volIndex;
         public int? VolIndex { get { return _volIndex; } set { _volIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Loan.cs
+++ b/src/EncompassRest/Loans/Loan.cs
@@ -8,24 +8,26 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Loan : IDirty
     {
-        public AdditionalRequests AdditionalRequests { get; set; }
+        private AdditionalRequests _additionalRequests;
+        public AdditionalRequests AdditionalRequests { get { var v = _additionalRequests; return v ?? Interlocked.CompareExchange(ref _additionalRequests, (v = new AdditionalRequests()), null) ?? v; } set { _additionalRequests = value; } }
         private Value<DateTime?> _adverseActionDate;
         public DateTime? AdverseActionDate { get { return _adverseActionDate; } set { _adverseActionDate = value; } }
-        private Value<List<AffiliatedBusinessArrangement>> _affiliatedBusinessArrangements;
-        public List<AffiliatedBusinessArrangement> AffiliatedBusinessArrangements { get { return _affiliatedBusinessArrangements; } set { _affiliatedBusinessArrangements = value; } }
+        private DirtyList<AffiliatedBusinessArrangement> _affiliatedBusinessArrangements;
+        public IList<AffiliatedBusinessArrangement> AffiliatedBusinessArrangements { get { var v = _affiliatedBusinessArrangements; return v ?? Interlocked.CompareExchange(ref _affiliatedBusinessArrangements, (v = new DirtyList<AffiliatedBusinessArrangement>()), null) ?? v; } set { _affiliatedBusinessArrangements = new DirtyList<AffiliatedBusinessArrangement>(value); } }
         private Value<string> _agencyCaseIdentifier;
         public string AgencyCaseIdentifier { get { return _agencyCaseIdentifier; } set { _agencyCaseIdentifier = value; } }
         private Value<decimal?> _alterationsImprovementsOrRepairsAmount;
         public decimal? AlterationsImprovementsOrRepairsAmount { get { return _alterationsImprovementsOrRepairsAmount; } set { _alterationsImprovementsOrRepairsAmount = value; } }
-        private Value<List<Application>> _applications;
-        public List<Application> Applications { get { return _applications; } set { _applications = value; } }
+        private DirtyList<Application> _applications;
+        public IList<Application> Applications { get { var v = _applications; return v ?? Interlocked.CompareExchange(ref _applications, (v = new DirtyList<Application>()), null) ?? v; } set { _applications = new DirtyList<Application>(value); } }
         private Value<string> _applicationTakenMethodType;
         public string ApplicationTakenMethodType { get { return _applicationTakenMethodType; } set { _applicationTakenMethodType = value; } }
         private Value<DateTime?> _aprDisclosureDate;
         public DateTime? AprDisclosureDate { get { return _aprDisclosureDate; } set { _aprDisclosureDate = value; } }
         private Value<string> _armTypeDescription;
         public string ArmTypeDescription { get { return _armTypeDescription; } set { _armTypeDescription = value; } }
-        public ATRQMCommon ATRQMCommon { get; set; }
+        private ATRQMCommon _aTRQMCommon;
+        public ATRQMCommon ATRQMCommon { get { var v = _aTRQMCommon; return v ?? Interlocked.CompareExchange(ref _aTRQMCommon, (v = new ATRQMCommon()), null) ?? v; } set { _aTRQMCommon = value; } }
         private Value<decimal?> _baseLoanAmount;
         public decimal? BaseLoanAmount { get { return _baseLoanAmount; } set { _baseLoanAmount = value; } }
         private Value<bool?> _belowMarketSubordinateFinancingIndicator;
@@ -60,7 +62,8 @@ namespace EncompassRest.Loans
         public string Channel { get { return _channel; } set { _channel = value; } }
         private Value<DateTime?> _closingBillingDate;
         public DateTime? ClosingBillingDate { get { return _closingBillingDate; } set { _closingBillingDate = value; } }
-        public ClosingCost ClosingCost { get; set; }
+        private ClosingCost _closingCost;
+        public ClosingCost ClosingCost { get { var v = _closingCost; return v ?? Interlocked.CompareExchange(ref _closingCost, (v = new ClosingCost()), null) ?? v; } set { _closingCost = value; } }
         private Value<string> _closingCostProgram;
         public string ClosingCostProgram { get { return _closingCostProgram; } set { _closingCostProgram = value; } }
         private Value<decimal?> _closingCostsAndPrepaidsFromOtherLienAmount;
@@ -69,50 +72,56 @@ namespace EncompassRest.Loans
         public decimal? ClosingCostsPaidByOthersAmount { get { return _closingCostsPaidByOthersAmount; } set { _closingCostsPaidByOthersAmount = value; } }
         private Value<string> _closingDocsStackingOrder;
         public string ClosingDocsStackingOrder { get { return _closingDocsStackingOrder; } set { _closingDocsStackingOrder = value; } }
-        public ClosingDocument ClosingDocument { get; set; }
+        private ClosingDocument _closingDocument;
+        public ClosingDocument ClosingDocument { get { var v = _closingDocument; return v ?? Interlocked.CompareExchange(ref _closingDocument, (v = new ClosingDocument()), null) ?? v; } set { _closingDocument = value; } }
         private Value<int?> _collateralManagerScore;
         public int? CollateralManagerScore { get { return _collateralManagerScore; } set { _collateralManagerScore = value; } }
         private Value<decimal?> _combinedLtv;
         public decimal? CombinedLtv { get { return _combinedLtv; } set { _combinedLtv = value; } }
         private Value<string> _commitmentNumber;
         public string CommitmentNumber { get { return _commitmentNumber; } set { _commitmentNumber = value; } }
-        public CommitmentTerms CommitmentTerms { get; set; }
-        private Value<List<ComplianceTestLog>> _complianceTestLogs;
-        public List<ComplianceTestLog> ComplianceTestLogs { get { return _complianceTestLogs; } set { _complianceTestLogs = value; } }
+        private CommitmentTerms _commitmentTerms;
+        public CommitmentTerms CommitmentTerms { get { var v = _commitmentTerms; return v ?? Interlocked.CompareExchange(ref _commitmentTerms, (v = new CommitmentTerms()), null) ?? v; } set { _commitmentTerms = value; } }
+        private DirtyList<ComplianceTestLog> _complianceTestLogs;
+        public IList<ComplianceTestLog> ComplianceTestLogs { get { var v = _complianceTestLogs; return v ?? Interlocked.CompareExchange(ref _complianceTestLogs, (v = new DirtyList<ComplianceTestLog>()), null) ?? v; } set { _complianceTestLogs = new DirtyList<ComplianceTestLog>(value); } }
         private Value<string> _conformingJumbo;
         public string ConformingJumbo { get { return _conformingJumbo; } set { _conformingJumbo = value; } }
-        public ConstructionManagement ConstructionManagement { get; set; }
+        private ConstructionManagement _constructionManagement;
+        public ConstructionManagement ConstructionManagement { get { var v = _constructionManagement; return v ?? Interlocked.CompareExchange(ref _constructionManagement, (v = new ConstructionManagement()), null) ?? v; } set { _constructionManagement = value; } }
         private Value<string> _consumerConnectSiteID;
         public string ConsumerConnectSiteID { get { return _consumerConnectSiteID; } set { _consumerConnectSiteID = value; } }
-        private Value<List<Contact>> _contacts;
-        public List<Contact> Contacts { get { return _contacts; } set { _contacts = value; } }
+        private DirtyList<Contact> _contacts;
+        public IList<Contact> Contacts { get { var v = _contacts; return v ?? Interlocked.CompareExchange(ref _contacts, (v = new DirtyList<Contact>()), null) ?? v; } set { _contacts = new DirtyList<Contact>(value); } }
         private Value<bool?> _contactUpdatedIndicator;
         public bool? ContactUpdatedIndicator { get { return _contactUpdatedIndicator; } set { _contactUpdatedIndicator = value; } }
         private Value<decimal?> _contractSellerCreditAmount;
         public decimal? ContractSellerCreditAmount { get { return _contractSellerCreditAmount; } set { _contractSellerCreditAmount = value; } }
-        private Value<List<ConversationLog>> _conversationLogs;
-        public List<ConversationLog> ConversationLogs { get { return _conversationLogs; } set { _conversationLogs = value; } }
+        private DirtyList<ConversationLog> _conversationLogs;
+        public IList<ConversationLog> ConversationLogs { get { var v = _conversationLogs; return v ?? Interlocked.CompareExchange(ref _conversationLogs, (v = new DirtyList<ConversationLog>()), null) ?? v; } set { _conversationLogs = new DirtyList<ConversationLog>(value); } }
         private Value<bool?> _copyBrokerToLenderIndicator;
         public bool? CopyBrokerToLenderIndicator { get { return _copyBrokerToLenderIndicator; } set { _copyBrokerToLenderIndicator = value; } }
         private Value<string> _copyLoanNumLenderCaseNum;
         public string CopyLoanNumLenderCaseNum { get { return _copyLoanNumLenderCaseNum; } set { _copyLoanNumLenderCaseNum = value; } }
-        public Correspondent Correspondent { get; set; }
+        private Correspondent _correspondent;
+        public Correspondent Correspondent { get { var v = _correspondent; return v ?? Interlocked.CompareExchange(ref _correspondent, (v = new Correspondent()), null) ?? v; } set { _correspondent = value; } }
         private Value<string> _creditScoreToUse;
         public string CreditScoreToUse { get { return _creditScoreToUse; } set { _creditScoreToUse = value; } }
-        private Value<List<CrmLog>> _crmLogs;
-        public List<CrmLog> CrmLogs { get { return _crmLogs; } set { _crmLogs = value; } }
-        public Application CurrentApplication { get; set; }
+        private DirtyList<CrmLog> _crmLogs;
+        public IList<CrmLog> CrmLogs { get { var v = _crmLogs; return v ?? Interlocked.CompareExchange(ref _crmLogs, (v = new DirtyList<CrmLog>()), null) ?? v; } set { _crmLogs = new DirtyList<CrmLog>(value); } }
+        private Application _currentApplication;
+        public Application CurrentApplication { get { var v = _currentApplication; return v ?? Interlocked.CompareExchange(ref _currentApplication, (v = new Application()), null) ?? v; } set { _currentApplication = value; } }
         private Value<int?> _currentApplicationIndex;
         public int? CurrentApplicationIndex { get { return _currentApplicationIndex; } set { _currentApplicationIndex = value; } }
         private Value<bool?> _currentApplicationIsPrimary;
         public bool? CurrentApplicationIsPrimary { get { return _currentApplicationIsPrimary; } set { _currentApplicationIsPrimary = value; } }
         private Value<string> _currentFirstMortgageHolderType;
         public string CurrentFirstMortgageHolderType { get { return _currentFirstMortgageHolderType; } set { _currentFirstMortgageHolderType = value; } }
-        private Value<List<CustomField>> _customFields;
-        public List<CustomField> CustomFields { get { return _customFields; } set { _customFields = value; } }
-        public CustomModelFields CustomModelFields { get; set; }
-        private Value<List<DataTracLog>> _dataTracLogs;
-        public List<DataTracLog> DataTracLogs { get { return _dataTracLogs; } set { _dataTracLogs = value; } }
+        private DirtyList<CustomField> _customFields;
+        public IList<CustomField> CustomFields { get { var v = _customFields; return v ?? Interlocked.CompareExchange(ref _customFields, (v = new DirtyList<CustomField>()), null) ?? v; } set { _customFields = new DirtyList<CustomField>(value); } }
+        private CustomModelFields _customModelFields;
+        public CustomModelFields CustomModelFields { get { var v = _customModelFields; return v ?? Interlocked.CompareExchange(ref _customModelFields, (v = new CustomModelFields()), null) ?? v; } set { _customModelFields = value; } }
+        private DirtyList<DataTracLog> _dataTracLogs;
+        public IList<DataTracLog> DataTracLogs { get { var v = _dataTracLogs; return v ?? Interlocked.CompareExchange(ref _dataTracLogs, (v = new DirtyList<DataTracLog>()), null) ?? v; } set { _dataTracLogs = new DirtyList<DataTracLog>(value); } }
         private Value<bool?> _dBIndicator;
         public bool? DBIndicator { get { return _dBIndicator; } set { _dBIndicator = value; } }
         private Value<bool?> _deductOverwireAmountIndicator;
@@ -121,35 +130,40 @@ namespace EncompassRest.Loans
         public bool? DisableESignConsentAlert { get { return _disableESignConsentAlert; } set { _disableESignConsentAlert = value; } }
         private Value<bool?> _disableKeyPricingAlert;
         public bool? DisableKeyPricingAlert { get { return _disableKeyPricingAlert; } set { _disableKeyPricingAlert = value; } }
-        public DisclosureNotices DisclosureNotices { get; set; }
-        private Value<List<DisclosureTracking2015Log>> _disclosureTracking2015Logs;
-        public List<DisclosureTracking2015Log> DisclosureTracking2015Logs { get { return _disclosureTracking2015Logs; } set { _disclosureTracking2015Logs = value; } }
-        private Value<List<DisclosureTrackingLog>> _disclosureTrackingLogs;
-        public List<DisclosureTrackingLog> DisclosureTrackingLogs { get { return _disclosureTrackingLogs; } set { _disclosureTrackingLogs = value; } }
+        private DisclosureNotices _disclosureNotices;
+        public DisclosureNotices DisclosureNotices { get { var v = _disclosureNotices; return v ?? Interlocked.CompareExchange(ref _disclosureNotices, (v = new DisclosureNotices()), null) ?? v; } set { _disclosureNotices = value; } }
+        private DirtyList<DisclosureTracking2015Log> _disclosureTracking2015Logs;
+        public IList<DisclosureTracking2015Log> DisclosureTracking2015Logs { get { var v = _disclosureTracking2015Logs; return v ?? Interlocked.CompareExchange(ref _disclosureTracking2015Logs, (v = new DirtyList<DisclosureTracking2015Log>()), null) ?? v; } set { _disclosureTracking2015Logs = new DirtyList<DisclosureTracking2015Log>(value); } }
+        private DirtyList<DisclosureTrackingLog> _disclosureTrackingLogs;
+        public IList<DisclosureTrackingLog> DisclosureTrackingLogs { get { var v = _disclosureTrackingLogs; return v ?? Interlocked.CompareExchange(ref _disclosureTrackingLogs, (v = new DirtyList<DisclosureTrackingLog>()), null) ?? v; } set { _disclosureTrackingLogs = new DirtyList<DisclosureTrackingLog>(value); } }
         private Value<decimal?> _discountPoint;
         public decimal? DiscountPoint { get { return _discountPoint; } set { _discountPoint = value; } }
         private Value<string> _docEngine;
         public string DocEngine { get { return _docEngine; } set { _docEngine = value; } }
-        private Value<List<DocumentLog>> _documentLogs;
-        public List<DocumentLog> DocumentLogs { get { return _documentLogs; } set { _documentLogs = value; } }
+        private DirtyList<DocumentLog> _documentLogs;
+        public IList<DocumentLog> DocumentLogs { get { var v = _documentLogs; return v ?? Interlocked.CompareExchange(ref _documentLogs, (v = new DirtyList<DocumentLog>()), null) ?? v; } set { _documentLogs = new DirtyList<DocumentLog>(value); } }
         private Value<string> _doNotCheckEmail;
         public string DoNotCheckEmail { get { return _doNotCheckEmail; } set { _doNotCheckEmail = value; } }
         private Value<bool?> _doNotPrintCompensationFees;
         public bool? DoNotPrintCompensationFees { get { return _doNotPrintCompensationFees; } set { _doNotPrintCompensationFees = value; } }
-        private Value<List<DownloadLog>> _downloadLogs;
-        public List<DownloadLog> DownloadLogs { get { return _downloadLogs; } set { _downloadLogs = value; } }
-        public DownPayment DownPayment { get; set; }
+        private DirtyList<DownloadLog> _downloadLogs;
+        public IList<DownloadLog> DownloadLogs { get { var v = _downloadLogs; return v ?? Interlocked.CompareExchange(ref _downloadLogs, (v = new DirtyList<DownloadLog>()), null) ?? v; } set { _downloadLogs = new DirtyList<DownloadLog>(value); } }
+        private DownPayment _downPayment;
+        public DownPayment DownPayment { get { var v = _downPayment; return v ?? Interlocked.CompareExchange(ref _downPayment, (v = new DownPayment()), null) ?? v; } set { _downPayment = value; } }
         private Value<decimal?> _downPaymentPercent;
         public decimal? DownPaymentPercent { get { return _downPaymentPercent; } set { _downPaymentPercent = value; } }
-        private Value<List<EdmLog>> _edmLogs;
-        public List<EdmLog> EdmLogs { get { return _edmLogs; } set { _edmLogs = value; } }
-        //private Value<string> _elliUCDFields;
-        //public string ElliUCDFields { get { return _elliUCDFields; } set { _elliUCDFields = value; } }
-        private Value<List<EmailTriggerLog>> _emailTriggerLogs;
-        public List<EmailTriggerLog> EmailTriggerLogs { get { return _emailTriggerLogs; } set { _emailTriggerLogs = value; } }
-        public EmDocument EmDocument { get; set; }
-        public EmDocumentInvestor EmDocumentInvestor { get; set; }
-        public EmDocumentLender EmDocumentLender { get; set; }
+        private DirtyList<EdmLog> _edmLogs;
+        public IList<EdmLog> EdmLogs { get { var v = _edmLogs; return v ?? Interlocked.CompareExchange(ref _edmLogs, (v = new DirtyList<EdmLog>()), null) ?? v; } set { _edmLogs = new DirtyList<EdmLog>(value); } }
+        //private ElliUCDDetail _elliUCDFields;
+        //public ElliUCDDetail ElliUCDFields { get { var v = _elliUCDFields; return v ?? Interlocked.CompareExchange(ref _elliUCDFields, (v = new ElliUCDDetail()), null) ?? v; } set { _elliUCDFields = value; } }
+        private DirtyList<EmailTriggerLog> _emailTriggerLogs;
+        public IList<EmailTriggerLog> EmailTriggerLogs { get { var v = _emailTriggerLogs; return v ?? Interlocked.CompareExchange(ref _emailTriggerLogs, (v = new DirtyList<EmailTriggerLog>()), null) ?? v; } set { _emailTriggerLogs = new DirtyList<EmailTriggerLog>(value); } }
+        private EmDocument _emDocument;
+        public EmDocument EmDocument { get { var v = _emDocument; return v ?? Interlocked.CompareExchange(ref _emDocument, (v = new EmDocument()), null) ?? v; } set { _emDocument = value; } }
+        private EmDocumentInvestor _emDocumentInvestor;
+        public EmDocumentInvestor EmDocumentInvestor { get { var v = _emDocumentInvestor; return v ?? Interlocked.CompareExchange(ref _emDocumentInvestor, (v = new EmDocumentInvestor()), null) ?? v; } set { _emDocumentInvestor = value; } }
+        private EmDocumentLender _emDocumentLender;
+        public EmDocumentLender EmDocumentLender { get { var v = _emDocumentLender; return v ?? Interlocked.CompareExchange(ref _emDocumentLender, (v = new EmDocumentLender()), null) ?? v; } set { _emDocumentLender = value; } }
         private Value<string> _emXmlVersionId;
         public string EmXmlVersionId { get { return _emXmlVersionId; } set { _emXmlVersionId = value; } }
         private Value<string> _encompassId;
@@ -166,16 +180,18 @@ namespace EncompassRest.Loans
         public decimal? EstimatedPrepaidItemsAmount { get { return _estimatedPrepaidItemsAmount; } set { _estimatedPrepaidItemsAmount = value; } }
         private Value<string> _exportLoanNumber;
         public string ExportLoanNumber { get { return _exportLoanNumber; } set { _exportLoanNumber = value; } }
-        public FannieMae FannieMae { get; set; }
-        private Value<List<Fee>> _fees;
-        public List<Fee> Fees { get { return _fees; } set { _fees = value; } }
+        private FannieMae _fannieMae;
+        public FannieMae FannieMae { get { var v = _fannieMae; return v ?? Interlocked.CompareExchange(ref _fannieMae, (v = new FannieMae()), null) ?? v; } set { _fannieMae = value; } }
+        private DirtyList<Fee> _fees;
+        public IList<Fee> Fees { get { var v = _fees; return v ?? Interlocked.CompareExchange(ref _fees, (v = new DirtyList<Fee>()), null) ?? v; } set { _fees = new DirtyList<Fee>(value); } }
         private Value<decimal?> _fhaMiPremiumRefundAmount;
         public decimal? FhaMiPremiumRefundAmount { get { return _fhaMiPremiumRefundAmount; } set { _fhaMiPremiumRefundAmount = value; } }
-        public FhaVaLoan FhaVaLoan { get; set; }
+        private FhaVaLoan _fhaVaLoan;
+        public FhaVaLoan FhaVaLoan { get { var v = _fhaVaLoan; return v ?? Interlocked.CompareExchange(ref _fhaVaLoan, (v = new FhaVaLoan()), null) ?? v; } set { _fhaVaLoan = value; } }
         private Value<string> _fHAVALoanOriginatorIdentifier;
         public string FHAVALoanOriginatorIdentifier { get { return _fHAVALoanOriginatorIdentifier; } set { _fHAVALoanOriginatorIdentifier = value; } }
-        private Value<List<FieldLockData>> _fieldLockData;
-        public List<FieldLockData> FieldLockData { get { return _fieldLockData; } set { _fieldLockData = value; } }
+        private DirtyList<FieldLockData> _fieldLockData;
+        public IList<FieldLockData> FieldLockData { get { var v = _fieldLockData; return v ?? Interlocked.CompareExchange(ref _fieldLockData, (v = new DirtyList<FieldLockData>()), null) ?? v; } set { _fieldLockData = new DirtyList<FieldLockData>(value); } }
         private Value<decimal?> _firstAdjustmentMinimum;
         public decimal? FirstAdjustmentMinimum { get { return _firstAdjustmentMinimum; } set { _firstAdjustmentMinimum = value; } }
         private Value<decimal?> _firstSubordinateLienAmount;
@@ -188,19 +204,22 @@ namespace EncompassRest.Loans
         public bool? FnmCommunitySecondsIndicator { get { return _fnmCommunitySecondsIndicator; } set { _fnmCommunitySecondsIndicator = value; } }
         private Value<bool?> _fnmNeighborsMortgageEligibilityIndicator;
         public bool? FnmNeighborsMortgageEligibilityIndicator { get { return _fnmNeighborsMortgageEligibilityIndicator; } set { _fnmNeighborsMortgageEligibilityIndicator = value; } }
-        private Value<List<Form>> _forms;
-        public List<Form> Forms { get { return _forms; } set { _forms = value; } }
+        private DirtyList<Form> _forms;
+        public IList<Form> Forms { get { var v = _forms; return v ?? Interlocked.CompareExchange(ref _forms, (v = new DirtyList<Form>()), null) ?? v; } set { _forms = new DirtyList<Form>(value); } }
         private Value<int?> _fraudScore;
         public int? FraudScore { get { return _fraudScore; } set { _fraudScore = value; } }
-        public FreddieMac FreddieMac { get; set; }
-        public Funding Funding { get; set; }
+        private FreddieMac _freddieMac;
+        public FreddieMac FreddieMac { get { var v = _freddieMac; return v ?? Interlocked.CompareExchange(ref _freddieMac, (v = new FreddieMac()), null) ?? v; } set { _freddieMac = value; } }
+        private Funding _funding;
+        public Funding Funding { get { var v = _funding; return v ?? Interlocked.CompareExchange(ref _funding, (v = new Funding()), null) ?? v; } set { _funding = value; } }
         private Value<string> _fundingDeductionList;
         public string FundingDeductionList { get { return _fundingDeductionList; } set { _fundingDeductionList = value; } }
         private Value<string> _fundingFeeList;
         public string FundingFeeList { get { return _fundingFeeList; } set { _fundingFeeList = value; } }
-        private Value<List<FundingFee>> _fundingFees;
-        public List<FundingFee> FundingFees { get { return _fundingFees; } set { _fundingFees = value; } }
-        public Gfe Gfe { get; set; }
+        private DirtyList<FundingFee> _fundingFees;
+        public IList<FundingFee> FundingFees { get { var v = _fundingFees; return v ?? Interlocked.CompareExchange(ref _fundingFees, (v = new DirtyList<FundingFee>()), null) ?? v; } set { _fundingFees = new DirtyList<FundingFee>(value); } }
+        private Gfe _gfe;
+        public Gfe Gfe { get { var v = _gfe; return v ?? Interlocked.CompareExchange(ref _gfe, (v = new Gfe()), null) ?? v; } set { _gfe = value; } }
         private Value<string> _governmentLoanLenderIdentifier;
         public string GovernmentLoanLenderIdentifier { get { return _governmentLoanLenderIdentifier; } set { _governmentLoanLenderIdentifier = value; } }
         private Value<string> _governmentLoanSponsorIdentifier;
@@ -213,9 +232,10 @@ namespace EncompassRest.Loans
         public decimal? HcltvHtltv { get { return _hcltvHtltv; } set { _hcltvHtltv = value; } }
         private Value<decimal?> _helocTeaserRate;
         public decimal? HelocTeaserRate { get { return _helocTeaserRate; } set { _helocTeaserRate = value; } }
-        public Hmda Hmda { get; set; }
-        private Value<List<HomeCounselingProvider>> _homeCounselingProviders;
-        public List<HomeCounselingProvider> HomeCounselingProviders { get { return _homeCounselingProviders; } set { _homeCounselingProviders = value; } }
+        private Hmda _hmda;
+        public Hmda Hmda { get { var v = _hmda; return v ?? Interlocked.CompareExchange(ref _hmda, (v = new Hmda()), null) ?? v; } set { _hmda = value; } }
+        private DirtyList<HomeCounselingProvider> _homeCounselingProviders;
+        public IList<HomeCounselingProvider> HomeCounselingProviders { get { var v = _homeCounselingProviders; return v ?? Interlocked.CompareExchange(ref _homeCounselingProviders, (v = new DirtyList<HomeCounselingProvider>()), null) ?? v; } set { _homeCounselingProviders = new DirtyList<HomeCounselingProvider>(value); } }
         private Value<string> _homeCounselingProvidersDistance;
         public string HomeCounselingProvidersDistance { get { return _homeCounselingProvidersDistance; } set { _homeCounselingProvidersDistance = value; } }
         private Value<string> _homeCounselingProvidersLanguageNames;
@@ -224,14 +244,16 @@ namespace EncompassRest.Loans
         public string HomeCounselingProvidersServiceNames { get { return _homeCounselingProvidersServiceNames; } set { _homeCounselingProvidersServiceNames = value; } }
         private Value<int?> _householdSizeCount;
         public int? HouseholdSizeCount { get { return _householdSizeCount; } set { _householdSizeCount = value; } }
-        private Value<List<HtmlEmailLog>> _htmlEmailLogs;
-        public List<HtmlEmailLog> HtmlEmailLogs { get { return _htmlEmailLogs; } set { _htmlEmailLogs = value; } }
-        public Hud1Es Hud1Es { get; set; }
+        private DirtyList<HtmlEmailLog> _htmlEmailLogs;
+        public IList<HtmlEmailLog> HtmlEmailLogs { get { var v = _htmlEmailLogs; return v ?? Interlocked.CompareExchange(ref _htmlEmailLogs, (v = new DirtyList<HtmlEmailLog>()), null) ?? v; } set { _htmlEmailLogs = new DirtyList<HtmlEmailLog>(value); } }
+        private Hud1Es _hud1Es;
+        public Hud1Es Hud1Es { get { var v = _hud1Es; return v ?? Interlocked.CompareExchange(ref _hud1Es, (v = new Hud1Es()), null) ?? v; } set { _hud1Es = value; } }
         private Value<decimal?> _hudIncomeLimitAdjustmentFactor;
         public decimal? HudIncomeLimitAdjustmentFactor { get { return _hudIncomeLimitAdjustmentFactor; } set { _hudIncomeLimitAdjustmentFactor = value; } }
         private Value<decimal?> _hudLendingIncomeLimitAmount;
         public decimal? HudLendingIncomeLimitAmount { get { return _hudLendingIncomeLimitAmount; } set { _hudLendingIncomeLimitAmount = value; } }
-        public HudLoanData HudLoanData { get; set; }
+        private HudLoanData _hudLoanData;
+        public HudLoanData HudLoanData { get { var v = _hudLoanData; return v ?? Interlocked.CompareExchange(ref _hudLoanData, (v = new HudLoanData()), null) ?? v; } set { _hudLoanData = value; } }
         private Value<decimal?> _hudMedianIncomeAmount;
         public decimal? HudMedianIncomeAmount { get { return _hudMedianIncomeAmount; } set { _hudMedianIncomeAmount = value; } }
         private Value<string> _id;
@@ -242,7 +264,8 @@ namespace EncompassRest.Loans
         public decimal? InitialInterestRate { get { return _initialInterestRate; } set { _initialInterestRate = value; } }
         private Value<string> _insuranceAuthorizationIndicator;
         public string InsuranceAuthorizationIndicator { get { return _insuranceAuthorizationIndicator; } set { _insuranceAuthorizationIndicator = value; } }
-        public InterimServicing InterimServicing { get; set; }
+        private InterimServicing _interimServicing;
+        public InterimServicing InterimServicing { get { var v = _interimServicing; return v ?? Interlocked.CompareExchange(ref _interimServicing, (v = new InterimServicing()), null) ?? v; } set { _interimServicing = value; } }
         private Value<DateTime?> _interviewerApplicationSignedDate;
         public DateTime? InterviewerApplicationSignedDate { get { return _interviewerApplicationSignedDate; } set { _interviewerApplicationSignedDate = value; } }
         private Value<string> _interviewerEmail;
@@ -289,10 +312,12 @@ namespace EncompassRest.Loans
         public decimal? LifeInsuranceEstimatedMonthlyAmount { get { return _lifeInsuranceEstimatedMonthlyAmount; } set { _lifeInsuranceEstimatedMonthlyAmount = value; } }
         private Value<decimal?> _lifeInsuranceTotalProtectedMonthlyAmount;
         public decimal? LifeInsuranceTotalProtectedMonthlyAmount { get { return _lifeInsuranceTotalProtectedMonthlyAmount; } set { _lifeInsuranceTotalProtectedMonthlyAmount = value; } }
+        private Value<decimal?> _linkedBorrowerRequestedLoanAmount;
+        public decimal? LinkedBorrowerRequestedLoanAmount { get { return _linkedBorrowerRequestedLoanAmount; } set { _linkedBorrowerRequestedLoanAmount = value; } }
         private Value<string> _linkId;
         public string LinkId { get { return _linkId; } set { _linkId = value; } }
-        private Value<List<LoanActionLog>> _loanActionLogs;
-        public List<LoanActionLog> LoanActionLogs { get { return _loanActionLogs; } set { _loanActionLogs = value; } }
+        private DirtyList<LoanActionLog> _loanActionLogs;
+        public IList<LoanActionLog> LoanActionLogs { get { var v = _loanActionLogs; return v ?? Interlocked.CompareExchange(ref _loanActionLogs, (v = new DirtyList<LoanActionLog>()), null) ?? v; } set { _loanActionLogs = new DirtyList<LoanActionLog>(value); } }
         private Value<int?> _loanAmortizationTermMonths;
         public int? LoanAmortizationTermMonths { get { return _loanAmortizationTermMonths; } set { _loanAmortizationTermMonths = value; } }
         private Value<string> _loanAmortizationType;
@@ -309,16 +334,18 @@ namespace EncompassRest.Loans
         public string LoanLinkSyncType { get { return _loanLinkSyncType; } set { _loanLinkSyncType = value; } }
         private Value<string> _loanNumber;
         public string LoanNumber { get { return _loanNumber; } set { _loanNumber = value; } }
-        public LoanProductData LoanProductData { get; set; }
+        private LoanProductData _loanProductData;
+        public LoanProductData LoanProductData { get { var v = _loanProductData; return v ?? Interlocked.CompareExchange(ref _loanProductData, (v = new LoanProductData()), null) ?? v; } set { _loanProductData = value; } }
         private Value<string> _loanProgramName;
         public string LoanProgramName { get { return _loanProgramName; } set { _loanProgramName = value; } }
-        private Value<List<LoanProgram>> _loanPrograms;
-        public List<LoanProgram> LoanPrograms { get { return _loanPrograms; } set { _loanPrograms = value; } }
+        private DirtyList<LoanProgram> _loanPrograms;
+        public IList<LoanProgram> LoanPrograms { get { var v = _loanPrograms; return v ?? Interlocked.CompareExchange(ref _loanPrograms, (v = new DirtyList<LoanProgram>()), null) ?? v; } set { _loanPrograms = new DirtyList<LoanProgram>(value); } }
         private Value<string> _loanPurposeOfRefinanceType;
         public string LoanPurposeOfRefinanceType { get { return _loanPurposeOfRefinanceType; } set { _loanPurposeOfRefinanceType = value; } }
         private Value<string> _loanSource;
         public string LoanSource { get { return _loanSource; } set { _loanSource = value; } }
-        public LoanSubmission LoanSubmission { get; set; }
+        private LoanSubmission _loanSubmission;
+        public LoanSubmission LoanSubmission { get { var v = _loanSubmission; return v ?? Interlocked.CompareExchange(ref _loanSubmission, (v = new LoanSubmission()), null) ?? v; } set { _loanSubmission = value; } }
         private Value<decimal?> _loanTotalProposedMonthlyMaintenanceAmount;
         public decimal? LoanTotalProposedMonthlyMaintenanceAmount { get { return _loanTotalProposedMonthlyMaintenanceAmount; } set { _loanTotalProposedMonthlyMaintenanceAmount = value; } }
         private Value<decimal?> _loanTotalProposedMonthlyUtilitiesAmount;
@@ -333,15 +360,16 @@ namespace EncompassRest.Loans
         public decimal? LoanVAResidualIncomeAmount { get { return _loanVAResidualIncomeAmount; } set { _loanVAResidualIncomeAmount = value; } }
         private Value<int?> _loanVersionId;
         public int? LoanVersionId { get { return _loanVersionId; } set { _loanVersionId = value; } }
-        private Value<List<LockConfirmLog>> _lockConfirmLogs;
-        public List<LockConfirmLog> LockConfirmLogs { get { return _lockConfirmLogs; } set { _lockConfirmLogs = value; } }
-        private Value<List<LockDenialLog>> _lockDenialLogs;
-        public List<LockDenialLog> LockDenialLogs { get { return _lockDenialLogs; } set { _lockDenialLogs = value; } }
-        private Value<List<LockRequestLog>> _lockRequestLogs;
-        public List<LockRequestLog> LockRequestLogs { get { return _lockRequestLogs; } set { _lockRequestLogs = value; } }
-        public ElliLOCompensation LOCompensation { get; set; }
-        private Value<List<LogEntryLog>> _logEntryLogs;
-        public List<LogEntryLog> LogEntryLogs { get { return _logEntryLogs; } set { _logEntryLogs = value; } }
+        private DirtyList<LockConfirmLog> _lockConfirmLogs;
+        public IList<LockConfirmLog> LockConfirmLogs { get { var v = _lockConfirmLogs; return v ?? Interlocked.CompareExchange(ref _lockConfirmLogs, (v = new DirtyList<LockConfirmLog>()), null) ?? v; } set { _lockConfirmLogs = new DirtyList<LockConfirmLog>(value); } }
+        private DirtyList<LockDenialLog> _lockDenialLogs;
+        public IList<LockDenialLog> LockDenialLogs { get { var v = _lockDenialLogs; return v ?? Interlocked.CompareExchange(ref _lockDenialLogs, (v = new DirtyList<LockDenialLog>()), null) ?? v; } set { _lockDenialLogs = new DirtyList<LockDenialLog>(value); } }
+        private DirtyList<LockRequestLog> _lockRequestLogs;
+        public IList<LockRequestLog> LockRequestLogs { get { var v = _lockRequestLogs; return v ?? Interlocked.CompareExchange(ref _lockRequestLogs, (v = new DirtyList<LockRequestLog>()), null) ?? v; } set { _lockRequestLogs = new DirtyList<LockRequestLog>(value); } }
+        private ElliLOCompensation _lOCompensation;
+        public ElliLOCompensation LOCompensation { get { var v = _lOCompensation; return v ?? Interlocked.CompareExchange(ref _lOCompensation, (v = new ElliLOCompensation()), null) ?? v; } set { _lOCompensation = value; } }
+        private DirtyList<LogEntryLog> _logEntryLogs;
+        public IList<LogEntryLog> LogEntryLogs { get { var v = _logEntryLogs; return v ?? Interlocked.CompareExchange(ref _logEntryLogs, (v = new DirtyList<LogEntryLog>()), null) ?? v; } set { _logEntryLogs = new DirtyList<LogEntryLog>(value); } }
         private Value<decimal?> _ltv;
         public decimal? Ltv { get { return _ltv; } set { _ltv = value; } }
         private Value<decimal?> _ltvPropertyValue;
@@ -354,7 +382,8 @@ namespace EncompassRest.Loans
         public decimal? MaxBackRatio { get { return _maxBackRatio; } set { _maxBackRatio = value; } }
         private Value<decimal?> _maxFrontRatio;
         public decimal? MaxFrontRatio { get { return _maxFrontRatio; } set { _maxFrontRatio = value; } }
-        public Mcaw Mcaw { get; set; }
+        private Mcaw _mcaw;
+        public Mcaw Mcaw { get { var v = _mcaw; return v ?? Interlocked.CompareExchange(ref _mcaw, (v = new Mcaw()), null) ?? v; } set { _mcaw = value; } }
         private Value<string> _mersNumber;
         public string MersNumber { get { return _mersNumber; } set { _mersNumber = value; } }
         private Value<DateTime?> _mersNumberRegistrationDate;
@@ -383,14 +412,14 @@ namespace EncompassRest.Loans
         public int? MilestoneDuration { get { return _milestoneDuration; } set { _milestoneDuration = value; } }
         private Value<DateTime?> _milestoneFileStartedDate;
         public DateTime? MilestoneFileStartedDate { get { return _milestoneFileStartedDate; } set { _milestoneFileStartedDate = value; } }
-        private Value<List<MilestoneFreeRoleLog>> _milestoneFreeRoleLogs;
-        public List<MilestoneFreeRoleLog> MilestoneFreeRoleLogs { get { return _milestoneFreeRoleLogs; } set { _milestoneFreeRoleLogs = value; } }
+        private DirtyList<MilestoneFreeRoleLog> _milestoneFreeRoleLogs;
+        public IList<MilestoneFreeRoleLog> MilestoneFreeRoleLogs { get { var v = _milestoneFreeRoleLogs; return v ?? Interlocked.CompareExchange(ref _milestoneFreeRoleLogs, (v = new DirtyList<MilestoneFreeRoleLog>()), null) ?? v; } set { _milestoneFreeRoleLogs = new DirtyList<MilestoneFreeRoleLog>(value); } }
         private Value<DateTime?> _milestoneFundedDate;
         public DateTime? MilestoneFundedDate { get { return _milestoneFundedDate; } set { _milestoneFundedDate = value; } }
         private Value<DateTime?> _milestoneFundedDueDate;
         public DateTime? MilestoneFundedDueDate { get { return _milestoneFundedDueDate; } set { _milestoneFundedDueDate = value; } }
-        private Value<List<MilestoneLog>> _milestoneLogs;
-        public List<MilestoneLog> MilestoneLogs { get { return _milestoneLogs; } set { _milestoneLogs = value; } }
+        private DirtyList<MilestoneLog> _milestoneLogs;
+        public IList<MilestoneLog> MilestoneLogs { get { var v = _milestoneLogs; return v ?? Interlocked.CompareExchange(ref _milestoneLogs, (v = new DirtyList<MilestoneLog>()), null) ?? v; } set { _milestoneLogs = new DirtyList<MilestoneLog>(value); } }
         private Value<DateTime?> _milestoneProcessedDate;
         public DateTime? MilestoneProcessedDate { get { return _milestoneProcessedDate; } set { _milestoneProcessedDate = value; } }
         private Value<string> _milestoneStage;
@@ -399,15 +428,16 @@ namespace EncompassRest.Loans
         public DateTime? MilestoneSubmittedDate { get { return _milestoneSubmittedDate; } set { _milestoneSubmittedDate = value; } }
         private Value<DateTime?> _milestoneSubmittedDueDate;
         public DateTime? MilestoneSubmittedDueDate { get { return _milestoneSubmittedDueDate; } set { _milestoneSubmittedDueDate = value; } }
-        private Value<List<MilestoneTaskLog>> _milestoneTaskLogs;
-        public List<MilestoneTaskLog> MilestoneTaskLogs { get { return _milestoneTaskLogs; } set { _milestoneTaskLogs = value; } }
-        private Value<List<MilestoneTemplateLog>> _milestoneTemplateLogs;
-        public List<MilestoneTemplateLog> MilestoneTemplateLogs { get { return _milestoneTemplateLogs; } set { _milestoneTemplateLogs = value; } }
+        private DirtyList<MilestoneTaskLog> _milestoneTaskLogs;
+        public IList<MilestoneTaskLog> MilestoneTaskLogs { get { var v = _milestoneTaskLogs; return v ?? Interlocked.CompareExchange(ref _milestoneTaskLogs, (v = new DirtyList<MilestoneTaskLog>()), null) ?? v; } set { _milestoneTaskLogs = new DirtyList<MilestoneTaskLog>(value); } }
+        private DirtyList<MilestoneTemplateLog> _milestoneTemplateLogs;
+        public IList<MilestoneTemplateLog> MilestoneTemplateLogs { get { var v = _milestoneTemplateLogs; return v ?? Interlocked.CompareExchange(ref _milestoneTemplateLogs, (v = new DirtyList<MilestoneTemplateLog>()), null) ?? v; } set { _milestoneTemplateLogs = new DirtyList<MilestoneTemplateLog>(value); } }
         private Value<decimal?> _mipBorrowerPaidInCashAmount;
         public decimal? MipBorrowerPaidInCashAmount { get { return _mipBorrowerPaidInCashAmount; } set { _mipBorrowerPaidInCashAmount = value; } }
         private Value<decimal?> _mipPaidInCashAmount;
         public decimal? MipPaidInCashAmount { get { return _mipPaidInCashAmount; } set { _mipPaidInCashAmount = value; } }
-        public Miscellaneous Miscellaneous { get; set; }
+        private Miscellaneous _miscellaneous;
+        public Miscellaneous Miscellaneous { get { var v = _miscellaneous; return v ?? Interlocked.CompareExchange(ref _miscellaneous, (v = new Miscellaneous()), null) ?? v; } set { _miscellaneous = value; } }
         private Value<decimal?> _monthlyPIPaymentAmountForLE1andCD1;
         public decimal? MonthlyPIPaymentAmountForLE1andCD1 { get { return _monthlyPIPaymentAmountForLE1andCD1; } set { _monthlyPIPaymentAmountForLE1andCD1 = value; } }
         private Value<decimal?> _mortgageInsurancePremiumFHARefundAmount;
@@ -418,13 +448,16 @@ namespace EncompassRest.Loans
         public string MortgageType { get { return _mortgageType; } set { _mortgageType = value; } }
         private Value<string> _msaIdentifier;
         public string MsaIdentifier { get { return _msaIdentifier; } set { _msaIdentifier = value; } }
-        public NetTangibleBenefit NetTangibleBenefit { get; set; }
+        private NetTangibleBenefit _netTangibleBenefit;
+        public NetTangibleBenefit NetTangibleBenefit { get { var v = _netTangibleBenefit; return v ?? Interlocked.CompareExchange(ref _netTangibleBenefit, (v = new NetTangibleBenefit()), null) ?? v; } set { _netTangibleBenefit = value; } }
         private Value<decimal?> _newFirstMortgageAmount;
         public decimal? NewFirstMortgageAmount { get { return _newFirstMortgageAmount; } set { _newFirstMortgageAmount = value; } }
         private Value<string> _nmlsLoanOriginatorId;
         public string NmlsLoanOriginatorId { get { return _nmlsLoanOriginatorId; } set { _nmlsLoanOriginatorId = value; } }
         private Value<bool?> _noClosingCostOption;
         public bool? NoClosingCostOption { get { return _noClosingCostOption; } set { _noClosingCostOption = value; } }
+        //private DirtyList<NonVol> _nonVols;
+        //public IList<NonVol> NonVols { get { var v = _nonVols; return v ?? Interlocked.CompareExchange(ref _nonVols, (v = new DirtyList<NonVol>()), null) ?? v; } set { _nonVols = new DirtyList<NonVol>(value); } }
         private Value<bool?> _notRequiredForPurchaseSaleOrRefinance;
         public bool? NotRequiredForPurchaseSaleOrRefinance { get { return _notRequiredForPurchaseSaleOrRefinance; } set { _notRequiredForPurchaseSaleOrRefinance = value; } }
         private Value<bool?> _notRequiredForSettlementOfYourLoan;
@@ -463,20 +496,24 @@ namespace EncompassRest.Loans
         public decimal? PercentageOwnershipInterest { get { return _percentageOwnershipInterest; } set { _percentageOwnershipInterest = value; } }
         private Value<bool?> _pmiIndicator;
         public bool? PmiIndicator { get { return _pmiIndicator; } set { _pmiIndicator = value; } }
-        private Value<List<PostClosingConditionLog>> _postClosingConditionLogs;
-        public List<PostClosingConditionLog> PostClosingConditionLogs { get { return _postClosingConditionLogs; } set { _postClosingConditionLogs = value; } }
-        private Value<List<PreliminaryConditionLog>> _preliminaryConditionLogs;
-        public List<PreliminaryConditionLog> PreliminaryConditionLogs { get { return _preliminaryConditionLogs; } set { _preliminaryConditionLogs = value; } }
-        public Prequalification Prequalification { get; set; }
+        private DirtyList<PostClosingConditionLog> _postClosingConditionLogs;
+        public IList<PostClosingConditionLog> PostClosingConditionLogs { get { var v = _postClosingConditionLogs; return v ?? Interlocked.CompareExchange(ref _postClosingConditionLogs, (v = new DirtyList<PostClosingConditionLog>()), null) ?? v; } set { _postClosingConditionLogs = new DirtyList<PostClosingConditionLog>(value); } }
+        private DirtyList<PreliminaryConditionLog> _preliminaryConditionLogs;
+        public IList<PreliminaryConditionLog> PreliminaryConditionLogs { get { var v = _preliminaryConditionLogs; return v ?? Interlocked.CompareExchange(ref _preliminaryConditionLogs, (v = new DirtyList<PreliminaryConditionLog>()), null) ?? v; } set { _preliminaryConditionLogs = new DirtyList<PreliminaryConditionLog>(value); } }
+        private Prequalification _prequalification;
+        public Prequalification Prequalification { get { var v = _prequalification; return v ?? Interlocked.CompareExchange(ref _prequalification, (v = new Prequalification()), null) ?? v; } set { _prequalification = value; } }
         private Value<decimal?> _principalAndInterestMonthlyPaymentAmount;
         public decimal? PrincipalAndInterestMonthlyPaymentAmount { get { return _principalAndInterestMonthlyPaymentAmount; } set { _principalAndInterestMonthlyPaymentAmount = value; } }
         private Value<string> _print2003Application;
         public string Print2003Application { get { return _print2003Application; } set { _print2003Application = value; } }
-        private Value<List<PrintLog>> _printLogs;
-        public List<PrintLog> PrintLogs { get { return _printLogs; } set { _printLogs = value; } }
-        public PrivacyPolicy PrivacyPolicy { get; set; }
-        public ProfitManagement ProfitManagement { get; set; }
-        public Property Property { get; set; }
+        private DirtyList<PrintLog> _printLogs;
+        public IList<PrintLog> PrintLogs { get { var v = _printLogs; return v ?? Interlocked.CompareExchange(ref _printLogs, (v = new DirtyList<PrintLog>()), null) ?? v; } set { _printLogs = new DirtyList<PrintLog>(value); } }
+        private PrivacyPolicy _privacyPolicy;
+        public PrivacyPolicy PrivacyPolicy { get { var v = _privacyPolicy; return v ?? Interlocked.CompareExchange(ref _privacyPolicy, (v = new PrivacyPolicy()), null) ?? v; } set { _privacyPolicy = value; } }
+        private ProfitManagement _profitManagement;
+        public ProfitManagement ProfitManagement { get { var v = _profitManagement; return v ?? Interlocked.CompareExchange(ref _profitManagement, (v = new ProfitManagement()), null) ?? v; } set { _profitManagement = value; } }
+        private Property _property;
+        public Property Property { get { var v = _property; return v ?? Interlocked.CompareExchange(ref _property, (v = new Property()), null) ?? v; } set { _property = value; } }
         private Value<int?> _propertyAppraisedValueAmount;
         public int? PropertyAppraisedValueAmount { get { return _propertyAppraisedValueAmount; } set { _propertyAppraisedValueAmount = value; } }
         private Value<bool?> _propertyEnergyEfficientHomeIndicator;
@@ -501,11 +538,12 @@ namespace EncompassRest.Loans
         public decimal? ProposedOtherMortgagesAmount { get { return _proposedOtherMortgagesAmount; } set { _proposedOtherMortgagesAmount = value; } }
         private Value<string> _proposedRealEstateTaxesAmount;
         public string ProposedRealEstateTaxesAmount { get { return _proposedRealEstateTaxesAmount; } set { _proposedRealEstateTaxesAmount = value; } }
-        private Value<List<PurchaseCredit>> _purchaseCredits;
-        public List<PurchaseCredit> PurchaseCredits { get { return _purchaseCredits; } set { _purchaseCredits = value; } }
+        private DirtyList<PurchaseCredit> _purchaseCredits;
+        public IList<PurchaseCredit> PurchaseCredits { get { var v = _purchaseCredits; return v ?? Interlocked.CompareExchange(ref _purchaseCredits, (v = new DirtyList<PurchaseCredit>()), null) ?? v; } set { _purchaseCredits = new DirtyList<PurchaseCredit>(value); } }
         private Value<decimal?> _purchasePriceAmount;
         public decimal? PurchasePriceAmount { get { return _purchasePriceAmount; } set { _purchasePriceAmount = value; } }
-        public RateLock RateLock { get; set; }
+        private RateLock _rateLock;
+        public RateLock RateLock { get { var v = _rateLock; return v ?? Interlocked.CompareExchange(ref _rateLock, (v = new RateLock()), null) ?? v; } set { _rateLock = value; } }
         private Value<string> _referralAddress;
         public string ReferralAddress { get { return _referralAddress; } set { _referralAddress = value; } }
         private Value<string> _referralCity;
@@ -520,11 +558,12 @@ namespace EncompassRest.Loans
         public string ReferralState { get { return _referralState; } set { _referralState = value; } }
         private Value<decimal?> _refinanceIncludingDebtsToBePaidOffAmount;
         public decimal? RefinanceIncludingDebtsToBePaidOffAmount { get { return _refinanceIncludingDebtsToBePaidOffAmount; } set { _refinanceIncludingDebtsToBePaidOffAmount = value; } }
-        private Value<List<RegistrationLog>> _registrationLogs;
-        public List<RegistrationLog> RegistrationLogs { get { return _registrationLogs; } set { _registrationLogs = value; } }
-        public RegulationZ RegulationZ { get; set; }
-        private Value<List<RemovedLogRecord>> _removedLogRecords;
-        public List<RemovedLogRecord> RemovedLogRecords { get { return _removedLogRecords; } set { _removedLogRecords = value; } }
+        private DirtyList<RegistrationLog> _registrationLogs;
+        public IList<RegistrationLog> RegistrationLogs { get { var v = _registrationLogs; return v ?? Interlocked.CompareExchange(ref _registrationLogs, (v = new DirtyList<RegistrationLog>()), null) ?? v; } set { _registrationLogs = new DirtyList<RegistrationLog>(value); } }
+        private RegulationZ _regulationZ;
+        public RegulationZ RegulationZ { get { var v = _regulationZ; return v ?? Interlocked.CompareExchange(ref _regulationZ, (v = new RegulationZ()), null) ?? v; } set { _regulationZ = value; } }
+        private DirtyList<RemovedLogRecord> _removedLogRecords;
+        public IList<RemovedLogRecord> RemovedLogRecords { get { var v = _removedLogRecords; return v ?? Interlocked.CompareExchange(ref _removedLogRecords, (v = new DirtyList<RemovedLogRecord>()), null) ?? v; } set { _removedLogRecords = new DirtyList<RemovedLogRecord>(value); } }
         private Value<decimal?> _repurchaseCostAmount;
         public decimal? RepurchaseCostAmount { get { return _repurchaseCostAmount; } set { _repurchaseCostAmount = value; } }
         private Value<DateTime?> _repurchaseDate;
@@ -535,36 +574,42 @@ namespace EncompassRest.Loans
         public decimal? SalesConcessionAmount { get { return _salesConcessionAmount; } set { _salesConcessionAmount = value; } }
         private Value<decimal?> _secondSubordinateAmount;
         public decimal? SecondSubordinateAmount { get { return _secondSubordinateAmount; } set { _secondSubordinateAmount = value; } }
-        public Section32 Section32 { get; set; }
+        private Section32 _section32;
+        public Section32 Section32 { get { var v = _section32; return v ?? Interlocked.CompareExchange(ref _section32, (v = new Section32()), null) ?? v; } set { _section32 = value; } }
         private Value<string> _sectionOfActType;
         public string SectionOfActType { get { return _sectionOfActType; } set { _sectionOfActType = value; } }
-        public SelectedHomeCounselingProvider SelectedHomeCounselingProvider { get; set; }
+        private SelectedHomeCounselingProvider _selectedHomeCounselingProvider;
+        public SelectedHomeCounselingProvider SelectedHomeCounselingProvider { get { var v = _selectedHomeCounselingProvider; return v ?? Interlocked.CompareExchange(ref _selectedHomeCounselingProvider, (v = new SelectedHomeCounselingProvider()), null) ?? v; } set { _selectedHomeCounselingProvider = value; } }
         private Value<decimal?> _sellerPaidClosingCostsAmount;
         public decimal? SellerPaidClosingCostsAmount { get { return _sellerPaidClosingCostsAmount; } set { _sellerPaidClosingCostsAmount = value; } }
         private Value<string> _serviceProviderAdditionalInfo;
         public string ServiceProviderAdditionalInfo { get { return _serviceProviderAdditionalInfo; } set { _serviceProviderAdditionalInfo = value; } }
-        private Value<List<ServiceProviderContact>> _serviceProviderContacts;
-        public List<ServiceProviderContact> ServiceProviderContacts { get { return _serviceProviderContacts; } set { _serviceProviderContacts = value; } }
+        private DirtyList<ServiceProviderContact> _serviceProviderContacts;
+        public IList<ServiceProviderContact> ServiceProviderContacts { get { var v = _serviceProviderContacts; return v ?? Interlocked.CompareExchange(ref _serviceProviderContacts, (v = new DirtyList<ServiceProviderContact>()), null) ?? v; } set { _serviceProviderContacts = new DirtyList<ServiceProviderContact>(value); } }
         private Value<DateTime?> _serviceProviderDateIssued;
         public DateTime? ServiceProviderDateIssued { get { return _serviceProviderDateIssued; } set { _serviceProviderDateIssued = value; } }
-        public ServicingDisclosure ServicingDisclosure { get; set; }
+        private ServicingDisclosure _servicingDisclosure;
+        public ServicingDisclosure ServicingDisclosure { get { var v = _servicingDisclosure; return v ?? Interlocked.CompareExchange(ref _servicingDisclosure, (v = new ServicingDisclosure()), null) ?? v; } set { _servicingDisclosure = value; } }
         private Value<bool?> _setForSettlementServicesOfAnAttorney;
         public bool? SetForSettlementServicesOfAnAttorney { get { return _setForSettlementServicesOfAnAttorney; } set { _setForSettlementServicesOfAnAttorney = value; } }
         private Value<bool?> _setForTheSettlementServicesListed;
         public bool? SetForTheSettlementServicesListed { get { return _setForTheSettlementServicesListed; } set { _setForTheSettlementServicesListed = value; } }
-        private Value<List<SettlementServiceCharge>> _settlementServiceCharges;
-        public List<SettlementServiceCharge> SettlementServiceCharges { get { return _settlementServiceCharges; } set { _settlementServiceCharges = value; } }
-        public Shipping Shipping { get; set; }
+        private DirtyList<SettlementServiceCharge> _settlementServiceCharges;
+        public IList<SettlementServiceCharge> SettlementServiceCharges { get { var v = _settlementServiceCharges; return v ?? Interlocked.CompareExchange(ref _settlementServiceCharges, (v = new DirtyList<SettlementServiceCharge>()), null) ?? v; } set { _settlementServiceCharges = new DirtyList<SettlementServiceCharge>(value); } }
+        private Shipping _shipping;
+        public Shipping Shipping { get { var v = _shipping; return v ?? Interlocked.CompareExchange(ref _shipping, (v = new Shipping()), null) ?? v; } set { _shipping = value; } }
         private Value<bool?> _simpleRefinanceType;
         public bool? SimpleRefinanceType { get { return _simpleRefinanceType; } set { _simpleRefinanceType = value; } }
         private Value<decimal?> _startingAdjPrice;
         public decimal? StartingAdjPrice { get { return _startingAdjPrice; } set { _startingAdjPrice = value; } }
         private Value<decimal?> _startingAdjRate;
         public decimal? StartingAdjRate { get { return _startingAdjRate; } set { _startingAdjRate = value; } }
-        public StateDisclosure StateDisclosure { get; set; }
-        public StatementCreditDenial StatementCreditDenial { get; set; }
-        private Value<List<StatusOnlineLog>> _statusOnlineLogs;
-        public List<StatusOnlineLog> StatusOnlineLogs { get { return _statusOnlineLogs; } set { _statusOnlineLogs = value; } }
+        private StateDisclosure _stateDisclosure;
+        public StateDisclosure StateDisclosure { get { var v = _stateDisclosure; return v ?? Interlocked.CompareExchange(ref _stateDisclosure, (v = new StateDisclosure()), null) ?? v; } set { _stateDisclosure = value; } }
+        private StatementCreditDenial _statementCreditDenial;
+        public StatementCreditDenial StatementCreditDenial { get { var v = _statementCreditDenial; return v ?? Interlocked.CompareExchange(ref _statementCreditDenial, (v = new StatementCreditDenial()), null) ?? v; } set { _statementCreditDenial = value; } }
+        private DirtyList<StatusOnlineLog> _statusOnlineLogs;
+        public IList<StatusOnlineLog> StatusOnlineLogs { get { var v = _statusOnlineLogs; return v ?? Interlocked.CompareExchange(ref _statusOnlineLogs, (v = new DirtyList<StatusOnlineLog>()), null) ?? v; } set { _statusOnlineLogs = new DirtyList<StatusOnlineLog>(value); } }
         private Value<decimal?> _subjectPropertyGrossRentalIncomeAmount;
         public decimal? SubjectPropertyGrossRentalIncomeAmount { get { return _subjectPropertyGrossRentalIncomeAmount; } set { _subjectPropertyGrossRentalIncomeAmount = value; } }
         private Value<decimal?> _subjectPropertyOccupancyPercent;
@@ -597,16 +642,22 @@ namespace EncompassRest.Loans
         public decimal? TotalPaidToBrokerAmount { get { return _totalPaidToBrokerAmount; } set { _totalPaidToBrokerAmount = value; } }
         private Value<decimal?> _totalWireTransferAmount;
         public decimal? TotalWireTransferAmount { get { return _totalWireTransferAmount; } set { _totalWireTransferAmount = value; } }
-        public TPO TPO { get; set; }
-        public TQL TQL { get; set; }
-        public TrustAccount TrustAccount { get; set; }
-        public Tsum Tsum { get; set; }
+        private TPO _tPO;
+        public TPO TPO { get { var v = _tPO; return v ?? Interlocked.CompareExchange(ref _tPO, (v = new TPO()), null) ?? v; } set { _tPO = value; } }
+        private TQL _tQL;
+        public TQL TQL { get { var v = _tQL; return v ?? Interlocked.CompareExchange(ref _tQL, (v = new TQL()), null) ?? v; } set { _tQL = value; } }
+        private TrustAccount _trustAccount;
+        public TrustAccount TrustAccount { get { var v = _trustAccount; return v ?? Interlocked.CompareExchange(ref _trustAccount, (v = new TrustAccount()), null) ?? v; } set { _trustAccount = value; } }
+        private Tsum _tsum;
+        public Tsum Tsum { get { var v = _tsum; return v ?? Interlocked.CompareExchange(ref _tsum, (v = new Tsum()), null) ?? v; } set { _tsum = value; } }
         private Value<bool?> _twelveMonthMortgageRentalHistoryIndicator;
         public bool? TwelveMonthMortgageRentalHistoryIndicator { get { return _twelveMonthMortgageRentalHistoryIndicator; } set { _twelveMonthMortgageRentalHistoryIndicator = value; } }
-        public Uldd Uldd { get; set; }
-        public UnderwriterSummary UnderwriterSummary { get; set; }
-        private Value<List<UnderwritingConditionLog>> _underwritingConditionLogs;
-        public List<UnderwritingConditionLog> UnderwritingConditionLogs { get { return _underwritingConditionLogs; } set { _underwritingConditionLogs = value; } }
+        private Uldd _uldd;
+        public Uldd Uldd { get { var v = _uldd; return v ?? Interlocked.CompareExchange(ref _uldd, (v = new Uldd()), null) ?? v; } set { _uldd = value; } }
+        private UnderwriterSummary _underwriterSummary;
+        public UnderwriterSummary UnderwriterSummary { get { var v = _underwriterSummary; return v ?? Interlocked.CompareExchange(ref _underwriterSummary, (v = new UnderwriterSummary()), null) ?? v; } set { _underwriterSummary = value; } }
+        private DirtyList<UnderwritingConditionLog> _underwritingConditionLogs;
+        public IList<UnderwritingConditionLog> UnderwritingConditionLogs { get { var v = _underwritingConditionLogs; return v ?? Interlocked.CompareExchange(ref _underwritingConditionLogs, (v = new DirtyList<UnderwritingConditionLog>()), null) ?? v; } set { _underwritingConditionLogs = new DirtyList<UnderwritingConditionLog>(value); } }
         private Value<bool?> _underwritingEscrowIndicator;
         public bool? UnderwritingEscrowIndicator { get { return _underwritingEscrowIndicator; } set { _underwritingEscrowIndicator = value; } }
         private Value<decimal?> _undiscountedRate;
@@ -617,7 +668,8 @@ namespace EncompassRest.Loans
         public int? UnimprovedEstimatedValue { get { return _unimprovedEstimatedValue; } set { _unimprovedEstimatedValue = value; } }
         private Value<string> _urlPage4Comments;
         public string UrlPage4Comments { get { return _urlPage4Comments; } set { _urlPage4Comments = value; } }
-        public Usda Usda { get; set; }
+        private Usda _usda;
+        public Usda Usda { get { var v = _usda; return v ?? Interlocked.CompareExchange(ref _usda, (v = new Usda()), null) ?? v; } set { _usda = value; } }
         private Value<string> _usdaGovernmentLoanType;
         public string UsdaGovernmentLoanType { get { return _usdaGovernmentLoanType; } set { _usdaGovernmentLoanType = value; } }
         private Value<bool?> _use2018DiIndicator;
@@ -628,9 +680,10 @@ namespace EncompassRest.Loans
         public bool? UseNewHudIndicator { get { return _useNewHudIndicator; } set { _useNewHudIndicator = value; } }
         private Value<decimal?> _vAEntitlementAmount;
         public decimal? VAEntitlementAmount { get { return _vAEntitlementAmount; } set { _vAEntitlementAmount = value; } }
-        public VaLoanData VaLoanData { get; set; }
-        private Value<List<VerificationLog>> _verificationLogs;
-        public List<VerificationLog> VerificationLogs { get { return _verificationLogs; } set { _verificationLogs = value; } }
+        private VaLoanData _vaLoanData;
+        public VaLoanData VaLoanData { get { var v = _vaLoanData; return v ?? Interlocked.CompareExchange(ref _vaLoanData, (v = new VaLoanData()), null) ?? v; } set { _vaLoanData = value; } }
+        private DirtyList<VerificationLog> _verificationLogs;
+        public IList<VerificationLog> VerificationLogs { get { var v = _verificationLogs; return v ?? Interlocked.CompareExchange(ref _verificationLogs, (v = new DirtyList<VerificationLog>()), null) ?? v; } set { _verificationLogs = new DirtyList<VerificationLog>(value); } }
         //private Value<string> _virtualFields;
         //public string VirtualFields { get { return _virtualFields; } set { _virtualFields = value; } }
         private Value<string> _websiteId;
@@ -643,10 +696,8 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _adverseActionDate.Dirty
-                    || _affiliatedBusinessArrangements.Dirty
                     || _agencyCaseIdentifier.Dirty
                     || _alterationsImprovementsOrRepairsAmount.Dirty
-                    || _applications.Dirty
                     || _applicationTakenMethodType.Dirty
                     || _aprDisclosureDate.Dirty
                     || _armTypeDescription.Dirty
@@ -674,38 +725,25 @@ namespace EncompassRest.Loans
                     || _collateralManagerScore.Dirty
                     || _combinedLtv.Dirty
                     || _commitmentNumber.Dirty
-                    || _complianceTestLogs.Dirty
                     || _conformingJumbo.Dirty
                     || _consumerConnectSiteID.Dirty
-                    || _contacts.Dirty
                     || _contactUpdatedIndicator.Dirty
                     || _contractSellerCreditAmount.Dirty
-                    || _conversationLogs.Dirty
                     || _copyBrokerToLenderIndicator.Dirty
                     || _copyLoanNumLenderCaseNum.Dirty
                     || _creditScoreToUse.Dirty
-                    || _crmLogs.Dirty
                     || _currentApplicationIndex.Dirty
                     || _currentApplicationIsPrimary.Dirty
                     || _currentFirstMortgageHolderType.Dirty
-                    || _customFields.Dirty
-                    || _dataTracLogs.Dirty
                     || _dBIndicator.Dirty
                     || _deductOverwireAmountIndicator.Dirty
                     || _disableESignConsentAlert.Dirty
                     || _disableKeyPricingAlert.Dirty
-                    || _disclosureTracking2015Logs.Dirty
-                    || _disclosureTrackingLogs.Dirty
                     || _discountPoint.Dirty
                     || _docEngine.Dirty
-                    || _documentLogs.Dirty
                     || _doNotCheckEmail.Dirty
                     || _doNotPrintCompensationFees.Dirty
-                    || _downloadLogs.Dirty
                     || _downPaymentPercent.Dirty
-                    || _edmLogs.Dirty
-                    //|| _elliUCDFields.Dirty
-                    || _emailTriggerLogs.Dirty
                     || _emXmlVersionId.Dirty
                     || _encompassId.Dirty
                     || _encompassVersion.Dirty
@@ -714,33 +752,27 @@ namespace EncompassRest.Loans
                     || _estimatedConstructionInterest.Dirty
                     || _estimatedPrepaidItemsAmount.Dirty
                     || _exportLoanNumber.Dirty
-                    || _fees.Dirty
                     || _fhaMiPremiumRefundAmount.Dirty
                     || _fHAVALoanOriginatorIdentifier.Dirty
-                    || _fieldLockData.Dirty
                     || _firstAdjustmentMinimum.Dirty
                     || _firstSubordinateLienAmount.Dirty
                     || _firstTimeHomebuyersIndicator.Dirty
                     || _fnmCommunityLendingProductName.Dirty
                     || _fnmCommunitySecondsIndicator.Dirty
                     || _fnmNeighborsMortgageEligibilityIndicator.Dirty
-                    || _forms.Dirty
                     || _fraudScore.Dirty
                     || _fundingDeductionList.Dirty
                     || _fundingFeeList.Dirty
-                    || _fundingFees.Dirty
                     || _governmentLoanLenderIdentifier.Dirty
                     || _governmentLoanSponsorIdentifier.Dirty
                     || _governmentMortgageCreditCertificateAmount.Dirty
                     || _hasAbusinessRelationshipWith.Dirty
                     || _hcltvHtltv.Dirty
                     || _helocTeaserRate.Dirty
-                    || _homeCounselingProviders.Dirty
                     || _homeCounselingProvidersDistance.Dirty
                     || _homeCounselingProvidersLanguageNames.Dirty
                     || _homeCounselingProvidersServiceNames.Dirty
                     || _householdSizeCount.Dirty
-                    || _htmlEmailLogs.Dirty
                     || _hudIncomeLimitAdjustmentFactor.Dirty
                     || _hudLendingIncomeLimitAmount.Dirty
                     || _hudMedianIncomeAmount.Dirty
@@ -771,8 +803,8 @@ namespace EncompassRest.Loans
                     || _lifeInsuranceCoverageAmount.Dirty
                     || _lifeInsuranceEstimatedMonthlyAmount.Dirty
                     || _lifeInsuranceTotalProtectedMonthlyAmount.Dirty
+                    || _linkedBorrowerRequestedLoanAmount.Dirty
                     || _linkId.Dirty
-                    || _loanActionLogs.Dirty
                     || _loanAmortizationTermMonths.Dirty
                     || _loanAmortizationType.Dirty
                     || _loanCreatedDate.Dirty
@@ -782,7 +814,6 @@ namespace EncompassRest.Loans
                     || _loanLinkSyncType.Dirty
                     || _loanNumber.Dirty
                     || _loanProgramName.Dirty
-                    || _loanPrograms.Dirty
                     || _loanPurposeOfRefinanceType.Dirty
                     || _loanSource.Dirty
                     || _loanTotalProposedMonthlyMaintenanceAmount.Dirty
@@ -792,10 +823,6 @@ namespace EncompassRest.Loans
                     || _loanVARateReductionInitialComputationTotalAmount.Dirty
                     || _loanVAResidualIncomeAmount.Dirty
                     || _loanVersionId.Dirty
-                    || _lockConfirmLogs.Dirty
-                    || _lockDenialLogs.Dirty
-                    || _lockRequestLogs.Dirty
-                    || _logEntryLogs.Dirty
                     || _ltv.Dirty
                     || _ltvPropertyValue.Dirty
                     || _masterCommitmentNumber.Dirty
@@ -816,16 +843,12 @@ namespace EncompassRest.Loans
                     || _milestoneDocSignedDueDate.Dirty
                     || _milestoneDuration.Dirty
                     || _milestoneFileStartedDate.Dirty
-                    || _milestoneFreeRoleLogs.Dirty
                     || _milestoneFundedDate.Dirty
                     || _milestoneFundedDueDate.Dirty
-                    || _milestoneLogs.Dirty
                     || _milestoneProcessedDate.Dirty
                     || _milestoneStage.Dirty
                     || _milestoneSubmittedDate.Dirty
                     || _milestoneSubmittedDueDate.Dirty
-                    || _milestoneTaskLogs.Dirty
-                    || _milestoneTemplateLogs.Dirty
                     || _mipBorrowerPaidInCashAmount.Dirty
                     || _mipPaidInCashAmount.Dirty
                     || _monthlyPIPaymentAmountForLE1andCD1.Dirty
@@ -855,11 +878,8 @@ namespace EncompassRest.Loans
                     || _percentageOfOwnership.Dirty
                     || _percentageOwnershipInterest.Dirty
                     || _pmiIndicator.Dirty
-                    || _postClosingConditionLogs.Dirty
-                    || _preliminaryConditionLogs.Dirty
                     || _principalAndInterestMonthlyPaymentAmount.Dirty
                     || _print2003Application.Dirty
-                    || _printLogs.Dirty
                     || _propertyAppraisedValueAmount.Dirty
                     || _propertyEnergyEfficientHomeIndicator.Dirty
                     || _propertyEstimatedValueAmount.Dirty
@@ -872,7 +892,6 @@ namespace EncompassRest.Loans
                     || _proposedOtherAmount.Dirty
                     || _proposedOtherMortgagesAmount.Dirty
                     || _proposedRealEstateTaxesAmount.Dirty
-                    || _purchaseCredits.Dirty
                     || _purchasePriceAmount.Dirty
                     || _referralAddress.Dirty
                     || _referralCity.Dirty
@@ -881,8 +900,6 @@ namespace EncompassRest.Loans
                     || _referralSource.Dirty
                     || _referralState.Dirty
                     || _refinanceIncludingDebtsToBePaidOffAmount.Dirty
-                    || _registrationLogs.Dirty
-                    || _removedLogRecords.Dirty
                     || _repurchaseCostAmount.Dirty
                     || _repurchaseDate.Dirty
                     || _requestedInterestRatePercent.Dirty
@@ -891,15 +908,12 @@ namespace EncompassRest.Loans
                     || _sectionOfActType.Dirty
                     || _sellerPaidClosingCostsAmount.Dirty
                     || _serviceProviderAdditionalInfo.Dirty
-                    || _serviceProviderContacts.Dirty
                     || _serviceProviderDateIssued.Dirty
                     || _setForSettlementServicesOfAnAttorney.Dirty
                     || _setForTheSettlementServicesListed.Dirty
-                    || _settlementServiceCharges.Dirty
                     || _simpleRefinanceType.Dirty
                     || _startingAdjPrice.Dirty
                     || _startingAdjRate.Dirty
-                    || _statusOnlineLogs.Dirty
                     || _subjectPropertyGrossRentalIncomeAmount.Dirty
                     || _subjectPropertyOccupancyPercent.Dirty
                     || _subordinateLienAmount.Dirty
@@ -917,7 +931,6 @@ namespace EncompassRest.Loans
                     || _totalPaidToBrokerAmount.Dirty
                     || _totalWireTransferAmount.Dirty
                     || _twelveMonthMortgageRentalHistoryIndicator.Dirty
-                    || _underwritingConditionLogs.Dirty
                     || _underwritingEscrowIndicator.Dirty
                     || _undiscountedRate.Dirty
                     || _unimprovedAppraisedValue.Dirty
@@ -928,58 +941,100 @@ namespace EncompassRest.Loans
                     || _useNew2015FormsIndicator.Dirty
                     || _useNewHudIndicator.Dirty
                     || _vAEntitlementAmount.Dirty
-                    || _verificationLogs.Dirty
                     //|| _virtualFields.Dirty
                     || _websiteId.Dirty
-                    || AdditionalRequests?.Dirty == true
-                    || ATRQMCommon?.Dirty == true
-                    || ClosingCost?.Dirty == true
-                    || ClosingDocument?.Dirty == true
-                    || CommitmentTerms?.Dirty == true
-                    || ConstructionManagement?.Dirty == true
-                    || Correspondent?.Dirty == true
-                    || CurrentApplication?.Dirty == true
-                    || CustomModelFields?.Dirty == true
-                    || DisclosureNotices?.Dirty == true
-                    || DownPayment?.Dirty == true
-                    || EmDocument?.Dirty == true
-                    || EmDocumentInvestor?.Dirty == true
-                    || EmDocumentLender?.Dirty == true
-                    || FannieMae?.Dirty == true
-                    || FhaVaLoan?.Dirty == true
-                    || FreddieMac?.Dirty == true
-                    || Funding?.Dirty == true
-                    || Gfe?.Dirty == true
-                    || Hmda?.Dirty == true
-                    || Hud1Es?.Dirty == true
-                    || HudLoanData?.Dirty == true
-                    || InterimServicing?.Dirty == true
-                    || LoanProductData?.Dirty == true
-                    || LoanSubmission?.Dirty == true
-                    || LOCompensation?.Dirty == true
-                    || Mcaw?.Dirty == true
-                    || Miscellaneous?.Dirty == true
-                    || NetTangibleBenefit?.Dirty == true
-                    || Prequalification?.Dirty == true
-                    || PrivacyPolicy?.Dirty == true
-                    || ProfitManagement?.Dirty == true
-                    || Property?.Dirty == true
-                    || RateLock?.Dirty == true
-                    || RegulationZ?.Dirty == true
-                    || Section32?.Dirty == true
-                    || SelectedHomeCounselingProvider?.Dirty == true
-                    || ServicingDisclosure?.Dirty == true
-                    || Shipping?.Dirty == true
-                    || StateDisclosure?.Dirty == true
-                    || StatementCreditDenial?.Dirty == true
-                    || TPO?.Dirty == true
-                    || TQL?.Dirty == true
-                    || TrustAccount?.Dirty == true
-                    || Tsum?.Dirty == true
-                    || Uldd?.Dirty == true
-                    || UnderwriterSummary?.Dirty == true
-                    || Usda?.Dirty == true
-                    || VaLoanData?.Dirty == true;
+                    || _additionalRequests?.Dirty == true
+                    || _affiliatedBusinessArrangements?.Dirty == true
+                    || _applications?.Dirty == true
+                    || _aTRQMCommon?.Dirty == true
+                    || _closingCost?.Dirty == true
+                    || _closingDocument?.Dirty == true
+                    || _commitmentTerms?.Dirty == true
+                    || _complianceTestLogs?.Dirty == true
+                    || _constructionManagement?.Dirty == true
+                    || _contacts?.Dirty == true
+                    || _conversationLogs?.Dirty == true
+                    || _correspondent?.Dirty == true
+                    || _crmLogs?.Dirty == true
+                    || _currentApplication?.Dirty == true
+                    || _customFields?.Dirty == true
+                    || _customModelFields?.Dirty == true
+                    || _dataTracLogs?.Dirty == true
+                    || _disclosureNotices?.Dirty == true
+                    || _disclosureTracking2015Logs?.Dirty == true
+                    || _disclosureTrackingLogs?.Dirty == true
+                    || _documentLogs?.Dirty == true
+                    || _downloadLogs?.Dirty == true
+                    || _downPayment?.Dirty == true
+                    || _edmLogs?.Dirty == true
+                    //|| _elliUCDFields?.Dirty == true
+                    || _emailTriggerLogs?.Dirty == true
+                    || _emDocument?.Dirty == true
+                    || _emDocumentInvestor?.Dirty == true
+                    || _emDocumentLender?.Dirty == true
+                    || _fannieMae?.Dirty == true
+                    || _fees?.Dirty == true
+                    || _fhaVaLoan?.Dirty == true
+                    || _fieldLockData?.Dirty == true
+                    || _forms?.Dirty == true
+                    || _freddieMac?.Dirty == true
+                    || _funding?.Dirty == true
+                    || _fundingFees?.Dirty == true
+                    || _gfe?.Dirty == true
+                    || _hmda?.Dirty == true
+                    || _homeCounselingProviders?.Dirty == true
+                    || _htmlEmailLogs?.Dirty == true
+                    || _hud1Es?.Dirty == true
+                    || _hudLoanData?.Dirty == true
+                    || _interimServicing?.Dirty == true
+                    || _loanActionLogs?.Dirty == true
+                    || _loanProductData?.Dirty == true
+                    || _loanPrograms?.Dirty == true
+                    || _loanSubmission?.Dirty == true
+                    || _lockConfirmLogs?.Dirty == true
+                    || _lockDenialLogs?.Dirty == true
+                    || _lockRequestLogs?.Dirty == true
+                    || _lOCompensation?.Dirty == true
+                    || _logEntryLogs?.Dirty == true
+                    || _mcaw?.Dirty == true
+                    || _milestoneFreeRoleLogs?.Dirty == true
+                    || _milestoneLogs?.Dirty == true
+                    || _milestoneTaskLogs?.Dirty == true
+                    || _milestoneTemplateLogs?.Dirty == true
+                    || _miscellaneous?.Dirty == true
+                    || _netTangibleBenefit?.Dirty == true
+                    //|| _nonVols?.Dirty == true
+                    || _postClosingConditionLogs?.Dirty == true
+                    || _preliminaryConditionLogs?.Dirty == true
+                    || _prequalification?.Dirty == true
+                    || _printLogs?.Dirty == true
+                    || _privacyPolicy?.Dirty == true
+                    || _profitManagement?.Dirty == true
+                    || _property?.Dirty == true
+                    || _purchaseCredits?.Dirty == true
+                    || _rateLock?.Dirty == true
+                    || _registrationLogs?.Dirty == true
+                    || _regulationZ?.Dirty == true
+                    || _removedLogRecords?.Dirty == true
+                    || _section32?.Dirty == true
+                    || _selectedHomeCounselingProvider?.Dirty == true
+                    || _serviceProviderContacts?.Dirty == true
+                    || _servicingDisclosure?.Dirty == true
+                    || _settlementServiceCharges?.Dirty == true
+                    || _shipping?.Dirty == true
+                    || _stateDisclosure?.Dirty == true
+                    || _statementCreditDenial?.Dirty == true
+                    || _statusOnlineLogs?.Dirty == true
+                    || _tPO?.Dirty == true
+                    || _tQL?.Dirty == true
+                    || _trustAccount?.Dirty == true
+                    || _tsum?.Dirty == true
+                    || _uldd?.Dirty == true
+                    || _underwriterSummary?.Dirty == true
+                    || _underwritingConditionLogs?.Dirty == true
+                    || _usda?.Dirty == true
+                    || _vaLoanData?.Dirty == true
+                    || _verificationLogs?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -987,10 +1042,8 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _adverseActionDate.Dirty = value;
-                _affiliatedBusinessArrangements.Dirty = value;
                 _agencyCaseIdentifier.Dirty = value;
                 _alterationsImprovementsOrRepairsAmount.Dirty = value;
-                _applications.Dirty = value;
                 _applicationTakenMethodType.Dirty = value;
                 _aprDisclosureDate.Dirty = value;
                 _armTypeDescription.Dirty = value;
@@ -1018,38 +1071,25 @@ namespace EncompassRest.Loans
                 _collateralManagerScore.Dirty = value;
                 _combinedLtv.Dirty = value;
                 _commitmentNumber.Dirty = value;
-                _complianceTestLogs.Dirty = value;
                 _conformingJumbo.Dirty = value;
                 _consumerConnectSiteID.Dirty = value;
-                _contacts.Dirty = value;
                 _contactUpdatedIndicator.Dirty = value;
                 _contractSellerCreditAmount.Dirty = value;
-                _conversationLogs.Dirty = value;
                 _copyBrokerToLenderIndicator.Dirty = value;
                 _copyLoanNumLenderCaseNum.Dirty = value;
                 _creditScoreToUse.Dirty = value;
-                _crmLogs.Dirty = value;
                 _currentApplicationIndex.Dirty = value;
                 _currentApplicationIsPrimary.Dirty = value;
                 _currentFirstMortgageHolderType.Dirty = value;
-                _customFields.Dirty = value;
-                _dataTracLogs.Dirty = value;
                 _dBIndicator.Dirty = value;
                 _deductOverwireAmountIndicator.Dirty = value;
                 _disableESignConsentAlert.Dirty = value;
                 _disableKeyPricingAlert.Dirty = value;
-                _disclosureTracking2015Logs.Dirty = value;
-                _disclosureTrackingLogs.Dirty = value;
                 _discountPoint.Dirty = value;
                 _docEngine.Dirty = value;
-                _documentLogs.Dirty = value;
                 _doNotCheckEmail.Dirty = value;
                 _doNotPrintCompensationFees.Dirty = value;
-                _downloadLogs.Dirty = value;
                 _downPaymentPercent.Dirty = value;
-                _edmLogs.Dirty = value;
-                //_elliUCDFields.Dirty = value;
-                _emailTriggerLogs.Dirty = value;
                 _emXmlVersionId.Dirty = value;
                 _encompassId.Dirty = value;
                 _encompassVersion.Dirty = value;
@@ -1058,33 +1098,27 @@ namespace EncompassRest.Loans
                 _estimatedConstructionInterest.Dirty = value;
                 _estimatedPrepaidItemsAmount.Dirty = value;
                 _exportLoanNumber.Dirty = value;
-                _fees.Dirty = value;
                 _fhaMiPremiumRefundAmount.Dirty = value;
                 _fHAVALoanOriginatorIdentifier.Dirty = value;
-                _fieldLockData.Dirty = value;
                 _firstAdjustmentMinimum.Dirty = value;
                 _firstSubordinateLienAmount.Dirty = value;
                 _firstTimeHomebuyersIndicator.Dirty = value;
                 _fnmCommunityLendingProductName.Dirty = value;
                 _fnmCommunitySecondsIndicator.Dirty = value;
                 _fnmNeighborsMortgageEligibilityIndicator.Dirty = value;
-                _forms.Dirty = value;
                 _fraudScore.Dirty = value;
                 _fundingDeductionList.Dirty = value;
                 _fundingFeeList.Dirty = value;
-                _fundingFees.Dirty = value;
                 _governmentLoanLenderIdentifier.Dirty = value;
                 _governmentLoanSponsorIdentifier.Dirty = value;
                 _governmentMortgageCreditCertificateAmount.Dirty = value;
                 _hasAbusinessRelationshipWith.Dirty = value;
                 _hcltvHtltv.Dirty = value;
                 _helocTeaserRate.Dirty = value;
-                _homeCounselingProviders.Dirty = value;
                 _homeCounselingProvidersDistance.Dirty = value;
                 _homeCounselingProvidersLanguageNames.Dirty = value;
                 _homeCounselingProvidersServiceNames.Dirty = value;
                 _householdSizeCount.Dirty = value;
-                _htmlEmailLogs.Dirty = value;
                 _hudIncomeLimitAdjustmentFactor.Dirty = value;
                 _hudLendingIncomeLimitAmount.Dirty = value;
                 _hudMedianIncomeAmount.Dirty = value;
@@ -1115,8 +1149,8 @@ namespace EncompassRest.Loans
                 _lifeInsuranceCoverageAmount.Dirty = value;
                 _lifeInsuranceEstimatedMonthlyAmount.Dirty = value;
                 _lifeInsuranceTotalProtectedMonthlyAmount.Dirty = value;
+                _linkedBorrowerRequestedLoanAmount.Dirty = value;
                 _linkId.Dirty = value;
-                _loanActionLogs.Dirty = value;
                 _loanAmortizationTermMonths.Dirty = value;
                 _loanAmortizationType.Dirty = value;
                 _loanCreatedDate.Dirty = value;
@@ -1126,7 +1160,6 @@ namespace EncompassRest.Loans
                 _loanLinkSyncType.Dirty = value;
                 _loanNumber.Dirty = value;
                 _loanProgramName.Dirty = value;
-                _loanPrograms.Dirty = value;
                 _loanPurposeOfRefinanceType.Dirty = value;
                 _loanSource.Dirty = value;
                 _loanTotalProposedMonthlyMaintenanceAmount.Dirty = value;
@@ -1136,10 +1169,6 @@ namespace EncompassRest.Loans
                 _loanVARateReductionInitialComputationTotalAmount.Dirty = value;
                 _loanVAResidualIncomeAmount.Dirty = value;
                 _loanVersionId.Dirty = value;
-                _lockConfirmLogs.Dirty = value;
-                _lockDenialLogs.Dirty = value;
-                _lockRequestLogs.Dirty = value;
-                _logEntryLogs.Dirty = value;
                 _ltv.Dirty = value;
                 _ltvPropertyValue.Dirty = value;
                 _masterCommitmentNumber.Dirty = value;
@@ -1160,16 +1189,12 @@ namespace EncompassRest.Loans
                 _milestoneDocSignedDueDate.Dirty = value;
                 _milestoneDuration.Dirty = value;
                 _milestoneFileStartedDate.Dirty = value;
-                _milestoneFreeRoleLogs.Dirty = value;
                 _milestoneFundedDate.Dirty = value;
                 _milestoneFundedDueDate.Dirty = value;
-                _milestoneLogs.Dirty = value;
                 _milestoneProcessedDate.Dirty = value;
                 _milestoneStage.Dirty = value;
                 _milestoneSubmittedDate.Dirty = value;
                 _milestoneSubmittedDueDate.Dirty = value;
-                _milestoneTaskLogs.Dirty = value;
-                _milestoneTemplateLogs.Dirty = value;
                 _mipBorrowerPaidInCashAmount.Dirty = value;
                 _mipPaidInCashAmount.Dirty = value;
                 _monthlyPIPaymentAmountForLE1andCD1.Dirty = value;
@@ -1199,11 +1224,8 @@ namespace EncompassRest.Loans
                 _percentageOfOwnership.Dirty = value;
                 _percentageOwnershipInterest.Dirty = value;
                 _pmiIndicator.Dirty = value;
-                _postClosingConditionLogs.Dirty = value;
-                _preliminaryConditionLogs.Dirty = value;
                 _principalAndInterestMonthlyPaymentAmount.Dirty = value;
                 _print2003Application.Dirty = value;
-                _printLogs.Dirty = value;
                 _propertyAppraisedValueAmount.Dirty = value;
                 _propertyEnergyEfficientHomeIndicator.Dirty = value;
                 _propertyEstimatedValueAmount.Dirty = value;
@@ -1216,7 +1238,6 @@ namespace EncompassRest.Loans
                 _proposedOtherAmount.Dirty = value;
                 _proposedOtherMortgagesAmount.Dirty = value;
                 _proposedRealEstateTaxesAmount.Dirty = value;
-                _purchaseCredits.Dirty = value;
                 _purchasePriceAmount.Dirty = value;
                 _referralAddress.Dirty = value;
                 _referralCity.Dirty = value;
@@ -1225,8 +1246,6 @@ namespace EncompassRest.Loans
                 _referralSource.Dirty = value;
                 _referralState.Dirty = value;
                 _refinanceIncludingDebtsToBePaidOffAmount.Dirty = value;
-                _registrationLogs.Dirty = value;
-                _removedLogRecords.Dirty = value;
                 _repurchaseCostAmount.Dirty = value;
                 _repurchaseDate.Dirty = value;
                 _requestedInterestRatePercent.Dirty = value;
@@ -1235,15 +1254,12 @@ namespace EncompassRest.Loans
                 _sectionOfActType.Dirty = value;
                 _sellerPaidClosingCostsAmount.Dirty = value;
                 _serviceProviderAdditionalInfo.Dirty = value;
-                _serviceProviderContacts.Dirty = value;
                 _serviceProviderDateIssued.Dirty = value;
                 _setForSettlementServicesOfAnAttorney.Dirty = value;
                 _setForTheSettlementServicesListed.Dirty = value;
-                _settlementServiceCharges.Dirty = value;
                 _simpleRefinanceType.Dirty = value;
                 _startingAdjPrice.Dirty = value;
                 _startingAdjRate.Dirty = value;
-                _statusOnlineLogs.Dirty = value;
                 _subjectPropertyGrossRentalIncomeAmount.Dirty = value;
                 _subjectPropertyOccupancyPercent.Dirty = value;
                 _subordinateLienAmount.Dirty = value;
@@ -1261,7 +1277,6 @@ namespace EncompassRest.Loans
                 _totalPaidToBrokerAmount.Dirty = value;
                 _totalWireTransferAmount.Dirty = value;
                 _twelveMonthMortgageRentalHistoryIndicator.Dirty = value;
-                _underwritingConditionLogs.Dirty = value;
                 _underwritingEscrowIndicator.Dirty = value;
                 _undiscountedRate.Dirty = value;
                 _unimprovedAppraisedValue.Dirty = value;
@@ -1272,58 +1287,100 @@ namespace EncompassRest.Loans
                 _useNew2015FormsIndicator.Dirty = value;
                 _useNewHudIndicator.Dirty = value;
                 _vAEntitlementAmount.Dirty = value;
-                _verificationLogs.Dirty = value;
                 //_virtualFields.Dirty = value;
                 _websiteId.Dirty = value;
-                if (AdditionalRequests != null) AdditionalRequests.Dirty = value;
-                if (ATRQMCommon != null) ATRQMCommon.Dirty = value;
-                if (ClosingCost != null) ClosingCost.Dirty = value;
-                if (ClosingDocument != null) ClosingDocument.Dirty = value;
-                if (CommitmentTerms != null) CommitmentTerms.Dirty = value;
-                if (ConstructionManagement != null) ConstructionManagement.Dirty = value;
-                if (Correspondent != null) Correspondent.Dirty = value;
-                if (CurrentApplication != null) CurrentApplication.Dirty = value;
-                if (CustomModelFields != null) CustomModelFields.Dirty = value;
-                if (DisclosureNotices != null) DisclosureNotices.Dirty = value;
-                if (DownPayment != null) DownPayment.Dirty = value;
-                if (EmDocument != null) EmDocument.Dirty = value;
-                if (EmDocumentInvestor != null) EmDocumentInvestor.Dirty = value;
-                if (EmDocumentLender != null) EmDocumentLender.Dirty = value;
-                if (FannieMae != null) FannieMae.Dirty = value;
-                if (FhaVaLoan != null) FhaVaLoan.Dirty = value;
-                if (FreddieMac != null) FreddieMac.Dirty = value;
-                if (Funding != null) Funding.Dirty = value;
-                if (Gfe != null) Gfe.Dirty = value;
-                if (Hmda != null) Hmda.Dirty = value;
-                if (Hud1Es != null) Hud1Es.Dirty = value;
-                if (HudLoanData != null) HudLoanData.Dirty = value;
-                if (InterimServicing != null) InterimServicing.Dirty = value;
-                if (LoanProductData != null) LoanProductData.Dirty = value;
-                if (LoanSubmission != null) LoanSubmission.Dirty = value;
-                if (LOCompensation != null) LOCompensation.Dirty = value;
-                if (Mcaw != null) Mcaw.Dirty = value;
-                if (Miscellaneous != null) Miscellaneous.Dirty = value;
-                if (NetTangibleBenefit != null) NetTangibleBenefit.Dirty = value;
-                if (Prequalification != null) Prequalification.Dirty = value;
-                if (PrivacyPolicy != null) PrivacyPolicy.Dirty = value;
-                if (ProfitManagement != null) ProfitManagement.Dirty = value;
-                if (Property != null) Property.Dirty = value;
-                if (RateLock != null) RateLock.Dirty = value;
-                if (RegulationZ != null) RegulationZ.Dirty = value;
-                if (Section32 != null) Section32.Dirty = value;
-                if (SelectedHomeCounselingProvider != null) SelectedHomeCounselingProvider.Dirty = value;
-                if (ServicingDisclosure != null) ServicingDisclosure.Dirty = value;
-                if (Shipping != null) Shipping.Dirty = value;
-                if (StateDisclosure != null) StateDisclosure.Dirty = value;
-                if (StatementCreditDenial != null) StatementCreditDenial.Dirty = value;
-                if (TPO != null) TPO.Dirty = value;
-                if (TQL != null) TQL.Dirty = value;
-                if (TrustAccount != null) TrustAccount.Dirty = value;
-                if (Tsum != null) Tsum.Dirty = value;
-                if (Uldd != null) Uldd.Dirty = value;
-                if (UnderwriterSummary != null) UnderwriterSummary.Dirty = value;
-                if (Usda != null) Usda.Dirty = value;
-                if (VaLoanData != null) VaLoanData.Dirty = value;
+                if (_additionalRequests != null) _additionalRequests.Dirty = value;
+                if (_affiliatedBusinessArrangements != null) _affiliatedBusinessArrangements.Dirty = value;
+                if (_applications != null) _applications.Dirty = value;
+                if (_aTRQMCommon != null) _aTRQMCommon.Dirty = value;
+                if (_closingCost != null) _closingCost.Dirty = value;
+                if (_closingDocument != null) _closingDocument.Dirty = value;
+                if (_commitmentTerms != null) _commitmentTerms.Dirty = value;
+                if (_complianceTestLogs != null) _complianceTestLogs.Dirty = value;
+                if (_constructionManagement != null) _constructionManagement.Dirty = value;
+                if (_contacts != null) _contacts.Dirty = value;
+                if (_conversationLogs != null) _conversationLogs.Dirty = value;
+                if (_correspondent != null) _correspondent.Dirty = value;
+                if (_crmLogs != null) _crmLogs.Dirty = value;
+                if (_currentApplication != null) _currentApplication.Dirty = value;
+                if (_customFields != null) _customFields.Dirty = value;
+                if (_customModelFields != null) _customModelFields.Dirty = value;
+                if (_dataTracLogs != null) _dataTracLogs.Dirty = value;
+                if (_disclosureNotices != null) _disclosureNotices.Dirty = value;
+                if (_disclosureTracking2015Logs != null) _disclosureTracking2015Logs.Dirty = value;
+                if (_disclosureTrackingLogs != null) _disclosureTrackingLogs.Dirty = value;
+                if (_documentLogs != null) _documentLogs.Dirty = value;
+                if (_downloadLogs != null) _downloadLogs.Dirty = value;
+                if (_downPayment != null) _downPayment.Dirty = value;
+                if (_edmLogs != null) _edmLogs.Dirty = value;
+                //if (_elliUCDFields != null) _elliUCDFields.Dirty = value;
+                if (_emailTriggerLogs != null) _emailTriggerLogs.Dirty = value;
+                if (_emDocument != null) _emDocument.Dirty = value;
+                if (_emDocumentInvestor != null) _emDocumentInvestor.Dirty = value;
+                if (_emDocumentLender != null) _emDocumentLender.Dirty = value;
+                if (_fannieMae != null) _fannieMae.Dirty = value;
+                if (_fees != null) _fees.Dirty = value;
+                if (_fhaVaLoan != null) _fhaVaLoan.Dirty = value;
+                if (_fieldLockData != null) _fieldLockData.Dirty = value;
+                if (_forms != null) _forms.Dirty = value;
+                if (_freddieMac != null) _freddieMac.Dirty = value;
+                if (_funding != null) _funding.Dirty = value;
+                if (_fundingFees != null) _fundingFees.Dirty = value;
+                if (_gfe != null) _gfe.Dirty = value;
+                if (_hmda != null) _hmda.Dirty = value;
+                if (_homeCounselingProviders != null) _homeCounselingProviders.Dirty = value;
+                if (_htmlEmailLogs != null) _htmlEmailLogs.Dirty = value;
+                if (_hud1Es != null) _hud1Es.Dirty = value;
+                if (_hudLoanData != null) _hudLoanData.Dirty = value;
+                if (_interimServicing != null) _interimServicing.Dirty = value;
+                if (_loanActionLogs != null) _loanActionLogs.Dirty = value;
+                if (_loanProductData != null) _loanProductData.Dirty = value;
+                if (_loanPrograms != null) _loanPrograms.Dirty = value;
+                if (_loanSubmission != null) _loanSubmission.Dirty = value;
+                if (_lockConfirmLogs != null) _lockConfirmLogs.Dirty = value;
+                if (_lockDenialLogs != null) _lockDenialLogs.Dirty = value;
+                if (_lockRequestLogs != null) _lockRequestLogs.Dirty = value;
+                if (_lOCompensation != null) _lOCompensation.Dirty = value;
+                if (_logEntryLogs != null) _logEntryLogs.Dirty = value;
+                if (_mcaw != null) _mcaw.Dirty = value;
+                if (_milestoneFreeRoleLogs != null) _milestoneFreeRoleLogs.Dirty = value;
+                if (_milestoneLogs != null) _milestoneLogs.Dirty = value;
+                if (_milestoneTaskLogs != null) _milestoneTaskLogs.Dirty = value;
+                if (_milestoneTemplateLogs != null) _milestoneTemplateLogs.Dirty = value;
+                if (_miscellaneous != null) _miscellaneous.Dirty = value;
+                if (_netTangibleBenefit != null) _netTangibleBenefit.Dirty = value;
+                //if (_nonVols != null) _nonVols.Dirty = value;
+                if (_postClosingConditionLogs != null) _postClosingConditionLogs.Dirty = value;
+                if (_preliminaryConditionLogs != null) _preliminaryConditionLogs.Dirty = value;
+                if (_prequalification != null) _prequalification.Dirty = value;
+                if (_printLogs != null) _printLogs.Dirty = value;
+                if (_privacyPolicy != null) _privacyPolicy.Dirty = value;
+                if (_profitManagement != null) _profitManagement.Dirty = value;
+                if (_property != null) _property.Dirty = value;
+                if (_purchaseCredits != null) _purchaseCredits.Dirty = value;
+                if (_rateLock != null) _rateLock.Dirty = value;
+                if (_registrationLogs != null) _registrationLogs.Dirty = value;
+                if (_regulationZ != null) _regulationZ.Dirty = value;
+                if (_removedLogRecords != null) _removedLogRecords.Dirty = value;
+                if (_section32 != null) _section32.Dirty = value;
+                if (_selectedHomeCounselingProvider != null) _selectedHomeCounselingProvider.Dirty = value;
+                if (_serviceProviderContacts != null) _serviceProviderContacts.Dirty = value;
+                if (_servicingDisclosure != null) _servicingDisclosure.Dirty = value;
+                if (_settlementServiceCharges != null) _settlementServiceCharges.Dirty = value;
+                if (_shipping != null) _shipping.Dirty = value;
+                if (_stateDisclosure != null) _stateDisclosure.Dirty = value;
+                if (_statementCreditDenial != null) _statementCreditDenial.Dirty = value;
+                if (_statusOnlineLogs != null) _statusOnlineLogs.Dirty = value;
+                if (_tPO != null) _tPO.Dirty = value;
+                if (_tQL != null) _tQL.Dirty = value;
+                if (_trustAccount != null) _trustAccount.Dirty = value;
+                if (_tsum != null) _tsum.Dirty = value;
+                if (_uldd != null) _uldd.Dirty = value;
+                if (_underwriterSummary != null) _underwriterSummary.Dirty = value;
+                if (_underwritingConditionLogs != null) _underwritingConditionLogs.Dirty = value;
+                if (_usda != null) _usda.Dirty = value;
+                if (_vaLoanData != null) _vaLoanData.Dirty = value;
+                if (_verificationLogs != null) _verificationLogs.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Loan.cs
+++ b/src/EncompassRest/Loans/Loan.cs
@@ -10,111 +10,111 @@ namespace EncompassRest.Loans
     {
         private AdditionalRequests _additionalRequests;
         public AdditionalRequests AdditionalRequests { get { var v = _additionalRequests; return v ?? Interlocked.CompareExchange(ref _additionalRequests, (v = new AdditionalRequests()), null) ?? v; } set { _additionalRequests = value; } }
-        private Value<DateTime?> _adverseActionDate;
+        private DirtyValue<DateTime?> _adverseActionDate;
         public DateTime? AdverseActionDate { get { return _adverseActionDate; } set { _adverseActionDate = value; } }
         private DirtyList<AffiliatedBusinessArrangement> _affiliatedBusinessArrangements;
         public IList<AffiliatedBusinessArrangement> AffiliatedBusinessArrangements { get { var v = _affiliatedBusinessArrangements; return v ?? Interlocked.CompareExchange(ref _affiliatedBusinessArrangements, (v = new DirtyList<AffiliatedBusinessArrangement>()), null) ?? v; } set { _affiliatedBusinessArrangements = new DirtyList<AffiliatedBusinessArrangement>(value); } }
-        private Value<string> _agencyCaseIdentifier;
+        private DirtyValue<string> _agencyCaseIdentifier;
         public string AgencyCaseIdentifier { get { return _agencyCaseIdentifier; } set { _agencyCaseIdentifier = value; } }
-        private Value<decimal?> _alterationsImprovementsOrRepairsAmount;
+        private DirtyValue<decimal?> _alterationsImprovementsOrRepairsAmount;
         public decimal? AlterationsImprovementsOrRepairsAmount { get { return _alterationsImprovementsOrRepairsAmount; } set { _alterationsImprovementsOrRepairsAmount = value; } }
         private DirtyList<Application> _applications;
         public IList<Application> Applications { get { var v = _applications; return v ?? Interlocked.CompareExchange(ref _applications, (v = new DirtyList<Application>()), null) ?? v; } set { _applications = new DirtyList<Application>(value); } }
-        private Value<string> _applicationTakenMethodType;
+        private DirtyValue<string> _applicationTakenMethodType;
         public string ApplicationTakenMethodType { get { return _applicationTakenMethodType; } set { _applicationTakenMethodType = value; } }
-        private Value<DateTime?> _aprDisclosureDate;
+        private DirtyValue<DateTime?> _aprDisclosureDate;
         public DateTime? AprDisclosureDate { get { return _aprDisclosureDate; } set { _aprDisclosureDate = value; } }
-        private Value<string> _armTypeDescription;
+        private DirtyValue<string> _armTypeDescription;
         public string ArmTypeDescription { get { return _armTypeDescription; } set { _armTypeDescription = value; } }
         private ATRQMCommon _aTRQMCommon;
         public ATRQMCommon ATRQMCommon { get { var v = _aTRQMCommon; return v ?? Interlocked.CompareExchange(ref _aTRQMCommon, (v = new ATRQMCommon()), null) ?? v; } set { _aTRQMCommon = value; } }
-        private Value<decimal?> _baseLoanAmount;
+        private DirtyValue<decimal?> _baseLoanAmount;
         public decimal? BaseLoanAmount { get { return _baseLoanAmount; } set { _baseLoanAmount = value; } }
-        private Value<bool?> _belowMarketSubordinateFinancingIndicator;
+        private DirtyValue<bool?> _belowMarketSubordinateFinancingIndicator;
         public bool? BelowMarketSubordinateFinancingIndicator { get { return _belowMarketSubordinateFinancingIndicator; } set { _belowMarketSubordinateFinancingIndicator = value; } }
-        private Value<string> _billingCategory;
+        private DirtyValue<string> _billingCategory;
         public string BillingCategory { get { return _billingCategory; } set { _billingCategory = value; } }
-        private Value<decimal?> _biweeklyPaymentAmount;
+        private DirtyValue<decimal?> _biweeklyPaymentAmount;
         public decimal? BiweeklyPaymentAmount { get { return _biweeklyPaymentAmount; } set { _biweeklyPaymentAmount = value; } }
-        private Value<int?> _bLTV;
+        private DirtyValue<int?> _bLTV;
         public int? BLTV { get { return _bLTV; } set { _bLTV = value; } }
-        private Value<bool?> _borrowerCoBorrowerMarriedIndicator;
+        private DirtyValue<bool?> _borrowerCoBorrowerMarriedIndicator;
         public bool? BorrowerCoBorrowerMarriedIndicator { get { return _borrowerCoBorrowerMarriedIndicator; } set { _borrowerCoBorrowerMarriedIndicator = value; } }
-        private Value<decimal?> _borrowerPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _borrowerPaidClosingCostsAmount;
         public decimal? BorrowerPaidClosingCostsAmount { get { return _borrowerPaidClosingCostsAmount; } set { _borrowerPaidClosingCostsAmount = value; } }
-        private Value<decimal?> _borrowerPaidDiscountPointsAmount;
+        private DirtyValue<decimal?> _borrowerPaidDiscountPointsAmount;
         public decimal? BorrowerPaidDiscountPointsAmount { get { return _borrowerPaidDiscountPointsAmount; } set { _borrowerPaidDiscountPointsAmount = value; } }
-        private Value<decimal?> _borrowerPaidFHAVAClosingCostsAmount;
+        private DirtyValue<decimal?> _borrowerPaidFHAVAClosingCostsAmount;
         public decimal? BorrowerPaidFHAVAClosingCostsAmount { get { return _borrowerPaidFHAVAClosingCostsAmount; } set { _borrowerPaidFHAVAClosingCostsAmount = value; } }
-        private Value<decimal?> _borrowerRequestedLoanAmount;
+        private DirtyValue<decimal?> _borrowerRequestedLoanAmount;
         public decimal? BorrowerRequestedLoanAmount { get { return _borrowerRequestedLoanAmount; } set { _borrowerRequestedLoanAmount = value; } }
-        private Value<decimal?> _brokerPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _brokerPaidClosingCostsAmount;
         public decimal? BrokerPaidClosingCostsAmount { get { return _brokerPaidClosingCostsAmount; } set { _brokerPaidClosingCostsAmount = value; } }
-        private Value<bool?> _buydownIndicator;
+        private DirtyValue<bool?> _buydownIndicator;
         public bool? BuydownIndicator { get { return _buydownIndicator; } set { _buydownIndicator = value; } }
-        private Value<decimal?> _buydownMonthlyPaymentAmount;
+        private DirtyValue<decimal?> _buydownMonthlyPaymentAmount;
         public decimal? BuydownMonthlyPaymentAmount { get { return _buydownMonthlyPaymentAmount; } set { _buydownMonthlyPaymentAmount = value; } }
-        private Value<decimal?> _buydownRatePercent;
+        private DirtyValue<decimal?> _buydownRatePercent;
         public decimal? BuydownRatePercent { get { return _buydownRatePercent; } set { _buydownRatePercent = value; } }
-        private Value<decimal?> _cashFromToBorrowerAmount;
+        private DirtyValue<decimal?> _cashFromToBorrowerAmount;
         public decimal? CashFromToBorrowerAmount { get { return _cashFromToBorrowerAmount; } set { _cashFromToBorrowerAmount = value; } }
-        private Value<string> _channel;
+        private DirtyValue<string> _channel;
         public string Channel { get { return _channel; } set { _channel = value; } }
-        private Value<DateTime?> _closingBillingDate;
+        private DirtyValue<DateTime?> _closingBillingDate;
         public DateTime? ClosingBillingDate { get { return _closingBillingDate; } set { _closingBillingDate = value; } }
         private ClosingCost _closingCost;
         public ClosingCost ClosingCost { get { var v = _closingCost; return v ?? Interlocked.CompareExchange(ref _closingCost, (v = new ClosingCost()), null) ?? v; } set { _closingCost = value; } }
-        private Value<string> _closingCostProgram;
+        private DirtyValue<string> _closingCostProgram;
         public string ClosingCostProgram { get { return _closingCostProgram; } set { _closingCostProgram = value; } }
-        private Value<decimal?> _closingCostsAndPrepaidsFromOtherLienAmount;
+        private DirtyValue<decimal?> _closingCostsAndPrepaidsFromOtherLienAmount;
         public decimal? ClosingCostsAndPrepaidsFromOtherLienAmount { get { return _closingCostsAndPrepaidsFromOtherLienAmount; } set { _closingCostsAndPrepaidsFromOtherLienAmount = value; } }
-        private Value<decimal?> _closingCostsPaidByOthersAmount;
+        private DirtyValue<decimal?> _closingCostsPaidByOthersAmount;
         public decimal? ClosingCostsPaidByOthersAmount { get { return _closingCostsPaidByOthersAmount; } set { _closingCostsPaidByOthersAmount = value; } }
-        private Value<string> _closingDocsStackingOrder;
+        private DirtyValue<string> _closingDocsStackingOrder;
         public string ClosingDocsStackingOrder { get { return _closingDocsStackingOrder; } set { _closingDocsStackingOrder = value; } }
         private ClosingDocument _closingDocument;
         public ClosingDocument ClosingDocument { get { var v = _closingDocument; return v ?? Interlocked.CompareExchange(ref _closingDocument, (v = new ClosingDocument()), null) ?? v; } set { _closingDocument = value; } }
-        private Value<int?> _collateralManagerScore;
+        private DirtyValue<int?> _collateralManagerScore;
         public int? CollateralManagerScore { get { return _collateralManagerScore; } set { _collateralManagerScore = value; } }
-        private Value<decimal?> _combinedLtv;
+        private DirtyValue<decimal?> _combinedLtv;
         public decimal? CombinedLtv { get { return _combinedLtv; } set { _combinedLtv = value; } }
-        private Value<string> _commitmentNumber;
+        private DirtyValue<string> _commitmentNumber;
         public string CommitmentNumber { get { return _commitmentNumber; } set { _commitmentNumber = value; } }
         private CommitmentTerms _commitmentTerms;
         public CommitmentTerms CommitmentTerms { get { var v = _commitmentTerms; return v ?? Interlocked.CompareExchange(ref _commitmentTerms, (v = new CommitmentTerms()), null) ?? v; } set { _commitmentTerms = value; } }
         private DirtyList<ComplianceTestLog> _complianceTestLogs;
         public IList<ComplianceTestLog> ComplianceTestLogs { get { var v = _complianceTestLogs; return v ?? Interlocked.CompareExchange(ref _complianceTestLogs, (v = new DirtyList<ComplianceTestLog>()), null) ?? v; } set { _complianceTestLogs = new DirtyList<ComplianceTestLog>(value); } }
-        private Value<string> _conformingJumbo;
+        private DirtyValue<string> _conformingJumbo;
         public string ConformingJumbo { get { return _conformingJumbo; } set { _conformingJumbo = value; } }
         private ConstructionManagement _constructionManagement;
         public ConstructionManagement ConstructionManagement { get { var v = _constructionManagement; return v ?? Interlocked.CompareExchange(ref _constructionManagement, (v = new ConstructionManagement()), null) ?? v; } set { _constructionManagement = value; } }
-        private Value<string> _consumerConnectSiteID;
+        private DirtyValue<string> _consumerConnectSiteID;
         public string ConsumerConnectSiteID { get { return _consumerConnectSiteID; } set { _consumerConnectSiteID = value; } }
         private DirtyList<Contact> _contacts;
         public IList<Contact> Contacts { get { var v = _contacts; return v ?? Interlocked.CompareExchange(ref _contacts, (v = new DirtyList<Contact>()), null) ?? v; } set { _contacts = new DirtyList<Contact>(value); } }
-        private Value<bool?> _contactUpdatedIndicator;
+        private DirtyValue<bool?> _contactUpdatedIndicator;
         public bool? ContactUpdatedIndicator { get { return _contactUpdatedIndicator; } set { _contactUpdatedIndicator = value; } }
-        private Value<decimal?> _contractSellerCreditAmount;
+        private DirtyValue<decimal?> _contractSellerCreditAmount;
         public decimal? ContractSellerCreditAmount { get { return _contractSellerCreditAmount; } set { _contractSellerCreditAmount = value; } }
         private DirtyList<ConversationLog> _conversationLogs;
         public IList<ConversationLog> ConversationLogs { get { var v = _conversationLogs; return v ?? Interlocked.CompareExchange(ref _conversationLogs, (v = new DirtyList<ConversationLog>()), null) ?? v; } set { _conversationLogs = new DirtyList<ConversationLog>(value); } }
-        private Value<bool?> _copyBrokerToLenderIndicator;
+        private DirtyValue<bool?> _copyBrokerToLenderIndicator;
         public bool? CopyBrokerToLenderIndicator { get { return _copyBrokerToLenderIndicator; } set { _copyBrokerToLenderIndicator = value; } }
-        private Value<string> _copyLoanNumLenderCaseNum;
+        private DirtyValue<string> _copyLoanNumLenderCaseNum;
         public string CopyLoanNumLenderCaseNum { get { return _copyLoanNumLenderCaseNum; } set { _copyLoanNumLenderCaseNum = value; } }
         private Correspondent _correspondent;
         public Correspondent Correspondent { get { var v = _correspondent; return v ?? Interlocked.CompareExchange(ref _correspondent, (v = new Correspondent()), null) ?? v; } set { _correspondent = value; } }
-        private Value<string> _creditScoreToUse;
+        private DirtyValue<string> _creditScoreToUse;
         public string CreditScoreToUse { get { return _creditScoreToUse; } set { _creditScoreToUse = value; } }
         private DirtyList<CrmLog> _crmLogs;
         public IList<CrmLog> CrmLogs { get { var v = _crmLogs; return v ?? Interlocked.CompareExchange(ref _crmLogs, (v = new DirtyList<CrmLog>()), null) ?? v; } set { _crmLogs = new DirtyList<CrmLog>(value); } }
         private Application _currentApplication;
         public Application CurrentApplication { get { var v = _currentApplication; return v ?? Interlocked.CompareExchange(ref _currentApplication, (v = new Application()), null) ?? v; } set { _currentApplication = value; } }
-        private Value<int?> _currentApplicationIndex;
+        private DirtyValue<int?> _currentApplicationIndex;
         public int? CurrentApplicationIndex { get { return _currentApplicationIndex; } set { _currentApplicationIndex = value; } }
-        private Value<bool?> _currentApplicationIsPrimary;
+        private DirtyValue<bool?> _currentApplicationIsPrimary;
         public bool? CurrentApplicationIsPrimary { get { return _currentApplicationIsPrimary; } set { _currentApplicationIsPrimary = value; } }
-        private Value<string> _currentFirstMortgageHolderType;
+        private DirtyValue<string> _currentFirstMortgageHolderType;
         public string CurrentFirstMortgageHolderType { get { return _currentFirstMortgageHolderType; } set { _currentFirstMortgageHolderType = value; } }
         private DirtyList<CustomField> _customFields;
         public IList<CustomField> CustomFields { get { var v = _customFields; return v ?? Interlocked.CompareExchange(ref _customFields, (v = new DirtyList<CustomField>()), null) ?? v; } set { _customFields = new DirtyList<CustomField>(value); } }
@@ -122,13 +122,13 @@ namespace EncompassRest.Loans
         public CustomModelFields CustomModelFields { get { var v = _customModelFields; return v ?? Interlocked.CompareExchange(ref _customModelFields, (v = new CustomModelFields()), null) ?? v; } set { _customModelFields = value; } }
         private DirtyList<DataTracLog> _dataTracLogs;
         public IList<DataTracLog> DataTracLogs { get { var v = _dataTracLogs; return v ?? Interlocked.CompareExchange(ref _dataTracLogs, (v = new DirtyList<DataTracLog>()), null) ?? v; } set { _dataTracLogs = new DirtyList<DataTracLog>(value); } }
-        private Value<bool?> _dBIndicator;
+        private DirtyValue<bool?> _dBIndicator;
         public bool? DBIndicator { get { return _dBIndicator; } set { _dBIndicator = value; } }
-        private Value<bool?> _deductOverwireAmountIndicator;
+        private DirtyValue<bool?> _deductOverwireAmountIndicator;
         public bool? DeductOverwireAmountIndicator { get { return _deductOverwireAmountIndicator; } set { _deductOverwireAmountIndicator = value; } }
-        private Value<bool?> _disableESignConsentAlert;
+        private DirtyValue<bool?> _disableESignConsentAlert;
         public bool? DisableESignConsentAlert { get { return _disableESignConsentAlert; } set { _disableESignConsentAlert = value; } }
-        private Value<bool?> _disableKeyPricingAlert;
+        private DirtyValue<bool?> _disableKeyPricingAlert;
         public bool? DisableKeyPricingAlert { get { return _disableKeyPricingAlert; } set { _disableKeyPricingAlert = value; } }
         private DisclosureNotices _disclosureNotices;
         public DisclosureNotices DisclosureNotices { get { var v = _disclosureNotices; return v ?? Interlocked.CompareExchange(ref _disclosureNotices, (v = new DisclosureNotices()), null) ?? v; } set { _disclosureNotices = value; } }
@@ -136,21 +136,21 @@ namespace EncompassRest.Loans
         public IList<DisclosureTracking2015Log> DisclosureTracking2015Logs { get { var v = _disclosureTracking2015Logs; return v ?? Interlocked.CompareExchange(ref _disclosureTracking2015Logs, (v = new DirtyList<DisclosureTracking2015Log>()), null) ?? v; } set { _disclosureTracking2015Logs = new DirtyList<DisclosureTracking2015Log>(value); } }
         private DirtyList<DisclosureTrackingLog> _disclosureTrackingLogs;
         public IList<DisclosureTrackingLog> DisclosureTrackingLogs { get { var v = _disclosureTrackingLogs; return v ?? Interlocked.CompareExchange(ref _disclosureTrackingLogs, (v = new DirtyList<DisclosureTrackingLog>()), null) ?? v; } set { _disclosureTrackingLogs = new DirtyList<DisclosureTrackingLog>(value); } }
-        private Value<decimal?> _discountPoint;
+        private DirtyValue<decimal?> _discountPoint;
         public decimal? DiscountPoint { get { return _discountPoint; } set { _discountPoint = value; } }
-        private Value<string> _docEngine;
+        private DirtyValue<string> _docEngine;
         public string DocEngine { get { return _docEngine; } set { _docEngine = value; } }
         private DirtyList<DocumentLog> _documentLogs;
         public IList<DocumentLog> DocumentLogs { get { var v = _documentLogs; return v ?? Interlocked.CompareExchange(ref _documentLogs, (v = new DirtyList<DocumentLog>()), null) ?? v; } set { _documentLogs = new DirtyList<DocumentLog>(value); } }
-        private Value<string> _doNotCheckEmail;
+        private DirtyValue<string> _doNotCheckEmail;
         public string DoNotCheckEmail { get { return _doNotCheckEmail; } set { _doNotCheckEmail = value; } }
-        private Value<bool?> _doNotPrintCompensationFees;
+        private DirtyValue<bool?> _doNotPrintCompensationFees;
         public bool? DoNotPrintCompensationFees { get { return _doNotPrintCompensationFees; } set { _doNotPrintCompensationFees = value; } }
         private DirtyList<DownloadLog> _downloadLogs;
         public IList<DownloadLog> DownloadLogs { get { var v = _downloadLogs; return v ?? Interlocked.CompareExchange(ref _downloadLogs, (v = new DirtyList<DownloadLog>()), null) ?? v; } set { _downloadLogs = new DirtyList<DownloadLog>(value); } }
         private DownPayment _downPayment;
         public DownPayment DownPayment { get { var v = _downPayment; return v ?? Interlocked.CompareExchange(ref _downPayment, (v = new DownPayment()), null) ?? v; } set { _downPayment = value; } }
-        private Value<decimal?> _downPaymentPercent;
+        private DirtyValue<decimal?> _downPaymentPercent;
         public decimal? DownPaymentPercent { get { return _downPaymentPercent; } set { _downPaymentPercent = value; } }
         private DirtyList<EdmLog> _edmLogs;
         public IList<EdmLog> EdmLogs { get { var v = _edmLogs; return v ?? Interlocked.CompareExchange(ref _edmLogs, (v = new DirtyList<EdmLog>()), null) ?? v; } set { _edmLogs = new DirtyList<EdmLog>(value); } }
@@ -164,201 +164,201 @@ namespace EncompassRest.Loans
         public EmDocumentInvestor EmDocumentInvestor { get { var v = _emDocumentInvestor; return v ?? Interlocked.CompareExchange(ref _emDocumentInvestor, (v = new EmDocumentInvestor()), null) ?? v; } set { _emDocumentInvestor = value; } }
         private EmDocumentLender _emDocumentLender;
         public EmDocumentLender EmDocumentLender { get { var v = _emDocumentLender; return v ?? Interlocked.CompareExchange(ref _emDocumentLender, (v = new EmDocumentLender()), null) ?? v; } set { _emDocumentLender = value; } }
-        private Value<string> _emXmlVersionId;
+        private DirtyValue<string> _emXmlVersionId;
         public string EmXmlVersionId { get { return _emXmlVersionId; } set { _emXmlVersionId = value; } }
-        private Value<string> _encompassId;
+        private DirtyValue<string> _encompassId;
         public string EncompassId { get { return _encompassId; } set { _encompassId = value; } }
-        private Value<string> _encompassVersion;
+        private DirtyValue<string> _encompassVersion;
         public string EncompassVersion { get { return _encompassVersion; } set { _encompassVersion = value; } }
-        private Value<bool?> _enforceCountyLoanLimit;
+        private DirtyValue<bool?> _enforceCountyLoanLimit;
         public bool? EnforceCountyLoanLimit { get { return _enforceCountyLoanLimit; } set { _enforceCountyLoanLimit = value; } }
-        private Value<decimal?> _estimatedClosingCostsAmount;
+        private DirtyValue<decimal?> _estimatedClosingCostsAmount;
         public decimal? EstimatedClosingCostsAmount { get { return _estimatedClosingCostsAmount; } set { _estimatedClosingCostsAmount = value; } }
-        private Value<decimal?> _estimatedConstructionInterest;
+        private DirtyValue<decimal?> _estimatedConstructionInterest;
         public decimal? EstimatedConstructionInterest { get { return _estimatedConstructionInterest; } set { _estimatedConstructionInterest = value; } }
-        private Value<decimal?> _estimatedPrepaidItemsAmount;
+        private DirtyValue<decimal?> _estimatedPrepaidItemsAmount;
         public decimal? EstimatedPrepaidItemsAmount { get { return _estimatedPrepaidItemsAmount; } set { _estimatedPrepaidItemsAmount = value; } }
-        private Value<string> _exportLoanNumber;
+        private DirtyValue<string> _exportLoanNumber;
         public string ExportLoanNumber { get { return _exportLoanNumber; } set { _exportLoanNumber = value; } }
         private FannieMae _fannieMae;
         public FannieMae FannieMae { get { var v = _fannieMae; return v ?? Interlocked.CompareExchange(ref _fannieMae, (v = new FannieMae()), null) ?? v; } set { _fannieMae = value; } }
         private DirtyList<Fee> _fees;
         public IList<Fee> Fees { get { var v = _fees; return v ?? Interlocked.CompareExchange(ref _fees, (v = new DirtyList<Fee>()), null) ?? v; } set { _fees = new DirtyList<Fee>(value); } }
-        private Value<decimal?> _fhaMiPremiumRefundAmount;
+        private DirtyValue<decimal?> _fhaMiPremiumRefundAmount;
         public decimal? FhaMiPremiumRefundAmount { get { return _fhaMiPremiumRefundAmount; } set { _fhaMiPremiumRefundAmount = value; } }
         private FhaVaLoan _fhaVaLoan;
         public FhaVaLoan FhaVaLoan { get { var v = _fhaVaLoan; return v ?? Interlocked.CompareExchange(ref _fhaVaLoan, (v = new FhaVaLoan()), null) ?? v; } set { _fhaVaLoan = value; } }
-        private Value<string> _fHAVALoanOriginatorIdentifier;
+        private DirtyValue<string> _fHAVALoanOriginatorIdentifier;
         public string FHAVALoanOriginatorIdentifier { get { return _fHAVALoanOriginatorIdentifier; } set { _fHAVALoanOriginatorIdentifier = value; } }
         private DirtyList<FieldLockData> _fieldLockData;
         public IList<FieldLockData> FieldLockData { get { var v = _fieldLockData; return v ?? Interlocked.CompareExchange(ref _fieldLockData, (v = new DirtyList<FieldLockData>()), null) ?? v; } set { _fieldLockData = new DirtyList<FieldLockData>(value); } }
-        private Value<decimal?> _firstAdjustmentMinimum;
+        private DirtyValue<decimal?> _firstAdjustmentMinimum;
         public decimal? FirstAdjustmentMinimum { get { return _firstAdjustmentMinimum; } set { _firstAdjustmentMinimum = value; } }
-        private Value<decimal?> _firstSubordinateLienAmount;
+        private DirtyValue<decimal?> _firstSubordinateLienAmount;
         public decimal? FirstSubordinateLienAmount { get { return _firstSubordinateLienAmount; } set { _firstSubordinateLienAmount = value; } }
-        private Value<bool?> _firstTimeHomebuyersIndicator;
+        private DirtyValue<bool?> _firstTimeHomebuyersIndicator;
         public bool? FirstTimeHomebuyersIndicator { get { return _firstTimeHomebuyersIndicator; } set { _firstTimeHomebuyersIndicator = value; } }
-        private Value<string> _fnmCommunityLendingProductName;
+        private DirtyValue<string> _fnmCommunityLendingProductName;
         public string FnmCommunityLendingProductName { get { return _fnmCommunityLendingProductName; } set { _fnmCommunityLendingProductName = value; } }
-        private Value<bool?> _fnmCommunitySecondsIndicator;
+        private DirtyValue<bool?> _fnmCommunitySecondsIndicator;
         public bool? FnmCommunitySecondsIndicator { get { return _fnmCommunitySecondsIndicator; } set { _fnmCommunitySecondsIndicator = value; } }
-        private Value<bool?> _fnmNeighborsMortgageEligibilityIndicator;
+        private DirtyValue<bool?> _fnmNeighborsMortgageEligibilityIndicator;
         public bool? FnmNeighborsMortgageEligibilityIndicator { get { return _fnmNeighborsMortgageEligibilityIndicator; } set { _fnmNeighborsMortgageEligibilityIndicator = value; } }
         private DirtyList<Form> _forms;
         public IList<Form> Forms { get { var v = _forms; return v ?? Interlocked.CompareExchange(ref _forms, (v = new DirtyList<Form>()), null) ?? v; } set { _forms = new DirtyList<Form>(value); } }
-        private Value<int?> _fraudScore;
+        private DirtyValue<int?> _fraudScore;
         public int? FraudScore { get { return _fraudScore; } set { _fraudScore = value; } }
         private FreddieMac _freddieMac;
         public FreddieMac FreddieMac { get { var v = _freddieMac; return v ?? Interlocked.CompareExchange(ref _freddieMac, (v = new FreddieMac()), null) ?? v; } set { _freddieMac = value; } }
         private Funding _funding;
         public Funding Funding { get { var v = _funding; return v ?? Interlocked.CompareExchange(ref _funding, (v = new Funding()), null) ?? v; } set { _funding = value; } }
-        private Value<string> _fundingDeductionList;
+        private DirtyValue<string> _fundingDeductionList;
         public string FundingDeductionList { get { return _fundingDeductionList; } set { _fundingDeductionList = value; } }
-        private Value<string> _fundingFeeList;
+        private DirtyValue<string> _fundingFeeList;
         public string FundingFeeList { get { return _fundingFeeList; } set { _fundingFeeList = value; } }
         private DirtyList<FundingFee> _fundingFees;
         public IList<FundingFee> FundingFees { get { var v = _fundingFees; return v ?? Interlocked.CompareExchange(ref _fundingFees, (v = new DirtyList<FundingFee>()), null) ?? v; } set { _fundingFees = new DirtyList<FundingFee>(value); } }
         private Gfe _gfe;
         public Gfe Gfe { get { var v = _gfe; return v ?? Interlocked.CompareExchange(ref _gfe, (v = new Gfe()), null) ?? v; } set { _gfe = value; } }
-        private Value<string> _governmentLoanLenderIdentifier;
+        private DirtyValue<string> _governmentLoanLenderIdentifier;
         public string GovernmentLoanLenderIdentifier { get { return _governmentLoanLenderIdentifier; } set { _governmentLoanLenderIdentifier = value; } }
-        private Value<string> _governmentLoanSponsorIdentifier;
+        private DirtyValue<string> _governmentLoanSponsorIdentifier;
         public string GovernmentLoanSponsorIdentifier { get { return _governmentLoanSponsorIdentifier; } set { _governmentLoanSponsorIdentifier = value; } }
-        private Value<decimal?> _governmentMortgageCreditCertificateAmount;
+        private DirtyValue<decimal?> _governmentMortgageCreditCertificateAmount;
         public decimal? GovernmentMortgageCreditCertificateAmount { get { return _governmentMortgageCreditCertificateAmount; } set { _governmentMortgageCreditCertificateAmount = value; } }
-        private Value<string> _hasAbusinessRelationshipWith;
+        private DirtyValue<string> _hasAbusinessRelationshipWith;
         public string HasAbusinessRelationshipWith { get { return _hasAbusinessRelationshipWith; } set { _hasAbusinessRelationshipWith = value; } }
-        private Value<decimal?> _hcltvHtltv;
+        private DirtyValue<decimal?> _hcltvHtltv;
         public decimal? HcltvHtltv { get { return _hcltvHtltv; } set { _hcltvHtltv = value; } }
-        private Value<decimal?> _helocTeaserRate;
+        private DirtyValue<decimal?> _helocTeaserRate;
         public decimal? HelocTeaserRate { get { return _helocTeaserRate; } set { _helocTeaserRate = value; } }
         private Hmda _hmda;
         public Hmda Hmda { get { var v = _hmda; return v ?? Interlocked.CompareExchange(ref _hmda, (v = new Hmda()), null) ?? v; } set { _hmda = value; } }
         private DirtyList<HomeCounselingProvider> _homeCounselingProviders;
         public IList<HomeCounselingProvider> HomeCounselingProviders { get { var v = _homeCounselingProviders; return v ?? Interlocked.CompareExchange(ref _homeCounselingProviders, (v = new DirtyList<HomeCounselingProvider>()), null) ?? v; } set { _homeCounselingProviders = new DirtyList<HomeCounselingProvider>(value); } }
-        private Value<string> _homeCounselingProvidersDistance;
+        private DirtyValue<string> _homeCounselingProvidersDistance;
         public string HomeCounselingProvidersDistance { get { return _homeCounselingProvidersDistance; } set { _homeCounselingProvidersDistance = value; } }
-        private Value<string> _homeCounselingProvidersLanguageNames;
+        private DirtyValue<string> _homeCounselingProvidersLanguageNames;
         public string HomeCounselingProvidersLanguageNames { get { return _homeCounselingProvidersLanguageNames; } set { _homeCounselingProvidersLanguageNames = value; } }
-        private Value<string> _homeCounselingProvidersServiceNames;
+        private DirtyValue<string> _homeCounselingProvidersServiceNames;
         public string HomeCounselingProvidersServiceNames { get { return _homeCounselingProvidersServiceNames; } set { _homeCounselingProvidersServiceNames = value; } }
-        private Value<int?> _householdSizeCount;
+        private DirtyValue<int?> _householdSizeCount;
         public int? HouseholdSizeCount { get { return _householdSizeCount; } set { _householdSizeCount = value; } }
         private DirtyList<HtmlEmailLog> _htmlEmailLogs;
         public IList<HtmlEmailLog> HtmlEmailLogs { get { var v = _htmlEmailLogs; return v ?? Interlocked.CompareExchange(ref _htmlEmailLogs, (v = new DirtyList<HtmlEmailLog>()), null) ?? v; } set { _htmlEmailLogs = new DirtyList<HtmlEmailLog>(value); } }
         private Hud1Es _hud1Es;
         public Hud1Es Hud1Es { get { var v = _hud1Es; return v ?? Interlocked.CompareExchange(ref _hud1Es, (v = new Hud1Es()), null) ?? v; } set { _hud1Es = value; } }
-        private Value<decimal?> _hudIncomeLimitAdjustmentFactor;
+        private DirtyValue<decimal?> _hudIncomeLimitAdjustmentFactor;
         public decimal? HudIncomeLimitAdjustmentFactor { get { return _hudIncomeLimitAdjustmentFactor; } set { _hudIncomeLimitAdjustmentFactor = value; } }
-        private Value<decimal?> _hudLendingIncomeLimitAmount;
+        private DirtyValue<decimal?> _hudLendingIncomeLimitAmount;
         public decimal? HudLendingIncomeLimitAmount { get { return _hudLendingIncomeLimitAmount; } set { _hudLendingIncomeLimitAmount = value; } }
         private HudLoanData _hudLoanData;
         public HudLoanData HudLoanData { get { var v = _hudLoanData; return v ?? Interlocked.CompareExchange(ref _hudLoanData, (v = new HudLoanData()), null) ?? v; } set { _hudLoanData = value; } }
-        private Value<decimal?> _hudMedianIncomeAmount;
+        private DirtyValue<decimal?> _hudMedianIncomeAmount;
         public decimal? HudMedianIncomeAmount { get { return _hudMedianIncomeAmount; } set { _hudMedianIncomeAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _includeUSDAFeeInClosing;
+        private DirtyValue<bool?> _includeUSDAFeeInClosing;
         public bool? IncludeUSDAFeeInClosing { get { return _includeUSDAFeeInClosing; } set { _includeUSDAFeeInClosing = value; } }
-        private Value<decimal?> _initialInterestRate;
+        private DirtyValue<decimal?> _initialInterestRate;
         public decimal? InitialInterestRate { get { return _initialInterestRate; } set { _initialInterestRate = value; } }
-        private Value<string> _insuranceAuthorizationIndicator;
+        private DirtyValue<string> _insuranceAuthorizationIndicator;
         public string InsuranceAuthorizationIndicator { get { return _insuranceAuthorizationIndicator; } set { _insuranceAuthorizationIndicator = value; } }
         private InterimServicing _interimServicing;
         public InterimServicing InterimServicing { get { var v = _interimServicing; return v ?? Interlocked.CompareExchange(ref _interimServicing, (v = new InterimServicing()), null) ?? v; } set { _interimServicing = value; } }
-        private Value<DateTime?> _interviewerApplicationSignedDate;
+        private DirtyValue<DateTime?> _interviewerApplicationSignedDate;
         public DateTime? InterviewerApplicationSignedDate { get { return _interviewerApplicationSignedDate; } set { _interviewerApplicationSignedDate = value; } }
-        private Value<string> _interviewerEmail;
+        private DirtyValue<string> _interviewerEmail;
         public string InterviewerEmail { get { return _interviewerEmail; } set { _interviewerEmail = value; } }
-        private Value<string> _interviewerLicenseIdentifier;
+        private DirtyValue<string> _interviewerLicenseIdentifier;
         public string InterviewerLicenseIdentifier { get { return _interviewerLicenseIdentifier; } set { _interviewerLicenseIdentifier = value; } }
-        private Value<string> _interviewerPhoneNumber;
+        private DirtyValue<string> _interviewerPhoneNumber;
         public string InterviewerPhoneNumber { get { return _interviewerPhoneNumber; } set { _interviewerPhoneNumber = value; } }
-        private Value<string> _interviewersCompanyStateLicense;
+        private DirtyValue<string> _interviewersCompanyStateLicense;
         public string InterviewersCompanyStateLicense { get { return _interviewersCompanyStateLicense; } set { _interviewersCompanyStateLicense = value; } }
-        private Value<string> _interviewersId;
+        private DirtyValue<string> _interviewersId;
         public string InterviewersId { get { return _interviewersId; } set { _interviewersId = value; } }
-        private Value<string> _inverviewerName;
+        private DirtyValue<string> _inverviewerName;
         public string InverviewerName { get { return _inverviewerName; } set { _inverviewerName = value; } }
-        private Value<bool?> _isCreditorProhibitsBorrower;
+        private DirtyValue<bool?> _isCreditorProhibitsBorrower;
         public bool? IsCreditorProhibitsBorrower { get { return _isCreditorProhibitsBorrower; } set { _isCreditorProhibitsBorrower = value; } }
-        private Value<bool?> _isEmployeeLoan;
+        private DirtyValue<bool?> _isEmployeeLoan;
         public bool? IsEmployeeLoan { get { return _isEmployeeLoan; } set { _isEmployeeLoan = value; } }
-        private Value<bool?> _isLSSecondaryFile;
+        private DirtyValue<bool?> _isLSSecondaryFile;
         public bool? IsLSSecondaryFile { get { return _isLSSecondaryFile; } set { _isLSSecondaryFile = value; } }
-        private Value<bool?> _isRequiredInterestReserveCompoundInterest;
+        private DirtyValue<bool?> _isRequiredInterestReserveCompoundInterest;
         public bool? IsRequiredInterestReserveCompoundInterest { get { return _isRequiredInterestReserveCompoundInterest; } set { _isRequiredInterestReserveCompoundInterest = value; } }
-        private Value<decimal?> _landIfAcquiredSeperatelyAmount;
+        private DirtyValue<decimal?> _landIfAcquiredSeperatelyAmount;
         public decimal? LandIfAcquiredSeperatelyAmount { get { return _landIfAcquiredSeperatelyAmount; } set { _landIfAcquiredSeperatelyAmount = value; } }
-        private Value<string> _leadSource;
+        private DirtyValue<string> _leadSource;
         public string LeadSource { get { return _leadSource; } set { _leadSource = value; } }
-        private Value<string> _lenderCaseIdentifier;
+        private DirtyValue<string> _lenderCaseIdentifier;
         public string LenderCaseIdentifier { get { return _lenderCaseIdentifier; } set { _lenderCaseIdentifier = value; } }
-        private Value<string> _lenderChannel;
+        private DirtyValue<string> _lenderChannel;
         public string LenderChannel { get { return _lenderChannel; } set { _lenderChannel = value; } }
-        private Value<decimal?> _lenderCreditsInFunding;
+        private DirtyValue<decimal?> _lenderCreditsInFunding;
         public decimal? LenderCreditsInFunding { get { return _lenderCreditsInFunding; } set { _lenderCreditsInFunding = value; } }
-        private Value<string> _lenderInvestorCode;
+        private DirtyValue<string> _lenderInvestorCode;
         public string LenderInvestorCode { get { return _lenderInvestorCode; } set { _lenderInvestorCode = value; } }
-        private Value<decimal?> _lenderPaidClosignCostsDotAmount;
+        private DirtyValue<decimal?> _lenderPaidClosignCostsDotAmount;
         public decimal? LenderPaidClosignCostsDotAmount { get { return _lenderPaidClosignCostsDotAmount; } set { _lenderPaidClosignCostsDotAmount = value; } }
-        private Value<decimal?> _lenderPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _lenderPaidClosingCostsAmount;
         public decimal? LenderPaidClosingCostsAmount { get { return _lenderPaidClosingCostsAmount; } set { _lenderPaidClosingCostsAmount = value; } }
-        private Value<decimal?> _lesserAppraisedValueOrSalesPrice;
+        private DirtyValue<decimal?> _lesserAppraisedValueOrSalesPrice;
         public decimal? LesserAppraisedValueOrSalesPrice { get { return _lesserAppraisedValueOrSalesPrice; } set { _lesserAppraisedValueOrSalesPrice = value; } }
-        private Value<decimal?> _lifeInsuranceCoverageAmount;
+        private DirtyValue<decimal?> _lifeInsuranceCoverageAmount;
         public decimal? LifeInsuranceCoverageAmount { get { return _lifeInsuranceCoverageAmount; } set { _lifeInsuranceCoverageAmount = value; } }
-        private Value<decimal?> _lifeInsuranceEstimatedMonthlyAmount;
+        private DirtyValue<decimal?> _lifeInsuranceEstimatedMonthlyAmount;
         public decimal? LifeInsuranceEstimatedMonthlyAmount { get { return _lifeInsuranceEstimatedMonthlyAmount; } set { _lifeInsuranceEstimatedMonthlyAmount = value; } }
-        private Value<decimal?> _lifeInsuranceTotalProtectedMonthlyAmount;
+        private DirtyValue<decimal?> _lifeInsuranceTotalProtectedMonthlyAmount;
         public decimal? LifeInsuranceTotalProtectedMonthlyAmount { get { return _lifeInsuranceTotalProtectedMonthlyAmount; } set { _lifeInsuranceTotalProtectedMonthlyAmount = value; } }
-        private Value<decimal?> _linkedBorrowerRequestedLoanAmount;
+        private DirtyValue<decimal?> _linkedBorrowerRequestedLoanAmount;
         public decimal? LinkedBorrowerRequestedLoanAmount { get { return _linkedBorrowerRequestedLoanAmount; } set { _linkedBorrowerRequestedLoanAmount = value; } }
-        private Value<string> _linkId;
+        private DirtyValue<string> _linkId;
         public string LinkId { get { return _linkId; } set { _linkId = value; } }
         private DirtyList<LoanActionLog> _loanActionLogs;
         public IList<LoanActionLog> LoanActionLogs { get { var v = _loanActionLogs; return v ?? Interlocked.CompareExchange(ref _loanActionLogs, (v = new DirtyList<LoanActionLog>()), null) ?? v; } set { _loanActionLogs = new DirtyList<LoanActionLog>(value); } }
-        private Value<int?> _loanAmortizationTermMonths;
+        private DirtyValue<int?> _loanAmortizationTermMonths;
         public int? LoanAmortizationTermMonths { get { return _loanAmortizationTermMonths; } set { _loanAmortizationTermMonths = value; } }
-        private Value<string> _loanAmortizationType;
+        private DirtyValue<string> _loanAmortizationType;
         public string LoanAmortizationType { get { return _loanAmortizationType; } set { _loanAmortizationType = value; } }
-        private Value<string> _loanCreatedDate;
+        private DirtyValue<string> _loanCreatedDate;
         public string LoanCreatedDate { get { return _loanCreatedDate; } set { _loanCreatedDate = value; } }
-        private Value<DateTime?> _loanCreatedDateUtc;
+        private DirtyValue<DateTime?> _loanCreatedDateUtc;
         public DateTime? LoanCreatedDateUtc { get { return _loanCreatedDateUtc; } set { _loanCreatedDateUtc = value; } }
-        private Value<string> _loanIdNumber;
+        private DirtyValue<string> _loanIdNumber;
         public string LoanIdNumber { get { return _loanIdNumber; } set { _loanIdNumber = value; } }
-        private Value<bool?> _loanImportStatusIndicator;
+        private DirtyValue<bool?> _loanImportStatusIndicator;
         public bool? LoanImportStatusIndicator { get { return _loanImportStatusIndicator; } set { _loanImportStatusIndicator = value; } }
-        private Value<string> _loanLinkSyncType;
+        private DirtyValue<string> _loanLinkSyncType;
         public string LoanLinkSyncType { get { return _loanLinkSyncType; } set { _loanLinkSyncType = value; } }
-        private Value<string> _loanNumber;
+        private DirtyValue<string> _loanNumber;
         public string LoanNumber { get { return _loanNumber; } set { _loanNumber = value; } }
         private LoanProductData _loanProductData;
         public LoanProductData LoanProductData { get { var v = _loanProductData; return v ?? Interlocked.CompareExchange(ref _loanProductData, (v = new LoanProductData()), null) ?? v; } set { _loanProductData = value; } }
-        private Value<string> _loanProgramName;
+        private DirtyValue<string> _loanProgramName;
         public string LoanProgramName { get { return _loanProgramName; } set { _loanProgramName = value; } }
         private DirtyList<LoanProgram> _loanPrograms;
         public IList<LoanProgram> LoanPrograms { get { var v = _loanPrograms; return v ?? Interlocked.CompareExchange(ref _loanPrograms, (v = new DirtyList<LoanProgram>()), null) ?? v; } set { _loanPrograms = new DirtyList<LoanProgram>(value); } }
-        private Value<string> _loanPurposeOfRefinanceType;
+        private DirtyValue<string> _loanPurposeOfRefinanceType;
         public string LoanPurposeOfRefinanceType { get { return _loanPurposeOfRefinanceType; } set { _loanPurposeOfRefinanceType = value; } }
-        private Value<string> _loanSource;
+        private DirtyValue<string> _loanSource;
         public string LoanSource { get { return _loanSource; } set { _loanSource = value; } }
         private LoanSubmission _loanSubmission;
         public LoanSubmission LoanSubmission { get { var v = _loanSubmission; return v ?? Interlocked.CompareExchange(ref _loanSubmission, (v = new LoanSubmission()), null) ?? v; } set { _loanSubmission = value; } }
-        private Value<decimal?> _loanTotalProposedMonthlyMaintenanceAmount;
+        private DirtyValue<decimal?> _loanTotalProposedMonthlyMaintenanceAmount;
         public decimal? LoanTotalProposedMonthlyMaintenanceAmount { get { return _loanTotalProposedMonthlyMaintenanceAmount; } set { _loanTotalProposedMonthlyMaintenanceAmount = value; } }
-        private Value<decimal?> _loanTotalProposedMonthlyUtilitiesAmount;
+        private DirtyValue<decimal?> _loanTotalProposedMonthlyUtilitiesAmount;
         public decimal? LoanTotalProposedMonthlyUtilitiesAmount { get { return _loanTotalProposedMonthlyUtilitiesAmount; } set { _loanTotalProposedMonthlyUtilitiesAmount = value; } }
-        private Value<string> _loanUnderwriterCHUMSIdentifier;
+        private DirtyValue<string> _loanUnderwriterCHUMSIdentifier;
         public string LoanUnderwriterCHUMSIdentifier { get { return _loanUnderwriterCHUMSIdentifier; } set { _loanUnderwriterCHUMSIdentifier = value; } }
-        private Value<string> _loanVALoanProcedureType;
+        private DirtyValue<string> _loanVALoanProcedureType;
         public string LoanVALoanProcedureType { get { return _loanVALoanProcedureType; } set { _loanVALoanProcedureType = value; } }
-        private Value<decimal?> _loanVARateReductionInitialComputationTotalAmount;
+        private DirtyValue<decimal?> _loanVARateReductionInitialComputationTotalAmount;
         public decimal? LoanVARateReductionInitialComputationTotalAmount { get { return _loanVARateReductionInitialComputationTotalAmount; } set { _loanVARateReductionInitialComputationTotalAmount = value; } }
-        private Value<decimal?> _loanVAResidualIncomeAmount;
+        private DirtyValue<decimal?> _loanVAResidualIncomeAmount;
         public decimal? LoanVAResidualIncomeAmount { get { return _loanVAResidualIncomeAmount; } set { _loanVAResidualIncomeAmount = value; } }
-        private Value<int?> _loanVersionId;
+        private DirtyValue<int?> _loanVersionId;
         public int? LoanVersionId { get { return _loanVersionId; } set { _loanVersionId = value; } }
         private DirtyList<LockConfirmLog> _lockConfirmLogs;
         public IList<LockConfirmLog> LockConfirmLogs { get { var v = _lockConfirmLogs; return v ?? Interlocked.CompareExchange(ref _lockConfirmLogs, (v = new DirtyList<LockConfirmLog>()), null) ?? v; } set { _lockConfirmLogs = new DirtyList<LockConfirmLog>(value); } }
@@ -370,131 +370,131 @@ namespace EncompassRest.Loans
         public ElliLOCompensation LOCompensation { get { var v = _lOCompensation; return v ?? Interlocked.CompareExchange(ref _lOCompensation, (v = new ElliLOCompensation()), null) ?? v; } set { _lOCompensation = value; } }
         private DirtyList<LogEntryLog> _logEntryLogs;
         public IList<LogEntryLog> LogEntryLogs { get { var v = _logEntryLogs; return v ?? Interlocked.CompareExchange(ref _logEntryLogs, (v = new DirtyList<LogEntryLog>()), null) ?? v; } set { _logEntryLogs = new DirtyList<LogEntryLog>(value); } }
-        private Value<decimal?> _ltv;
+        private DirtyValue<decimal?> _ltv;
         public decimal? Ltv { get { return _ltv; } set { _ltv = value; } }
-        private Value<decimal?> _ltvPropertyValue;
+        private DirtyValue<decimal?> _ltvPropertyValue;
         public decimal? LtvPropertyValue { get { return _ltvPropertyValue; } set { _ltvPropertyValue = value; } }
-        private Value<string> _masterCommitmentNumber;
+        private DirtyValue<string> _masterCommitmentNumber;
         public string MasterCommitmentNumber { get { return _masterCommitmentNumber; } set { _masterCommitmentNumber = value; } }
-        private Value<DateTime?> _maturityDate;
+        private DirtyValue<DateTime?> _maturityDate;
         public DateTime? MaturityDate { get { return _maturityDate; } set { _maturityDate = value; } }
-        private Value<decimal?> _maxBackRatio;
+        private DirtyValue<decimal?> _maxBackRatio;
         public decimal? MaxBackRatio { get { return _maxBackRatio; } set { _maxBackRatio = value; } }
-        private Value<decimal?> _maxFrontRatio;
+        private DirtyValue<decimal?> _maxFrontRatio;
         public decimal? MaxFrontRatio { get { return _maxFrontRatio; } set { _maxFrontRatio = value; } }
         private Mcaw _mcaw;
         public Mcaw Mcaw { get { var v = _mcaw; return v ?? Interlocked.CompareExchange(ref _mcaw, (v = new Mcaw()), null) ?? v; } set { _mcaw = value; } }
-        private Value<string> _mersNumber;
+        private DirtyValue<string> _mersNumber;
         public string MersNumber { get { return _mersNumber; } set { _mersNumber = value; } }
-        private Value<DateTime?> _mersNumberRegistrationDate;
+        private DirtyValue<DateTime?> _mersNumberRegistrationDate;
         public DateTime? MersNumberRegistrationDate { get { return _mersNumberRegistrationDate; } set { _mersNumberRegistrationDate = value; } }
-        private Value<decimal?> _miAndFundingFeeFinancedAmount;
+        private DirtyValue<decimal?> _miAndFundingFeeFinancedAmount;
         public decimal? MiAndFundingFeeFinancedAmount { get { return _miAndFundingFeeFinancedAmount; } set { _miAndFundingFeeFinancedAmount = value; } }
-        private Value<decimal?> _miAndFundingFeeTotalAmount;
+        private DirtyValue<decimal?> _miAndFundingFeeTotalAmount;
         public decimal? MiAndFundingFeeTotalAmount { get { return _miAndFundingFeeTotalAmount; } set { _miAndFundingFeeTotalAmount = value; } }
-        private Value<DateTime?> _milestoneApprovedDate;
+        private DirtyValue<DateTime?> _milestoneApprovedDate;
         public DateTime? MilestoneApprovedDate { get { return _milestoneApprovedDate; } set { _milestoneApprovedDate = value; } }
-        private Value<DateTime?> _milestoneApprovedDueDate;
+        private DirtyValue<DateTime?> _milestoneApprovedDueDate;
         public DateTime? MilestoneApprovedDueDate { get { return _milestoneApprovedDueDate; } set { _milestoneApprovedDueDate = value; } }
-        private Value<DateTime?> _milestoneCompletedDate;
+        private DirtyValue<DateTime?> _milestoneCompletedDate;
         public DateTime? MilestoneCompletedDate { get { return _milestoneCompletedDate; } set { _milestoneCompletedDate = value; } }
-        private Value<DateTime?> _milestoneCompletedDueDate;
+        private DirtyValue<DateTime?> _milestoneCompletedDueDate;
         public DateTime? MilestoneCompletedDueDate { get { return _milestoneCompletedDueDate; } set { _milestoneCompletedDueDate = value; } }
-        private Value<DateTime?> _milestoneCurrentDateUtc;
+        private DirtyValue<DateTime?> _milestoneCurrentDateUtc;
         public DateTime? MilestoneCurrentDateUtc { get { return _milestoneCurrentDateUtc; } set { _milestoneCurrentDateUtc = value; } }
-        private Value<string> _milestoneCurrentName;
+        private DirtyValue<string> _milestoneCurrentName;
         public string MilestoneCurrentName { get { return _milestoneCurrentName; } set { _milestoneCurrentName = value; } }
-        private Value<DateTime?> _milestoneDocSignedDate;
+        private DirtyValue<DateTime?> _milestoneDocSignedDate;
         public DateTime? MilestoneDocSignedDate { get { return _milestoneDocSignedDate; } set { _milestoneDocSignedDate = value; } }
-        private Value<DateTime?> _milestoneDocSignedDueDate;
+        private DirtyValue<DateTime?> _milestoneDocSignedDueDate;
         public DateTime? MilestoneDocSignedDueDate { get { return _milestoneDocSignedDueDate; } set { _milestoneDocSignedDueDate = value; } }
-        private Value<int?> _milestoneDuration;
+        private DirtyValue<int?> _milestoneDuration;
         public int? MilestoneDuration { get { return _milestoneDuration; } set { _milestoneDuration = value; } }
-        private Value<DateTime?> _milestoneFileStartedDate;
+        private DirtyValue<DateTime?> _milestoneFileStartedDate;
         public DateTime? MilestoneFileStartedDate { get { return _milestoneFileStartedDate; } set { _milestoneFileStartedDate = value; } }
         private DirtyList<MilestoneFreeRoleLog> _milestoneFreeRoleLogs;
         public IList<MilestoneFreeRoleLog> MilestoneFreeRoleLogs { get { var v = _milestoneFreeRoleLogs; return v ?? Interlocked.CompareExchange(ref _milestoneFreeRoleLogs, (v = new DirtyList<MilestoneFreeRoleLog>()), null) ?? v; } set { _milestoneFreeRoleLogs = new DirtyList<MilestoneFreeRoleLog>(value); } }
-        private Value<DateTime?> _milestoneFundedDate;
+        private DirtyValue<DateTime?> _milestoneFundedDate;
         public DateTime? MilestoneFundedDate { get { return _milestoneFundedDate; } set { _milestoneFundedDate = value; } }
-        private Value<DateTime?> _milestoneFundedDueDate;
+        private DirtyValue<DateTime?> _milestoneFundedDueDate;
         public DateTime? MilestoneFundedDueDate { get { return _milestoneFundedDueDate; } set { _milestoneFundedDueDate = value; } }
         private DirtyList<MilestoneLog> _milestoneLogs;
         public IList<MilestoneLog> MilestoneLogs { get { var v = _milestoneLogs; return v ?? Interlocked.CompareExchange(ref _milestoneLogs, (v = new DirtyList<MilestoneLog>()), null) ?? v; } set { _milestoneLogs = new DirtyList<MilestoneLog>(value); } }
-        private Value<DateTime?> _milestoneProcessedDate;
+        private DirtyValue<DateTime?> _milestoneProcessedDate;
         public DateTime? MilestoneProcessedDate { get { return _milestoneProcessedDate; } set { _milestoneProcessedDate = value; } }
-        private Value<string> _milestoneStage;
+        private DirtyValue<string> _milestoneStage;
         public string MilestoneStage { get { return _milestoneStage; } set { _milestoneStage = value; } }
-        private Value<DateTime?> _milestoneSubmittedDate;
+        private DirtyValue<DateTime?> _milestoneSubmittedDate;
         public DateTime? MilestoneSubmittedDate { get { return _milestoneSubmittedDate; } set { _milestoneSubmittedDate = value; } }
-        private Value<DateTime?> _milestoneSubmittedDueDate;
+        private DirtyValue<DateTime?> _milestoneSubmittedDueDate;
         public DateTime? MilestoneSubmittedDueDate { get { return _milestoneSubmittedDueDate; } set { _milestoneSubmittedDueDate = value; } }
         private DirtyList<MilestoneTaskLog> _milestoneTaskLogs;
         public IList<MilestoneTaskLog> MilestoneTaskLogs { get { var v = _milestoneTaskLogs; return v ?? Interlocked.CompareExchange(ref _milestoneTaskLogs, (v = new DirtyList<MilestoneTaskLog>()), null) ?? v; } set { _milestoneTaskLogs = new DirtyList<MilestoneTaskLog>(value); } }
         private DirtyList<MilestoneTemplateLog> _milestoneTemplateLogs;
         public IList<MilestoneTemplateLog> MilestoneTemplateLogs { get { var v = _milestoneTemplateLogs; return v ?? Interlocked.CompareExchange(ref _milestoneTemplateLogs, (v = new DirtyList<MilestoneTemplateLog>()), null) ?? v; } set { _milestoneTemplateLogs = new DirtyList<MilestoneTemplateLog>(value); } }
-        private Value<decimal?> _mipBorrowerPaidInCashAmount;
+        private DirtyValue<decimal?> _mipBorrowerPaidInCashAmount;
         public decimal? MipBorrowerPaidInCashAmount { get { return _mipBorrowerPaidInCashAmount; } set { _mipBorrowerPaidInCashAmount = value; } }
-        private Value<decimal?> _mipPaidInCashAmount;
+        private DirtyValue<decimal?> _mipPaidInCashAmount;
         public decimal? MipPaidInCashAmount { get { return _mipPaidInCashAmount; } set { _mipPaidInCashAmount = value; } }
         private Miscellaneous _miscellaneous;
         public Miscellaneous Miscellaneous { get { var v = _miscellaneous; return v ?? Interlocked.CompareExchange(ref _miscellaneous, (v = new Miscellaneous()), null) ?? v; } set { _miscellaneous = value; } }
-        private Value<decimal?> _monthlyPIPaymentAmountForLE1andCD1;
+        private DirtyValue<decimal?> _monthlyPIPaymentAmountForLE1andCD1;
         public decimal? MonthlyPIPaymentAmountForLE1andCD1 { get { return _monthlyPIPaymentAmountForLE1andCD1; } set { _monthlyPIPaymentAmountForLE1andCD1 = value; } }
-        private Value<decimal?> _mortgageInsurancePremiumFHARefundAmount;
+        private DirtyValue<decimal?> _mortgageInsurancePremiumFHARefundAmount;
         public decimal? MortgageInsurancePremiumFHARefundAmount { get { return _mortgageInsurancePremiumFHARefundAmount; } set { _mortgageInsurancePremiumFHARefundAmount = value; } }
-        private Value<decimal?> _mortgageInsurancePremiumUpfrontFactorPercent;
+        private DirtyValue<decimal?> _mortgageInsurancePremiumUpfrontFactorPercent;
         public decimal? MortgageInsurancePremiumUpfrontFactorPercent { get { return _mortgageInsurancePremiumUpfrontFactorPercent; } set { _mortgageInsurancePremiumUpfrontFactorPercent = value; } }
-        private Value<string> _mortgageType;
+        private DirtyValue<string> _mortgageType;
         public string MortgageType { get { return _mortgageType; } set { _mortgageType = value; } }
-        private Value<string> _msaIdentifier;
+        private DirtyValue<string> _msaIdentifier;
         public string MsaIdentifier { get { return _msaIdentifier; } set { _msaIdentifier = value; } }
         private NetTangibleBenefit _netTangibleBenefit;
         public NetTangibleBenefit NetTangibleBenefit { get { var v = _netTangibleBenefit; return v ?? Interlocked.CompareExchange(ref _netTangibleBenefit, (v = new NetTangibleBenefit()), null) ?? v; } set { _netTangibleBenefit = value; } }
-        private Value<decimal?> _newFirstMortgageAmount;
+        private DirtyValue<decimal?> _newFirstMortgageAmount;
         public decimal? NewFirstMortgageAmount { get { return _newFirstMortgageAmount; } set { _newFirstMortgageAmount = value; } }
-        private Value<string> _nmlsLoanOriginatorId;
+        private DirtyValue<string> _nmlsLoanOriginatorId;
         public string NmlsLoanOriginatorId { get { return _nmlsLoanOriginatorId; } set { _nmlsLoanOriginatorId = value; } }
-        private Value<bool?> _noClosingCostOption;
+        private DirtyValue<bool?> _noClosingCostOption;
         public bool? NoClosingCostOption { get { return _noClosingCostOption; } set { _noClosingCostOption = value; } }
         //private DirtyList<NonVol> _nonVols;
         //public IList<NonVol> NonVols { get { var v = _nonVols; return v ?? Interlocked.CompareExchange(ref _nonVols, (v = new DirtyList<NonVol>()), null) ?? v; } set { _nonVols = new DirtyList<NonVol>(value); } }
-        private Value<bool?> _notRequiredForPurchaseSaleOrRefinance;
+        private DirtyValue<bool?> _notRequiredForPurchaseSaleOrRefinance;
         public bool? NotRequiredForPurchaseSaleOrRefinance { get { return _notRequiredForPurchaseSaleOrRefinance; } set { _notRequiredForPurchaseSaleOrRefinance = value; } }
-        private Value<bool?> _notRequiredForSettlementOfYourLoan;
+        private DirtyValue<bool?> _notRequiredForSettlementOfYourLoan;
         public bool? NotRequiredForSettlementOfYourLoan { get { return _notRequiredForSettlementOfYourLoan; } set { _notRequiredForSettlementOfYourLoan = value; } }
-        private Value<string> _occupancyType;
+        private DirtyValue<string> _occupancyType;
         public string OccupancyType { get { return _occupancyType; } set { _occupancyType = value; } }
-        private Value<string> _openingDocsInvestorCode;
+        private DirtyValue<string> _openingDocsInvestorCode;
         public string OpeningDocsInvestorCode { get { return _openingDocsInvestorCode; } set { _openingDocsInvestorCode = value; } }
-        private Value<string> _openingDocsLoanProgramType;
+        private DirtyValue<string> _openingDocsLoanProgramType;
         public string OpeningDocsLoanProgramType { get { return _openingDocsLoanProgramType; } set { _openingDocsLoanProgramType = value; } }
-        private Value<string> _openingDocsPlanDescription;
+        private DirtyValue<string> _openingDocsPlanDescription;
         public string OpeningDocsPlanDescription { get { return _openingDocsPlanDescription; } set { _openingDocsPlanDescription = value; } }
-        private Value<string> _openingDocsPlanId;
+        private DirtyValue<string> _openingDocsPlanId;
         public string OpeningDocsPlanId { get { return _openingDocsPlanId; } set { _openingDocsPlanId = value; } }
-        private Value<string> _openingDocsProgramCode;
+        private DirtyValue<string> _openingDocsProgramCode;
         public string OpeningDocsProgramCode { get { return _openingDocsProgramCode; } set { _openingDocsProgramCode = value; } }
-        private Value<string> _openingDocsStackingOrder;
+        private DirtyValue<string> _openingDocsStackingOrder;
         public string OpeningDocsStackingOrder { get { return _openingDocsStackingOrder; } set { _openingDocsStackingOrder = value; } }
-        private Value<string> _organizationCode;
+        private DirtyValue<string> _organizationCode;
         public string OrganizationCode { get { return _organizationCode; } set { _organizationCode = value; } }
-        private Value<DateTime?> _originationDate;
+        private DirtyValue<DateTime?> _originationDate;
         public DateTime? OriginationDate { get { return _originationDate; } set { _originationDate = value; } }
-        private Value<string> _otherAmortizationTypeDescription;
+        private DirtyValue<string> _otherAmortizationTypeDescription;
         public string OtherAmortizationTypeDescription { get { return _otherAmortizationTypeDescription; } set { _otherAmortizationTypeDescription = value; } }
-        private Value<string> _otherMortgageTypeDescription;
+        private DirtyValue<string> _otherMortgageTypeDescription;
         public string OtherMortgageTypeDescription { get { return _otherMortgageTypeDescription; } set { _otherMortgageTypeDescription = value; } }
-        private Value<decimal?> _otherPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _otherPaidClosingCostsAmount;
         public decimal? OtherPaidClosingCostsAmount { get { return _otherPaidClosingCostsAmount; } set { _otherPaidClosingCostsAmount = value; } }
-        private Value<decimal?> _overwireAmount;
+        private DirtyValue<decimal?> _overwireAmount;
         public decimal? OverwireAmount { get { return _overwireAmount; } set { _overwireAmount = value; } }
-        private Value<bool?> _paymentScheduleCalcRequiredIndicator;
+        private DirtyValue<bool?> _paymentScheduleCalcRequiredIndicator;
         public bool? PaymentScheduleCalcRequiredIndicator { get { return _paymentScheduleCalcRequiredIndicator; } set { _paymentScheduleCalcRequiredIndicator = value; } }
-        private Value<string> _percentageOfOwnership;
+        private DirtyValue<string> _percentageOfOwnership;
         public string PercentageOfOwnership { get { return _percentageOfOwnership; } set { _percentageOfOwnership = value; } }
-        private Value<decimal?> _percentageOwnershipInterest;
+        private DirtyValue<decimal?> _percentageOwnershipInterest;
         public decimal? PercentageOwnershipInterest { get { return _percentageOwnershipInterest; } set { _percentageOwnershipInterest = value; } }
-        private Value<bool?> _pmiIndicator;
+        private DirtyValue<bool?> _pmiIndicator;
         public bool? PmiIndicator { get { return _pmiIndicator; } set { _pmiIndicator = value; } }
         private DirtyList<PostClosingConditionLog> _postClosingConditionLogs;
         public IList<PostClosingConditionLog> PostClosingConditionLogs { get { var v = _postClosingConditionLogs; return v ?? Interlocked.CompareExchange(ref _postClosingConditionLogs, (v = new DirtyList<PostClosingConditionLog>()), null) ?? v; } set { _postClosingConditionLogs = new DirtyList<PostClosingConditionLog>(value); } }
@@ -502,9 +502,9 @@ namespace EncompassRest.Loans
         public IList<PreliminaryConditionLog> PreliminaryConditionLogs { get { var v = _preliminaryConditionLogs; return v ?? Interlocked.CompareExchange(ref _preliminaryConditionLogs, (v = new DirtyList<PreliminaryConditionLog>()), null) ?? v; } set { _preliminaryConditionLogs = new DirtyList<PreliminaryConditionLog>(value); } }
         private Prequalification _prequalification;
         public Prequalification Prequalification { get { var v = _prequalification; return v ?? Interlocked.CompareExchange(ref _prequalification, (v = new Prequalification()), null) ?? v; } set { _prequalification = value; } }
-        private Value<decimal?> _principalAndInterestMonthlyPaymentAmount;
+        private DirtyValue<decimal?> _principalAndInterestMonthlyPaymentAmount;
         public decimal? PrincipalAndInterestMonthlyPaymentAmount { get { return _principalAndInterestMonthlyPaymentAmount; } set { _principalAndInterestMonthlyPaymentAmount = value; } }
-        private Value<string> _print2003Application;
+        private DirtyValue<string> _print2003Application;
         public string Print2003Application { get { return _print2003Application; } set { _print2003Application = value; } }
         private DirtyList<PrintLog> _printLogs;
         public IList<PrintLog> PrintLogs { get { var v = _printLogs; return v ?? Interlocked.CompareExchange(ref _printLogs, (v = new DirtyList<PrintLog>()), null) ?? v; } set { _printLogs = new DirtyList<PrintLog>(value); } }
@@ -514,49 +514,49 @@ namespace EncompassRest.Loans
         public ProfitManagement ProfitManagement { get { var v = _profitManagement; return v ?? Interlocked.CompareExchange(ref _profitManagement, (v = new ProfitManagement()), null) ?? v; } set { _profitManagement = value; } }
         private Property _property;
         public Property Property { get { var v = _property; return v ?? Interlocked.CompareExchange(ref _property, (v = new Property()), null) ?? v; } set { _property = value; } }
-        private Value<int?> _propertyAppraisedValueAmount;
+        private DirtyValue<int?> _propertyAppraisedValueAmount;
         public int? PropertyAppraisedValueAmount { get { return _propertyAppraisedValueAmount; } set { _propertyAppraisedValueAmount = value; } }
-        private Value<bool?> _propertyEnergyEfficientHomeIndicator;
+        private DirtyValue<bool?> _propertyEnergyEfficientHomeIndicator;
         public bool? PropertyEnergyEfficientHomeIndicator { get { return _propertyEnergyEfficientHomeIndicator; } set { _propertyEnergyEfficientHomeIndicator = value; } }
-        private Value<int?> _propertyEstimatedValueAmount;
+        private DirtyValue<int?> _propertyEstimatedValueAmount;
         public int? PropertyEstimatedValueAmount { get { return _propertyEstimatedValueAmount; } set { _propertyEstimatedValueAmount = value; } }
-        private Value<string> _proposedDuesAmount;
+        private DirtyValue<string> _proposedDuesAmount;
         public string ProposedDuesAmount { get { return _proposedDuesAmount; } set { _proposedDuesAmount = value; } }
-        private Value<decimal?> _proposedFirstMortgageAmount;
+        private DirtyValue<decimal?> _proposedFirstMortgageAmount;
         public decimal? ProposedFirstMortgageAmount { get { return _proposedFirstMortgageAmount; } set { _proposedFirstMortgageAmount = value; } }
-        private Value<decimal?> _proposedGroundRentAmount;
+        private DirtyValue<decimal?> _proposedGroundRentAmount;
         public decimal? ProposedGroundRentAmount { get { return _proposedGroundRentAmount; } set { _proposedGroundRentAmount = value; } }
-        private Value<string> _proposedHazardInsuranceAmount;
+        private DirtyValue<string> _proposedHazardInsuranceAmount;
         public string ProposedHazardInsuranceAmount { get { return _proposedHazardInsuranceAmount; } set { _proposedHazardInsuranceAmount = value; } }
-        private Value<decimal?> _proposedHousingExpenseTotal;
+        private DirtyValue<decimal?> _proposedHousingExpenseTotal;
         public decimal? ProposedHousingExpenseTotal { get { return _proposedHousingExpenseTotal; } set { _proposedHousingExpenseTotal = value; } }
-        private Value<string> _proposedMortgageInsuranceAmount;
+        private DirtyValue<string> _proposedMortgageInsuranceAmount;
         public string ProposedMortgageInsuranceAmount { get { return _proposedMortgageInsuranceAmount; } set { _proposedMortgageInsuranceAmount = value; } }
-        private Value<decimal?> _proposedOtherAmount;
+        private DirtyValue<decimal?> _proposedOtherAmount;
         public decimal? ProposedOtherAmount { get { return _proposedOtherAmount; } set { _proposedOtherAmount = value; } }
-        private Value<decimal?> _proposedOtherMortgagesAmount;
+        private DirtyValue<decimal?> _proposedOtherMortgagesAmount;
         public decimal? ProposedOtherMortgagesAmount { get { return _proposedOtherMortgagesAmount; } set { _proposedOtherMortgagesAmount = value; } }
-        private Value<string> _proposedRealEstateTaxesAmount;
+        private DirtyValue<string> _proposedRealEstateTaxesAmount;
         public string ProposedRealEstateTaxesAmount { get { return _proposedRealEstateTaxesAmount; } set { _proposedRealEstateTaxesAmount = value; } }
         private DirtyList<PurchaseCredit> _purchaseCredits;
         public IList<PurchaseCredit> PurchaseCredits { get { var v = _purchaseCredits; return v ?? Interlocked.CompareExchange(ref _purchaseCredits, (v = new DirtyList<PurchaseCredit>()), null) ?? v; } set { _purchaseCredits = new DirtyList<PurchaseCredit>(value); } }
-        private Value<decimal?> _purchasePriceAmount;
+        private DirtyValue<decimal?> _purchasePriceAmount;
         public decimal? PurchasePriceAmount { get { return _purchasePriceAmount; } set { _purchasePriceAmount = value; } }
         private RateLock _rateLock;
         public RateLock RateLock { get { var v = _rateLock; return v ?? Interlocked.CompareExchange(ref _rateLock, (v = new RateLock()), null) ?? v; } set { _rateLock = value; } }
-        private Value<string> _referralAddress;
+        private DirtyValue<string> _referralAddress;
         public string ReferralAddress { get { return _referralAddress; } set { _referralAddress = value; } }
-        private Value<string> _referralCity;
+        private DirtyValue<string> _referralCity;
         public string ReferralCity { get { return _referralCity; } set { _referralCity = value; } }
-        private Value<decimal?> _referralFeeAmount;
+        private DirtyValue<decimal?> _referralFeeAmount;
         public decimal? ReferralFeeAmount { get { return _referralFeeAmount; } set { _referralFeeAmount = value; } }
-        private Value<string> _referralPostalCode;
+        private DirtyValue<string> _referralPostalCode;
         public string ReferralPostalCode { get { return _referralPostalCode; } set { _referralPostalCode = value; } }
-        private Value<string> _referralSource;
+        private DirtyValue<string> _referralSource;
         public string ReferralSource { get { return _referralSource; } set { _referralSource = value; } }
-        private Value<string> _referralState;
+        private DirtyValue<string> _referralState;
         public string ReferralState { get { return _referralState; } set { _referralState = value; } }
-        private Value<decimal?> _refinanceIncludingDebtsToBePaidOffAmount;
+        private DirtyValue<decimal?> _refinanceIncludingDebtsToBePaidOffAmount;
         public decimal? RefinanceIncludingDebtsToBePaidOffAmount { get { return _refinanceIncludingDebtsToBePaidOffAmount; } set { _refinanceIncludingDebtsToBePaidOffAmount = value; } }
         private DirtyList<RegistrationLog> _registrationLogs;
         public IList<RegistrationLog> RegistrationLogs { get { var v = _registrationLogs; return v ?? Interlocked.CompareExchange(ref _registrationLogs, (v = new DirtyList<RegistrationLog>()), null) ?? v; } set { _registrationLogs = new DirtyList<RegistrationLog>(value); } }
@@ -564,45 +564,45 @@ namespace EncompassRest.Loans
         public RegulationZ RegulationZ { get { var v = _regulationZ; return v ?? Interlocked.CompareExchange(ref _regulationZ, (v = new RegulationZ()), null) ?? v; } set { _regulationZ = value; } }
         private DirtyList<RemovedLogRecord> _removedLogRecords;
         public IList<RemovedLogRecord> RemovedLogRecords { get { var v = _removedLogRecords; return v ?? Interlocked.CompareExchange(ref _removedLogRecords, (v = new DirtyList<RemovedLogRecord>()), null) ?? v; } set { _removedLogRecords = new DirtyList<RemovedLogRecord>(value); } }
-        private Value<decimal?> _repurchaseCostAmount;
+        private DirtyValue<decimal?> _repurchaseCostAmount;
         public decimal? RepurchaseCostAmount { get { return _repurchaseCostAmount; } set { _repurchaseCostAmount = value; } }
-        private Value<DateTime?> _repurchaseDate;
+        private DirtyValue<DateTime?> _repurchaseDate;
         public DateTime? RepurchaseDate { get { return _repurchaseDate; } set { _repurchaseDate = value; } }
-        private Value<decimal?> _requestedInterestRatePercent;
+        private DirtyValue<decimal?> _requestedInterestRatePercent;
         public decimal? RequestedInterestRatePercent { get { return _requestedInterestRatePercent; } set { _requestedInterestRatePercent = value; } }
-        private Value<decimal?> _salesConcessionAmount;
+        private DirtyValue<decimal?> _salesConcessionAmount;
         public decimal? SalesConcessionAmount { get { return _salesConcessionAmount; } set { _salesConcessionAmount = value; } }
-        private Value<decimal?> _secondSubordinateAmount;
+        private DirtyValue<decimal?> _secondSubordinateAmount;
         public decimal? SecondSubordinateAmount { get { return _secondSubordinateAmount; } set { _secondSubordinateAmount = value; } }
         private Section32 _section32;
         public Section32 Section32 { get { var v = _section32; return v ?? Interlocked.CompareExchange(ref _section32, (v = new Section32()), null) ?? v; } set { _section32 = value; } }
-        private Value<string> _sectionOfActType;
+        private DirtyValue<string> _sectionOfActType;
         public string SectionOfActType { get { return _sectionOfActType; } set { _sectionOfActType = value; } }
         private SelectedHomeCounselingProvider _selectedHomeCounselingProvider;
         public SelectedHomeCounselingProvider SelectedHomeCounselingProvider { get { var v = _selectedHomeCounselingProvider; return v ?? Interlocked.CompareExchange(ref _selectedHomeCounselingProvider, (v = new SelectedHomeCounselingProvider()), null) ?? v; } set { _selectedHomeCounselingProvider = value; } }
-        private Value<decimal?> _sellerPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _sellerPaidClosingCostsAmount;
         public decimal? SellerPaidClosingCostsAmount { get { return _sellerPaidClosingCostsAmount; } set { _sellerPaidClosingCostsAmount = value; } }
-        private Value<string> _serviceProviderAdditionalInfo;
+        private DirtyValue<string> _serviceProviderAdditionalInfo;
         public string ServiceProviderAdditionalInfo { get { return _serviceProviderAdditionalInfo; } set { _serviceProviderAdditionalInfo = value; } }
         private DirtyList<ServiceProviderContact> _serviceProviderContacts;
         public IList<ServiceProviderContact> ServiceProviderContacts { get { var v = _serviceProviderContacts; return v ?? Interlocked.CompareExchange(ref _serviceProviderContacts, (v = new DirtyList<ServiceProviderContact>()), null) ?? v; } set { _serviceProviderContacts = new DirtyList<ServiceProviderContact>(value); } }
-        private Value<DateTime?> _serviceProviderDateIssued;
+        private DirtyValue<DateTime?> _serviceProviderDateIssued;
         public DateTime? ServiceProviderDateIssued { get { return _serviceProviderDateIssued; } set { _serviceProviderDateIssued = value; } }
         private ServicingDisclosure _servicingDisclosure;
         public ServicingDisclosure ServicingDisclosure { get { var v = _servicingDisclosure; return v ?? Interlocked.CompareExchange(ref _servicingDisclosure, (v = new ServicingDisclosure()), null) ?? v; } set { _servicingDisclosure = value; } }
-        private Value<bool?> _setForSettlementServicesOfAnAttorney;
+        private DirtyValue<bool?> _setForSettlementServicesOfAnAttorney;
         public bool? SetForSettlementServicesOfAnAttorney { get { return _setForSettlementServicesOfAnAttorney; } set { _setForSettlementServicesOfAnAttorney = value; } }
-        private Value<bool?> _setForTheSettlementServicesListed;
+        private DirtyValue<bool?> _setForTheSettlementServicesListed;
         public bool? SetForTheSettlementServicesListed { get { return _setForTheSettlementServicesListed; } set { _setForTheSettlementServicesListed = value; } }
         private DirtyList<SettlementServiceCharge> _settlementServiceCharges;
         public IList<SettlementServiceCharge> SettlementServiceCharges { get { var v = _settlementServiceCharges; return v ?? Interlocked.CompareExchange(ref _settlementServiceCharges, (v = new DirtyList<SettlementServiceCharge>()), null) ?? v; } set { _settlementServiceCharges = new DirtyList<SettlementServiceCharge>(value); } }
         private Shipping _shipping;
         public Shipping Shipping { get { var v = _shipping; return v ?? Interlocked.CompareExchange(ref _shipping, (v = new Shipping()), null) ?? v; } set { _shipping = value; } }
-        private Value<bool?> _simpleRefinanceType;
+        private DirtyValue<bool?> _simpleRefinanceType;
         public bool? SimpleRefinanceType { get { return _simpleRefinanceType; } set { _simpleRefinanceType = value; } }
-        private Value<decimal?> _startingAdjPrice;
+        private DirtyValue<decimal?> _startingAdjPrice;
         public decimal? StartingAdjPrice { get { return _startingAdjPrice; } set { _startingAdjPrice = value; } }
-        private Value<decimal?> _startingAdjRate;
+        private DirtyValue<decimal?> _startingAdjRate;
         public decimal? StartingAdjRate { get { return _startingAdjRate; } set { _startingAdjRate = value; } }
         private StateDisclosure _stateDisclosure;
         public StateDisclosure StateDisclosure { get { var v = _stateDisclosure; return v ?? Interlocked.CompareExchange(ref _stateDisclosure, (v = new StateDisclosure()), null) ?? v; } set { _stateDisclosure = value; } }
@@ -610,37 +610,37 @@ namespace EncompassRest.Loans
         public StatementCreditDenial StatementCreditDenial { get { var v = _statementCreditDenial; return v ?? Interlocked.CompareExchange(ref _statementCreditDenial, (v = new StatementCreditDenial()), null) ?? v; } set { _statementCreditDenial = value; } }
         private DirtyList<StatusOnlineLog> _statusOnlineLogs;
         public IList<StatusOnlineLog> StatusOnlineLogs { get { var v = _statusOnlineLogs; return v ?? Interlocked.CompareExchange(ref _statusOnlineLogs, (v = new DirtyList<StatusOnlineLog>()), null) ?? v; } set { _statusOnlineLogs = new DirtyList<StatusOnlineLog>(value); } }
-        private Value<decimal?> _subjectPropertyGrossRentalIncomeAmount;
+        private DirtyValue<decimal?> _subjectPropertyGrossRentalIncomeAmount;
         public decimal? SubjectPropertyGrossRentalIncomeAmount { get { return _subjectPropertyGrossRentalIncomeAmount; } set { _subjectPropertyGrossRentalIncomeAmount = value; } }
-        private Value<decimal?> _subjectPropertyOccupancyPercent;
+        private DirtyValue<decimal?> _subjectPropertyOccupancyPercent;
         public decimal? SubjectPropertyOccupancyPercent { get { return _subjectPropertyOccupancyPercent; } set { _subjectPropertyOccupancyPercent = value; } }
-        private Value<decimal?> _subordinateLienAmount;
+        private DirtyValue<decimal?> _subordinateLienAmount;
         public decimal? SubordinateLienAmount { get { return _subordinateLienAmount; } set { _subordinateLienAmount = value; } }
-        private Value<string> _systemIdGuid;
+        private DirtyValue<string> _systemIdGuid;
         public string SystemIdGuid { get { return _systemIdGuid; } set { _systemIdGuid = value; } }
-        private Value<DateTime?> _tilApplicationDate;
+        private DirtyValue<DateTime?> _tilApplicationDate;
         public DateTime? TilApplicationDate { get { return _tilApplicationDate; } set { _tilApplicationDate = value; } }
-        private Value<string> _titleHolderName1;
+        private DirtyValue<string> _titleHolderName1;
         public string TitleHolderName1 { get { return _titleHolderName1; } set { _titleHolderName1 = value; } }
-        private Value<string> _titleHolderName2;
+        private DirtyValue<string> _titleHolderName2;
         public string TitleHolderName2 { get { return _titleHolderName2; } set { _titleHolderName2 = value; } }
-        private Value<decimal?> _tltv;
+        private DirtyValue<decimal?> _tltv;
         public decimal? Tltv { get { return _tltv; } set { _tltv = value; } }
-        private Value<decimal?> _totalClosingCostsAmount;
+        private DirtyValue<decimal?> _totalClosingCostsAmount;
         public decimal? TotalClosingCostsAmount { get { return _totalClosingCostsAmount; } set { _totalClosingCostsAmount = value; } }
-        private Value<decimal?> _totalDeductionsAmount;
+        private DirtyValue<decimal?> _totalDeductionsAmount;
         public decimal? TotalDeductionsAmount { get { return _totalDeductionsAmount; } set { _totalDeductionsAmount = value; } }
-        private Value<decimal?> _totalFeesCostAmount;
+        private DirtyValue<decimal?> _totalFeesCostAmount;
         public decimal? TotalFeesCostAmount { get { return _totalFeesCostAmount; } set { _totalFeesCostAmount = value; } }
-        private Value<decimal?> _totalFeesCreditAmount;
+        private DirtyValue<decimal?> _totalFeesCreditAmount;
         public decimal? TotalFeesCreditAmount { get { return _totalFeesCreditAmount; } set { _totalFeesCreditAmount = value; } }
-        private Value<decimal?> _totalNonborrowerPaidClosingCostsAmount;
+        private DirtyValue<decimal?> _totalNonborrowerPaidClosingCostsAmount;
         public decimal? TotalNonborrowerPaidClosingCostsAmount { get { return _totalNonborrowerPaidClosingCostsAmount; } set { _totalNonborrowerPaidClosingCostsAmount = value; } }
-        private Value<decimal?> _totalPaidOutsideClosingAmount;
+        private DirtyValue<decimal?> _totalPaidOutsideClosingAmount;
         public decimal? TotalPaidOutsideClosingAmount { get { return _totalPaidOutsideClosingAmount; } set { _totalPaidOutsideClosingAmount = value; } }
-        private Value<decimal?> _totalPaidToBrokerAmount;
+        private DirtyValue<decimal?> _totalPaidToBrokerAmount;
         public decimal? TotalPaidToBrokerAmount { get { return _totalPaidToBrokerAmount; } set { _totalPaidToBrokerAmount = value; } }
-        private Value<decimal?> _totalWireTransferAmount;
+        private DirtyValue<decimal?> _totalWireTransferAmount;
         public decimal? TotalWireTransferAmount { get { return _totalWireTransferAmount; } set { _totalWireTransferAmount = value; } }
         private TPO _tPO;
         public TPO TPO { get { var v = _tPO; return v ?? Interlocked.CompareExchange(ref _tPO, (v = new TPO()), null) ?? v; } set { _tPO = value; } }
@@ -650,7 +650,7 @@ namespace EncompassRest.Loans
         public TrustAccount TrustAccount { get { var v = _trustAccount; return v ?? Interlocked.CompareExchange(ref _trustAccount, (v = new TrustAccount()), null) ?? v; } set { _trustAccount = value; } }
         private Tsum _tsum;
         public Tsum Tsum { get { var v = _tsum; return v ?? Interlocked.CompareExchange(ref _tsum, (v = new Tsum()), null) ?? v; } set { _tsum = value; } }
-        private Value<bool?> _twelveMonthMortgageRentalHistoryIndicator;
+        private DirtyValue<bool?> _twelveMonthMortgageRentalHistoryIndicator;
         public bool? TwelveMonthMortgageRentalHistoryIndicator { get { return _twelveMonthMortgageRentalHistoryIndicator; } set { _twelveMonthMortgageRentalHistoryIndicator = value; } }
         private Uldd _uldd;
         public Uldd Uldd { get { var v = _uldd; return v ?? Interlocked.CompareExchange(ref _uldd, (v = new Uldd()), null) ?? v; } set { _uldd = value; } }
@@ -658,27 +658,27 @@ namespace EncompassRest.Loans
         public UnderwriterSummary UnderwriterSummary { get { var v = _underwriterSummary; return v ?? Interlocked.CompareExchange(ref _underwriterSummary, (v = new UnderwriterSummary()), null) ?? v; } set { _underwriterSummary = value; } }
         private DirtyList<UnderwritingConditionLog> _underwritingConditionLogs;
         public IList<UnderwritingConditionLog> UnderwritingConditionLogs { get { var v = _underwritingConditionLogs; return v ?? Interlocked.CompareExchange(ref _underwritingConditionLogs, (v = new DirtyList<UnderwritingConditionLog>()), null) ?? v; } set { _underwritingConditionLogs = new DirtyList<UnderwritingConditionLog>(value); } }
-        private Value<bool?> _underwritingEscrowIndicator;
+        private DirtyValue<bool?> _underwritingEscrowIndicator;
         public bool? UnderwritingEscrowIndicator { get { return _underwritingEscrowIndicator; } set { _underwritingEscrowIndicator = value; } }
-        private Value<decimal?> _undiscountedRate;
+        private DirtyValue<decimal?> _undiscountedRate;
         public decimal? UndiscountedRate { get { return _undiscountedRate; } set { _undiscountedRate = value; } }
-        private Value<int?> _unimprovedAppraisedValue;
+        private DirtyValue<int?> _unimprovedAppraisedValue;
         public int? UnimprovedAppraisedValue { get { return _unimprovedAppraisedValue; } set { _unimprovedAppraisedValue = value; } }
-        private Value<int?> _unimprovedEstimatedValue;
+        private DirtyValue<int?> _unimprovedEstimatedValue;
         public int? UnimprovedEstimatedValue { get { return _unimprovedEstimatedValue; } set { _unimprovedEstimatedValue = value; } }
-        private Value<string> _urlPage4Comments;
+        private DirtyValue<string> _urlPage4Comments;
         public string UrlPage4Comments { get { return _urlPage4Comments; } set { _urlPage4Comments = value; } }
         private Usda _usda;
         public Usda Usda { get { var v = _usda; return v ?? Interlocked.CompareExchange(ref _usda, (v = new Usda()), null) ?? v; } set { _usda = value; } }
-        private Value<string> _usdaGovernmentLoanType;
+        private DirtyValue<string> _usdaGovernmentLoanType;
         public string UsdaGovernmentLoanType { get { return _usdaGovernmentLoanType; } set { _usdaGovernmentLoanType = value; } }
-        private Value<bool?> _use2018DiIndicator;
+        private DirtyValue<bool?> _use2018DiIndicator;
         public bool? Use2018DiIndicator { get { return _use2018DiIndicator; } set { _use2018DiIndicator = value; } }
-        private Value<string> _useNew2015FormsIndicator;
+        private DirtyValue<string> _useNew2015FormsIndicator;
         public string UseNew2015FormsIndicator { get { return _useNew2015FormsIndicator; } set { _useNew2015FormsIndicator = value; } }
-        private Value<bool?> _useNewHudIndicator;
+        private DirtyValue<bool?> _useNewHudIndicator;
         public bool? UseNewHudIndicator { get { return _useNewHudIndicator; } set { _useNewHudIndicator = value; } }
-        private Value<decimal?> _vAEntitlementAmount;
+        private DirtyValue<decimal?> _vAEntitlementAmount;
         public decimal? VAEntitlementAmount { get { return _vAEntitlementAmount; } set { _vAEntitlementAmount = value; } }
         private VaLoanData _vaLoanData;
         public VaLoanData VaLoanData { get { var v = _vaLoanData; return v ?? Interlocked.CompareExchange(ref _vaLoanData, (v = new VaLoanData()), null) ?? v; } set { _vaLoanData = value; } }
@@ -686,7 +686,7 @@ namespace EncompassRest.Loans
         public IList<VerificationLog> VerificationLogs { get { var v = _verificationLogs; return v ?? Interlocked.CompareExchange(ref _verificationLogs, (v = new DirtyList<VerificationLog>()), null) ?? v; } set { _verificationLogs = new DirtyList<VerificationLog>(value); } }
         //private Value<string> _virtualFields;
         //public string VirtualFields { get { return _virtualFields; } set { _virtualFields = value; } }
-        private Value<string> _websiteId;
+        private DirtyValue<string> _websiteId;
         public string WebsiteId { get { return _websiteId; } set { _websiteId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanActionLog.cs
+++ b/src/EncompassRest/Loans/LoanActionLog.cs
@@ -12,15 +12,15 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _loanActionType;
+        private DirtyValue<string> _loanActionType;
         public string LoanActionType { get { return _loanActionType; } set { _loanActionType = value; } }
-        private Value<string> _triggeredBy;
+        private DirtyValue<string> _triggeredBy;
         public string TriggeredBy { get { return _triggeredBy; } set { _triggeredBy = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanActionLog.cs
+++ b/src/EncompassRest/Loans/LoanActionLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanActionLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -29,26 +29,26 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _dateUtc.Dirty
                     || _id.Dirty
                     || _loanActionType.Dirty
-                    || _triggeredBy.Dirty;
+                    || _triggeredBy.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _id.Dirty = value;
                 _loanActionType.Dirty = value;
                 _triggeredBy.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LoanAssociate.cs
+++ b/src/EncompassRest/Loans/LoanAssociate.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanAssociate : IDirty
     {
-        private Value<string> _cellPhone;
+        private DirtyValue<string> _cellPhone;
         public string CellPhone { get { return _cellPhone; } set { _cellPhone = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _idString;
+        private DirtyValue<string> _idString;
         public string IdString { get { return _idString; } set { _idString = value; } }
-        private Value<string> _loanAssociateType;
+        private DirtyValue<string> _loanAssociateType;
         public string LoanAssociateType { get { return _loanAssociateType; } set { _loanAssociateType = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<int?> _roleId;
+        private DirtyValue<int?> _roleId;
         public int? RoleId { get { return _roleId; } set { _roleId = value; } }
-        private Value<string> _roleName;
+        private DirtyValue<string> _roleName;
         public string RoleName { get { return _roleName; } set { _roleName = value; } }
-        private Value<string> _writeAccess;
+        private DirtyValue<string> _writeAccess;
         public string WriteAccess { get { return _writeAccess; } set { _writeAccess = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanEstimate1.cs
+++ b/src/EncompassRest/Loans/LoanEstimate1.cs
@@ -8,247 +8,247 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanEstimate1 : IDirty
     {
-        private Value<string> _adjustsTermType;
+        private DirtyValue<string> _adjustsTermType;
         public string AdjustsTermType { get { return _adjustsTermType; } set { _adjustsTermType = value; } }
-        private Value<string> _changedCircumstanceComments;
+        private DirtyValue<string> _changedCircumstanceComments;
         public string ChangedCircumstanceComments { get { return _changedCircumstanceComments; } set { _changedCircumstanceComments = value; } }
-        private Value<DateTime?> _closingCostEstimateExpirationDate;
+        private DirtyValue<DateTime?> _closingCostEstimateExpirationDate;
         public DateTime? ClosingCostEstimateExpirationDate { get { return _closingCostEstimateExpirationDate; } set { _closingCostEstimateExpirationDate = value; } }
-        private Value<string> _closingCostEstimateExpirationTime;
+        private DirtyValue<string> _closingCostEstimateExpirationTime;
         public string ClosingCostEstimateExpirationTime { get { return _closingCostEstimateExpirationTime; } set { _closingCostEstimateExpirationTime = value; } }
-        private Value<string> _closingCostEstimateExpirationTimeZone;
+        private DirtyValue<string> _closingCostEstimateExpirationTimeZone;
         public string ClosingCostEstimateExpirationTimeZone { get { return _closingCostEstimateExpirationTimeZone; } set { _closingCostEstimateExpirationTimeZone = value; } }
-        private Value<string> _disclosureBy;
+        private DirtyValue<string> _disclosureBy;
         public string DisclosureBy { get { return _disclosureBy; } set { _disclosureBy = value; } }
-        private Value<DateTime?> _disclosureClosingCostExpDate;
+        private DirtyValue<DateTime?> _disclosureClosingCostExpDate;
         public DateTime? DisclosureClosingCostExpDate { get { return _disclosureClosingCostExpDate; } set { _disclosureClosingCostExpDate = value; } }
-        private Value<string> _disclosureClosingCostExpTime;
+        private DirtyValue<string> _disclosureClosingCostExpTime;
         public string DisclosureClosingCostExpTime { get { return _disclosureClosingCostExpTime; } set { _disclosureClosingCostExpTime = value; } }
-        private Value<string> _disclosureClosingCostExpTimeZone;
+        private DirtyValue<string> _disclosureClosingCostExpTimeZone;
         public string DisclosureClosingCostExpTimeZone { get { return _disclosureClosingCostExpTimeZone; } set { _disclosureClosingCostExpTimeZone = value; } }
-        private Value<string> _disclosureComments;
+        private DirtyValue<string> _disclosureComments;
         public string DisclosureComments { get { return _disclosureComments; } set { _disclosureComments = value; } }
-        private Value<DateTime?> _disclosureLastSentDate;
+        private DirtyValue<DateTime?> _disclosureLastSentDate;
         public DateTime? DisclosureLastSentDate { get { return _disclosureLastSentDate; } set { _disclosureLastSentDate = value; } }
-        private Value<DateTime?> _disclosureReceivedDate;
+        private DirtyValue<DateTime?> _disclosureReceivedDate;
         public DateTime? DisclosureReceivedDate { get { return _disclosureReceivedDate; } set { _disclosureReceivedDate = value; } }
-        private Value<string> _disclosureSentMethod;
+        private DirtyValue<string> _disclosureSentMethod;
         public string DisclosureSentMethod { get { return _disclosureSentMethod; } set { _disclosureSentMethod = value; } }
-        private Value<decimal?> _estimatedTaxesInsuranceAssessments;
+        private DirtyValue<decimal?> _estimatedTaxesInsuranceAssessments;
         public decimal? EstimatedTaxesInsuranceAssessments { get { return _estimatedTaxesInsuranceAssessments; } set { _estimatedTaxesInsuranceAssessments = value; } }
-        private Value<string> _estimatedTaxesInsuranceAssessmentsUI;
+        private DirtyValue<string> _estimatedTaxesInsuranceAssessmentsUI;
         public string EstimatedTaxesInsuranceAssessmentsUI { get { return _estimatedTaxesInsuranceAssessmentsUI; } set { _estimatedTaxesInsuranceAssessmentsUI = value; } }
-        private Value<decimal?> _highestMonthlyPI;
+        private DirtyValue<decimal?> _highestMonthlyPI;
         public decimal? HighestMonthlyPI { get { return _highestMonthlyPI; } set { _highestMonthlyPI = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _inEscrowHomeownerInsurance;
+        private DirtyValue<string> _inEscrowHomeownerInsurance;
         public string InEscrowHomeownerInsurance { get { return _inEscrowHomeownerInsurance; } set { _inEscrowHomeownerInsurance = value; } }
-        private Value<string> _inEscrowOther;
+        private DirtyValue<string> _inEscrowOther;
         public string InEscrowOther { get { return _inEscrowOther; } set { _inEscrowOther = value; } }
-        private Value<string> _inEscrowPropertyTaxes;
+        private DirtyValue<string> _inEscrowPropertyTaxes;
         public string InEscrowPropertyTaxes { get { return _inEscrowPropertyTaxes; } set { _inEscrowPropertyTaxes = value; } }
-        private Value<string> _interestRateAdjustsEveryYears;
+        private DirtyValue<string> _interestRateAdjustsEveryYears;
         public string InterestRateAdjustsEveryYears { get { return _interestRateAdjustsEveryYears; } set { _interestRateAdjustsEveryYears = value; } }
-        private Value<int?> _interestRateAdjustsInYear;
+        private DirtyValue<int?> _interestRateAdjustsInYear;
         public int? InterestRateAdjustsInYear { get { return _interestRateAdjustsInYear; } set { _interestRateAdjustsInYear = value; } }
-        private Value<string> _interestRateAdjustsStartingInType;
+        private DirtyValue<string> _interestRateAdjustsStartingInType;
         public string InterestRateAdjustsStartingInType { get { return _interestRateAdjustsStartingInType; } set { _interestRateAdjustsStartingInType = value; } }
-        private Value<int?> _interestRateAfterAdjustment;
+        private DirtyValue<int?> _interestRateAfterAdjustment;
         public int? InterestRateAfterAdjustment { get { return _interestRateAfterAdjustment; } set { _interestRateAfterAdjustment = value; } }
-        private Value<string> _interestRateCanGoGoes;
+        private DirtyValue<string> _interestRateCanGoGoes;
         public string InterestRateCanGoGoes { get { return _interestRateCanGoGoes; } set { _interestRateCanGoGoes = value; } }
-        private Value<DateTime?> _lEDateIssued;
+        private DirtyValue<DateTime?> _lEDateIssued;
         public DateTime? LEDateIssued { get { return _lEDateIssued; } set { _lEDateIssued = value; } }
-        private Value<string> _loanAmountCanGoGoes;
+        private DirtyValue<string> _loanAmountCanGoGoes;
         public string LoanAmountCanGoGoes { get { return _loanAmountCanGoGoes; } set { _loanAmountCanGoGoes = value; } }
-        private Value<string> _loanAmountCanIncreaseOrIncreases;
+        private DirtyValue<string> _loanAmountCanIncreaseOrIncreases;
         public string LoanAmountCanIncreaseOrIncreases { get { return _loanAmountCanIncreaseOrIncreases; } set { _loanAmountCanIncreaseOrIncreases = value; } }
-        private Value<string> _loanProduct;
+        private DirtyValue<string> _loanProduct;
         public string LoanProduct { get { return _loanProduct; } set { _loanProduct = value; } }
-        private Value<string> _loanPurpose;
+        private DirtyValue<string> _loanPurpose;
         public string LoanPurpose { get { return _loanPurpose; } set { _loanPurpose = value; } }
-        private Value<int?> _loanTermMonths;
+        private DirtyValue<int?> _loanTermMonths;
         public int? LoanTermMonths { get { return _loanTermMonths; } set { _loanTermMonths = value; } }
-        private Value<int?> _loanTermYears;
+        private DirtyValue<int?> _loanTermYears;
         public int? LoanTermYears { get { return _loanTermYears; } set { _loanTermYears = value; } }
-        private Value<string> _monthlyPIAdjustedInDateType;
+        private DirtyValue<string> _monthlyPIAdjustedInDateType;
         public string MonthlyPIAdjustedInDateType { get { return _monthlyPIAdjustedInDateType; } set { _monthlyPIAdjustedInDateType = value; } }
-        private Value<string> _monthlyPIAdjustsEveryYears;
+        private DirtyValue<string> _monthlyPIAdjustsEveryYears;
         public string MonthlyPIAdjustsEveryYears { get { return _monthlyPIAdjustsEveryYears; } set { _monthlyPIAdjustsEveryYears = value; } }
-        private Value<int?> _monthlyPIAdjustsInYear;
+        private DirtyValue<int?> _monthlyPIAdjustsInYear;
         public int? MonthlyPIAdjustsInYear { get { return _monthlyPIAdjustsInYear; } set { _monthlyPIAdjustsInYear = value; } }
-        private Value<string> _monthlyPIAdjustsStartingInType;
+        private DirtyValue<string> _monthlyPIAdjustsStartingInType;
         public string MonthlyPIAdjustsStartingInType { get { return _monthlyPIAdjustsStartingInType; } set { _monthlyPIAdjustsStartingInType = value; } }
-        private Value<string> _monthlyPIAdjustsTermType;
+        private DirtyValue<string> _monthlyPIAdjustsTermType;
         public string MonthlyPIAdjustsTermType { get { return _monthlyPIAdjustsTermType; } set { _monthlyPIAdjustsTermType = value; } }
-        private Value<int?> _monthlyPIAfterAdjustment;
+        private DirtyValue<int?> _monthlyPIAfterAdjustment;
         public int? MonthlyPIAfterAdjustment { get { return _monthlyPIAfterAdjustment; } set { _monthlyPIAfterAdjustment = value; } }
-        private Value<string> _monthlyPICanGoGoes;
+        private DirtyValue<string> _monthlyPICanGoGoes;
         public string MonthlyPICanGoGoes { get { return _monthlyPICanGoGoes; } set { _monthlyPICanGoGoes = value; } }
-        private Value<string> _monthlyPIInterestOnlyDateType;
+        private DirtyValue<string> _monthlyPIInterestOnlyDateType;
         public string MonthlyPIInterestOnlyDateType { get { return _monthlyPIInterestOnlyDateType; } set { _monthlyPIInterestOnlyDateType = value; } }
-        private Value<int?> _monthlyPIInterestOnlyUntilYear;
+        private DirtyValue<int?> _monthlyPIInterestOnlyUntilYear;
         public int? MonthlyPIInterestOnlyUntilYear { get { return _monthlyPIInterestOnlyUntilYear; } set { _monthlyPIInterestOnlyUntilYear = value; } }
-        private Value<int?> _pPC1EstimatedEscrowAmount;
+        private DirtyValue<int?> _pPC1EstimatedEscrowAmount;
         public int? PPC1EstimatedEscrowAmount { get { return _pPC1EstimatedEscrowAmount; } set { _pPC1EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC1EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC1EstimatedEscrowAmountUI;
         public string PPC1EstimatedEscrowAmountUI { get { return _pPC1EstimatedEscrowAmountUI; } set { _pPC1EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC1InterestOnly;
+        private DirtyValue<bool?> _pPC1InterestOnly;
         public bool? PPC1InterestOnly { get { return _pPC1InterestOnly; } set { _pPC1InterestOnly = value; } }
-        private Value<decimal?> _pPC1MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC1MaximumMonthlyPayment;
         public decimal? PPC1MaximumMonthlyPayment { get { return _pPC1MaximumMonthlyPayment; } set { _pPC1MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC1MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC1MaximumMonthlyPaymentUI;
         public string PPC1MaximumMonthlyPaymentUI { get { return _pPC1MaximumMonthlyPaymentUI; } set { _pPC1MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC1MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC1MaximumPIPayment;
         public decimal? PPC1MaximumPIPayment { get { return _pPC1MaximumPIPayment; } set { _pPC1MaximumPIPayment = value; } }
-        private Value<string> _pPC1MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC1MaximumPIPaymentUI;
         public string PPC1MaximumPIPaymentUI { get { return _pPC1MaximumPIPaymentUI; } set { _pPC1MaximumPIPaymentUI = value; } }
-        private Value<int?> _pPC1MIAmount;
+        private DirtyValue<int?> _pPC1MIAmount;
         public int? PPC1MIAmount { get { return _pPC1MIAmount; } set { _pPC1MIAmount = value; } }
-        private Value<string> _pPC1MIAmountUI;
+        private DirtyValue<string> _pPC1MIAmountUI;
         public string PPC1MIAmountUI { get { return _pPC1MIAmountUI; } set { _pPC1MIAmountUI = value; } }
-        private Value<int?> _pPC1MinimumMonthlyPayment;
+        private DirtyValue<int?> _pPC1MinimumMonthlyPayment;
         public int? PPC1MinimumMonthlyPayment { get { return _pPC1MinimumMonthlyPayment; } set { _pPC1MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC1MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC1MinimumMonthlyPaymentUI;
         public string PPC1MinimumMonthlyPaymentUI { get { return _pPC1MinimumMonthlyPaymentUI; } set { _pPC1MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC1MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC1MinimumPIPayment;
         public decimal? PPC1MinimumPIPayment { get { return _pPC1MinimumPIPayment; } set { _pPC1MinimumPIPayment = value; } }
-        private Value<string> _pPC1MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC1MinimumPIPaymentUI;
         public string PPC1MinimumPIPaymentUI { get { return _pPC1MinimumPIPaymentUI; } set { _pPC1MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC1Year;
+        private DirtyValue<int?> _pPC1Year;
         public int? PPC1Year { get { return _pPC1Year; } set { _pPC1Year = value; } }
-        private Value<int?> _pPC2EstimatedEscrowAmount;
+        private DirtyValue<int?> _pPC2EstimatedEscrowAmount;
         public int? PPC2EstimatedEscrowAmount { get { return _pPC2EstimatedEscrowAmount; } set { _pPC2EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC2EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC2EstimatedEscrowAmountUI;
         public string PPC2EstimatedEscrowAmountUI { get { return _pPC2EstimatedEscrowAmountUI; } set { _pPC2EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC2InterestOnly;
+        private DirtyValue<bool?> _pPC2InterestOnly;
         public bool? PPC2InterestOnly { get { return _pPC2InterestOnly; } set { _pPC2InterestOnly = value; } }
-        private Value<decimal?> _pPC2MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC2MaximumMonthlyPayment;
         public decimal? PPC2MaximumMonthlyPayment { get { return _pPC2MaximumMonthlyPayment; } set { _pPC2MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC2MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC2MaximumMonthlyPaymentUI;
         public string PPC2MaximumMonthlyPaymentUI { get { return _pPC2MaximumMonthlyPaymentUI; } set { _pPC2MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC2MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC2MaximumPIPayment;
         public decimal? PPC2MaximumPIPayment { get { return _pPC2MaximumPIPayment; } set { _pPC2MaximumPIPayment = value; } }
-        private Value<string> _pPC2MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC2MaximumPIPaymentUI;
         public string PPC2MaximumPIPaymentUI { get { return _pPC2MaximumPIPaymentUI; } set { _pPC2MaximumPIPaymentUI = value; } }
-        private Value<int?> _pPC2MIAmount;
+        private DirtyValue<int?> _pPC2MIAmount;
         public int? PPC2MIAmount { get { return _pPC2MIAmount; } set { _pPC2MIAmount = value; } }
-        private Value<string> _pPC2MIAmountUI;
+        private DirtyValue<string> _pPC2MIAmountUI;
         public string PPC2MIAmountUI { get { return _pPC2MIAmountUI; } set { _pPC2MIAmountUI = value; } }
-        private Value<int?> _pPC2MinimumMonthlyPayment;
+        private DirtyValue<int?> _pPC2MinimumMonthlyPayment;
         public int? PPC2MinimumMonthlyPayment { get { return _pPC2MinimumMonthlyPayment; } set { _pPC2MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC2MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC2MinimumMonthlyPaymentUI;
         public string PPC2MinimumMonthlyPaymentUI { get { return _pPC2MinimumMonthlyPaymentUI; } set { _pPC2MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC2MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC2MinimumPIPayment;
         public decimal? PPC2MinimumPIPayment { get { return _pPC2MinimumPIPayment; } set { _pPC2MinimumPIPayment = value; } }
-        private Value<string> _pPC2MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC2MinimumPIPaymentUI;
         public string PPC2MinimumPIPaymentUI { get { return _pPC2MinimumPIPaymentUI; } set { _pPC2MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC2YearFrom;
+        private DirtyValue<int?> _pPC2YearFrom;
         public int? PPC2YearFrom { get { return _pPC2YearFrom; } set { _pPC2YearFrom = value; } }
-        private Value<int?> _pPC2YearTo;
+        private DirtyValue<int?> _pPC2YearTo;
         public int? PPC2YearTo { get { return _pPC2YearTo; } set { _pPC2YearTo = value; } }
-        private Value<int?> _pPC3EstimatedEscrowAmount;
+        private DirtyValue<int?> _pPC3EstimatedEscrowAmount;
         public int? PPC3EstimatedEscrowAmount { get { return _pPC3EstimatedEscrowAmount; } set { _pPC3EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC3EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC3EstimatedEscrowAmountUI;
         public string PPC3EstimatedEscrowAmountUI { get { return _pPC3EstimatedEscrowAmountUI; } set { _pPC3EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC3InterestOnly;
+        private DirtyValue<bool?> _pPC3InterestOnly;
         public bool? PPC3InterestOnly { get { return _pPC3InterestOnly; } set { _pPC3InterestOnly = value; } }
-        private Value<decimal?> _pPC3MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC3MaximumMonthlyPayment;
         public decimal? PPC3MaximumMonthlyPayment { get { return _pPC3MaximumMonthlyPayment; } set { _pPC3MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC3MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC3MaximumMonthlyPaymentUI;
         public string PPC3MaximumMonthlyPaymentUI { get { return _pPC3MaximumMonthlyPaymentUI; } set { _pPC3MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC3MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC3MaximumPIPayment;
         public decimal? PPC3MaximumPIPayment { get { return _pPC3MaximumPIPayment; } set { _pPC3MaximumPIPayment = value; } }
-        private Value<string> _pPC3MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC3MaximumPIPaymentUI;
         public string PPC3MaximumPIPaymentUI { get { return _pPC3MaximumPIPaymentUI; } set { _pPC3MaximumPIPaymentUI = value; } }
-        private Value<int?> _pPC3MIAmount;
+        private DirtyValue<int?> _pPC3MIAmount;
         public int? PPC3MIAmount { get { return _pPC3MIAmount; } set { _pPC3MIAmount = value; } }
-        private Value<string> _pPC3MIAmountUI;
+        private DirtyValue<string> _pPC3MIAmountUI;
         public string PPC3MIAmountUI { get { return _pPC3MIAmountUI; } set { _pPC3MIAmountUI = value; } }
-        private Value<int?> _pPC3MinimumMonthlyPayment;
+        private DirtyValue<int?> _pPC3MinimumMonthlyPayment;
         public int? PPC3MinimumMonthlyPayment { get { return _pPC3MinimumMonthlyPayment; } set { _pPC3MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC3MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC3MinimumMonthlyPaymentUI;
         public string PPC3MinimumMonthlyPaymentUI { get { return _pPC3MinimumMonthlyPaymentUI; } set { _pPC3MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC3MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC3MinimumPIPayment;
         public decimal? PPC3MinimumPIPayment { get { return _pPC3MinimumPIPayment; } set { _pPC3MinimumPIPayment = value; } }
-        private Value<string> _pPC3MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC3MinimumPIPaymentUI;
         public string PPC3MinimumPIPaymentUI { get { return _pPC3MinimumPIPaymentUI; } set { _pPC3MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC3YearFrom;
+        private DirtyValue<int?> _pPC3YearFrom;
         public int? PPC3YearFrom { get { return _pPC3YearFrom; } set { _pPC3YearFrom = value; } }
-        private Value<int?> _pPC3YearTo;
+        private DirtyValue<int?> _pPC3YearTo;
         public int? PPC3YearTo { get { return _pPC3YearTo; } set { _pPC3YearTo = value; } }
-        private Value<int?> _pPC4EstimatedEscrowAmount;
+        private DirtyValue<int?> _pPC4EstimatedEscrowAmount;
         public int? PPC4EstimatedEscrowAmount { get { return _pPC4EstimatedEscrowAmount; } set { _pPC4EstimatedEscrowAmount = value; } }
-        private Value<string> _pPC4EstimatedEscrowAmountUI;
+        private DirtyValue<string> _pPC4EstimatedEscrowAmountUI;
         public string PPC4EstimatedEscrowAmountUI { get { return _pPC4EstimatedEscrowAmountUI; } set { _pPC4EstimatedEscrowAmountUI = value; } }
-        private Value<bool?> _pPC4InterestOnly;
+        private DirtyValue<bool?> _pPC4InterestOnly;
         public bool? PPC4InterestOnly { get { return _pPC4InterestOnly; } set { _pPC4InterestOnly = value; } }
-        private Value<decimal?> _pPC4MaximumMonthlyPayment;
+        private DirtyValue<decimal?> _pPC4MaximumMonthlyPayment;
         public decimal? PPC4MaximumMonthlyPayment { get { return _pPC4MaximumMonthlyPayment; } set { _pPC4MaximumMonthlyPayment = value; } }
-        private Value<string> _pPC4MaximumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC4MaximumMonthlyPaymentUI;
         public string PPC4MaximumMonthlyPaymentUI { get { return _pPC4MaximumMonthlyPaymentUI; } set { _pPC4MaximumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC4MaximumPIPayment;
+        private DirtyValue<decimal?> _pPC4MaximumPIPayment;
         public decimal? PPC4MaximumPIPayment { get { return _pPC4MaximumPIPayment; } set { _pPC4MaximumPIPayment = value; } }
-        private Value<string> _pPC4MaximumPIPaymentUI;
+        private DirtyValue<string> _pPC4MaximumPIPaymentUI;
         public string PPC4MaximumPIPaymentUI { get { return _pPC4MaximumPIPaymentUI; } set { _pPC4MaximumPIPaymentUI = value; } }
-        private Value<int?> _pPC4MIAmount;
+        private DirtyValue<int?> _pPC4MIAmount;
         public int? PPC4MIAmount { get { return _pPC4MIAmount; } set { _pPC4MIAmount = value; } }
-        private Value<string> _pPC4MIAmountUI;
+        private DirtyValue<string> _pPC4MIAmountUI;
         public string PPC4MIAmountUI { get { return _pPC4MIAmountUI; } set { _pPC4MIAmountUI = value; } }
-        private Value<int?> _pPC4MinimumMonthlyPayment;
+        private DirtyValue<int?> _pPC4MinimumMonthlyPayment;
         public int? PPC4MinimumMonthlyPayment { get { return _pPC4MinimumMonthlyPayment; } set { _pPC4MinimumMonthlyPayment = value; } }
-        private Value<string> _pPC4MinimumMonthlyPaymentUI;
+        private DirtyValue<string> _pPC4MinimumMonthlyPaymentUI;
         public string PPC4MinimumMonthlyPaymentUI { get { return _pPC4MinimumMonthlyPaymentUI; } set { _pPC4MinimumMonthlyPaymentUI = value; } }
-        private Value<decimal?> _pPC4MinimumPIPayment;
+        private DirtyValue<decimal?> _pPC4MinimumPIPayment;
         public decimal? PPC4MinimumPIPayment { get { return _pPC4MinimumPIPayment; } set { _pPC4MinimumPIPayment = value; } }
-        private Value<string> _pPC4MinimumPIPaymentUI;
+        private DirtyValue<string> _pPC4MinimumPIPaymentUI;
         public string PPC4MinimumPIPaymentUI { get { return _pPC4MinimumPIPaymentUI; } set { _pPC4MinimumPIPaymentUI = value; } }
-        private Value<int?> _pPC4YearFrom;
+        private DirtyValue<int?> _pPC4YearFrom;
         public int? PPC4YearFrom { get { return _pPC4YearFrom; } set { _pPC4YearFrom = value; } }
-        private Value<int?> _pPC4YearTo;
+        private DirtyValue<int?> _pPC4YearTo;
         public int? PPC4YearTo { get { return _pPC4YearTo; } set { _pPC4YearTo = value; } }
-        private Value<bool?> _pPEstimatedEscrowIndicator;
+        private DirtyValue<bool?> _pPEstimatedEscrowIndicator;
         public bool? PPEstimatedEscrowIndicator { get { return _pPEstimatedEscrowIndicator; } set { _pPEstimatedEscrowIndicator = value; } }
-        private Value<int?> _prepaymentPenaltyPayOffDuringYear;
+        private DirtyValue<int?> _prepaymentPenaltyPayOffDuringYear;
         public int? PrepaymentPenaltyPayOffDuringYear { get { return _prepaymentPenaltyPayOffDuringYear; } set { _prepaymentPenaltyPayOffDuringYear = value; } }
-        private Value<string> _prepaymentPenaltyPayOffInDateType;
+        private DirtyValue<string> _prepaymentPenaltyPayOffInDateType;
         public string PrepaymentPenaltyPayOffInDateType { get { return _prepaymentPenaltyPayOffInDateType; } set { _prepaymentPenaltyPayOffInDateType = value; } }
-        private Value<string> _prepaymentPenaltyPayOffInFirstYear;
+        private DirtyValue<string> _prepaymentPenaltyPayOffInFirstYear;
         public string PrepaymentPenaltyPayOffInFirstYear { get { return _prepaymentPenaltyPayOffInFirstYear; } set { _prepaymentPenaltyPayOffInFirstYear = value; } }
-        private Value<bool?> _rangePaymentIndicatorC1;
+        private DirtyValue<bool?> _rangePaymentIndicatorC1;
         public bool? RangePaymentIndicatorC1 { get { return _rangePaymentIndicatorC1; } set { _rangePaymentIndicatorC1 = value; } }
-        private Value<bool?> _rangePaymentIndicatorC2;
+        private DirtyValue<bool?> _rangePaymentIndicatorC2;
         public bool? RangePaymentIndicatorC2 { get { return _rangePaymentIndicatorC2; } set { _rangePaymentIndicatorC2 = value; } }
-        private Value<bool?> _rangePaymentIndicatorC3;
+        private DirtyValue<bool?> _rangePaymentIndicatorC3;
         public bool? RangePaymentIndicatorC3 { get { return _rangePaymentIndicatorC3; } set { _rangePaymentIndicatorC3 = value; } }
-        private Value<bool?> _rangePaymentIndicatorC4;
+        private DirtyValue<bool?> _rangePaymentIndicatorC4;
         public bool? RangePaymentIndicatorC4 { get { return _rangePaymentIndicatorC4; } set { _rangePaymentIndicatorC4 = value; } }
-        private Value<string> _rateLockExpirationTime;
+        private DirtyValue<string> _rateLockExpirationTime;
         public string RateLockExpirationTime { get { return _rateLockExpirationTime; } set { _rateLockExpirationTime = value; } }
-        private Value<string> _rateLockExpirationTimeZone;
+        private DirtyValue<string> _rateLockExpirationTimeZone;
         public string RateLockExpirationTimeZone { get { return _rateLockExpirationTimeZone; } set { _rateLockExpirationTimeZone = value; } }
-        private Value<string> _reasonChangedCircumstanceFlags;
+        private DirtyValue<string> _reasonChangedCircumstanceFlags;
         public string ReasonChangedCircumstanceFlags { get { return _reasonChangedCircumstanceFlags; } set { _reasonChangedCircumstanceFlags = value; } }
-        private Value<bool?> _reasonDelayedSettlement;
+        private DirtyValue<bool?> _reasonDelayedSettlement;
         public bool? ReasonDelayedSettlement { get { return _reasonDelayedSettlement; } set { _reasonDelayedSettlement = value; } }
-        private Value<bool?> _reasonEligibility;
+        private DirtyValue<bool?> _reasonEligibility;
         public bool? ReasonEligibility { get { return _reasonEligibility; } set { _reasonEligibility = value; } }
-        private Value<bool?> _reasonExpiration;
+        private DirtyValue<bool?> _reasonExpiration;
         public bool? ReasonExpiration { get { return _reasonExpiration; } set { _reasonExpiration = value; } }
-        private Value<bool?> _reasonInterestRate;
+        private DirtyValue<bool?> _reasonInterestRate;
         public bool? ReasonInterestRate { get { return _reasonInterestRate; } set { _reasonInterestRate = value; } }
-        private Value<bool?> _reasonOther;
+        private DirtyValue<bool?> _reasonOther;
         public bool? ReasonOther { get { return _reasonOther; } set { _reasonOther = value; } }
-        private Value<string> _reasonOtherDescription;
+        private DirtyValue<string> _reasonOtherDescription;
         public string ReasonOtherDescription { get { return _reasonOtherDescription; } set { _reasonOtherDescription = value; } }
-        private Value<bool?> _reasonRevisions;
+        private DirtyValue<bool?> _reasonRevisions;
         public bool? ReasonRevisions { get { return _reasonRevisions; } set { _reasonRevisions = value; } }
-        private Value<bool?> _reasonSettlementCharges;
+        private DirtyValue<bool?> _reasonSettlementCharges;
         public bool? ReasonSettlementCharges { get { return _reasonSettlementCharges; } set { _reasonSettlementCharges = value; } }
-        private Value<decimal?> _totalEstimatedCashClose;
+        private DirtyValue<decimal?> _totalEstimatedCashClose;
         public decimal? TotalEstimatedCashClose { get { return _totalEstimatedCashClose; } set { _totalEstimatedCashClose = value; } }
-        private Value<int?> _yearsToRecast;
+        private DirtyValue<int?> _yearsToRecast;
         public int? YearsToRecast { get { return _yearsToRecast; } set { _yearsToRecast = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanEstimate2.cs
+++ b/src/EncompassRest/Loans/LoanEstimate2.cs
@@ -8,115 +8,115 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanEstimate2 : IDirty
     {
-        private Value<decimal?> _actualLenderCredits;
+        private DirtyValue<decimal?> _actualLenderCredits;
         public decimal? ActualLenderCredits { get { return _actualLenderCredits; } set { _actualLenderCredits = value; } }
-        private Value<decimal?> _actualSTDLESellerCredits;
+        private DirtyValue<decimal?> _actualSTDLESellerCredits;
         public decimal? ActualSTDLESellerCredits { get { return _actualSTDLESellerCredits; } set { _actualSTDLESellerCredits = value; } }
-        private Value<decimal?> _actualSTDLETotalClosingCostJ;
+        private DirtyValue<decimal?> _actualSTDLETotalClosingCostJ;
         public decimal? ActualSTDLETotalClosingCostJ { get { return _actualSTDLETotalClosingCostJ; } set { _actualSTDLETotalClosingCostJ = value; } }
-        private Value<decimal?> _adjustmentsOtherCredits;
+        private DirtyValue<decimal?> _adjustmentsOtherCredits;
         public decimal? AdjustmentsOtherCredits { get { return _adjustmentsOtherCredits; } set { _adjustmentsOtherCredits = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt1;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt1;
         public decimal? AdjustmentsOtherCreditsAmt1 { get { return _adjustmentsOtherCreditsAmt1; } set { _adjustmentsOtherCreditsAmt1 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt10;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt10;
         public decimal? AdjustmentsOtherCreditsAmt10 { get { return _adjustmentsOtherCreditsAmt10; } set { _adjustmentsOtherCreditsAmt10 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt2;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt2;
         public decimal? AdjustmentsOtherCreditsAmt2 { get { return _adjustmentsOtherCreditsAmt2; } set { _adjustmentsOtherCreditsAmt2 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt3;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt3;
         public decimal? AdjustmentsOtherCreditsAmt3 { get { return _adjustmentsOtherCreditsAmt3; } set { _adjustmentsOtherCreditsAmt3 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt4;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt4;
         public decimal? AdjustmentsOtherCreditsAmt4 { get { return _adjustmentsOtherCreditsAmt4; } set { _adjustmentsOtherCreditsAmt4 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt5;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt5;
         public decimal? AdjustmentsOtherCreditsAmt5 { get { return _adjustmentsOtherCreditsAmt5; } set { _adjustmentsOtherCreditsAmt5 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt6;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt6;
         public decimal? AdjustmentsOtherCreditsAmt6 { get { return _adjustmentsOtherCreditsAmt6; } set { _adjustmentsOtherCreditsAmt6 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt7;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt7;
         public decimal? AdjustmentsOtherCreditsAmt7 { get { return _adjustmentsOtherCreditsAmt7; } set { _adjustmentsOtherCreditsAmt7 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt8;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt8;
         public decimal? AdjustmentsOtherCreditsAmt8 { get { return _adjustmentsOtherCreditsAmt8; } set { _adjustmentsOtherCreditsAmt8 = value; } }
-        private Value<decimal?> _adjustmentsOtherCreditsAmt9;
+        private DirtyValue<decimal?> _adjustmentsOtherCreditsAmt9;
         public decimal? AdjustmentsOtherCreditsAmt9 { get { return _adjustmentsOtherCreditsAmt9; } set { _adjustmentsOtherCreditsAmt9 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc1;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc1;
         public string AdjustmentsOtherCreditsDesc1 { get { return _adjustmentsOtherCreditsDesc1; } set { _adjustmentsOtherCreditsDesc1 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc10;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc10;
         public string AdjustmentsOtherCreditsDesc10 { get { return _adjustmentsOtherCreditsDesc10; } set { _adjustmentsOtherCreditsDesc10 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc2;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc2;
         public string AdjustmentsOtherCreditsDesc2 { get { return _adjustmentsOtherCreditsDesc2; } set { _adjustmentsOtherCreditsDesc2 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc3;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc3;
         public string AdjustmentsOtherCreditsDesc3 { get { return _adjustmentsOtherCreditsDesc3; } set { _adjustmentsOtherCreditsDesc3 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc4;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc4;
         public string AdjustmentsOtherCreditsDesc4 { get { return _adjustmentsOtherCreditsDesc4; } set { _adjustmentsOtherCreditsDesc4 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc5;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc5;
         public string AdjustmentsOtherCreditsDesc5 { get { return _adjustmentsOtherCreditsDesc5; } set { _adjustmentsOtherCreditsDesc5 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc6;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc6;
         public string AdjustmentsOtherCreditsDesc6 { get { return _adjustmentsOtherCreditsDesc6; } set { _adjustmentsOtherCreditsDesc6 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc7;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc7;
         public string AdjustmentsOtherCreditsDesc7 { get { return _adjustmentsOtherCreditsDesc7; } set { _adjustmentsOtherCreditsDesc7 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc8;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc8;
         public string AdjustmentsOtherCreditsDesc8 { get { return _adjustmentsOtherCreditsDesc8; } set { _adjustmentsOtherCreditsDesc8 = value; } }
-        private Value<string> _adjustmentsOtherCreditsDesc9;
+        private DirtyValue<string> _adjustmentsOtherCreditsDesc9;
         public string AdjustmentsOtherCreditsDesc9 { get { return _adjustmentsOtherCreditsDesc9; } set { _adjustmentsOtherCreditsDesc9 = value; } }
-        private Value<decimal?> _closingCostsFinanced;
+        private DirtyValue<decimal?> _closingCostsFinanced;
         public decimal? ClosingCostsFinanced { get { return _closingCostsFinanced; } set { _closingCostsFinanced = value; } }
-        private Value<decimal?> _downPayment;
+        private DirtyValue<decimal?> _downPayment;
         public decimal? DownPayment { get { return _downPayment; } set { _downPayment = value; } }
-        private Value<decimal?> _estimatedCashToCloseAV;
+        private DirtyValue<decimal?> _estimatedCashToCloseAV;
         public decimal? EstimatedCashToCloseAV { get { return _estimatedCashToCloseAV; } set { _estimatedCashToCloseAV = value; } }
-        private Value<decimal?> _estimatedCashToCloseSV;
+        private DirtyValue<decimal?> _estimatedCashToCloseSV;
         public decimal? EstimatedCashToCloseSV { get { return _estimatedCashToCloseSV; } set { _estimatedCashToCloseSV = value; } }
-        private Value<int?> _estimatedTotalPayoffsAndPaymentsAmount;
+        private DirtyValue<int?> _estimatedTotalPayoffsAndPaymentsAmount;
         public int? EstimatedTotalPayoffsAndPaymentsAmount { get { return _estimatedTotalPayoffsAndPaymentsAmount; } set { _estimatedTotalPayoffsAndPaymentsAmount = value; } }
-        private Value<int?> _firstChangeFrequencyMonth;
+        private DirtyValue<int?> _firstChangeFrequencyMonth;
         public int? firstChangeFrequencyMonth { get { return _firstChangeFrequencyMonth; } set { _firstChangeFrequencyMonth = value; } }
-        private Value<string> _firstChangeMonthSuffix;
+        private DirtyValue<string> _firstChangeMonthSuffix;
         public string firstChangeMonthSuffix { get { return _firstChangeMonthSuffix; } set { _firstChangeMonthSuffix = value; } }
-        private Value<string> _fromOrToBorrower;
+        private DirtyValue<string> _fromOrToBorrower;
         public string FromOrToBorrower { get { return _fromOrToBorrower; } set { _fromOrToBorrower = value; } }
-        private Value<decimal?> _fundsForBorrower;
+        private DirtyValue<decimal?> _fundsForBorrower;
         public decimal? FundsForBorrower { get { return _fundsForBorrower; } set { _fundsForBorrower = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _indexMargin;
+        private DirtyValue<string> _indexMargin;
         public string IndexMargin { get { return _indexMargin; } set { _indexMargin = value; } }
-        private Value<int?> _initialEscrowPaymentClosingSubTotal;
+        private DirtyValue<int?> _initialEscrowPaymentClosingSubTotal;
         public int? InitialEscrowPaymentClosingSubTotal { get { return _initialEscrowPaymentClosingSubTotal; } set { _initialEscrowPaymentClosingSubTotal = value; } }
-        private Value<bool?> _itemizeServiceSectionCType;
+        private DirtyValue<bool?> _itemizeServiceSectionCType;
         public bool? ItemizeServiceSectionCType { get { return _itemizeServiceSectionCType; } set { _itemizeServiceSectionCType = value; } }
-        private Value<int?> _lenderCredits;
+        private DirtyValue<int?> _lenderCredits;
         public int? LenderCredits { get { return _lenderCredits; } set { _lenderCredits = value; } }
-        private Value<int?> _originationChargesSubTotal;
+        private DirtyValue<int?> _originationChargesSubTotal;
         public int? OriginationChargesSubTotal { get { return _originationChargesSubTotal; } set { _originationChargesSubTotal = value; } }
-        private Value<int?> _otherSubTotal;
+        private DirtyValue<int?> _otherSubTotal;
         public int? OtherSubTotal { get { return _otherSubTotal; } set { _otherSubTotal = value; } }
-        private Value<int?> _prepaidsSubTotal;
+        private DirtyValue<int?> _prepaidsSubTotal;
         public int? PrepaidsSubTotal { get { return _prepaidsSubTotal; } set { _prepaidsSubTotal = value; } }
-        private Value<int?> _sellerCreditAmount;
+        private DirtyValue<int?> _sellerCreditAmount;
         public int? SellerCreditAmount { get { return _sellerCreditAmount; } set { _sellerCreditAmount = value; } }
-        private Value<int?> _servicesYouNotShopSubTotal;
+        private DirtyValue<int?> _servicesYouNotShopSubTotal;
         public int? ServicesYouNotShopSubTotal { get { return _servicesYouNotShopSubTotal; } set { _servicesYouNotShopSubTotal = value; } }
-        private Value<int?> _servicesYouShopSubTotal;
+        private DirtyValue<int?> _servicesYouShopSubTotal;
         public int? ServicesYouShopSubTotal { get { return _servicesYouShopSubTotal; } set { _servicesYouShopSubTotal = value; } }
-        private Value<string> _subseqChangeMonthSuffix;
+        private DirtyValue<string> _subseqChangeMonthSuffix;
         public string subseqChangeMonthSuffix { get { return _subseqChangeMonthSuffix; } set { _subseqChangeMonthSuffix = value; } }
-        private Value<int?> _taxesGovFeesSubTotal;
+        private DirtyValue<int?> _taxesGovFeesSubTotal;
         public int? TaxesGovFeesSubTotal { get { return _taxesGovFeesSubTotal; } set { _taxesGovFeesSubTotal = value; } }
-        private Value<decimal?> _thirdPartyPaymentsNotOtherwiseDisclosed;
+        private DirtyValue<decimal?> _thirdPartyPaymentsNotOtherwiseDisclosed;
         public decimal? ThirdPartyPaymentsNotOtherwiseDisclosed { get { return _thirdPartyPaymentsNotOtherwiseDisclosed; } set { _thirdPartyPaymentsNotOtherwiseDisclosed = value; } }
-        private Value<int?> _totalClosingCosts;
+        private DirtyValue<int?> _totalClosingCosts;
         public int? TotalClosingCosts { get { return _totalClosingCosts; } set { _totalClosingCosts = value; } }
-        private Value<int?> _totalLoanAndOtherCosts;
+        private DirtyValue<int?> _totalLoanAndOtherCosts;
         public int? TotalLoanAndOtherCosts { get { return _totalLoanAndOtherCosts; } set { _totalLoanAndOtherCosts = value; } }
-        private Value<int?> _totalLoanCosts;
+        private DirtyValue<int?> _totalLoanCosts;
         public int? TotalLoanCosts { get { return _totalLoanCosts; } set { _totalLoanCosts = value; } }
-        private Value<int?> _totalOtherCosts;
+        private DirtyValue<int?> _totalOtherCosts;
         public int? TotalOtherCosts { get { return _totalOtherCosts; } set { _totalOtherCosts = value; } }
-        private Value<decimal?> _unroundedTotalLoanCosts;
+        private DirtyValue<decimal?> _unroundedTotalLoanCosts;
         public decimal? UnroundedTotalLoanCosts { get { return _unroundedTotalLoanCosts; } set { _unroundedTotalLoanCosts = value; } }
-        private Value<decimal?> _unroundedTotalOtherCosts;
+        private DirtyValue<decimal?> _unroundedTotalOtherCosts;
         public decimal? UnroundedTotalOtherCosts { get { return _unroundedTotalOtherCosts; } set { _unroundedTotalOtherCosts = value; } }
-        private Value<bool?> _useActualDownPaymentAndClosingCostsFinancedIndicator;
+        private DirtyValue<bool?> _useActualDownPaymentAndClosingCostsFinancedIndicator;
         public bool? UseActualDownPaymentAndClosingCostsFinancedIndicator { get { return _useActualDownPaymentAndClosingCostsFinancedIndicator; } set { _useActualDownPaymentAndClosingCostsFinancedIndicator = value; } }
-        private Value<bool?> _useAlternate;
+        private DirtyValue<bool?> _useAlternate;
         public bool? UseAlternate { get { return _useAlternate; } set { _useAlternate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanEstimate3.cs
+++ b/src/EncompassRest/Loans/LoanEstimate3.cs
@@ -8,57 +8,57 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanEstimate3 : IDirty
     {
-        private Value<string> _appraisal;
+        private DirtyValue<string> _appraisal;
         public string Appraisal { get { return _appraisal; } set { _appraisal = value; } }
-        private Value<string> _assumption;
+        private DirtyValue<string> _assumption;
         public string Assumption { get { return _assumption; } set { _assumption = value; } }
-        private Value<bool?> _constructionLoan;
+        private DirtyValue<bool?> _constructionLoan;
         public bool? ConstructionLoan { get { return _constructionLoan; } set { _constructionLoan = value; } }
-        private Value<bool?> _homeownerInsurance;
+        private DirtyValue<bool?> _homeownerInsurance;
         public bool? HomeownerInsurance { get { return _homeownerInsurance; } set { _homeownerInsurance = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _in5YearsPrincipalYouWillHavePaidOff;
+        private DirtyValue<int?> _in5YearsPrincipalYouWillHavePaidOff;
         public int? In5YearsPrincipalYouWillHavePaidOff { get { return _in5YearsPrincipalYouWillHavePaidOff; } set { _in5YearsPrincipalYouWillHavePaidOff = value; } }
-        private Value<int?> _in5YearsTotalYouWillHavePaid;
+        private DirtyValue<int?> _in5YearsTotalYouWillHavePaid;
         public int? In5YearsTotalYouWillHavePaid { get { return _in5YearsTotalYouWillHavePaid; } set { _in5YearsTotalYouWillHavePaid = value; } }
-        private Value<string> _lenderEmail;
+        private DirtyValue<string> _lenderEmail;
         public string LenderEmail { get { return _lenderEmail; } set { _lenderEmail = value; } }
-        private Value<string> _lenderLicenseID;
+        private DirtyValue<string> _lenderLicenseID;
         public string LenderLicenseID { get { return _lenderLicenseID; } set { _lenderLicenseID = value; } }
-        private Value<string> _lenderLicenseState;
+        private DirtyValue<string> _lenderLicenseState;
         public string LenderLicenseState { get { return _lenderLicenseState; } set { _lenderLicenseState = value; } }
-        private Value<string> _lenderLoanOfficer;
+        private DirtyValue<string> _lenderLoanOfficer;
         public string LenderLoanOfficer { get { return _lenderLoanOfficer; } set { _lenderLoanOfficer = value; } }
-        private Value<string> _lenderLoanOfficerLicenseState;
+        private DirtyValue<string> _lenderLoanOfficerLicenseState;
         public string LenderLoanOfficerLicenseState { get { return _lenderLoanOfficerLicenseState; } set { _lenderLoanOfficerLicenseState = value; } }
-        private Value<string> _lenderLoanOfficerNMLSId;
+        private DirtyValue<string> _lenderLoanOfficerNMLSId;
         public string LenderLoanOfficerNMLSId { get { return _lenderLoanOfficerNMLSId; } set { _lenderLoanOfficerNMLSId = value; } }
-        private Value<string> _lenderPhone;
+        private DirtyValue<string> _lenderPhone;
         public string LenderPhone { get { return _lenderPhone; } set { _lenderPhone = value; } }
-        private Value<string> _mortgageBrokerEmail;
+        private DirtyValue<string> _mortgageBrokerEmail;
         public string MortgageBrokerEmail { get { return _mortgageBrokerEmail; } set { _mortgageBrokerEmail = value; } }
-        private Value<string> _mortgageBrokerLicenseID;
+        private DirtyValue<string> _mortgageBrokerLicenseID;
         public string MortgageBrokerLicenseID { get { return _mortgageBrokerLicenseID; } set { _mortgageBrokerLicenseID = value; } }
-        private Value<string> _mortgageBrokerLicenseState;
+        private DirtyValue<string> _mortgageBrokerLicenseState;
         public string MortgageBrokerLicenseState { get { return _mortgageBrokerLicenseState; } set { _mortgageBrokerLicenseState = value; } }
-        private Value<string> _mortgageBrokerLoanOfficer;
+        private DirtyValue<string> _mortgageBrokerLoanOfficer;
         public string MortgageBrokerLoanOfficer { get { return _mortgageBrokerLoanOfficer; } set { _mortgageBrokerLoanOfficer = value; } }
-        private Value<string> _mortgageBrokerLoanOfficerLicenseID;
+        private DirtyValue<string> _mortgageBrokerLoanOfficerLicenseID;
         public string MortgageBrokerLoanOfficerLicenseID { get { return _mortgageBrokerLoanOfficerLicenseID; } set { _mortgageBrokerLoanOfficerLicenseID = value; } }
-        private Value<string> _mortgageBrokerLoanOfficerLicenseState;
+        private DirtyValue<string> _mortgageBrokerLoanOfficerLicenseState;
         public string MortgageBrokerLoanOfficerLicenseState { get { return _mortgageBrokerLoanOfficerLicenseState; } set { _mortgageBrokerLoanOfficerLicenseState = value; } }
-        private Value<string> _mortgageBrokerLoanOfficerNMLSId;
+        private DirtyValue<string> _mortgageBrokerLoanOfficerNMLSId;
         public string MortgageBrokerLoanOfficerNMLSId { get { return _mortgageBrokerLoanOfficerNMLSId; } set { _mortgageBrokerLoanOfficerNMLSId = value; } }
-        private Value<string> _mortgageBrokerPhone;
+        private DirtyValue<string> _mortgageBrokerPhone;
         public string MortgageBrokerPhone { get { return _mortgageBrokerPhone; } set { _mortgageBrokerPhone = value; } }
-        private Value<string> _mortgageLenderLoanOfficerLicenseID;
+        private DirtyValue<string> _mortgageLenderLoanOfficerLicenseID;
         public string MortgageLenderLoanOfficerLicenseID { get { return _mortgageLenderLoanOfficerLicenseID; } set { _mortgageLenderLoanOfficerLicenseID = value; } }
-        private Value<string> _servicing;
+        private DirtyValue<string> _servicing;
         public string Servicing { get { return _servicing; } set { _servicing = value; } }
-        private Value<string> _signatureType;
+        private DirtyValue<string> _signatureType;
         public string SignatureType { get { return _signatureType; } set { _signatureType = value; } }
-        private Value<decimal?> _totalInterestPercentage;
+        private DirtyValue<decimal?> _totalInterestPercentage;
         public decimal? TotalInterestPercentage { get { return _totalInterestPercentage; } set { _totalInterestPercentage = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanProductData.cs
+++ b/src/EncompassRest/Loans/LoanProductData.cs
@@ -8,211 +8,211 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanProductData : IDirty
     {
-        private Value<decimal?> _annualFeeNeededAmount;
+        private DirtyValue<decimal?> _annualFeeNeededAmount;
         public decimal? AnnualFeeNeededAmount { get { return _annualFeeNeededAmount; } set { _annualFeeNeededAmount = value; } }
-        private Value<bool?> _applyLifeCapLowIndicator;
+        private DirtyValue<bool?> _applyLifeCapLowIndicator;
         public bool? ApplyLifeCapLowIndicator { get { return _applyLifeCapLowIndicator; } set { _applyLifeCapLowIndicator = value; } }
-        private Value<string> _armDisclosureType;
+        private DirtyValue<string> _armDisclosureType;
         public string ArmDisclosureType { get { return _armDisclosureType; } set { _armDisclosureType = value; } }
-        private Value<string> _armIndexType;
+        private DirtyValue<string> _armIndexType;
         public string ArmIndexType { get { return _armIndexType; } set { _armIndexType = value; } }
-        private Value<bool?> _balloonIndicator;
+        private DirtyValue<bool?> _balloonIndicator;
         public bool? BalloonIndicator { get { return _balloonIndicator; } set { _balloonIndicator = value; } }
-        private Value<int?> _balloonLoanMaturityTermMonthsCount;
+        private DirtyValue<int?> _balloonLoanMaturityTermMonthsCount;
         public int? BalloonLoanMaturityTermMonthsCount { get { return _balloonLoanMaturityTermMonthsCount; } set { _balloonLoanMaturityTermMonthsCount = value; } }
-        private Value<DateTime?> _borrowerEstimatedClosingDate;
+        private DirtyValue<DateTime?> _borrowerEstimatedClosingDate;
         public DateTime? BorrowerEstimatedClosingDate { get { return _borrowerEstimatedClosingDate; } set { _borrowerEstimatedClosingDate = value; } }
-        private Value<string> _branchLocationNmlsId;
+        private DirtyValue<string> _branchLocationNmlsId;
         public string BranchLocationNmlsId { get { return _branchLocationNmlsId; } set { _branchLocationNmlsId = value; } }
-        private Value<string> _branchManagerNmlsId;
+        private DirtyValue<string> _branchManagerNmlsId;
         public string BranchManagerNmlsId { get { return _branchManagerNmlsId; } set { _branchManagerNmlsId = value; } }
         private DirtyList<Buydown> _buydowns;
         public IList<Buydown> Buydowns { get { var v = _buydowns; return v ?? Interlocked.CompareExchange(ref _buydowns, (v = new DirtyList<Buydown>()), null) ?? v; } set { _buydowns = new DirtyList<Buydown>(value); } }
-        private Value<bool?> _convertibleIndicator;
+        private DirtyValue<bool?> _convertibleIndicator;
         public bool? ConvertibleIndicator { get { return _convertibleIndicator; } set { _convertibleIndicator = value; } }
-        private Value<string> _discounted;
+        private DirtyValue<string> _discounted;
         public string Discounted { get { return _discounted; } set { _discounted = value; } }
-        private Value<decimal?> _discountedRate;
+        private DirtyValue<decimal?> _discountedRate;
         public decimal? DiscountedRate { get { return _discountedRate; } set { _discountedRate = value; } }
-        private Value<int?> _drawPeriodMonthsCount;
+        private DirtyValue<int?> _drawPeriodMonthsCount;
         public int? DrawPeriodMonthsCount { get { return _drawPeriodMonthsCount; } set { _drawPeriodMonthsCount = value; } }
-        private Value<bool?> _escrowWaiverIndicator;
+        private DirtyValue<bool?> _escrowWaiverIndicator;
         public bool? EscrowWaiverIndicator { get { return _escrowWaiverIndicator; } set { _escrowWaiverIndicator = value; } }
-        private Value<bool?> _excludeLoanFromNMLSReportIndicator;
+        private DirtyValue<bool?> _excludeLoanFromNMLSReportIndicator;
         public bool? ExcludeLoanFromNMLSReportIndicator { get { return _excludeLoanFromNMLSReportIndicator; } set { _excludeLoanFromNMLSReportIndicator = value; } }
-        private Value<string> _floorBasis;
+        private DirtyValue<string> _floorBasis;
         public string FloorBasis { get { return _floorBasis; } set { _floorBasis = value; } }
-        private Value<decimal?> _floorPercent;
+        private DirtyValue<decimal?> _floorPercent;
         public decimal? FloorPercent { get { return _floorPercent; } set { _floorPercent = value; } }
-        private Value<string> _floorVerbiage;
+        private DirtyValue<string> _floorVerbiage;
         public string FloorVerbiage { get { return _floorVerbiage; } set { _floorVerbiage = value; } }
-        private Value<string> _fnmProductPlanIdentifier;
+        private DirtyValue<string> _fnmProductPlanIdentifier;
         public string FnmProductPlanIdentifier { get { return _fnmProductPlanIdentifier; } set { _fnmProductPlanIdentifier = value; } }
-        private Value<string> _freddieMacArmIndexType;
+        private DirtyValue<string> _freddieMacArmIndexType;
         public string FreddieMacArmIndexType { get { return _freddieMacArmIndexType; } set { _freddieMacArmIndexType = value; } }
-        private Value<string> _freOfferingIdentifier;
+        private DirtyValue<string> _freOfferingIdentifier;
         public string FreOfferingIdentifier { get { return _freOfferingIdentifier; } set { _freOfferingIdentifier = value; } }
-        private Value<string> _fullPrepaymentPenaltyOptionType;
+        private DirtyValue<string> _fullPrepaymentPenaltyOptionType;
         public string FullPrepaymentPenaltyOptionType { get { return _fullPrepaymentPenaltyOptionType; } set { _fullPrepaymentPenaltyOptionType = value; } }
-        private Value<string> _gseProjectClassificationType;
+        private DirtyValue<string> _gseProjectClassificationType;
         public string GseProjectClassificationType { get { return _gseProjectClassificationType; } set { _gseProjectClassificationType = value; } }
-        private Value<string> _gsePropertyType;
+        private DirtyValue<string> _gsePropertyType;
         public string GsePropertyType { get { return _gsePropertyType; } set { _gsePropertyType = value; } }
-        private Value<int?> _hardPrepaymentPenaltyMonths;
+        private DirtyValue<int?> _hardPrepaymentPenaltyMonths;
         public int? HardPrepaymentPenaltyMonths { get { return _hardPrepaymentPenaltyMonths; } set { _hardPrepaymentPenaltyMonths = value; } }
-        private Value<string> _helocPeriodTemplateName;
+        private DirtyValue<string> _helocPeriodTemplateName;
         public string HelocPeriodTemplateName { get { return _helocPeriodTemplateName; } set { _helocPeriodTemplateName = value; } }
         private DirtyList<HelocRepaymentDrawPeriod> _helocRepaymentDrawPeriods;
         public IList<HelocRepaymentDrawPeriod> HelocRepaymentDrawPeriods { get { var v = _helocRepaymentDrawPeriods; return v ?? Interlocked.CompareExchange(ref _helocRepaymentDrawPeriods, (v = new DirtyList<HelocRepaymentDrawPeriod>()), null) ?? v; } set { _helocRepaymentDrawPeriods = new DirtyList<HelocRepaymentDrawPeriod>(value); } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _indexCurrentValuePercent;
+        private DirtyValue<decimal?> _indexCurrentValuePercent;
         public decimal? IndexCurrentValuePercent { get { return _indexCurrentValuePercent; } set { _indexCurrentValuePercent = value; } }
-        private Value<string> _indexLookbackPeriod;
+        private DirtyValue<string> _indexLookbackPeriod;
         public string IndexLookbackPeriod { get { return _indexLookbackPeriod; } set { _indexLookbackPeriod = value; } }
-        private Value<decimal?> _indexMarginPercent;
+        private DirtyValue<decimal?> _indexMarginPercent;
         public decimal? IndexMarginPercent { get { return _indexMarginPercent; } set { _indexMarginPercent = value; } }
-        private Value<decimal?> _initialAdvanceAmount;
+        private DirtyValue<decimal?> _initialAdvanceAmount;
         public decimal? InitialAdvanceAmount { get { return _initialAdvanceAmount; } set { _initialAdvanceAmount = value; } }
-        private Value<decimal?> _initialApplicationAmount;
+        private DirtyValue<decimal?> _initialApplicationAmount;
         public decimal? InitialApplicationAmount { get { return _initialApplicationAmount; } set { _initialApplicationAmount = value; } }
-        private Value<bool?> _inquiryOrPreQualificationIndicator;
+        private DirtyValue<bool?> _inquiryOrPreQualificationIndicator;
         public bool? InquiryOrPreQualificationIndicator { get { return _inquiryOrPreQualificationIndicator; } set { _inquiryOrPreQualificationIndicator = value; } }
-        private Value<string> _lienPriorityType;
+        private DirtyValue<string> _lienPriorityType;
         public string LienPriorityType { get { return _lienPriorityType; } set { _lienPriorityType = value; } }
-        private Value<string> _loanDocumentationType;
+        private DirtyValue<string> _loanDocumentationType;
         public string LoanDocumentationType { get { return _loanDocumentationType; } set { _loanDocumentationType = value; } }
-        private Value<string> _loanRepaymentType;
+        private DirtyValue<string> _loanRepaymentType;
         public string LoanRepaymentType { get { return _loanRepaymentType; } set { _loanRepaymentType = value; } }
-        private Value<DateTime?> _loanScheduledClosingDate;
+        private DirtyValue<DateTime?> _loanScheduledClosingDate;
         public DateTime? LoanScheduledClosingDate { get { return _loanScheduledClosingDate; } set { _loanScheduledClosingDate = value; } }
-        private Value<decimal?> _maximumMonthlyPayment;
+        private DirtyValue<decimal?> _maximumMonthlyPayment;
         public decimal? MaximumMonthlyPayment { get { return _maximumMonthlyPayment; } set { _maximumMonthlyPayment = value; } }
-        private Value<decimal?> _maxLifeInterestCapPercent;
+        private DirtyValue<decimal?> _maxLifeInterestCapPercent;
         public decimal? MaxLifeInterestCapPercent { get { return _maxLifeInterestCapPercent; } set { _maxLifeInterestCapPercent = value; } }
-        private Value<decimal?> _miCoveragePercent;
+        private DirtyValue<decimal?> _miCoveragePercent;
         public decimal? MiCoveragePercent { get { return _miCoveragePercent; } set { _miCoveragePercent = value; } }
-        private Value<decimal?> _minimumAdvanceAmount;
+        private DirtyValue<decimal?> _minimumAdvanceAmount;
         public decimal? MinimumAdvanceAmount { get { return _minimumAdvanceAmount; } set { _minimumAdvanceAmount = value; } }
-        private Value<decimal?> _minimumAllowableApr;
+        private DirtyValue<decimal?> _minimumAllowableApr;
         public decimal? MinimumAllowableApr { get { return _minimumAllowableApr; } set { _minimumAllowableApr = value; } }
-        private Value<decimal?> _minimumDrawPeroidPaymentPercent;
+        private DirtyValue<decimal?> _minimumDrawPeroidPaymentPercent;
         public decimal? MinimumDrawPeroidPaymentPercent { get { return _minimumDrawPeroidPaymentPercent; } set { _minimumDrawPeroidPaymentPercent = value; } }
-        private Value<decimal?> _minimumPaymentAmount;
+        private DirtyValue<decimal?> _minimumPaymentAmount;
         public decimal? MinimumPaymentAmount { get { return _minimumPaymentAmount; } set { _minimumPaymentAmount = value; } }
-        private Value<decimal?> _minimumPaymentLessThanAmount;
+        private DirtyValue<decimal?> _minimumPaymentLessThanAmount;
         public decimal? MinimumPaymentLessThanAmount { get { return _minimumPaymentLessThanAmount; } set { _minimumPaymentLessThanAmount = value; } }
-        private Value<decimal?> _minimumPaymentPercent;
+        private DirtyValue<decimal?> _minimumPaymentPercent;
         public decimal? MinimumPaymentPercent { get { return _minimumPaymentPercent; } set { _minimumPaymentPercent = value; } }
-        private Value<decimal?> _minimumPaymentUpbAmount;
+        private DirtyValue<decimal?> _minimumPaymentUpbAmount;
         public decimal? MinimumPaymentUpbAmount { get { return _minimumPaymentUpbAmount; } set { _minimumPaymentUpbAmount = value; } }
-        private Value<decimal?> _minimumPaymentUpbPercent;
+        private DirtyValue<decimal?> _minimumPaymentUpbPercent;
         public decimal? MinimumPaymentUpbPercent { get { return _minimumPaymentUpbPercent; } set { _minimumPaymentUpbPercent = value; } }
-        private Value<decimal?> _minimumRepayPeriodPaymentPercent;
+        private DirtyValue<decimal?> _minimumRepayPeriodPaymentPercent;
         public decimal? MinimumRepayPeriodPaymentPercent { get { return _minimumRepayPeriodPaymentPercent; } set { _minimumRepayPeriodPaymentPercent = value; } }
-        private Value<int?> _monthsAppliedToPrepaymentPenaltyFeeCount;
+        private DirtyValue<int?> _monthsAppliedToPrepaymentPenaltyFeeCount;
         public int? MonthsAppliedToPrepaymentPenaltyFeeCount { get { return _monthsAppliedToPrepaymentPenaltyFeeCount; } set { _monthsAppliedToPrepaymentPenaltyFeeCount = value; } }
-        private Value<decimal?> _negativeAmortizationLimitPercent;
+        private DirtyValue<decimal?> _negativeAmortizationLimitPercent;
         public decimal? NegativeAmortizationLimitPercent { get { return _negativeAmortizationLimitPercent; } set { _negativeAmortizationLimitPercent = value; } }
-        private Value<decimal?> _netInitialAndFinal;
+        private DirtyValue<decimal?> _netInitialAndFinal;
         public decimal? NetInitialAndFinal { get { return _netInitialAndFinal; } set { _netInitialAndFinal = value; } }
-        private Value<string> _nmlsDocumentationType;
+        private DirtyValue<string> _nmlsDocumentationType;
         public string NmlsDocumentationType { get { return _nmlsDocumentationType; } set { _nmlsDocumentationType = value; } }
-        private Value<string> _nmlsFirstMortgageType;
+        private DirtyValue<string> _nmlsFirstMortgageType;
         public string NmlsFirstMortgageType { get { return _nmlsFirstMortgageType; } set { _nmlsFirstMortgageType = value; } }
-        private Value<string> _nmlsLoanType;
+        private DirtyValue<string> _nmlsLoanType;
         public string NmlsLoanType { get { return _nmlsLoanType; } set { _nmlsLoanType = value; } }
-        private Value<bool?> _nmlsOptionARMIndicator;
+        private DirtyValue<bool?> _nmlsOptionARMIndicator;
         public bool? NmlsOptionARMIndicator { get { return _nmlsOptionARMIndicator; } set { _nmlsOptionARMIndicator = value; } }
-        private Value<bool?> _nmlsPiggyBackOrFundedHELOCIndicator;
+        private DirtyValue<bool?> _nmlsPiggyBackOrFundedHELOCIndicator;
         public bool? NmlsPiggyBackOrFundedHELOCIndicator { get { return _nmlsPiggyBackOrFundedHELOCIndicator; } set { _nmlsPiggyBackOrFundedHELOCIndicator = value; } }
-        private Value<string> _nmlsProductionSoldToType;
+        private DirtyValue<string> _nmlsProductionSoldToType;
         public string NmlsProductionSoldToType { get { return _nmlsProductionSoldToType; } set { _nmlsProductionSoldToType = value; } }
-        private Value<string> _nmlsRefinancePurposeType;
+        private DirtyValue<string> _nmlsRefinancePurposeType;
         public string NmlsRefinancePurposeType { get { return _nmlsRefinancePurposeType; } set { _nmlsRefinancePurposeType = value; } }
-        private Value<string> _nmlsReverseMortgageType;
+        private DirtyValue<string> _nmlsReverseMortgageType;
         public string NmlsReverseMortgageType { get { return _nmlsReverseMortgageType; } set { _nmlsReverseMortgageType = value; } }
-        private Value<bool?> _oralRequestForExtensionOfCreditIndicator;
+        private DirtyValue<bool?> _oralRequestForExtensionOfCreditIndicator;
         public bool? OralRequestForExtensionOfCreditIndicator { get { return _oralRequestForExtensionOfCreditIndicator; } set { _oralRequestForExtensionOfCreditIndicator = value; } }
-        private Value<decimal?> _overLimitCharge;
+        private DirtyValue<decimal?> _overLimitCharge;
         public decimal? OverLimitCharge { get { return _overLimitCharge; } set { _overLimitCharge = value; } }
-        private Value<decimal?> _overLimitReturnCharge;
+        private DirtyValue<decimal?> _overLimitReturnCharge;
         public decimal? OverLimitReturnCharge { get { return _overLimitReturnCharge; } set { _overLimitReturnCharge = value; } }
-        private Value<decimal?> _participationFees;
+        private DirtyValue<decimal?> _participationFees;
         public decimal? ParticipationFees { get { return _participationFees; } set { _participationFees = value; } }
-        private Value<int?> _paymentAdjustmentDurationMonthsCount;
+        private DirtyValue<int?> _paymentAdjustmentDurationMonthsCount;
         public int? PaymentAdjustmentDurationMonthsCount { get { return _paymentAdjustmentDurationMonthsCount; } set { _paymentAdjustmentDurationMonthsCount = value; } }
-        private Value<decimal?> _paymentAdjustmentPeriodicCapPercent;
+        private DirtyValue<decimal?> _paymentAdjustmentPeriodicCapPercent;
         public decimal? PaymentAdjustmentPeriodicCapPercent { get { return _paymentAdjustmentPeriodicCapPercent; } set { _paymentAdjustmentPeriodicCapPercent = value; } }
-        private Value<string> _paymentFrequencyType;
+        private DirtyValue<string> _paymentFrequencyType;
         public string PaymentFrequencyType { get { return _paymentFrequencyType; } set { _paymentFrequencyType = value; } }
         private DirtyList<PrepaymentPenalty> _prepaymentPenalties;
         public IList<PrepaymentPenalty> PrepaymentPenalties { get { var v = _prepaymentPenalties; return v ?? Interlocked.CompareExchange(ref _prepaymentPenalties, (v = new DirtyList<PrepaymentPenalty>()), null) ?? v; } set { _prepaymentPenalties = new DirtyList<PrepaymentPenalty>(value); } }
-        private Value<string> _prepaymentPenaltyBasedOn;
+        private DirtyValue<string> _prepaymentPenaltyBasedOn;
         public string PrepaymentPenaltyBasedOn { get { return _prepaymentPenaltyBasedOn; } set { _prepaymentPenaltyBasedOn = value; } }
-        private Value<bool?> _prepaymentPenaltyIndicator;
+        private DirtyValue<bool?> _prepaymentPenaltyIndicator;
         public bool? PrepaymentPenaltyIndicator { get { return _prepaymentPenaltyIndicator; } set { _prepaymentPenaltyIndicator = value; } }
-        private Value<decimal?> _prepaymentPenaltyPercent;
+        private DirtyValue<decimal?> _prepaymentPenaltyPercent;
         public decimal? PrepaymentPenaltyPercent { get { return _prepaymentPenaltyPercent; } set { _prepaymentPenaltyPercent = value; } }
-        private Value<int?> _prepaymentPenaltyTermMonthsCount;
+        private DirtyValue<int?> _prepaymentPenaltyTermMonthsCount;
         public int? PrepaymentPenaltyTermMonthsCount { get { return _prepaymentPenaltyTermMonthsCount; } set { _prepaymentPenaltyTermMonthsCount = value; } }
-        private Value<string> _prepaymentPenaltyVerbiage;
+        private DirtyValue<string> _prepaymentPenaltyVerbiage;
         public string PrepaymentPenaltyVerbiage { get { return _prepaymentPenaltyVerbiage; } set { _prepaymentPenaltyVerbiage = value; } }
-        private Value<string> _productName;
+        private DirtyValue<string> _productName;
         public string ProductName { get { return _productName; } set { _productName = value; } }
-        private Value<decimal?> _qualifyingRatePercent;
+        private DirtyValue<decimal?> _qualifyingRatePercent;
         public decimal? QualifyingRatePercent { get { return _qualifyingRatePercent; } set { _qualifyingRatePercent = value; } }
-        private Value<int?> _rateAdjustmentDurationMonthsCount;
+        private DirtyValue<int?> _rateAdjustmentDurationMonthsCount;
         public int? RateAdjustmentDurationMonthsCount { get { return _rateAdjustmentDurationMonthsCount; } set { _rateAdjustmentDurationMonthsCount = value; } }
-        private Value<decimal?> _rateAdjustmentLifetimeCapPercent;
+        private DirtyValue<decimal?> _rateAdjustmentLifetimeCapPercent;
         public decimal? RateAdjustmentLifetimeCapPercent { get { return _rateAdjustmentLifetimeCapPercent; } set { _rateAdjustmentLifetimeCapPercent = value; } }
-        private Value<decimal?> _rateAdjustmentPercent;
+        private DirtyValue<decimal?> _rateAdjustmentPercent;
         public decimal? RateAdjustmentPercent { get { return _rateAdjustmentPercent; } set { _rateAdjustmentPercent = value; } }
-        private Value<decimal?> _rateAdjustmentSubsequentCapPercent;
+        private DirtyValue<decimal?> _rateAdjustmentSubsequentCapPercent;
         public decimal? RateAdjustmentSubsequentCapPercent { get { return _rateAdjustmentSubsequentCapPercent; } set { _rateAdjustmentSubsequentCapPercent = value; } }
-        private Value<decimal?> _releaseRecoringCharge;
+        private DirtyValue<decimal?> _releaseRecoringCharge;
         public decimal? ReleaseRecoringCharge { get { return _releaseRecoringCharge; } set { _releaseRecoringCharge = value; } }
-        private Value<decimal?> _remainingBuydownAmount;
+        private DirtyValue<decimal?> _remainingBuydownAmount;
         public decimal? RemainingBuydownAmount { get { return _remainingBuydownAmount; } set { _remainingBuydownAmount = value; } }
-        private Value<int?> _repayPeriodMonthsCount;
+        private DirtyValue<int?> _repayPeriodMonthsCount;
         public int? RepayPeriodMonthsCount { get { return _repayPeriodMonthsCount; } set { _repayPeriodMonthsCount = value; } }
-        private Value<decimal?> _returnedCheckCharge;
+        private DirtyValue<decimal?> _returnedCheckCharge;
         public decimal? ReturnedCheckCharge { get { return _returnedCheckCharge; } set { _returnedCheckCharge = value; } }
-        private Value<decimal?> _returnedCheckChargeRatePercent;
+        private DirtyValue<decimal?> _returnedCheckChargeRatePercent;
         public decimal? ReturnedCheckChargeRatePercent { get { return _returnedCheckChargeRatePercent; } set { _returnedCheckChargeRatePercent = value; } }
-        private Value<decimal?> _returnedCheckMaxCharge;
+        private DirtyValue<decimal?> _returnedCheckMaxCharge;
         public decimal? ReturnedCheckMaxCharge { get { return _returnedCheckMaxCharge; } set { _returnedCheckMaxCharge = value; } }
-        private Value<decimal?> _returnedCheckMinCharge;
+        private DirtyValue<decimal?> _returnedCheckMinCharge;
         public decimal? ReturnedCheckMinCharge { get { return _returnedCheckMinCharge; } set { _returnedCheckMinCharge = value; } }
-        private Value<decimal?> _roundPercent;
+        private DirtyValue<decimal?> _roundPercent;
         public decimal? RoundPercent { get { return _roundPercent; } set { _roundPercent = value; } }
-        private Value<string> _roundType;
+        private DirtyValue<string> _roundType;
         public string RoundType { get { return _roundType; } set { _roundType = value; } }
-        private Value<DateTime?> _scheduledFirstPaymentAdjustmentDate;
+        private DirtyValue<DateTime?> _scheduledFirstPaymentAdjustmentDate;
         public DateTime? ScheduledFirstPaymentAdjustmentDate { get { return _scheduledFirstPaymentAdjustmentDate; } set { _scheduledFirstPaymentAdjustmentDate = value; } }
-        private Value<DateTime?> _scheduledFirstPaymentDate;
+        private DirtyValue<DateTime?> _scheduledFirstPaymentDate;
         public DateTime? ScheduledFirstPaymentDate { get { return _scheduledFirstPaymentDate; } set { _scheduledFirstPaymentDate = value; } }
-        private Value<decimal?> _stopPaymentCharge;
+        private DirtyValue<decimal?> _stopPaymentCharge;
         public decimal? StopPaymentCharge { get { return _stopPaymentCharge; } set { _stopPaymentCharge = value; } }
-        private Value<int?> _subsequentRateAdjustmentMonthsCount;
+        private DirtyValue<int?> _subsequentRateAdjustmentMonthsCount;
         public int? SubsequentRateAdjustmentMonthsCount { get { return _subsequentRateAdjustmentMonthsCount; } set { _subsequentRateAdjustmentMonthsCount = value; } }
-        private Value<decimal?> _terminationFeeAmount;
+        private DirtyValue<decimal?> _terminationFeeAmount;
         public decimal? TerminationFeeAmount { get { return _terminationFeeAmount; } set { _terminationFeeAmount = value; } }
-        private Value<int?> _terminationPeriodMonthsCount;
+        private DirtyValue<int?> _terminationPeriodMonthsCount;
         public int? TerminationPeriodMonthsCount { get { return _terminationPeriodMonthsCount; } set { _terminationPeriodMonthsCount = value; } }
-        private Value<decimal?> _thirdPartyFeeFromAmount;
+        private DirtyValue<decimal?> _thirdPartyFeeFromAmount;
         public decimal? ThirdPartyFeeFromAmount { get { return _thirdPartyFeeFromAmount; } set { _thirdPartyFeeFromAmount = value; } }
-        private Value<decimal?> _thirdPartyFeeToAmount;
+        private DirtyValue<decimal?> _thirdPartyFeeToAmount;
         public decimal? ThirdPartyFeeToAmount { get { return _thirdPartyFeeToAmount; } set { _thirdPartyFeeToAmount = value; } }
-        private Value<decimal?> _timelyPaymentRateReductionPercent;
+        private DirtyValue<decimal?> _timelyPaymentRateReductionPercent;
         public decimal? TimelyPaymentRateReductionPercent { get { return _timelyPaymentRateReductionPercent; } set { _timelyPaymentRateReductionPercent = value; } }
-        private Value<string> _timelyPaymentRewards;
+        private DirtyValue<string> _timelyPaymentRewards;
         public string TimelyPaymentRewards { get { return _timelyPaymentRewards; } set { _timelyPaymentRewards = value; } }
-        private Value<decimal?> _totalSubsidyAmount;
+        private DirtyValue<decimal?> _totalSubsidyAmount;
         public decimal? TotalSubsidyAmount { get { return _totalSubsidyAmount; } set { _totalSubsidyAmount = value; } }
-        private Value<decimal?> _transactionFees;
+        private DirtyValue<decimal?> _transactionFees;
         public decimal? TransactionFees { get { return _transactionFees; } set { _transactionFees = value; } }
-        private Value<decimal?> _wireFee;
+        private DirtyValue<decimal?> _wireFee;
         public decimal? WireFee { get { return _wireFee; } set { _wireFee = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanProductData.cs
+++ b/src/EncompassRest/Loans/LoanProductData.cs
@@ -26,8 +26,8 @@ namespace EncompassRest.Loans
         public string BranchLocationNmlsId { get { return _branchLocationNmlsId; } set { _branchLocationNmlsId = value; } }
         private Value<string> _branchManagerNmlsId;
         public string BranchManagerNmlsId { get { return _branchManagerNmlsId; } set { _branchManagerNmlsId = value; } }
-        private Value<List<Buydown>> _buydowns;
-        public List<Buydown> Buydowns { get { return _buydowns; } set { _buydowns = value; } }
+        private DirtyList<Buydown> _buydowns;
+        public IList<Buydown> Buydowns { get { var v = _buydowns; return v ?? Interlocked.CompareExchange(ref _buydowns, (v = new DirtyList<Buydown>()), null) ?? v; } set { _buydowns = new DirtyList<Buydown>(value); } }
         private Value<bool?> _convertibleIndicator;
         public bool? ConvertibleIndicator { get { return _convertibleIndicator; } set { _convertibleIndicator = value; } }
         private Value<string> _discounted;
@@ -62,8 +62,8 @@ namespace EncompassRest.Loans
         public int? HardPrepaymentPenaltyMonths { get { return _hardPrepaymentPenaltyMonths; } set { _hardPrepaymentPenaltyMonths = value; } }
         private Value<string> _helocPeriodTemplateName;
         public string HelocPeriodTemplateName { get { return _helocPeriodTemplateName; } set { _helocPeriodTemplateName = value; } }
-        private Value<List<HelocRepaymentDrawPeriod>> _helocRepaymentDrawPeriods;
-        public List<HelocRepaymentDrawPeriod> HelocRepaymentDrawPeriods { get { return _helocRepaymentDrawPeriods; } set { _helocRepaymentDrawPeriods = value; } }
+        private DirtyList<HelocRepaymentDrawPeriod> _helocRepaymentDrawPeriods;
+        public IList<HelocRepaymentDrawPeriod> HelocRepaymentDrawPeriods { get { var v = _helocRepaymentDrawPeriods; return v ?? Interlocked.CompareExchange(ref _helocRepaymentDrawPeriods, (v = new DirtyList<HelocRepaymentDrawPeriod>()), null) ?? v; } set { _helocRepaymentDrawPeriods = new DirtyList<HelocRepaymentDrawPeriod>(value); } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private Value<decimal?> _indexCurrentValuePercent;
@@ -146,8 +146,8 @@ namespace EncompassRest.Loans
         public decimal? PaymentAdjustmentPeriodicCapPercent { get { return _paymentAdjustmentPeriodicCapPercent; } set { _paymentAdjustmentPeriodicCapPercent = value; } }
         private Value<string> _paymentFrequencyType;
         public string PaymentFrequencyType { get { return _paymentFrequencyType; } set { _paymentFrequencyType = value; } }
-        private Value<List<PrepaymentPenalty>> _prepaymentPenalties;
-        public List<PrepaymentPenalty> PrepaymentPenalties { get { return _prepaymentPenalties; } set { _prepaymentPenalties = value; } }
+        private DirtyList<PrepaymentPenalty> _prepaymentPenalties;
+        public IList<PrepaymentPenalty> PrepaymentPenalties { get { var v = _prepaymentPenalties; return v ?? Interlocked.CompareExchange(ref _prepaymentPenalties, (v = new DirtyList<PrepaymentPenalty>()), null) ?? v; } set { _prepaymentPenalties = new DirtyList<PrepaymentPenalty>(value); } }
         private Value<string> _prepaymentPenaltyBasedOn;
         public string PrepaymentPenaltyBasedOn { get { return _prepaymentPenaltyBasedOn; } set { _prepaymentPenaltyBasedOn = value; } }
         private Value<bool?> _prepaymentPenaltyIndicator;
@@ -230,7 +230,6 @@ namespace EncompassRest.Loans
                     || _borrowerEstimatedClosingDate.Dirty
                     || _branchLocationNmlsId.Dirty
                     || _branchManagerNmlsId.Dirty
-                    || _buydowns.Dirty
                     || _convertibleIndicator.Dirty
                     || _discounted.Dirty
                     || _discountedRate.Dirty
@@ -248,7 +247,6 @@ namespace EncompassRest.Loans
                     || _gsePropertyType.Dirty
                     || _hardPrepaymentPenaltyMonths.Dirty
                     || _helocPeriodTemplateName.Dirty
-                    || _helocRepaymentDrawPeriods.Dirty
                     || _id.Dirty
                     || _indexCurrentValuePercent.Dirty
                     || _indexLookbackPeriod.Dirty
@@ -290,7 +288,6 @@ namespace EncompassRest.Loans
                     || _paymentAdjustmentDurationMonthsCount.Dirty
                     || _paymentAdjustmentPeriodicCapPercent.Dirty
                     || _paymentFrequencyType.Dirty
-                    || _prepaymentPenalties.Dirty
                     || _prepaymentPenaltyBasedOn.Dirty
                     || _prepaymentPenaltyIndicator.Dirty
                     || _prepaymentPenaltyPercent.Dirty
@@ -323,7 +320,10 @@ namespace EncompassRest.Loans
                     || _timelyPaymentRewards.Dirty
                     || _totalSubsidyAmount.Dirty
                     || _transactionFees.Dirty
-                    || _wireFee.Dirty;
+                    || _wireFee.Dirty
+                    || _buydowns?.Dirty == true
+                    || _helocRepaymentDrawPeriods?.Dirty == true
+                    || _prepaymentPenalties?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -339,7 +339,6 @@ namespace EncompassRest.Loans
                 _borrowerEstimatedClosingDate.Dirty = value;
                 _branchLocationNmlsId.Dirty = value;
                 _branchManagerNmlsId.Dirty = value;
-                _buydowns.Dirty = value;
                 _convertibleIndicator.Dirty = value;
                 _discounted.Dirty = value;
                 _discountedRate.Dirty = value;
@@ -357,7 +356,6 @@ namespace EncompassRest.Loans
                 _gsePropertyType.Dirty = value;
                 _hardPrepaymentPenaltyMonths.Dirty = value;
                 _helocPeriodTemplateName.Dirty = value;
-                _helocRepaymentDrawPeriods.Dirty = value;
                 _id.Dirty = value;
                 _indexCurrentValuePercent.Dirty = value;
                 _indexLookbackPeriod.Dirty = value;
@@ -399,7 +397,6 @@ namespace EncompassRest.Loans
                 _paymentAdjustmentDurationMonthsCount.Dirty = value;
                 _paymentAdjustmentPeriodicCapPercent.Dirty = value;
                 _paymentFrequencyType.Dirty = value;
-                _prepaymentPenalties.Dirty = value;
                 _prepaymentPenaltyBasedOn.Dirty = value;
                 _prepaymentPenaltyIndicator.Dirty = value;
                 _prepaymentPenaltyPercent.Dirty = value;
@@ -433,6 +430,9 @@ namespace EncompassRest.Loans
                 _totalSubsidyAmount.Dirty = value;
                 _transactionFees.Dirty = value;
                 _wireFee.Dirty = value;
+                if (_buydowns != null) _buydowns.Dirty = value;
+                if (_helocRepaymentDrawPeriods != null) _helocRepaymentDrawPeriods.Dirty = value;
+                if (_prepaymentPenalties != null) _prepaymentPenalties.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LoanProgram.cs
+++ b/src/EncompassRest/Loans/LoanProgram.cs
@@ -8,251 +8,251 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanProgram : IDirty
     {
-        private Value<string> _acquisition;
+        private DirtyValue<string> _acquisition;
         public string Acquisition { get { return _acquisition; } set { _acquisition = value; } }
-        private Value<string> _additionalArmInformation;
+        private DirtyValue<string> _additionalArmInformation;
         public string AdditionalArmInformation { get { return _additionalArmInformation; } set { _additionalArmInformation = value; } }
-        private Value<string> _allDateAndNumericalDisclosures;
+        private DirtyValue<string> _allDateAndNumericalDisclosures;
         public string AllDateAndNumericalDisclosures { get { return _allDateAndNumericalDisclosures; } set { _allDateAndNumericalDisclosures = value; } }
-        private Value<decimal?> _annualFeeNeeded;
+        private DirtyValue<decimal?> _annualFeeNeeded;
         public decimal? AnnualFeeNeeded { get { return _annualFeeNeeded; } set { _annualFeeNeeded = value; } }
-        private Value<string> _armTypeDescription;
+        private DirtyValue<string> _armTypeDescription;
         public string ArmTypeDescription { get { return _armTypeDescription; } set { _armTypeDescription = value; } }
-        private Value<string> _assumptionOnYourProperty;
+        private DirtyValue<string> _assumptionOnYourProperty;
         public string AssumptionOnYourProperty { get { return _assumptionOnYourProperty; } set { _assumptionOnYourProperty = value; } }
-        private Value<int?> _balloonLoanMaturityTermMonths;
+        private DirtyValue<int?> _balloonLoanMaturityTermMonths;
         public int? BalloonLoanMaturityTermMonths { get { return _balloonLoanMaturityTermMonths; } set { _balloonLoanMaturityTermMonths = value; } }
-        private Value<int?> _buydownChangeFrequencyMonths1;
+        private DirtyValue<int?> _buydownChangeFrequencyMonths1;
         public int? BuydownChangeFrequencyMonths1 { get { return _buydownChangeFrequencyMonths1; } set { _buydownChangeFrequencyMonths1 = value; } }
-        private Value<int?> _buydownChangeFrequencyMonths2;
+        private DirtyValue<int?> _buydownChangeFrequencyMonths2;
         public int? BuydownChangeFrequencyMonths2 { get { return _buydownChangeFrequencyMonths2; } set { _buydownChangeFrequencyMonths2 = value; } }
-        private Value<int?> _buydownChangeFrequencyMonths3;
+        private DirtyValue<int?> _buydownChangeFrequencyMonths3;
         public int? BuydownChangeFrequencyMonths3 { get { return _buydownChangeFrequencyMonths3; } set { _buydownChangeFrequencyMonths3 = value; } }
-        private Value<int?> _buydownChangeFrequencyMonths4;
+        private DirtyValue<int?> _buydownChangeFrequencyMonths4;
         public int? BuydownChangeFrequencyMonths4 { get { return _buydownChangeFrequencyMonths4; } set { _buydownChangeFrequencyMonths4 = value; } }
-        private Value<int?> _buydownChangeFrequencyMonths5;
+        private DirtyValue<int?> _buydownChangeFrequencyMonths5;
         public int? BuydownChangeFrequencyMonths5 { get { return _buydownChangeFrequencyMonths5; } set { _buydownChangeFrequencyMonths5 = value; } }
-        private Value<int?> _buydownChangeFrequencyMonths6;
+        private DirtyValue<int?> _buydownChangeFrequencyMonths6;
         public int? BuydownChangeFrequencyMonths6 { get { return _buydownChangeFrequencyMonths6; } set { _buydownChangeFrequencyMonths6 = value; } }
-        private Value<decimal?> _buydownIncreaseRatePercent1;
+        private DirtyValue<decimal?> _buydownIncreaseRatePercent1;
         public decimal? BuydownIncreaseRatePercent1 { get { return _buydownIncreaseRatePercent1; } set { _buydownIncreaseRatePercent1 = value; } }
-        private Value<decimal?> _buydownIncreaseRatePercent2;
+        private DirtyValue<decimal?> _buydownIncreaseRatePercent2;
         public decimal? BuydownIncreaseRatePercent2 { get { return _buydownIncreaseRatePercent2; } set { _buydownIncreaseRatePercent2 = value; } }
-        private Value<decimal?> _buydownIncreaseRatePercent3;
+        private DirtyValue<decimal?> _buydownIncreaseRatePercent3;
         public decimal? BuydownIncreaseRatePercent3 { get { return _buydownIncreaseRatePercent3; } set { _buydownIncreaseRatePercent3 = value; } }
-        private Value<decimal?> _buydownIncreaseRatePercent4;
+        private DirtyValue<decimal?> _buydownIncreaseRatePercent4;
         public decimal? BuydownIncreaseRatePercent4 { get { return _buydownIncreaseRatePercent4; } set { _buydownIncreaseRatePercent4 = value; } }
-        private Value<decimal?> _buydownIncreaseRatePercent5;
+        private DirtyValue<decimal?> _buydownIncreaseRatePercent5;
         public decimal? BuydownIncreaseRatePercent5 { get { return _buydownIncreaseRatePercent5; } set { _buydownIncreaseRatePercent5 = value; } }
-        private Value<decimal?> _buydownIncreaseRatePercent6;
+        private DirtyValue<decimal?> _buydownIncreaseRatePercent6;
         public decimal? BuydownIncreaseRatePercent6 { get { return _buydownIncreaseRatePercent6; } set { _buydownIncreaseRatePercent6 = value; } }
-        private Value<string> _calculateBasedOnRemainingBalance;
+        private DirtyValue<string> _calculateBasedOnRemainingBalance;
         public string CalculateBasedOnRemainingBalance { get { return _calculateBasedOnRemainingBalance; } set { _calculateBasedOnRemainingBalance = value; } }
-        private Value<string> _closingCostProgram;
+        private DirtyValue<string> _closingCostProgram;
         public string ClosingCostProgram { get { return _closingCostProgram; } set { _closingCostProgram = value; } }
-        private Value<string> _constructionDescription;
+        private DirtyValue<string> _constructionDescription;
         public string ConstructionDescription { get { return _constructionDescription; } set { _constructionDescription = value; } }
-        private Value<decimal?> _constructionInterestReserveAmount;
+        private DirtyValue<decimal?> _constructionInterestReserveAmount;
         public decimal? ConstructionInterestReserveAmount { get { return _constructionInterestReserveAmount; } set { _constructionInterestReserveAmount = value; } }
-        private Value<string> _constructionLoanMethod;
+        private DirtyValue<string> _constructionLoanMethod;
         public string ConstructionLoanMethod { get { return _constructionLoanMethod; } set { _constructionLoanMethod = value; } }
-        private Value<int?> _constructionPeriodMonths;
+        private DirtyValue<int?> _constructionPeriodMonths;
         public int? ConstructionPeriodMonths { get { return _constructionPeriodMonths; } set { _constructionPeriodMonths = value; } }
-        private Value<decimal?> _constructionRate;
+        private DirtyValue<decimal?> _constructionRate;
         public decimal? ConstructionRate { get { return _constructionRate; } set { _constructionRate = value; } }
-        private Value<string> _convertible;
+        private DirtyValue<string> _convertible;
         public string Convertible { get { return _convertible; } set { _convertible = value; } }
-        private Value<string> _creditDisability;
+        private DirtyValue<string> _creditDisability;
         public string CreditDisability { get { return _creditDisability; } set { _creditDisability = value; } }
-        private Value<string> _creditLifeInsurance;
+        private DirtyValue<string> _creditLifeInsurance;
         public string CreditLifeInsurance { get { return _creditLifeInsurance; } set { _creditLifeInsurance = value; } }
-        private Value<string> _demandFeature;
+        private DirtyValue<string> _demandFeature;
         public string DemandFeature { get { return _demandFeature; } set { _demandFeature = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _disclosureType;
+        private DirtyValue<string> _disclosureType;
         public string DisclosureType { get { return _disclosureType; } set { _disclosureType = value; } }
-        private Value<string> _discounted;
+        private DirtyValue<string> _discounted;
         public string Discounted { get { return _discounted; } set { _discounted = value; } }
-        private Value<decimal?> _discountedRate;
+        private DirtyValue<decimal?> _discountedRate;
         public decimal? DiscountedRate { get { return _discountedRate; } set { _discountedRate = value; } }
-        private Value<string> _drawRepayPeriodTableName;
+        private DirtyValue<string> _drawRepayPeriodTableName;
         public string DrawRepayPeriodTableName { get { return _drawRepayPeriodTableName; } set { _drawRepayPeriodTableName = value; } }
-        private Value<decimal?> _fhaUpfrontMiPremiumPercent;
+        private DirtyValue<decimal?> _fhaUpfrontMiPremiumPercent;
         public decimal? FhaUpfrontMiPremiumPercent { get { return _fhaUpfrontMiPremiumPercent; } set { _fhaUpfrontMiPremiumPercent = value; } }
-        private Value<string> _floodInsurance;
+        private DirtyValue<string> _floodInsurance;
         public string FloodInsurance { get { return _floodInsurance; } set { _floodInsurance = value; } }
-        private Value<decimal?> _floorPercent;
+        private DirtyValue<decimal?> _floorPercent;
         public decimal? FloorPercent { get { return _floorPercent; } set { _floorPercent = value; } }
-        private Value<decimal?> _fundingFeePaidInCash;
+        private DirtyValue<decimal?> _fundingFeePaidInCash;
         public decimal? FundingFeePaidInCash { get { return _fundingFeePaidInCash; } set { _fundingFeePaidInCash = value; } }
-        private Value<decimal?> _gpmExtraPaymentForEarlyPayOff;
+        private DirtyValue<decimal?> _gpmExtraPaymentForEarlyPayOff;
         public decimal? GpmExtraPaymentForEarlyPayOff { get { return _gpmExtraPaymentForEarlyPayOff; } set { _gpmExtraPaymentForEarlyPayOff = value; } }
-        private Value<decimal?> _gpmRate;
+        private DirtyValue<decimal?> _gpmRate;
         public decimal? GpmRate { get { return _gpmRate; } set { _gpmRate = value; } }
-        private Value<int?> _gpmYears;
+        private DirtyValue<int?> _gpmYears;
         public int? GpmYears { get { return _gpmYears; } set { _gpmYears = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _ifYouPurchase;
+        private DirtyValue<string> _ifYouPurchase;
         public string IfYouPurchase { get { return _ifYouPurchase; } set { _ifYouPurchase = value; } }
-        private Value<string> _ifYouPurchaseType;
+        private DirtyValue<string> _ifYouPurchaseType;
         public string IfYouPurchaseType { get { return _ifYouPurchaseType; } set { _ifYouPurchaseType = value; } }
-        private Value<decimal?> _indexCurrentValuePercent;
+        private DirtyValue<decimal?> _indexCurrentValuePercent;
         public decimal? IndexCurrentValuePercent { get { return _indexCurrentValuePercent; } set { _indexCurrentValuePercent = value; } }
-        private Value<decimal?> _indexMarginPercent;
+        private DirtyValue<decimal?> _indexMarginPercent;
         public decimal? IndexMarginPercent { get { return _indexMarginPercent; } set { _indexMarginPercent = value; } }
-        private Value<decimal?> _initialAdvanceAmount;
+        private DirtyValue<decimal?> _initialAdvanceAmount;
         public decimal? InitialAdvanceAmount { get { return _initialAdvanceAmount; } set { _initialAdvanceAmount = value; } }
-        private Value<int?> _interestOnlyMonths;
+        private DirtyValue<int?> _interestOnlyMonths;
         public int? InterestOnlyMonths { get { return _interestOnlyMonths; } set { _interestOnlyMonths = value; } }
-        private Value<int?> _lateChargeDays;
+        private DirtyValue<int?> _lateChargeDays;
         public int? LateChargeDays { get { return _lateChargeDays; } set { _lateChargeDays = value; } }
-        private Value<decimal?> _lateChargePercent;
+        private DirtyValue<decimal?> _lateChargePercent;
         public decimal? LateChargePercent { get { return _lateChargePercent; } set { _lateChargePercent = value; } }
-        private Value<string> _lateChargeType;
+        private DirtyValue<string> _lateChargeType;
         public string LateChargeType { get { return _lateChargeType; } set { _lateChargeType = value; } }
-        private Value<string> _lenderInvestorCode;
+        private DirtyValue<string> _lenderInvestorCode;
         public string LenderInvestorCode { get { return _lenderInvestorCode; } set { _lenderInvestorCode = value; } }
-        private Value<string> _lienPriorityType;
+        private DirtyValue<string> _lienPriorityType;
         public string LienPriorityType { get { return _lienPriorityType; } set { _lienPriorityType = value; } }
-        private Value<int?> _loanAmortizationTermMonths;
+        private DirtyValue<int?> _loanAmortizationTermMonths;
         public int? LoanAmortizationTermMonths { get { return _loanAmortizationTermMonths; } set { _loanAmortizationTermMonths = value; } }
-        private Value<string> _loanAmortizationType;
+        private DirtyValue<string> _loanAmortizationType;
         public string LoanAmortizationType { get { return _loanAmortizationType; } set { _loanAmortizationType = value; } }
-        private Value<string> _loanDocumentationType;
+        private DirtyValue<string> _loanDocumentationType;
         public string LoanDocumentationType { get { return _loanDocumentationType; } set { _loanDocumentationType = value; } }
-        private Value<string> _loanFeaturesPaymentFrequencyType;
+        private DirtyValue<string> _loanFeaturesPaymentFrequencyType;
         public string LoanFeaturesPaymentFrequencyType { get { return _loanFeaturesPaymentFrequencyType; } set { _loanFeaturesPaymentFrequencyType = value; } }
-        private Value<string> _loanProgramName;
+        private DirtyValue<string> _loanProgramName;
         public string LoanProgramName { get { return _loanProgramName; } set { _loanProgramName = value; } }
-        private Value<string> _lockField;
+        private DirtyValue<string> _lockField;
         public string LockField { get { return _lockField; } set { _lockField = value; } }
-        private Value<decimal?> _maxBackRatio;
+        private DirtyValue<decimal?> _maxBackRatio;
         public decimal? MaxBackRatio { get { return _maxBackRatio; } set { _maxBackRatio = value; } }
-        private Value<decimal?> _maxCltv;
+        private DirtyValue<decimal?> _maxCltv;
         public decimal? MaxCltv { get { return _maxCltv; } set { _maxCltv = value; } }
-        private Value<decimal?> _maxFrontRatio;
+        private DirtyValue<decimal?> _maxFrontRatio;
         public decimal? MaxFrontRatio { get { return _maxFrontRatio; } set { _maxFrontRatio = value; } }
-        private Value<decimal?> _maximumBalance;
+        private DirtyValue<decimal?> _maximumBalance;
         public decimal? MaximumBalance { get { return _maximumBalance; } set { _maximumBalance = value; } }
-        private Value<decimal?> _maxLoanAmount;
+        private DirtyValue<decimal?> _maxLoanAmount;
         public decimal? MaxLoanAmount { get { return _maxLoanAmount; } set { _maxLoanAmount = value; } }
-        private Value<decimal?> _maxLtv;
+        private DirtyValue<decimal?> _maxLtv;
         public decimal? MaxLtv { get { return _maxLtv; } set { _maxLtv = value; } }
-        private Value<string> _meansAnEstimate;
+        private DirtyValue<string> _meansAnEstimate;
         public string MeansAnEstimate { get { return _meansAnEstimate; } set { _meansAnEstimate = value; } }
-        private Value<string> _miCalculationType;
+        private DirtyValue<string> _miCalculationType;
         public string MiCalculationType { get { return _miCalculationType; } set { _miCalculationType = value; } }
-        private Value<string> _midpointCancellation;
+        private DirtyValue<string> _midpointCancellation;
         public string MidpointCancellation { get { return _midpointCancellation; } set { _midpointCancellation = value; } }
-        private Value<string> _minCreditScore;
+        private DirtyValue<string> _minCreditScore;
         public string MinCreditScore { get { return _minCreditScore; } set { _minCreditScore = value; } }
-        private Value<decimal?> _minimumAdvanceAmount;
+        private DirtyValue<decimal?> _minimumAdvanceAmount;
         public decimal? MinimumAdvanceAmount { get { return _minimumAdvanceAmount; } set { _minimumAdvanceAmount = value; } }
-        private Value<decimal?> _minimumAllowableApr;
+        private DirtyValue<decimal?> _minimumAllowableApr;
         public decimal? MinimumAllowableApr { get { return _minimumAllowableApr; } set { _minimumAllowableApr = value; } }
-        private Value<decimal?> _minimumPaymentAmount;
+        private DirtyValue<decimal?> _minimumPaymentAmount;
         public decimal? MinimumPaymentAmount { get { return _minimumPaymentAmount; } set { _minimumPaymentAmount = value; } }
-        private Value<decimal?> _minimumPaymentPercent;
+        private DirtyValue<decimal?> _minimumPaymentPercent;
         public decimal? MinimumPaymentPercent { get { return _minimumPaymentPercent; } set { _minimumPaymentPercent = value; } }
-        private Value<decimal?> _mipPaidInCash;
+        private DirtyValue<decimal?> _mipPaidInCash;
         public decimal? MipPaidInCash { get { return _mipPaidInCash; } set { _mipPaidInCash = value; } }
-        private Value<string> _mmi;
+        private DirtyValue<string> _mmi;
         public string Mmi { get { return _mmi; } set { _mmi = value; } }
-        private Value<decimal?> _mortgageInsuranceAdjustmentFactor1;
+        private DirtyValue<decimal?> _mortgageInsuranceAdjustmentFactor1;
         public decimal? MortgageInsuranceAdjustmentFactor1 { get { return _mortgageInsuranceAdjustmentFactor1; } set { _mortgageInsuranceAdjustmentFactor1 = value; } }
-        private Value<decimal?> _mortgageInsuranceAdjustmentFactor2;
+        private DirtyValue<decimal?> _mortgageInsuranceAdjustmentFactor2;
         public decimal? MortgageInsuranceAdjustmentFactor2 { get { return _mortgageInsuranceAdjustmentFactor2; } set { _mortgageInsuranceAdjustmentFactor2 = value; } }
-        private Value<decimal?> _mortgageInsuranceCancelPercent;
+        private DirtyValue<decimal?> _mortgageInsuranceCancelPercent;
         public decimal? MortgageInsuranceCancelPercent { get { return _mortgageInsuranceCancelPercent; } set { _mortgageInsuranceCancelPercent = value; } }
-        private Value<decimal?> _mortgageInsuranceMonthlyPayment1;
+        private DirtyValue<decimal?> _mortgageInsuranceMonthlyPayment1;
         public decimal? MortgageInsuranceMonthlyPayment1 { get { return _mortgageInsuranceMonthlyPayment1; } set { _mortgageInsuranceMonthlyPayment1 = value; } }
-        private Value<decimal?> _mortgageInsuranceMonthlyPayment2;
+        private DirtyValue<decimal?> _mortgageInsuranceMonthlyPayment2;
         public decimal? MortgageInsuranceMonthlyPayment2 { get { return _mortgageInsuranceMonthlyPayment2; } set { _mortgageInsuranceMonthlyPayment2 = value; } }
-        private Value<int?> _mortgageInsuranceMonthsOfAdjustment1;
+        private DirtyValue<int?> _mortgageInsuranceMonthsOfAdjustment1;
         public int? MortgageInsuranceMonthsOfAdjustment1 { get { return _mortgageInsuranceMonthsOfAdjustment1; } set { _mortgageInsuranceMonthsOfAdjustment1 = value; } }
-        private Value<int?> _mortgageInsuranceMonthsOfAdjustment2;
+        private DirtyValue<int?> _mortgageInsuranceMonthsOfAdjustment2;
         public int? MortgageInsuranceMonthsOfAdjustment2 { get { return _mortgageInsuranceMonthsOfAdjustment2; } set { _mortgageInsuranceMonthsOfAdjustment2 = value; } }
-        private Value<string> _mortgageType;
+        private DirtyValue<string> _mortgageType;
         public string MortgageType { get { return _mortgageType; } set { _mortgageType = value; } }
-        private Value<string> _otherAmortizationTypeDescription;
+        private DirtyValue<string> _otherAmortizationTypeDescription;
         public string OtherAmortizationTypeDescription { get { return _otherAmortizationTypeDescription; } set { _otherAmortizationTypeDescription = value; } }
-        private Value<string> _otherLoanPurposeDescription;
+        private DirtyValue<string> _otherLoanPurposeDescription;
         public string OtherLoanPurposeDescription { get { return _otherLoanPurposeDescription; } set { _otherLoanPurposeDescription = value; } }
-        private Value<string> _otherMortgageTypeDescription;
+        private DirtyValue<string> _otherMortgageTypeDescription;
         public string OtherMortgageTypeDescription { get { return _otherMortgageTypeDescription; } set { _otherMortgageTypeDescription = value; } }
-        private Value<int?> _paymentAdjustmentDurationMonths;
+        private DirtyValue<int?> _paymentAdjustmentDurationMonths;
         public int? PaymentAdjustmentDurationMonths { get { return _paymentAdjustmentDurationMonths; } set { _paymentAdjustmentDurationMonths = value; } }
-        private Value<decimal?> _paymentAdjustmentPeriodicCapPercent;
+        private DirtyValue<decimal?> _paymentAdjustmentPeriodicCapPercent;
         public decimal? PaymentAdjustmentPeriodicCapPercent { get { return _paymentAdjustmentPeriodicCapPercent; } set { _paymentAdjustmentPeriodicCapPercent = value; } }
-        private Value<decimal?> _paymentFactor;
+        private DirtyValue<decimal?> _paymentFactor;
         public decimal? PaymentFactor { get { return _paymentFactor; } set { _paymentFactor = value; } }
-        private Value<decimal?> _percentageOfRental;
+        private DirtyValue<decimal?> _percentageOfRental;
         public decimal? PercentageOfRental { get { return _percentageOfRental; } set { _percentageOfRental = value; } }
-        private Value<string> _perDiemCalculationMethodType;
+        private DirtyValue<string> _perDiemCalculationMethodType;
         public string PerDiemCalculationMethodType { get { return _perDiemCalculationMethodType; } set { _perDiemCalculationMethodType = value; } }
-        private Value<string> _pmi;
+        private DirtyValue<string> _pmi;
         public string Pmi { get { return _pmi; } set { _pmi = value; } }
-        private Value<string> _prepaymentPenaltyIndicator;
+        private DirtyValue<string> _prepaymentPenaltyIndicator;
         public string PrepaymentPenaltyIndicator { get { return _prepaymentPenaltyIndicator; } set { _prepaymentPenaltyIndicator = value; } }
-        private Value<string> _programCode;
+        private DirtyValue<string> _programCode;
         public string ProgramCode { get { return _programCode; } set { _programCode = value; } }
-        private Value<string> _propertyInsurance;
+        private DirtyValue<string> _propertyInsurance;
         public string PropertyInsurance { get { return _propertyInsurance; } set { _propertyInsurance = value; } }
-        private Value<string> _propertyUsageType;
+        private DirtyValue<string> _propertyUsageType;
         public string PropertyUsageType { get { return _propertyUsageType; } set { _propertyUsageType = value; } }
-        private Value<decimal?> _qualifyingRatePercent;
+        private DirtyValue<decimal?> _qualifyingRatePercent;
         public decimal? QualifyingRatePercent { get { return _qualifyingRatePercent; } set { _qualifyingRatePercent = value; } }
-        private Value<int?> _rateAdjustmentDurationMonths;
+        private DirtyValue<int?> _rateAdjustmentDurationMonths;
         public int? RateAdjustmentDurationMonths { get { return _rateAdjustmentDurationMonths; } set { _rateAdjustmentDurationMonths = value; } }
-        private Value<decimal?> _rateAdjustmentLifetimeCapPercent;
+        private DirtyValue<decimal?> _rateAdjustmentLifetimeCapPercent;
         public decimal? RateAdjustmentLifetimeCapPercent { get { return _rateAdjustmentLifetimeCapPercent; } set { _rateAdjustmentLifetimeCapPercent = value; } }
-        private Value<decimal?> _rateAdjustmentPercent;
+        private DirtyValue<decimal?> _rateAdjustmentPercent;
         public decimal? RateAdjustmentPercent { get { return _rateAdjustmentPercent; } set { _rateAdjustmentPercent = value; } }
-        private Value<decimal?> _rateAdjustmentSubsequentCapPercent;
+        private DirtyValue<decimal?> _rateAdjustmentSubsequentCapPercent;
         public decimal? RateAdjustmentSubsequentCapPercent { get { return _rateAdjustmentSubsequentCapPercent; } set { _rateAdjustmentSubsequentCapPercent = value; } }
-        private Value<int?> _rateAdjustmentSubsequentRateAdjustmentMonths;
+        private DirtyValue<int?> _rateAdjustmentSubsequentRateAdjustmentMonths;
         public int? RateAdjustmentSubsequentRateAdjustmentMonths { get { return _rateAdjustmentSubsequentRateAdjustmentMonths; } set { _rateAdjustmentSubsequentRateAdjustmentMonths = value; } }
-        private Value<int?> _recastPaidMonths;
+        private DirtyValue<int?> _recastPaidMonths;
         public int? RecastPaidMonths { get { return _recastPaidMonths; } set { _recastPaidMonths = value; } }
-        private Value<int?> _recastStopMonths;
+        private DirtyValue<int?> _recastStopMonths;
         public int? RecastStopMonths { get { return _recastStopMonths; } set { _recastStopMonths = value; } }
-        private Value<string> _refundPaymentIndicator;
+        private DirtyValue<string> _refundPaymentIndicator;
         public string RefundPaymentIndicator { get { return _refundPaymentIndicator; } set { _refundPaymentIndicator = value; } }
-        private Value<decimal?> _requestedInterestRatePercent;
+        private DirtyValue<decimal?> _requestedInterestRatePercent;
         public decimal? RequestedInterestRatePercent { get { return _requestedInterestRatePercent; } set { _requestedInterestRatePercent = value; } }
-        private Value<string> _requiredDeposit;
+        private DirtyValue<string> _requiredDeposit;
         public string RequiredDeposit { get { return _requiredDeposit; } set { _requiredDeposit = value; } }
-        private Value<decimal?> _roundPercent;
+        private DirtyValue<decimal?> _roundPercent;
         public decimal? RoundPercent { get { return _roundPercent; } set { _roundPercent = value; } }
-        private Value<string> _roundType;
+        private DirtyValue<string> _roundType;
         public string RoundType { get { return _roundType; } set { _roundType = value; } }
-        private Value<string> _securityInterestInNameOf;
+        private DirtyValue<string> _securityInterestInNameOf;
         public string SecurityInterestInNameOf { get { return _securityInterestInNameOf; } set { _securityInterestInNameOf = value; } }
-        private Value<string> _securityType;
+        private DirtyValue<string> _securityType;
         public string SecurityType { get { return _securityType; } set { _securityType = value; } }
-        private Value<decimal?> _subjectPropertyGrossRentalIncome;
+        private DirtyValue<decimal?> _subjectPropertyGrossRentalIncome;
         public decimal? SubjectPropertyGrossRentalIncome { get { return _subjectPropertyGrossRentalIncome; } set { _subjectPropertyGrossRentalIncome = value; } }
-        private Value<decimal?> _teaserRate;
+        private DirtyValue<decimal?> _teaserRate;
         public decimal? TeaserRate { get { return _teaserRate; } set { _teaserRate = value; } }
-        private Value<decimal?> _terminationFeeAmount;
+        private DirtyValue<decimal?> _terminationFeeAmount;
         public decimal? TerminationFeeAmount { get { return _terminationFeeAmount; } set { _terminationFeeAmount = value; } }
-        private Value<int?> _terminationPeriodMonthsCount;
+        private DirtyValue<int?> _terminationPeriodMonthsCount;
         public int? TerminationPeriodMonthsCount { get { return _terminationPeriodMonthsCount; } set { _terminationPeriodMonthsCount = value; } }
-        private Value<decimal?> _thirdPartyFeeFrom;
+        private DirtyValue<decimal?> _thirdPartyFeeFrom;
         public decimal? ThirdPartyFeeFrom { get { return _thirdPartyFeeFrom; } set { _thirdPartyFeeFrom = value; } }
-        private Value<decimal?> _thirdPartyFeeTo;
+        private DirtyValue<decimal?> _thirdPartyFeeTo;
         public decimal? ThirdPartyFeeTo { get { return _thirdPartyFeeTo; } set { _thirdPartyFeeTo = value; } }
-        private Value<string> _type;
+        private DirtyValue<string> _type;
         public string Type { get { return _type; } set { _type = value; } }
-        private Value<string> _useDaysInYears;
+        private DirtyValue<string> _useDaysInYears;
         public string UseDaysInYears { get { return _useDaysInYears; } set { _useDaysInYears = value; } }
-        private Value<string> _usePitiForRatio;
+        private DirtyValue<string> _usePitiForRatio;
         public string UsePitiForRatio { get { return _usePitiForRatio; } set { _usePitiForRatio = value; } }
-        private Value<string> _variableRateFeature;
+        private DirtyValue<string> _variableRateFeature;
         public string VariableRateFeature { get { return _variableRateFeature; } set { _variableRateFeature = value; } }
-        private Value<decimal?> _yearlyTerm;
+        private DirtyValue<decimal?> _yearlyTerm;
         public decimal? YearlyTerm { get { return _yearlyTerm; } set { _yearlyTerm = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanSubmission.cs
+++ b/src/EncompassRest/Loans/LoanSubmission.cs
@@ -8,63 +8,63 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanSubmission : IDirty
     {
-        private Value<decimal?> _amountAvailable;
+        private DirtyValue<decimal?> _amountAvailable;
         public decimal? AmountAvailable { get { return _amountAvailable; } set { _amountAvailable = value; } }
-        private Value<decimal?> _amountRequiredToClose;
+        private DirtyValue<decimal?> _amountRequiredToClose;
         public decimal? AmountRequiredToClose { get { return _amountRequiredToClose; } set { _amountRequiredToClose = value; } }
-        private Value<string> _buydownDescription;
+        private DirtyValue<string> _buydownDescription;
         public string BuydownDescription { get { return _buydownDescription; } set { _buydownDescription = value; } }
-        private Value<string> _buydownMonthsPerAdjustment;
+        private DirtyValue<string> _buydownMonthsPerAdjustment;
         public string BuydownMonthsPerAdjustment { get { return _buydownMonthsPerAdjustment; } set { _buydownMonthsPerAdjustment = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _currentRateSetDate;
+        private DirtyValue<DateTime?> _currentRateSetDate;
         public DateTime? CurrentRateSetDate { get { return _currentRateSetDate; } set { _currentRateSetDate = value; } }
-        private Value<DateTime?> _dateLastPaymentReceived;
+        private DirtyValue<DateTime?> _dateLastPaymentReceived;
         public DateTime? DateLastPaymentReceived { get { return _dateLastPaymentReceived; } set { _dateLastPaymentReceived = value; } }
-        private Value<bool?> _floodIndicator;
+        private DirtyValue<bool?> _floodIndicator;
         public bool? FloodIndicator { get { return _floodIndicator; } set { _floodIndicator = value; } }
-        private Value<bool?> _hazardIndicator;
+        private DirtyValue<bool?> _hazardIndicator;
         public bool? HazardIndicator { get { return _hazardIndicator; } set { _hazardIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSecondaryRegistration;
+        private DirtyValue<bool?> _isSecondaryRegistration;
         public bool? IsSecondaryRegistration { get { return _isSecondaryRegistration; } set { _isSecondaryRegistration = value; } }
         private DirtyList<LoanSubmissionFee> _loanSubmissionFees;
         public IList<LoanSubmissionFee> LoanSubmissionFees { get { var v = _loanSubmissionFees; return v ?? Interlocked.CompareExchange(ref _loanSubmissionFees, (v = new DirtyList<LoanSubmissionFee>()), null) ?? v; } set { _loanSubmissionFees = new DirtyList<LoanSubmissionFee>(value); } }
-        private Value<DateTime?> _lockDate;
+        private DirtyValue<DateTime?> _lockDate;
         public DateTime? LockDate { get { return _lockDate; } set { _lockDate = value; } }
-        private Value<DateTime?> _lockDateTimestampUtc;
+        private DirtyValue<DateTime?> _lockDateTimestampUtc;
         public DateTime? LockDateTimestampUtc { get { return _lockDateTimestampUtc; } set { _lockDateTimestampUtc = value; } }
-        private Value<DateTime?> _lockExpiresDate;
+        private DirtyValue<DateTime?> _lockExpiresDate;
         public DateTime? LockExpiresDate { get { return _lockExpiresDate; } set { _lockExpiresDate = value; } }
-        private Value<bool?> _mmmPmiIndicator;
+        private DirtyValue<bool?> _mmmPmiIndicator;
         public bool? MmmPmiIndicator { get { return _mmmPmiIndicator; } set { _mmmPmiIndicator = value; } }
-        private Value<int?> _numberOfDays;
+        private DirtyValue<int?> _numberOfDays;
         public int? NumberOfDays { get { return _numberOfDays; } set { _numberOfDays = value; } }
-        private Value<string> _otherDescription;
+        private DirtyValue<string> _otherDescription;
         public string OtherDescription { get { return _otherDescription; } set { _otherDescription = value; } }
-        private Value<bool?> _otherIndicator;
+        private DirtyValue<bool?> _otherIndicator;
         public bool? OtherIndicator { get { return _otherIndicator; } set { _otherIndicator = value; } }
-        private Value<string> _programCode;
+        private DirtyValue<string> _programCode;
         public string ProgramCode { get { return _programCode; } set { _programCode = value; } }
-        private Value<string> _rateLock;
+        private DirtyValue<string> _rateLock;
         public string RateLock { get { return _rateLock; } set { _rateLock = value; } }
-        private Value<DateTime?> _rateLockDisclosureDate;
+        private DirtyValue<DateTime?> _rateLockDisclosureDate;
         public DateTime? RateLockDisclosureDate { get { return _rateLockDisclosureDate; } set { _rateLockDisclosureDate = value; } }
-        private Value<bool?> _reducedDocsIndicator;
+        private DirtyValue<bool?> _reducedDocsIndicator;
         public bool? ReducedDocsIndicator { get { return _reducedDocsIndicator; } set { _reducedDocsIndicator = value; } }
-        private Value<bool?> _taxesIndicator;
+        private DirtyValue<bool?> _taxesIndicator;
         public bool? TaxesIndicator { get { return _taxesIndicator; } set { _taxesIndicator = value; } }
-        private Value<decimal?> _total;
+        private DirtyValue<decimal?> _total;
         public decimal? Total { get { return _total; } set { _total = value; } }
-        private Value<decimal?> _totalDiscountPointCharged;
+        private DirtyValue<decimal?> _totalDiscountPointCharged;
         public decimal? TotalDiscountPointCharged { get { return _totalDiscountPointCharged; } set { _totalDiscountPointCharged = value; } }
-        private Value<decimal?> _totalForDueBroker;
+        private DirtyValue<decimal?> _totalForDueBroker;
         public decimal? TotalForDueBroker { get { return _totalForDueBroker; } set { _totalForDueBroker = value; } }
-        private Value<decimal?> _totalForDueLender;
+        private DirtyValue<decimal?> _totalForDueLender;
         public decimal? TotalForDueLender { get { return _totalForDueLender; } set { _totalForDueLender = value; } }
-        private Value<decimal?> _totalForPrimaryResidence;
+        private DirtyValue<decimal?> _totalForPrimaryResidence;
         public decimal? TotalForPrimaryResidence { get { return _totalForPrimaryResidence; } set { _totalForPrimaryResidence = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LoanSubmission.cs
+++ b/src/EncompassRest/Loans/LoanSubmission.cs
@@ -30,8 +30,8 @@ namespace EncompassRest.Loans
         public string Id { get { return _id; } set { _id = value; } }
         private Value<bool?> _isSecondaryRegistration;
         public bool? IsSecondaryRegistration { get { return _isSecondaryRegistration; } set { _isSecondaryRegistration = value; } }
-        private Value<List<LoanSubmissionFee>> _loanSubmissionFees;
-        public List<LoanSubmissionFee> LoanSubmissionFees { get { return _loanSubmissionFees; } set { _loanSubmissionFees = value; } }
+        private DirtyList<LoanSubmissionFee> _loanSubmissionFees;
+        public IList<LoanSubmissionFee> LoanSubmissionFees { get { var v = _loanSubmissionFees; return v ?? Interlocked.CompareExchange(ref _loanSubmissionFees, (v = new DirtyList<LoanSubmissionFee>()), null) ?? v; } set { _loanSubmissionFees = new DirtyList<LoanSubmissionFee>(value); } }
         private Value<DateTime?> _lockDate;
         public DateTime? LockDate { get { return _lockDate; } set { _lockDate = value; } }
         private Value<DateTime?> _lockDateTimestampUtc;
@@ -84,7 +84,6 @@ namespace EncompassRest.Loans
                     || _hazardIndicator.Dirty
                     || _id.Dirty
                     || _isSecondaryRegistration.Dirty
-                    || _loanSubmissionFees.Dirty
                     || _lockDate.Dirty
                     || _lockDateTimestampUtc.Dirty
                     || _lockExpiresDate.Dirty
@@ -101,7 +100,8 @@ namespace EncompassRest.Loans
                     || _totalDiscountPointCharged.Dirty
                     || _totalForDueBroker.Dirty
                     || _totalForDueLender.Dirty
-                    || _totalForPrimaryResidence.Dirty;
+                    || _totalForPrimaryResidence.Dirty
+                    || _loanSubmissionFees?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -119,7 +119,6 @@ namespace EncompassRest.Loans
                 _hazardIndicator.Dirty = value;
                 _id.Dirty = value;
                 _isSecondaryRegistration.Dirty = value;
-                _loanSubmissionFees.Dirty = value;
                 _lockDate.Dirty = value;
                 _lockDateTimestampUtc.Dirty = value;
                 _lockExpiresDate.Dirty = value;
@@ -137,6 +136,7 @@ namespace EncompassRest.Loans
                 _totalForDueBroker.Dirty = value;
                 _totalForDueLender.Dirty = value;
                 _totalForPrimaryResidence.Dirty = value;
+                if (_loanSubmissionFees != null) _loanSubmissionFees.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LoanSubmissionFee.cs
+++ b/src/EncompassRest/Loans/LoanSubmissionFee.cs
@@ -8,17 +8,17 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LoanSubmissionFee : IDirty
     {
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<decimal?> _dueBroker;
+        private DirtyValue<decimal?> _dueBroker;
         public decimal? DueBroker { get { return _dueBroker; } set { _dueBroker = value; } }
-        private Value<decimal?> _dueLender;
+        private DirtyValue<decimal?> _dueLender;
         public decimal? DueLender { get { return _dueLender; } set { _dueLender = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _loanSubmissionFeeType;
+        private DirtyValue<string> _loanSubmissionFeeType;
         public string LoanSubmissionFeeType { get { return _loanSubmissionFeeType; } set { _loanSubmissionFeeType = value; } }
-        private Value<decimal?> _total;
+        private DirtyValue<decimal?> _total;
         public decimal? Total { get { return _total; } set { _total = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LockCancellationLog.cs
+++ b/src/EncompassRest/Loans/LockCancellationLog.cs
@@ -8,35 +8,35 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LockCancellationLog : IDirty
     {
-        private Value<bool?> _alertIndicator;
+        private DirtyValue<bool?> _alertIndicator;
         public bool? AlertIndicator { get { return _alertIndicator; } set { _alertIndicator = value; } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<string> _cancelledBy;
+        private DirtyValue<string> _cancelledBy;
         public string CancelledBy { get { return _cancelledBy; } set { _cancelledBy = value; } }
-        private Value<string> _cancelledById;
+        private DirtyValue<string> _cancelledById;
         public string CancelledById { get { return _cancelledById; } set { _cancelledById = value; } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _requestGuid;
+        private DirtyValue<string> _requestGuid;
         public string RequestGuid { get { return _requestGuid; } set { _requestGuid = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _timeCancelled;
+        private DirtyValue<string> _timeCancelled;
         public string TimeCancelled { get { return _timeCancelled; } set { _timeCancelled = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LockConfirmLog.cs
+++ b/src/EncompassRest/Loans/LockConfirmLog.cs
@@ -8,43 +8,43 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LockConfirmLog : IDirty
     {
-        private Value<bool?> _alertIndicator;
+        private DirtyValue<bool?> _alertIndicator;
         public bool? AlertIndicator { get { return _alertIndicator; } set { _alertIndicator = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<DateTime?> _buySideExpirationDate;
+        private DirtyValue<DateTime?> _buySideExpirationDate;
         public DateTime? BuySideExpirationDate { get { return _buySideExpirationDate; } set { _buySideExpirationDate = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _confirmedBy;
+        private DirtyValue<string> _confirmedBy;
         public string ConfirmedBy { get { return _confirmedBy; } set { _confirmedBy = value; } }
-        private Value<bool?> _confirmedByIdIndicator;
+        private DirtyValue<bool?> _confirmedByIdIndicator;
         public bool? ConfirmedByIdIndicator { get { return _confirmedByIdIndicator; } set { _confirmedByIdIndicator = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _requestGuid;
+        private DirtyValue<string> _requestGuid;
         public string RequestGuid { get { return _requestGuid; } set { _requestGuid = value; } }
-        private Value<string> _sellSideDeliveredBy;
+        private DirtyValue<string> _sellSideDeliveredBy;
         public string SellSideDeliveredBy { get { return _sellSideDeliveredBy; } set { _sellSideDeliveredBy = value; } }
-        private Value<DateTime?> _sellSideDeliveryDate;
+        private DirtyValue<DateTime?> _sellSideDeliveryDate;
         public DateTime? SellSideDeliveryDate { get { return _sellSideDeliveryDate; } set { _sellSideDeliveryDate = value; } }
-        private Value<DateTime?> _sellSideExpirationDate;
+        private DirtyValue<DateTime?> _sellSideExpirationDate;
         public DateTime? SellSideExpirationDate { get { return _sellSideExpirationDate; } set { _sellSideExpirationDate = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _timeConfirmed;
+        private DirtyValue<string> _timeConfirmed;
         public string TimeConfirmed { get { return _timeConfirmed; } set { _timeConfirmed = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LockConfirmLog.cs
+++ b/src/EncompassRest/Loans/LockConfirmLog.cs
@@ -10,12 +10,12 @@ namespace EncompassRest.Loans
     {
         private Value<bool?> _alertIndicator;
         public bool? AlertIndicator { get { return _alertIndicator; } set { _alertIndicator = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<DateTime?> _buySideExpirationDate;
         public DateTime? BuySideExpirationDate { get { return _buySideExpirationDate; } set { _buySideExpirationDate = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _confirmedBy;
@@ -54,9 +54,7 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _alertIndicator.Dirty
-                    || _alerts.Dirty
                     || _buySideExpirationDate.Dirty
-                    || _commentList.Dirty
                     || _comments.Dirty
                     || _confirmedBy.Dirty
                     || _confirmedByIdIndicator.Dirty
@@ -71,7 +69,9 @@ namespace EncompassRest.Loans
                     || _sellSideDeliveryDate.Dirty
                     || _sellSideExpirationDate.Dirty
                     || _systemId.Dirty
-                    || _timeConfirmed.Dirty;
+                    || _timeConfirmed.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -79,9 +79,7 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _alertIndicator.Dirty = value;
-                _alerts.Dirty = value;
                 _buySideExpirationDate.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _confirmedBy.Dirty = value;
                 _confirmedByIdIndicator.Dirty = value;
@@ -97,6 +95,8 @@ namespace EncompassRest.Loans
                 _sellSideExpirationDate.Dirty = value;
                 _systemId.Dirty = value;
                 _timeConfirmed.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LockDenialLog.cs
+++ b/src/EncompassRest/Loans/LockDenialLog.cs
@@ -10,10 +10,10 @@ namespace EncompassRest.Loans
     {
         private Value<bool?> _alertIndicator;
         public bool? AlertIndicator { get { return _alertIndicator; } set { _alertIndicator = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -46,8 +46,6 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _alertIndicator.Dirty
-                    || _alerts.Dirty
-                    || _commentList.Dirty
                     || _comments.Dirty
                     || _dateUtc.Dirty
                     || _deniedBy.Dirty
@@ -59,7 +57,9 @@ namespace EncompassRest.Loans
                     || _logRecordIndex.Dirty
                     || _requestGuid.Dirty
                     || _systemId.Dirty
-                    || _timeDenied.Dirty;
+                    || _timeDenied.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -67,8 +67,6 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _alertIndicator.Dirty = value;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _deniedBy.Dirty = value;
@@ -81,6 +79,8 @@ namespace EncompassRest.Loans
                 _requestGuid.Dirty = value;
                 _systemId.Dirty = value;
                 _timeDenied.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LockDenialLog.cs
+++ b/src/EncompassRest/Loans/LockDenialLog.cs
@@ -8,35 +8,35 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LockDenialLog : IDirty
     {
-        private Value<bool?> _alertIndicator;
+        private DirtyValue<bool?> _alertIndicator;
         public bool? AlertIndicator { get { return _alertIndicator; } set { _alertIndicator = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _deniedBy;
+        private DirtyValue<string> _deniedBy;
         public string DeniedBy { get { return _deniedBy; } set { _deniedBy = value; } }
-        private Value<string> _deniedById;
+        private DirtyValue<string> _deniedById;
         public string DeniedById { get { return _deniedById; } set { _deniedById = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _requestGuid;
+        private DirtyValue<string> _requestGuid;
         public string RequestGuid { get { return _requestGuid; } set { _requestGuid = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _timeDenied;
+        private DirtyValue<string> _timeDenied;
         public string TimeDenied { get { return _timeDenied; } set { _timeDenied = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LockRequestBorrower.cs
+++ b/src/EncompassRest/Loans/LockRequestBorrower.cs
@@ -8,23 +8,23 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LockRequestBorrower : IDirty
     {
-        private Value<string> _equifaxScore;
+        private DirtyValue<string> _equifaxScore;
         public string EquifaxScore { get { return _equifaxScore; } set { _equifaxScore = value; } }
-        private Value<string> _experianScore;
+        private DirtyValue<string> _experianScore;
         public string ExperianScore { get { return _experianScore; } set { _experianScore = value; } }
-        private Value<string> _firstName;
+        private DirtyValue<string> _firstName;
         public string FirstName { get { return _firstName; } set { _firstName = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEmpty;
+        private DirtyValue<bool?> _isEmpty;
         public bool? IsEmpty { get { return _isEmpty; } set { _isEmpty = value; } }
-        private Value<string> _lastName;
+        private DirtyValue<string> _lastName;
         public string LastName { get { return _lastName; } set { _lastName = value; } }
-        private Value<int?> _lrbIndex;
+        private DirtyValue<int?> _lrbIndex;
         public int? LrbIndex { get { return _lrbIndex; } set { _lrbIndex = value; } }
-        private Value<string> _sSN;
+        private DirtyValue<string> _sSN;
         public string SSN { get { return _sSN; } set { _sSN = value; } }
-        private Value<string> _transUnionScore;
+        private DirtyValue<string> _transUnionScore;
         public string TransUnionScore { get { return _transUnionScore; } set { _transUnionScore = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LockRequestLog.cs
+++ b/src/EncompassRest/Loans/LockRequestLog.cs
@@ -8,8 +8,8 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LockRequestLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<DateTime?> _buySideExpirationDate;
@@ -20,8 +20,8 @@ namespace EncompassRest.Loans
         public int? BuySideNumDayExtended { get { return _buySideNumDayExtended; } set { _buySideNumDayExtended = value; } }
         private Value<int?> _buySideNumDayLocked;
         public int? BuySideNumDayLocked { get { return _buySideNumDayLocked; } set { _buySideNumDayLocked = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -83,13 +83,11 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _alertsXml.Dirty
+                var dirty = _alertsXml.Dirty
                     || _buySideExpirationDate.Dirty
                     || _buySideNewLockExtensionDate.Dirty
                     || _buySideNumDayExtended.Dirty
                     || _buySideNumDayLocked.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _dateUtc.Dirty
@@ -116,20 +114,20 @@ namespace EncompassRest.Loans
                     || _sellSideNumDayExtended.Dirty
                     || _snapshotXml.Dirty
                     || _systemId.Dirty
-                    || _timeRequested.Dirty;
+                    || _timeRequested.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _buySideExpirationDate.Dirty = value;
                 _buySideNewLockExtensionDate.Dirty = value;
                 _buySideNumDayExtended.Dirty = value;
                 _buySideNumDayLocked.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
@@ -157,6 +155,8 @@ namespace EncompassRest.Loans
                 _snapshotXml.Dirty = value;
                 _systemId.Dirty = value;
                 _timeRequested.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LockRequestLog.cs
+++ b/src/EncompassRest/Loans/LockRequestLog.cs
@@ -10,71 +10,71 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<DateTime?> _buySideExpirationDate;
+        private DirtyValue<DateTime?> _buySideExpirationDate;
         public DateTime? BuySideExpirationDate { get { return _buySideExpirationDate; } set { _buySideExpirationDate = value; } }
-        private Value<DateTime?> _buySideNewLockExtensionDate;
+        private DirtyValue<DateTime?> _buySideNewLockExtensionDate;
         public DateTime? BuySideNewLockExtensionDate { get { return _buySideNewLockExtensionDate; } set { _buySideNewLockExtensionDate = value; } }
-        private Value<int?> _buySideNumDayExtended;
+        private DirtyValue<int?> _buySideNumDayExtended;
         public int? BuySideNumDayExtended { get { return _buySideNumDayExtended; } set { _buySideNumDayExtended = value; } }
-        private Value<int?> _buySideNumDayLocked;
+        private DirtyValue<int?> _buySideNumDayLocked;
         public int? BuySideNumDayLocked { get { return _buySideNumDayLocked; } set { _buySideNumDayLocked = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<bool?> _hideLogIndicator;
+        private DirtyValue<bool?> _hideLogIndicator;
         public bool? HideLogIndicator { get { return _hideLogIndicator; } set { _hideLogIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _investorCommitment;
+        private DirtyValue<string> _investorCommitment;
         public string InvestorCommitment { get { return _investorCommitment; } set { _investorCommitment = value; } }
-        private Value<bool?> _isFakeRequestIndicator;
+        private DirtyValue<bool?> _isFakeRequestIndicator;
         public bool? IsFakeRequestIndicator { get { return _isFakeRequestIndicator; } set { _isFakeRequestIndicator = value; } }
-        private Value<bool?> _isLockCancellationIndicator;
+        private DirtyValue<bool?> _isLockCancellationIndicator;
         public bool? IsLockCancellationIndicator { get { return _isLockCancellationIndicator; } set { _isLockCancellationIndicator = value; } }
-        private Value<bool?> _isLockExtensionIndicator;
+        private DirtyValue<bool?> _isLockExtensionIndicator;
         public bool? IsLockExtensionIndicator { get { return _isLockExtensionIndicator; } set { _isLockExtensionIndicator = value; } }
-        private Value<bool?> _isReLockIndicator;
+        private DirtyValue<bool?> _isReLockIndicator;
         public bool? IsReLockIndicator { get { return _isReLockIndicator; } set { _isReLockIndicator = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<int?> _numDayLocked;
+        private DirtyValue<int?> _numDayLocked;
         public int? NumDayLocked { get { return _numDayLocked; } set { _numDayLocked = value; } }
-        private Value<string> _parentLockGuid;
+        private DirtyValue<string> _parentLockGuid;
         public string ParentLockGuid { get { return _parentLockGuid; } set { _parentLockGuid = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<string> _requestedName;
+        private DirtyValue<string> _requestedName;
         public string RequestedName { get { return _requestedName; } set { _requestedName = value; } }
-        private Value<string> _requestedStatus;
+        private DirtyValue<string> _requestedStatus;
         public string RequestedStatus { get { return _requestedStatus; } set { _requestedStatus = value; } }
-        private Value<string> _sellSideDeliveredBy;
+        private DirtyValue<string> _sellSideDeliveredBy;
         public string SellSideDeliveredBy { get { return _sellSideDeliveredBy; } set { _sellSideDeliveredBy = value; } }
-        private Value<DateTime?> _sellSideDeliveryDate;
+        private DirtyValue<DateTime?> _sellSideDeliveryDate;
         public DateTime? SellSideDeliveryDate { get { return _sellSideDeliveryDate; } set { _sellSideDeliveryDate = value; } }
-        private Value<DateTime?> _sellSideExpirationDate;
+        private DirtyValue<DateTime?> _sellSideExpirationDate;
         public DateTime? SellSideExpirationDate { get { return _sellSideExpirationDate; } set { _sellSideExpirationDate = value; } }
-        private Value<DateTime?> _sellSideNewLockExtensionDate;
+        private DirtyValue<DateTime?> _sellSideNewLockExtensionDate;
         public DateTime? SellSideNewLockExtensionDate { get { return _sellSideNewLockExtensionDate; } set { _sellSideNewLockExtensionDate = value; } }
-        private Value<int?> _sellSideNumDayExtended;
+        private DirtyValue<int?> _sellSideNumDayExtended;
         public int? SellSideNumDayExtended { get { return _sellSideNumDayExtended; } set { _sellSideNumDayExtended = value; } }
-        private Value<string> _snapshotXml;
+        private DirtyValue<string> _snapshotXml;
         public string SnapshotXml { get { return _snapshotXml; } set { _snapshotXml = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _timeRequested;
+        private DirtyValue<string> _timeRequested;
         public string TimeRequested { get { return _timeRequested; } set { _timeRequested = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LogAlert.cs
+++ b/src/EncompassRest/Loans/LogAlert.cs
@@ -14,7 +14,8 @@ namespace EncompassRest.Loans
         public DateTime? FollowedUpDate { get { return _followedUpDate; } set { _followedUpDate = value; } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        public LogRecord LogRecord { get; set; }
+        private LogRecord _logRecord;
+        public LogRecord LogRecord { get { var v = _logRecord; return v ?? Interlocked.CompareExchange(ref _logRecord, (v = new LogRecord()), null) ?? v; } set { _logRecord = value; } }
         private Value<int?> _roleId;
         public int? RoleId { get { return _roleId; } set { _roleId = value; } }
         private Value<string> _systemId;
@@ -34,7 +35,7 @@ namespace EncompassRest.Loans
                     || _roleId.Dirty
                     || _systemId.Dirty
                     || _userId.Dirty
-                    || LogRecord?.Dirty == true;
+                    || _logRecord?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -47,7 +48,7 @@ namespace EncompassRest.Loans
                 _roleId.Dirty = value;
                 _systemId.Dirty = value;
                 _userId.Dirty = value;
-                if (LogRecord != null) LogRecord.Dirty = value;
+                if (_logRecord != null) _logRecord.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LogAlert.cs
+++ b/src/EncompassRest/Loans/LogAlert.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LogAlert : IDirty
     {
-        private Value<DateTime?> _dueDate;
+        private DirtyValue<DateTime?> _dueDate;
         public DateTime? DueDate { get { return _dueDate; } set { _dueDate = value; } }
-        private Value<DateTime?> _followedUpDate;
+        private DirtyValue<DateTime?> _followedUpDate;
         public DateTime? FollowedUpDate { get { return _followedUpDate; } set { _followedUpDate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private LogRecord _logRecord;
         public LogRecord LogRecord { get { var v = _logRecord; return v ?? Interlocked.CompareExchange(ref _logRecord, (v = new LogRecord()), null) ?? v; } set { _logRecord = value; } }
-        private Value<int?> _roleId;
+        private DirtyValue<int?> _roleId;
         public int? RoleId { get { return _roleId; } set { _roleId = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _userId;
+        private DirtyValue<string> _userId;
         public string UserId { get { return _userId; } set { _userId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LogComment.cs
+++ b/src/EncompassRest/Loans/LogComment.cs
@@ -8,25 +8,25 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LogComment : IDirty
     {
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<string> _addedByName;
+        private DirtyValue<string> _addedByName;
         public string AddedByName { get { return _addedByName; } set { _addedByName = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _date;
+        private DirtyValue<DateTime?> _date;
         public DateTime? Date { get { return _date; } set { _date = value; } }
-        private Value<int?> _forRoleId;
+        private DirtyValue<int?> _forRoleId;
         public int? ForRoleId { get { return _forRoleId; } set { _forRoleId = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isInternal;
+        private DirtyValue<bool?> _isInternal;
         public bool? IsInternal { get { return _isInternal; } set { _isInternal = value; } }
-        private Value<string> _reviewedBy;
+        private DirtyValue<string> _reviewedBy;
         public string ReviewedBy { get { return _reviewedBy; } set { _reviewedBy = value; } }
-        private Value<DateTime?> _reviewedDate;
+        private DirtyValue<DateTime?> _reviewedDate;
         public DateTime? ReviewedDate { get { return _reviewedDate; } set { _reviewedDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LogEntryLog.cs
+++ b/src/EncompassRest/Loans/LogEntryLog.cs
@@ -12,25 +12,25 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _userId;
+        private DirtyValue<string> _userId;
         public string UserId { get { return _userId; } set { _userId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LogEntryLog.cs
+++ b/src/EncompassRest/Loans/LogEntryLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LogEntryLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -39,9 +39,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _dateUtc.Dirty
                     || _description.Dirty
                     || _fileAttachmentsMigrated.Dirty
@@ -50,15 +48,15 @@ namespace EncompassRest.Loans
                     || _isSystemSpecificIndicator.Dirty
                     || _logRecordIndex.Dirty
                     || _systemId.Dirty
-                    || _userId.Dirty;
+                    || _userId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _description.Dirty = value;
@@ -69,6 +67,8 @@ namespace EncompassRest.Loans
                 _logRecordIndex.Dirty = value;
                 _systemId.Dirty = value;
                 _userId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LogRecord.cs
+++ b/src/EncompassRest/Loans/LogRecord.cs
@@ -8,8 +8,8 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LogRecord : IDirty
     {
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -33,22 +33,21 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _dateUtc.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _guid.Dirty
                     || _id.Dirty
                     || _isSystemSpecificIndicator.Dirty
                     || _logRecordIndex.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
@@ -57,6 +56,7 @@ namespace EncompassRest.Loans
                 _isSystemSpecificIndicator.Dirty = value;
                 _logRecordIndex.Dirty = value;
                 _systemId.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/LogRecord.cs
+++ b/src/EncompassRest/Loans/LogRecord.cs
@@ -10,21 +10,21 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/LogSnapshotField.cs
+++ b/src/EncompassRest/Loans/LogSnapshotField.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class LogSnapshotField : IDirty
     {
-        private Value<string> _fieldID;
+        private DirtyValue<string> _fieldID;
         public string FieldID { get { return _fieldID; } set { _fieldID = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _modalPath;
+        private DirtyValue<string> _modalPath;
         public string ModalPath { get { return _modalPath; } set { _modalPath = value; } }
-        private Value<string> _value;
+        private DirtyValue<string> _value;
         public string Value { get { return _value; } set { _value = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Mcaw.cs
+++ b/src/EncompassRest/Loans/Mcaw.cs
@@ -8,99 +8,99 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Mcaw : IDirty
     {
-        private Value<string> _adequacyOfAvailableAssetsType;
+        private DirtyValue<string> _adequacyOfAvailableAssetsType;
         public string AdequacyOfAvailableAssetsType { get { return _adequacyOfAvailableAssetsType; } set { _adequacyOfAvailableAssetsType = value; } }
-        private Value<string> _adequacyOfEffectiveIncomeType;
+        private DirtyValue<string> _adequacyOfEffectiveIncomeType;
         public string AdequacyOfEffectiveIncomeType { get { return _adequacyOfEffectiveIncomeType; } set { _adequacyOfEffectiveIncomeType = value; } }
-        private Value<decimal?> _adjustedPurchasePrice;
+        private DirtyValue<decimal?> _adjustedPurchasePrice;
         public decimal? AdjustedPurchasePrice { get { return _adjustedPurchasePrice; } set { _adjustedPurchasePrice = value; } }
-        private Value<decimal?> _appraisedValue1;
+        private DirtyValue<decimal?> _appraisedValue1;
         public decimal? AppraisedValue1 { get { return _appraisedValue1; } set { _appraisedValue1 = value; } }
-        private Value<decimal?> _appraisedValue2;
+        private DirtyValue<decimal?> _appraisedValue2;
         public decimal? AppraisedValue2 { get { return _appraisedValue2; } set { _appraisedValue2 = value; } }
-        private Value<decimal?> _borrowerPaidClosingCost;
+        private DirtyValue<decimal?> _borrowerPaidClosingCost;
         public decimal? BorrowerPaidClosingCost { get { return _borrowerPaidClosingCost; } set { _borrowerPaidClosingCost = value; } }
-        private Value<decimal?> _calculatedMortgageAmount;
+        private DirtyValue<decimal?> _calculatedMortgageAmount;
         public decimal? CalculatedMortgageAmount { get { return _calculatedMortgageAmount; } set { _calculatedMortgageAmount = value; } }
-        private Value<decimal?> _cashReserves;
+        private DirtyValue<decimal?> _cashReserves;
         public decimal? CashReserves { get { return _cashReserves; } set { _cashReserves = value; } }
-        private Value<string> _constructionType;
+        private DirtyValue<string> _constructionType;
         public string ConstructionType { get { return _constructionType; } set { _constructionType = value; } }
-        private Value<decimal?> _contractSalesPrice;
+        private DirtyValue<decimal?> _contractSalesPrice;
         public decimal? ContractSalesPrice { get { return _contractSalesPrice; } set { _contractSalesPrice = value; } }
-        private Value<string> _creditCharacteristicsType;
+        private DirtyValue<string> _creditCharacteristicsType;
         public string CreditCharacteristicsType { get { return _creditCharacteristicsType; } set { _creditCharacteristicsType = value; } }
-        private Value<decimal?> _equityToExSpouse;
+        private DirtyValue<decimal?> _equityToExSpouse;
         public decimal? EquityToExSpouse { get { return _equityToExSpouse; } set { _equityToExSpouse = value; } }
-        private Value<decimal?> _fhaMaxLoanAmount;
+        private DirtyValue<decimal?> _fhaMaxLoanAmount;
         public decimal? FhaMaxLoanAmount { get { return _fhaMaxLoanAmount; } set { _fhaMaxLoanAmount = value; } }
-        private Value<string> _fhaUnderwriterChumsId;
+        private DirtyValue<string> _fhaUnderwriterChumsId;
         public string FhaUnderwriterChumsId { get { return _fhaUnderwriterChumsId; } set { _fhaUnderwriterChumsId = value; } }
-        private Value<string> _giftFundsSource;
+        private DirtyValue<string> _giftFundsSource;
         public string GiftFundsSource { get { return _giftFundsSource; } set { _giftFundsSource = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _lesserSalesPrice;
+        private DirtyValue<decimal?> _lesserSalesPrice;
         public decimal? LesserSalesPrice { get { return _lesserSalesPrice; } set { _lesserSalesPrice = value; } }
-        private Value<decimal?> _ltv1;
+        private DirtyValue<decimal?> _ltv1;
         public decimal? Ltv1 { get { return _ltv1; } set { _ltv1 = value; } }
-        private Value<decimal?> _ltv2;
+        private DirtyValue<decimal?> _ltv2;
         public decimal? Ltv2 { get { return _ltv2; } set { _ltv2 = value; } }
-        private Value<decimal?> _maximumSellerContribution4Percent;
+        private DirtyValue<decimal?> _maximumSellerContribution4Percent;
         public decimal? MaximumSellerContribution4Percent { get { return _maximumSellerContribution4Percent; } set { _maximumSellerContribution4Percent = value; } }
-        private Value<decimal?> _mortgageAmount;
+        private DirtyValue<decimal?> _mortgageAmount;
         public decimal? MortgageAmount { get { return _mortgageAmount; } set { _mortgageAmount = value; } }
-        private Value<decimal?> _mortgageAmountPercent;
+        private DirtyValue<decimal?> _mortgageAmountPercent;
         public decimal? MortgageAmountPercent { get { return _mortgageAmountPercent; } set { _mortgageAmountPercent = value; } }
-        private Value<decimal?> _mortgageBasisPurchase;
+        private DirtyValue<decimal?> _mortgageBasisPurchase;
         public decimal? MortgageBasisPurchase { get { return _mortgageBasisPurchase; } set { _mortgageBasisPurchase = value; } }
-        private Value<decimal?> _mortgageBasisRefinance;
+        private DirtyValue<decimal?> _mortgageBasisRefinance;
         public decimal? MortgageBasisRefinance { get { return _mortgageBasisRefinance; } set { _mortgageBasisRefinance = value; } }
-        private Value<string> _paidType1;
+        private DirtyValue<string> _paidType1;
         public string PaidType1 { get { return _paidType1; } set { _paidType1 = value; } }
-        private Value<string> _paidType2;
+        private DirtyValue<string> _paidType2;
         public string PaidType2 { get { return _paidType2; } set { _paidType2 = value; } }
-        private Value<decimal?> _principalBalance;
+        private DirtyValue<decimal?> _principalBalance;
         public decimal? PrincipalBalance { get { return _principalBalance; } set { _principalBalance = value; } }
-        private Value<string> _refinanceType;
+        private DirtyValue<string> _refinanceType;
         public string RefinanceType { get { return _refinanceType; } set { _refinanceType = value; } }
-        private Value<string> _remarks;
+        private DirtyValue<string> _remarks;
         public string Remarks { get { return _remarks; } set { _remarks = value; } }
-        private Value<decimal?> _repairsAndImprovements;
+        private DirtyValue<decimal?> _repairsAndImprovements;
         public decimal? RepairsAndImprovements { get { return _repairsAndImprovements; } set { _repairsAndImprovements = value; } }
-        private Value<string> _repairsAndImprovementsDescription;
+        private DirtyValue<string> _repairsAndImprovementsDescription;
         public string RepairsAndImprovementsDescription { get { return _repairsAndImprovementsDescription; } set { _repairsAndImprovementsDescription = value; } }
-        private Value<decimal?> _repairsImprovementAmount;
+        private DirtyValue<decimal?> _repairsImprovementAmount;
         public decimal? RepairsImprovementAmount { get { return _repairsImprovementAmount; } set { _repairsImprovementAmount = value; } }
-        private Value<decimal?> _repairsRequiredByAppraiser;
+        private DirtyValue<decimal?> _repairsRequiredByAppraiser;
         public decimal? RepairsRequiredByAppraiser { get { return _repairsRequiredByAppraiser; } set { _repairsRequiredByAppraiser = value; } }
-        private Value<decimal?> _requiredInvestment;
+        private DirtyValue<decimal?> _requiredInvestment;
         public decimal? RequiredInvestment { get { return _requiredInvestment; } set { _requiredInvestment = value; } }
-        private Value<decimal?> _requirementAdjustment;
+        private DirtyValue<decimal?> _requirementAdjustment;
         public decimal? RequirementAdjustment { get { return _requirementAdjustment; } set { _requirementAdjustment = value; } }
-        private Value<bool?> _roundTo50Indicator;
+        private DirtyValue<bool?> _roundTo50Indicator;
         public bool? RoundTo50Indicator { get { return _roundTo50Indicator; } set { _roundTo50Indicator = value; } }
-        private Value<decimal?> _seasonedSubordinateLiens;
+        private DirtyValue<decimal?> _seasonedSubordinateLiens;
         public decimal? SeasonedSubordinateLiens { get { return _seasonedSubordinateLiens; } set { _seasonedSubordinateLiens = value; } }
-        private Value<string> _secondMortgageSource;
+        private DirtyValue<string> _secondMortgageSource;
         public string SecondMortgageSource { get { return _secondMortgageSource; } set { _secondMortgageSource = value; } }
-        private Value<decimal?> _sixPercentOfLineA1;
+        private DirtyValue<decimal?> _sixPercentOfLineA1;
         public decimal? SixPercentOfLineA1 { get { return _sixPercentOfLineA1; } set { _sixPercentOfLineA1 = value; } }
-        private Value<string> _stabilityOfEffectiveIncomeType;
+        private DirtyValue<string> _stabilityOfEffectiveIncomeType;
         public string StabilityOfEffectiveIncomeType { get { return _stabilityOfEffectiveIncomeType; } set { _stabilityOfEffectiveIncomeType = value; } }
-        private Value<decimal?> _statutoryInvestment;
+        private DirtyValue<decimal?> _statutoryInvestment;
         public decimal? StatutoryInvestment { get { return _statutoryInvestment; } set { _statutoryInvestment = value; } }
-        private Value<decimal?> _toBePaidAmount;
+        private DirtyValue<decimal?> _toBePaidAmount;
         public decimal? ToBePaidAmount { get { return _toBePaidAmount; } set { _toBePaidAmount = value; } }
-        private Value<decimal?> _totalCashToClose;
+        private DirtyValue<decimal?> _totalCashToClose;
         public decimal? TotalCashToClose { get { return _totalCashToClose; } set { _totalCashToClose = value; } }
-        private Value<decimal?> _totalRequirements;
+        private DirtyValue<decimal?> _totalRequirements;
         public decimal? TotalRequirements { get { return _totalRequirements; } set { _totalRequirements = value; } }
-        private Value<decimal?> _totalSellerContribution;
+        private DirtyValue<decimal?> _totalSellerContribution;
         public decimal? TotalSellerContribution { get { return _totalSellerContribution; } set { _totalSellerContribution = value; } }
-        private Value<decimal?> _unadjustedAcquisition;
+        private DirtyValue<decimal?> _unadjustedAcquisition;
         public decimal? UnadjustedAcquisition { get { return _unadjustedAcquisition; } set { _unadjustedAcquisition = value; } }
-        private Value<bool?> _use85PercentRuleIndicator;
+        private DirtyValue<bool?> _use85PercentRuleIndicator;
         public bool? Use85PercentRuleIndicator { get { return _use85PercentRuleIndicator; } set { _use85PercentRuleIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/MilestoneFreeRoleLog.cs
+++ b/src/EncompassRest/Loans/MilestoneFreeRoleLog.cs
@@ -12,23 +12,23 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
         private LoanAssociate _loanAssociate;
         public LoanAssociate LoanAssociate { get { var v = _loanAssociate; return v ?? Interlocked.CompareExchange(ref _loanAssociate, (v = new LoanAssociate()), null) ?? v; } set { _loanAssociate = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/MilestoneFreeRoleLog.cs
+++ b/src/EncompassRest/Loans/MilestoneFreeRoleLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class MilestoneFreeRoleLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -24,7 +24,8 @@ namespace EncompassRest.Loans
         public string Id { get { return _id; } set { _id = value; } }
         private Value<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        public LoanAssociate LoanAssociate { get; set; }
+        private LoanAssociate _loanAssociate;
+        public LoanAssociate LoanAssociate { get { var v = _loanAssociate; return v ?? Interlocked.CompareExchange(ref _loanAssociate, (v = new LoanAssociate()), null) ?? v; } set { _loanAssociate = value; } }
         private Value<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
         private Value<string> _systemId;
@@ -36,9 +37,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _dateUtc.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _guid.Dirty
@@ -46,15 +45,15 @@ namespace EncompassRest.Loans
                     || _isSystemSpecificIndicator.Dirty
                     || _logRecordIndex.Dirty
                     || _systemId.Dirty
-                    || LoanAssociate?.Dirty == true;
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _loanAssociate?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
@@ -63,7 +62,9 @@ namespace EncompassRest.Loans
                 _isSystemSpecificIndicator.Dirty = value;
                 _logRecordIndex.Dirty = value;
                 _systemId.Dirty = value;
-                if (LoanAssociate != null) LoanAssociate.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_loanAssociate != null) _loanAssociate.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/MilestoneLog.cs
+++ b/src/EncompassRest/Loans/MilestoneLog.cs
@@ -12,37 +12,37 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<int?> _days;
+        private DirtyValue<int?> _days;
         public int? Days { get { return _days; } set { _days = value; } }
-        private Value<bool?> _doneIndicator;
+        private DirtyValue<bool?> _doneIndicator;
         public bool? DoneIndicator { get { return _doneIndicator; } set { _doneIndicator = value; } }
-        private Value<int?> _duration;
+        private DirtyValue<int?> _duration;
         public int? Duration { get { return _duration; } set { _duration = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
         private LoanAssociate _loanAssociate;
         public LoanAssociate LoanAssociate { get { var v = _loanAssociate; return v ?? Interlocked.CompareExchange(ref _loanAssociate, (v = new LoanAssociate()), null) ?? v; } set { _loanAssociate = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _milestoneIdString;
+        private DirtyValue<string> _milestoneIdString;
         public string MilestoneIdString { get { return _milestoneIdString; } set { _milestoneIdString = value; } }
-        private Value<bool?> _reviewedIndicator;
+        private DirtyValue<bool?> _reviewedIndicator;
         public bool? ReviewedIndicator { get { return _reviewedIndicator; } set { _reviewedIndicator = value; } }
-        private Value<string> _roleRequired;
+        private DirtyValue<string> _roleRequired;
         public string RoleRequired { get { return _roleRequired; } set { _roleRequired = value; } }
-        private Value<string> _stage;
+        private DirtyValue<string> _stage;
         public string Stage { get { return _stage; } set { _stage = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/MilestoneLog.cs
+++ b/src/EncompassRest/Loans/MilestoneLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class MilestoneLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -30,7 +30,8 @@ namespace EncompassRest.Loans
         public string Id { get { return _id; } set { _id = value; } }
         private Value<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        public LoanAssociate LoanAssociate { get; set; }
+        private LoanAssociate _loanAssociate;
+        public LoanAssociate LoanAssociate { get { var v = _loanAssociate; return v ?? Interlocked.CompareExchange(ref _loanAssociate, (v = new LoanAssociate()), null) ?? v; } set { _loanAssociate = value; } }
         private Value<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
         private Value<string> _milestoneIdString;
@@ -50,9 +51,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _dateUtc.Dirty
                     || _days.Dirty
                     || _doneIndicator.Dirty
@@ -67,15 +66,15 @@ namespace EncompassRest.Loans
                     || _roleRequired.Dirty
                     || _stage.Dirty
                     || _systemId.Dirty
-                    || LoanAssociate?.Dirty == true;
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _loanAssociate?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _days.Dirty = value;
@@ -91,7 +90,9 @@ namespace EncompassRest.Loans
                 _roleRequired.Dirty = value;
                 _stage.Dirty = value;
                 _systemId.Dirty = value;
-                if (LoanAssociate != null) LoanAssociate.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_loanAssociate != null) _loanAssociate.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/MilestoneTaskContact.cs
+++ b/src/EncompassRest/Loans/MilestoneTaskContact.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class MilestoneTaskContact : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _contactId;
+        private DirtyValue<string> _contactId;
         public string ContactId { get { return _contactId; } set { _contactId = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _role;
+        private DirtyValue<string> _role;
         public string Role { get { return _role; } set { _role = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _zip;
+        private DirtyValue<string> _zip;
         public string Zip { get { return _zip; } set { _zip = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/MilestoneTaskLog.cs
+++ b/src/EncompassRest/Loans/MilestoneTaskLog.cs
@@ -14,12 +14,12 @@ namespace EncompassRest.Loans
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
         private Value<string> _addedByUserId;
         public string AddedByUserId { get { return _addedByUserId; } set { _addedByUserId = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -34,8 +34,8 @@ namespace EncompassRest.Loans
         public DateTime? CompletedDateUtc { get { return _completedDateUtc; } set { _completedDateUtc = value; } }
         private Value<int?> _contactCount;
         public int? ContactCount { get { return _contactCount; } set { _contactCount = value; } }
-        private Value<List<MilestoneTaskContact>> _contacts;
-        public List<MilestoneTaskContact> Contacts { get { return _contacts; } set { _contacts = value; } }
+        private DirtyList<MilestoneTaskContact> _contacts;
+        public IList<MilestoneTaskContact> Contacts { get { var v = _contacts; return v ?? Interlocked.CompareExchange(ref _contacts, (v = new DirtyList<MilestoneTaskContact>()), null) ?? v; } set { _contacts = new DirtyList<MilestoneTaskContact>(value); } }
         private Value<string> _contactsXml;
         public string ContactsXml { get { return _contactsXml; } set { _contactsXml = value; } }
         private Value<DateTime?> _dateUtc;
@@ -82,9 +82,7 @@ namespace EncompassRest.Loans
                 var dirty = _addDate.Dirty
                     || _addedBy.Dirty
                     || _addedByUserId.Dirty
-                    || _alerts.Dirty
                     || _alertsXml.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _completed.Dirty
@@ -92,7 +90,6 @@ namespace EncompassRest.Loans
                     || _completedByUserId.Dirty
                     || _completedDateUtc.Dirty
                     || _contactCount.Dirty
-                    || _contacts.Dirty
                     || _contactsXml.Dirty
                     || _dateUtc.Dirty
                     || _daysToComplete.Dirty
@@ -110,7 +107,10 @@ namespace EncompassRest.Loans
                     || _systemId.Dirty
                     || _taskDescription.Dirty
                     || _taskGuid.Dirty
-                    || _taskName.Dirty;
+                    || _taskName.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _contacts?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -120,9 +120,7 @@ namespace EncompassRest.Loans
                 _addDate.Dirty = value;
                 _addedBy.Dirty = value;
                 _addedByUserId.Dirty = value;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _completed.Dirty = value;
@@ -130,7 +128,6 @@ namespace EncompassRest.Loans
                 _completedByUserId.Dirty = value;
                 _completedDateUtc.Dirty = value;
                 _contactCount.Dirty = value;
-                _contacts.Dirty = value;
                 _contactsXml.Dirty = value;
                 _dateUtc.Dirty = value;
                 _daysToComplete.Dirty = value;
@@ -149,6 +146,9 @@ namespace EncompassRest.Loans
                 _taskDescription.Dirty = value;
                 _taskGuid.Dirty = value;
                 _taskName.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_contacts != null) _contacts.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/MilestoneTaskLog.cs
+++ b/src/EncompassRest/Loans/MilestoneTaskLog.cs
@@ -8,69 +8,69 @@ namespace EncompassRest.Loans
 {
     public sealed partial class MilestoneTaskLog : IDirty
     {
-        private Value<DateTime?> _addDate;
+        private DirtyValue<DateTime?> _addDate;
         public DateTime? AddDate { get { return _addDate; } set { _addDate = value; } }
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<string> _addedByUserId;
+        private DirtyValue<string> _addedByUserId;
         public string AddedByUserId { get { return _addedByUserId; } set { _addedByUserId = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<bool?> _completed;
+        private DirtyValue<bool?> _completed;
         public bool? Completed { get { return _completed; } set { _completed = value; } }
-        private Value<string> _completedBy;
+        private DirtyValue<string> _completedBy;
         public string CompletedBy { get { return _completedBy; } set { _completedBy = value; } }
-        private Value<string> _completedByUserId;
+        private DirtyValue<string> _completedByUserId;
         public string CompletedByUserId { get { return _completedByUserId; } set { _completedByUserId = value; } }
-        private Value<DateTime?> _completedDateUtc;
+        private DirtyValue<DateTime?> _completedDateUtc;
         public DateTime? CompletedDateUtc { get { return _completedDateUtc; } set { _completedDateUtc = value; } }
-        private Value<int?> _contactCount;
+        private DirtyValue<int?> _contactCount;
         public int? ContactCount { get { return _contactCount; } set { _contactCount = value; } }
         private DirtyList<MilestoneTaskContact> _contacts;
         public IList<MilestoneTaskContact> Contacts { get { var v = _contacts; return v ?? Interlocked.CompareExchange(ref _contacts, (v = new DirtyList<MilestoneTaskContact>()), null) ?? v; } set { _contacts = new DirtyList<MilestoneTaskContact>(value); } }
-        private Value<string> _contactsXml;
+        private DirtyValue<string> _contactsXml;
         public string ContactsXml { get { return _contactsXml; } set { _contactsXml = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<int?> _daysToComplete;
+        private DirtyValue<int?> _daysToComplete;
         public int? DaysToComplete { get { return _daysToComplete; } set { _daysToComplete = value; } }
-        private Value<int?> _daysToCompleteFromSetting;
+        private DirtyValue<int?> _daysToCompleteFromSetting;
         public int? DaysToCompleteFromSetting { get { return _daysToCompleteFromSetting; } set { _daysToCompleteFromSetting = value; } }
-        private Value<DateTime?> _expectedDate;
+        private DirtyValue<DateTime?> _expectedDate;
         public DateTime? ExpectedDate { get { return _expectedDate; } set { _expectedDate = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isRequiredIndicator;
+        private DirtyValue<bool?> _isRequiredIndicator;
         public bool? IsRequiredIndicator { get { return _isRequiredIndicator; } set { _isRequiredIndicator = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<DateTime?> _milestoneTaskLogDateUtc;
+        private DirtyValue<DateTime?> _milestoneTaskLogDateUtc;
         public DateTime? MilestoneTaskLogDateUtc { get { return _milestoneTaskLogDateUtc; } set { _milestoneTaskLogDateUtc = value; } }
-        private Value<string> _priority;
+        private DirtyValue<string> _priority;
         public string Priority { get { return _priority; } set { _priority = value; } }
-        private Value<string> _stage;
+        private DirtyValue<string> _stage;
         public string Stage { get { return _stage; } set { _stage = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _taskDescription;
+        private DirtyValue<string> _taskDescription;
         public string TaskDescription { get { return _taskDescription; } set { _taskDescription = value; } }
-        private Value<string> _taskGuid;
+        private DirtyValue<string> _taskGuid;
         public string TaskGuid { get { return _taskGuid; } set { _taskGuid = value; } }
-        private Value<string> _taskName;
+        private DirtyValue<string> _taskName;
         public string TaskName { get { return _taskName; } set { _taskName = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/MilestoneTemplateLog.cs
+++ b/src/EncompassRest/Loans/MilestoneTemplateLog.cs
@@ -8,17 +8,17 @@ namespace EncompassRest.Loans
 {
     public sealed partial class MilestoneTemplateLog : IDirty
     {
-        private Value<int?> _elliLogRecordId;
+        private DirtyValue<int?> _elliLogRecordId;
         public int? ElliLogRecordId { get { return _elliLogRecordId; } set { _elliLogRecordId = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isTemplateDatesLocked;
+        private DirtyValue<bool?> _isTemplateDatesLocked;
         public bool? IsTemplateDatesLocked { get { return _isTemplateDatesLocked; } set { _isTemplateDatesLocked = value; } }
-        private Value<bool?> _isTemplateLocked;
+        private DirtyValue<bool?> _isTemplateLocked;
         public bool? IsTemplateLocked { get { return _isTemplateLocked; } set { _isTemplateLocked = value; } }
-        private Value<string> _milestoneTemplateID;
+        private DirtyValue<string> _milestoneTemplateID;
         public string MilestoneTemplateID { get { return _milestoneTemplateID; } set { _milestoneTemplateID = value; } }
-        private Value<string> _milestoneTemplateName;
+        private DirtyValue<string> _milestoneTemplateName;
         public string MilestoneTemplateName { get { return _milestoneTemplateName; } set { _milestoneTemplateName = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/MilitaryService.cs
+++ b/src/EncompassRest/Loans/MilitaryService.cs
@@ -8,23 +8,23 @@ namespace EncompassRest.Loans
 {
     public sealed partial class MilitaryService : IDirty
     {
-        private Value<string> _branch;
+        private DirtyValue<string> _branch;
         public string Branch { get { return _branch; } set { _branch = value; } }
-        private Value<DateTime?> _endDate;
+        private DirtyValue<DateTime?> _endDate;
         public DateTime? EndDate { get { return _endDate; } set { _endDate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _militaryServiceIndex;
+        private DirtyValue<int?> _militaryServiceIndex;
         public int? MilitaryServiceIndex { get { return _militaryServiceIndex; } set { _militaryServiceIndex = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _officerOrEnlisted;
+        private DirtyValue<string> _officerOrEnlisted;
         public string OfficerOrEnlisted { get { return _officerOrEnlisted; } set { _officerOrEnlisted = value; } }
-        private Value<string> _serviceNumber;
+        private DirtyValue<string> _serviceNumber;
         public string ServiceNumber { get { return _serviceNumber; } set { _serviceNumber = value; } }
-        private Value<string> _sSN;
+        private DirtyValue<string> _sSN;
         public string SSN { get { return _sSN; } set { _sSN = value; } }
-        private Value<DateTime?> _startDate;
+        private DirtyValue<DateTime?> _startDate;
         public DateTime? StartDate { get { return _startDate; } set { _startDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Miscellaneous.cs
+++ b/src/EncompassRest/Loans/Miscellaneous.cs
@@ -32,6 +32,14 @@ namespace EncompassRest.Loans
         public string ClosingTaxYear { get { return _closingTaxYear; } set { _closingTaxYear = value; } }
         private Value<decimal?> _closingTaxYearInterestReceived;
         public decimal? ClosingTaxYearInterestReceived { get { return _closingTaxYearInterestReceived; } set { _closingTaxYearInterestReceived = value; } }
+        private Value<string> _contactFax;
+        public string ContactFax { get { return _contactFax; } set { _contactFax = value; } }
+        private Value<string> _contactName;
+        public string ContactName { get { return _contactName; } set { _contactName = value; } }
+        private Value<string> _contactPhone;
+        public string ContactPhone { get { return _contactPhone; } set { _contactPhone = value; } }
+        private Value<string> _contactTitle;
+        public string ContactTitle { get { return _contactTitle; } set { _contactTitle = value; } }
         private Value<bool?> _copyFromSubjectProperty;
         public bool? CopyFromSubjectProperty { get { return _copyFromSubjectProperty; } set { _copyFromSubjectProperty = value; } }
         private Value<string> _dataTracLoanId;
@@ -213,6 +221,10 @@ namespace EncompassRest.Loans
                     || _closingCostProgramFile.Dirty
                     || _closingTaxYear.Dirty
                     || _closingTaxYearInterestReceived.Dirty
+                    || _contactFax.Dirty
+                    || _contactName.Dirty
+                    || _contactPhone.Dirty
+                    || _contactTitle.Dirty
                     || _copyFromSubjectProperty.Dirty
                     || _dataTracLoanId.Dirty
                     || _docSetFile.Dirty
@@ -312,6 +324,10 @@ namespace EncompassRest.Loans
                 _closingCostProgramFile.Dirty = value;
                 _closingTaxYear.Dirty = value;
                 _closingTaxYearInterestReceived.Dirty = value;
+                _contactFax.Dirty = value;
+                _contactName.Dirty = value;
+                _contactPhone.Dirty = value;
+                _contactTitle.Dirty = value;
                 _copyFromSubjectProperty.Dirty = value;
                 _dataTracLoanId.Dirty = value;
                 _docSetFile.Dirty = value;

--- a/src/EncompassRest/Loans/Miscellaneous.cs
+++ b/src/EncompassRest/Loans/Miscellaneous.cs
@@ -8,199 +8,199 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Miscellaneous : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _borrowerDescription1;
+        private DirtyValue<string> _borrowerDescription1;
         public string BorrowerDescription1 { get { return _borrowerDescription1; } set { _borrowerDescription1 = value; } }
-        private Value<string> _borrowerDescription2;
+        private DirtyValue<string> _borrowerDescription2;
         public string BorrowerDescription2 { get { return _borrowerDescription2; } set { _borrowerDescription2 = value; } }
-        private Value<string> _borrowerDescription3;
+        private DirtyValue<string> _borrowerDescription3;
         public string BorrowerDescription3 { get { return _borrowerDescription3; } set { _borrowerDescription3 = value; } }
-        private Value<string> _borrowerDescription4;
+        private DirtyValue<string> _borrowerDescription4;
         public string BorrowerDescription4 { get { return _borrowerDescription4; } set { _borrowerDescription4 = value; } }
-        private Value<string> _borrowerDescription5;
+        private DirtyValue<string> _borrowerDescription5;
         public string BorrowerDescription5 { get { return _borrowerDescription5; } set { _borrowerDescription5 = value; } }
-        private Value<string> _borrowerDescription6;
+        private DirtyValue<string> _borrowerDescription6;
         public string BorrowerDescription6 { get { return _borrowerDescription6; } set { _borrowerDescription6 = value; } }
-        private Value<string> _borrowerDescription7;
+        private DirtyValue<string> _borrowerDescription7;
         public string BorrowerDescription7 { get { return _borrowerDescription7; } set { _borrowerDescription7 = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _closingCostProgramFile;
+        private DirtyValue<string> _closingCostProgramFile;
         public string ClosingCostProgramFile { get { return _closingCostProgramFile; } set { _closingCostProgramFile = value; } }
-        private Value<string> _closingTaxYear;
+        private DirtyValue<string> _closingTaxYear;
         public string ClosingTaxYear { get { return _closingTaxYear; } set { _closingTaxYear = value; } }
-        private Value<decimal?> _closingTaxYearInterestReceived;
+        private DirtyValue<decimal?> _closingTaxYearInterestReceived;
         public decimal? ClosingTaxYearInterestReceived { get { return _closingTaxYearInterestReceived; } set { _closingTaxYearInterestReceived = value; } }
-        private Value<string> _contactFax;
+        private DirtyValue<string> _contactFax;
         public string ContactFax { get { return _contactFax; } set { _contactFax = value; } }
-        private Value<string> _contactName;
+        private DirtyValue<string> _contactName;
         public string ContactName { get { return _contactName; } set { _contactName = value; } }
-        private Value<string> _contactPhone;
+        private DirtyValue<string> _contactPhone;
         public string ContactPhone { get { return _contactPhone; } set { _contactPhone = value; } }
-        private Value<string> _contactTitle;
+        private DirtyValue<string> _contactTitle;
         public string ContactTitle { get { return _contactTitle; } set { _contactTitle = value; } }
-        private Value<bool?> _copyFromSubjectProperty;
+        private DirtyValue<bool?> _copyFromSubjectProperty;
         public bool? CopyFromSubjectProperty { get { return _copyFromSubjectProperty; } set { _copyFromSubjectProperty = value; } }
-        private Value<string> _dataTracLoanId;
+        private DirtyValue<string> _dataTracLoanId;
         public string DataTracLoanId { get { return _dataTracLoanId; } set { _dataTracLoanId = value; } }
-        private Value<string> _docSetFile;
+        private DirtyValue<string> _docSetFile;
         public string DocSetFile { get { return _docSetFile; } set { _docSetFile = value; } }
-        private Value<int?> _factorForRevolvingDebt;
+        private DirtyValue<int?> _factorForRevolvingDebt;
         public int? FactorForRevolvingDebt { get { return _factorForRevolvingDebt; } set { _factorForRevolvingDebt = value; } }
-        private Value<bool?> _fannieDuAutoOrderIndicator;
+        private DirtyValue<bool?> _fannieDuAutoOrderIndicator;
         public bool? FannieDuAutoOrderIndicator { get { return _fannieDuAutoOrderIndicator; } set { _fannieDuAutoOrderIndicator = value; } }
-        private Value<bool?> _fannieEcAutoOrderIndicator;
+        private DirtyValue<bool?> _fannieEcAutoOrderIndicator;
         public bool? FannieEcAutoOrderIndicator { get { return _fannieEcAutoOrderIndicator; } set { _fannieEcAutoOrderIndicator = value; } }
-        private Value<string> _floodInsuranceExcluded;
+        private DirtyValue<string> _floodInsuranceExcluded;
         public string FloodInsuranceExcluded { get { return _floodInsuranceExcluded; } set { _floodInsuranceExcluded = value; } }
-        private Value<string> _formListFile;
+        private DirtyValue<string> _formListFile;
         public string FormListFile { get { return _formListFile; } set { _formListFile = value; } }
-        private Value<bool?> _freddieLPAAutoOrderIndicator;
+        private DirtyValue<bool?> _freddieLPAAutoOrderIndicator;
         public bool? FreddieLPAAutoOrderIndicator { get { return _freddieLPAAutoOrderIndicator; } set { _freddieLPAAutoOrderIndicator = value; } }
-        private Value<bool?> _freddieLQAAutoOrderIndicator;
+        private DirtyValue<bool?> _freddieLQAAutoOrderIndicator;
         public bool? FreddieLQAAutoOrderIndicator { get { return _freddieLQAAutoOrderIndicator; } set { _freddieLQAAutoOrderIndicator = value; } }
-        private Value<decimal?> _housingExpenseIntRate1;
+        private DirtyValue<decimal?> _housingExpenseIntRate1;
         public decimal? HousingExpenseIntRate1 { get { return _housingExpenseIntRate1; } set { _housingExpenseIntRate1 = value; } }
-        private Value<decimal?> _housingExpenseIntRate2;
+        private DirtyValue<decimal?> _housingExpenseIntRate2;
         public decimal? HousingExpenseIntRate2 { get { return _housingExpenseIntRate2; } set { _housingExpenseIntRate2 = value; } }
-        private Value<decimal?> _housingExpenseLoanAmt1;
+        private DirtyValue<decimal?> _housingExpenseLoanAmt1;
         public decimal? HousingExpenseLoanAmt1 { get { return _housingExpenseLoanAmt1; } set { _housingExpenseLoanAmt1 = value; } }
-        private Value<decimal?> _housingExpenseLoanAmt2;
+        private DirtyValue<decimal?> _housingExpenseLoanAmt2;
         public decimal? HousingExpenseLoanAmt2 { get { return _housingExpenseLoanAmt2; } set { _housingExpenseLoanAmt2 = value; } }
-        private Value<decimal?> _housingExpensePayment1;
+        private DirtyValue<decimal?> _housingExpensePayment1;
         public decimal? HousingExpensePayment1 { get { return _housingExpensePayment1; } set { _housingExpensePayment1 = value; } }
-        private Value<decimal?> _housingExpensePayment2;
+        private DirtyValue<decimal?> _housingExpensePayment2;
         public decimal? HousingExpensePayment2 { get { return _housingExpensePayment2; } set { _housingExpensePayment2 = value; } }
-        private Value<int?> _housingExpenseTerm1;
+        private DirtyValue<int?> _housingExpenseTerm1;
         public int? HousingExpenseTerm1 { get { return _housingExpenseTerm1; } set { _housingExpenseTerm1 = value; } }
-        private Value<int?> _housingExpenseTerm2;
+        private DirtyValue<int?> _housingExpenseTerm2;
         public int? HousingExpenseTerm2 { get { return _housingExpenseTerm2; } set { _housingExpenseTerm2 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSameAddresswithPayer;
+        private DirtyValue<bool?> _isSameAddresswithPayer;
         public bool? IsSameAddresswithPayer { get { return _isSameAddresswithPayer; } set { _isSameAddresswithPayer = value; } }
-        private Value<string> _line1006Excluded;
+        private DirtyValue<string> _line1006Excluded;
         public string Line1006Excluded { get { return _line1006Excluded; } set { _line1006Excluded = value; } }
-        private Value<string> _line1007Excluded;
+        private DirtyValue<string> _line1007Excluded;
         public string Line1007Excluded { get { return _line1007Excluded; } set { _line1007Excluded = value; } }
-        private Value<string> _line1008Excluded;
+        private DirtyValue<string> _line1008Excluded;
         public string Line1008Excluded { get { return _line1008Excluded; } set { _line1008Excluded = value; } }
-        private Value<string> _line1010Excluded;
+        private DirtyValue<string> _line1010Excluded;
         public string Line1010Excluded { get { return _line1010Excluded; } set { _line1010Excluded = value; } }
-        private Value<string> _loanProgramFile;
+        private DirtyValue<string> _loanProgramFile;
         public string LoanProgramFile { get { return _loanProgramFile; } set { _loanProgramFile = value; } }
-        private Value<string> _loanTemplateFile;
+        private DirtyValue<string> _loanTemplateFile;
         public string LoanTemplateFile { get { return _loanTemplateFile; } set { _loanTemplateFile = value; } }
-        private Value<string> _maventATRQMResult;
+        private DirtyValue<string> _maventATRQMResult;
         public string MaventATRQMResult { get { return _maventATRQMResult; } set { _maventATRQMResult = value; } }
-        private Value<bool?> _maventAutoOrderIndicator;
+        private DirtyValue<bool?> _maventAutoOrderIndicator;
         public bool? MaventAutoOrderIndicator { get { return _maventAutoOrderIndicator; } set { _maventAutoOrderIndicator = value; } }
-        private Value<string> _maventCraxResult;
+        private DirtyValue<string> _maventCraxResult;
         public string MaventCraxResult { get { return _maventCraxResult; } set { _maventCraxResult = value; } }
-        private Value<string> _maventEnterpriseResult;
+        private DirtyValue<string> _maventEnterpriseResult;
         public string MaventEnterpriseResult { get { return _maventEnterpriseResult; } set { _maventEnterpriseResult = value; } }
-        private Value<string> _maventGseResult;
+        private DirtyValue<string> _maventGseResult;
         public string MaventGseResult { get { return _maventGseResult; } set { _maventGseResult = value; } }
-        private Value<string> _maventHighCostResult;
+        private DirtyValue<string> _maventHighCostResult;
         public string MaventHighCostResult { get { return _maventHighCostResult; } set { _maventHighCostResult = value; } }
-        private Value<string> _maventHmdaResult;
+        private DirtyValue<string> _maventHmdaResult;
         public string MaventHmdaResult { get { return _maventHmdaResult; } set { _maventHmdaResult = value; } }
-        private Value<string> _maventHpmlResult;
+        private DirtyValue<string> _maventHpmlResult;
         public string MaventHpmlResult { get { return _maventHpmlResult; } set { _maventHpmlResult = value; } }
-        private Value<string> _maventLicenseResult;
+        private DirtyValue<string> _maventLicenseResult;
         public string MaventLicenseResult { get { return _maventLicenseResult; } set { _maventLicenseResult = value; } }
-        private Value<string> _maventNmlsResult;
+        private DirtyValue<string> _maventNmlsResult;
         public string MaventNmlsResult { get { return _maventNmlsResult; } set { _maventNmlsResult = value; } }
-        private Value<string> _maventOfacResult;
+        private DirtyValue<string> _maventOfacResult;
         public string MaventOfacResult { get { return _maventOfacResult; } set { _maventOfacResult = value; } }
-        private Value<string> _maventOrderedBy;
+        private DirtyValue<string> _maventOrderedBy;
         public string MaventOrderedBy { get { return _maventOrderedBy; } set { _maventOrderedBy = value; } }
-        private Value<DateTime?> _maventOrderedDate;
+        private DirtyValue<DateTime?> _maventOrderedDate;
         public DateTime? MaventOrderedDate { get { return _maventOrderedDate; } set { _maventOrderedDate = value; } }
-        private Value<string> _maventOtherResult;
+        private DirtyValue<string> _maventOtherResult;
         public string MaventOtherResult { get { return _maventOtherResult; } set { _maventOtherResult = value; } }
-        private Value<string> _maventReviewResult;
+        private DirtyValue<string> _maventReviewResult;
         public string MaventReviewResult { get { return _maventReviewResult; } set { _maventReviewResult = value; } }
-        private Value<string> _maventStateResult;
+        private DirtyValue<string> _maventStateResult;
         public string MaventStateResult { get { return _maventStateResult; } set { _maventStateResult = value; } }
-        private Value<string> _maventTilaRorResult;
+        private DirtyValue<string> _maventTilaRorResult;
         public string MaventTilaRorResult { get { return _maventTilaRorResult; } set { _maventTilaRorResult = value; } }
-        private Value<string> _maventTilaToleranceResult;
+        private DirtyValue<string> _maventTilaToleranceResult;
         public string MaventTilaToleranceResult { get { return _maventTilaToleranceResult; } set { _maventTilaToleranceResult = value; } }
-        private Value<decimal?> _mIPremiums;
+        private DirtyValue<decimal?> _mIPremiums;
         public decimal? MIPremiums { get { return _mIPremiums; } set { _mIPremiums = value; } }
-        private Value<string> _miscDataFile;
+        private DirtyValue<string> _miscDataFile;
         public string MiscDataFile { get { return _miscDataFile; } set { _miscDataFile = value; } }
-        private Value<int?> _monthsToExclude;
+        private DirtyValue<int?> _monthsToExclude;
         public int? MonthsToExclude { get { return _monthsToExclude; } set { _monthsToExclude = value; } }
-        private Value<string> _optimalBlueHistoryData;
+        private DirtyValue<string> _optimalBlueHistoryData;
         public string OptimalBlueHistoryData { get { return _optimalBlueHistoryData; } set { _optimalBlueHistoryData = value; } }
-        private Value<string> _optimalBlueRequest;
+        private DirtyValue<string> _optimalBlueRequest;
         public string OptimalBlueRequest { get { return _optimalBlueRequest; } set { _optimalBlueRequest = value; } }
-        private Value<string> _optimalBlueResponse;
+        private DirtyValue<string> _optimalBlueResponse;
         public string OptimalBlueResponse { get { return _optimalBlueResponse; } set { _optimalBlueResponse = value; } }
-        private Value<decimal?> _otherPresentHousingExpense;
+        private DirtyValue<decimal?> _otherPresentHousingExpense;
         public decimal? OtherPresentHousingExpense { get { return _otherPresentHousingExpense; } set { _otherPresentHousingExpense = value; } }
-        private Value<decimal?> _outstandingMtgPrincipal;
+        private DirtyValue<decimal?> _outstandingMtgPrincipal;
         public decimal? OutstandingMtgPrincipal { get { return _outstandingMtgPrincipal; } set { _outstandingMtgPrincipal = value; } }
-        private Value<DateTime?> _outstandingMtgPrincipalDate;
+        private DirtyValue<DateTime?> _outstandingMtgPrincipalDate;
         public DateTime? OutstandingMtgPrincipalDate { get { return _outstandingMtgPrincipalDate; } set { _outstandingMtgPrincipalDate = value; } }
-        private Value<bool?> _participateHomePoints;
+        private DirtyValue<bool?> _participateHomePoints;
         public bool? ParticipateHomePoints { get { return _participateHomePoints; } set { _participateHomePoints = value; } }
-        private Value<string> _partnerEmail;
+        private DirtyValue<string> _partnerEmail;
         public string PartnerEmail { get { return _partnerEmail; } set { _partnerEmail = value; } }
-        private Value<string> _partnerName;
+        private DirtyValue<string> _partnerName;
         public string PartnerName { get { return _partnerName; } set { _partnerName = value; } }
-        private Value<string> _partnerPhone;
+        private DirtyValue<string> _partnerPhone;
         public string PartnerPhone { get { return _partnerPhone; } set { _partnerPhone = value; } }
-        private Value<decimal?> _pointsPaid;
+        private DirtyValue<decimal?> _pointsPaid;
         public decimal? PointsPaid { get { return _pointsPaid; } set { _pointsPaid = value; } }
-        private Value<DateTime?> _rateRegistrationExpirationDate;
+        private DirtyValue<DateTime?> _rateRegistrationExpirationDate;
         public DateTime? RateRegistrationExpirationDate { get { return _rateRegistrationExpirationDate; } set { _rateRegistrationExpirationDate = value; } }
-        private Value<string> _rateRegistrationInvestorName;
+        private DirtyValue<string> _rateRegistrationInvestorName;
         public string RateRegistrationInvestorName { get { return _rateRegistrationInvestorName; } set { _rateRegistrationInvestorName = value; } }
-        private Value<bool?> _rateRegistrationLoanIsRegistered;
+        private DirtyValue<bool?> _rateRegistrationLoanIsRegistered;
         public bool? RateRegistrationLoanIsRegistered { get { return _rateRegistrationLoanIsRegistered; } set { _rateRegistrationLoanIsRegistered = value; } }
-        private Value<string> _rateRegistrationReference;
+        private DirtyValue<string> _rateRegistrationReference;
         public string RateRegistrationReference { get { return _rateRegistrationReference; } set { _rateRegistrationReference = value; } }
-        private Value<string> _rateRegistrationRegisteredBy;
+        private DirtyValue<string> _rateRegistrationRegisteredBy;
         public string RateRegistrationRegisteredBy { get { return _rateRegistrationRegisteredBy; } set { _rateRegistrationRegisteredBy = value; } }
-        private Value<string> _rateRegistrationRegisteredUserId;
+        private DirtyValue<string> _rateRegistrationRegisteredUserId;
         public string RateRegistrationRegisteredUserId { get { return _rateRegistrationRegisteredUserId; } set { _rateRegistrationRegisteredUserId = value; } }
-        private Value<DateTime?> _rateRegistrationRegistrationDate;
+        private DirtyValue<DateTime?> _rateRegistrationRegistrationDate;
         public DateTime? RateRegistrationRegistrationDate { get { return _rateRegistrationRegistrationDate; } set { _rateRegistrationRegistrationDate = value; } }
-        private Value<decimal?> _refundOrOverpaidInterest;
+        private DirtyValue<decimal?> _refundOrOverpaidInterest;
         public decimal? RefundOrOverpaidInterest { get { return _refundOrOverpaidInterest; } set { _refundOrOverpaidInterest = value; } }
-        private Value<string> _schoolTaxExcluded;
+        private DirtyValue<string> _schoolTaxExcluded;
         public string SchoolTaxExcluded { get { return _schoolTaxExcluded; } set { _schoolTaxExcluded = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _statusUrl;
+        private DirtyValue<string> _statusUrl;
         public string StatusUrl { get { return _statusUrl; } set { _statusUrl = value; } }
-        private Value<DateTime?> _submitDate;
+        private DirtyValue<DateTime?> _submitDate;
         public DateTime? SubmitDate { get { return _submitDate; } set { _submitDate = value; } }
-        private Value<string> _subTaxYear;
+        private DirtyValue<string> _subTaxYear;
         public string SubTaxYear { get { return _subTaxYear; } set { _subTaxYear = value; } }
-        private Value<decimal?> _subTaxYearInterestReceived;
+        private DirtyValue<decimal?> _subTaxYearInterestReceived;
         public decimal? SubTaxYearInterestReceived { get { return _subTaxYearInterestReceived; } set { _subTaxYearInterestReceived = value; } }
-        private Value<decimal?> _subTaxYearMIPremiums;
+        private DirtyValue<decimal?> _subTaxYearMIPremiums;
         public decimal? SubTaxYearMIPremiums { get { return _subTaxYearMIPremiums; } set { _subTaxYearMIPremiums = value; } }
-        private Value<decimal?> _subTaxYearPointsPaid;
+        private DirtyValue<decimal?> _subTaxYearPointsPaid;
         public decimal? SubTaxYearPointsPaid { get { return _subTaxYearPointsPaid; } set { _subTaxYearPointsPaid = value; } }
-        private Value<decimal?> _subTaxYearRefundOrOverpaidInterest;
+        private DirtyValue<decimal?> _subTaxYearRefundOrOverpaidInterest;
         public decimal? SubTaxYearRefundOrOverpaidInterest { get { return _subTaxYearRefundOrOverpaidInterest; } set { _subTaxYearRefundOrOverpaidInterest = value; } }
-        private Value<string> _taxId;
+        private DirtyValue<string> _taxId;
         public string TaxId { get { return _taxId; } set { _taxId = value; } }
-        private Value<decimal?> _totalBox4;
+        private DirtyValue<decimal?> _totalBox4;
         public decimal? TotalBox4 { get { return _totalBox4; } set { _totalBox4 = value; } }
-        private Value<decimal?> _totalYearlyMi;
+        private DirtyValue<decimal?> _totalYearlyMi;
         public decimal? TotalYearlyMi { get { return _totalYearlyMi; } set { _totalYearlyMi = value; } }
-        private Value<string> _useGfeTax;
+        private DirtyValue<string> _useGfeTax;
         public string UseGfeTax { get { return _useGfeTax; } set { _useGfeTax = value; } }
-        private Value<string> _useRegZMi;
+        private DirtyValue<string> _useRegZMi;
         public string UseRegZMi { get { return _useRegZMi; } set { _useRegZMi = value; } }
-        private Value<string> _zip;
+        private DirtyValue<string> _zip;
         public string Zip { get { return _zip; } set { _zip = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/NetTangibleBenefit.cs
+++ b/src/EncompassRest/Loans/NetTangibleBenefit.cs
@@ -8,141 +8,141 @@ namespace EncompassRest.Loans
 {
     public sealed partial class NetTangibleBenefit : IDirty
     {
-        private Value<bool?> _aprNotExceedIndicator;
+        private DirtyValue<bool?> _aprNotExceedIndicator;
         public bool? AprNotExceedIndicator { get { return _aprNotExceedIndicator; } set { _aprNotExceedIndicator = value; } }
-        private Value<bool?> _avoidingForeclosureIndicator;
+        private DirtyValue<bool?> _avoidingForeclosureIndicator;
         public bool? AvoidingForeclosureIndicator { get { return _avoidingForeclosureIndicator; } set { _avoidingForeclosureIndicator = value; } }
-        private Value<bool?> _beneficialChangedForBorrowerIndicator;
+        private DirtyValue<bool?> _beneficialChangedForBorrowerIndicator;
         public bool? BeneficialChangedForBorrowerIndicator { get { return _beneficialChangedForBorrowerIndicator; } set { _beneficialChangedForBorrowerIndicator = value; } }
-        private Value<string> _bonaFideFinancialEmergency;
+        private DirtyValue<string> _bonaFideFinancialEmergency;
         public string BonaFideFinancialEmergency { get { return _bonaFideFinancialEmergency; } set { _bonaFideFinancialEmergency = value; } }
-        private Value<bool?> _borrowerCanRecoupCostofRefinancingIndicator;
+        private DirtyValue<bool?> _borrowerCanRecoupCostofRefinancingIndicator;
         public bool? BorrowerCanRecoupCostofRefinancingIndicator { get { return _borrowerCanRecoupCostofRefinancingIndicator; } set { _borrowerCanRecoupCostofRefinancingIndicator = value; } }
-        private Value<bool?> _borrowerCanRecoupIndicator;
+        private DirtyValue<bool?> _borrowerCanRecoupIndicator;
         public bool? BorrowerCanRecoupIndicator { get { return _borrowerCanRecoupIndicator; } set { _borrowerCanRecoupIndicator = value; } }
-        private Value<bool?> _borrowerMonthlyPaymentLowerThan20Indicator;
+        private DirtyValue<bool?> _borrowerMonthlyPaymentLowerThan20Indicator;
         public bool? BorrowerMonthlyPaymentLowerThan20Indicator { get { return _borrowerMonthlyPaymentLowerThan20Indicator; } set { _borrowerMonthlyPaymentLowerThan20Indicator = value; } }
-        private Value<string> _borrowerReceivedReasonable;
+        private DirtyValue<string> _borrowerReceivedReasonable;
         public string BorrowerReceivedReasonable { get { return _borrowerReceivedReasonable; } set { _borrowerReceivedReasonable = value; } }
-        private Value<bool?> _borrowerReceivesAmountExcessCostAndFeesIndicator;
+        private DirtyValue<bool?> _borrowerReceivesAmountExcessCostAndFeesIndicator;
         public bool? BorrowerReceivesAmountExcessCostAndFeesIndicator { get { return _borrowerReceivesAmountExcessCostAndFeesIndicator; } set { _borrowerReceivesAmountExcessCostAndFeesIndicator = value; } }
-        private Value<bool?> _changeLoanFromArmtoFixedIndicator;
+        private DirtyValue<bool?> _changeLoanFromArmtoFixedIndicator;
         public bool? ChangeLoanFromArmtoFixedIndicator { get { return _changeLoanFromArmtoFixedIndicator; } set { _changeLoanFromArmtoFixedIndicator = value; } }
-        private Value<bool?> _changingLoanToFixedRateIndicator;
+        private DirtyValue<bool?> _changingLoanToFixedRateIndicator;
         public bool? ChangingLoanToFixedRateIndicator { get { return _changingLoanToFixedRateIndicator; } set { _changingLoanToFixedRateIndicator = value; } }
-        private Value<bool?> _consolidatingOtherExistingLoansIntoNewLoanIndicator;
+        private DirtyValue<bool?> _consolidatingOtherExistingLoansIntoNewLoanIndicator;
         public bool? ConsolidatingOtherExistingLoansIntoNewLoanIndicator { get { return _consolidatingOtherExistingLoansIntoNewLoanIndicator; } set { _consolidatingOtherExistingLoansIntoNewLoanIndicator = value; } }
-        private Value<bool?> _eliminatingBalloonPaymentIndicator;
+        private DirtyValue<bool?> _eliminatingBalloonPaymentIndicator;
         public bool? EliminatingBalloonPaymentIndicator { get { return _eliminatingBalloonPaymentIndicator; } set { _eliminatingBalloonPaymentIndicator = value; } }
-        private Value<bool?> _eliminatingNegArmIndicator;
+        private DirtyValue<bool?> _eliminatingNegArmIndicator;
         public bool? EliminatingNegArmIndicator { get { return _eliminatingNegArmIndicator; } set { _eliminatingNegArmIndicator = value; } }
-        private Value<bool?> _eliminatingPrivateMortgageInsuranceIndicator;
+        private DirtyValue<bool?> _eliminatingPrivateMortgageInsuranceIndicator;
         public bool? EliminatingPrivateMortgageInsuranceIndicator { get { return _eliminatingPrivateMortgageInsuranceIndicator; } set { _eliminatingPrivateMortgageInsuranceIndicator = value; } }
-        private Value<decimal?> _existingLoanAprPercent;
+        private DirtyValue<decimal?> _existingLoanAprPercent;
         public decimal? ExistingLoanAprPercent { get { return _existingLoanAprPercent; } set { _existingLoanAprPercent = value; } }
-        private Value<bool?> _existingLoanBalloonIndicator;
+        private DirtyValue<bool?> _existingLoanBalloonIndicator;
         public bool? ExistingLoanBalloonIndicator { get { return _existingLoanBalloonIndicator; } set { _existingLoanBalloonIndicator = value; } }
-        private Value<decimal?> _existingLoanBorrowerReceivesCashOutAmount;
+        private DirtyValue<decimal?> _existingLoanBorrowerReceivesCashOutAmount;
         public decimal? ExistingLoanBorrowerReceivesCashOutAmount { get { return _existingLoanBorrowerReceivesCashOutAmount; } set { _existingLoanBorrowerReceivesCashOutAmount = value; } }
-        private Value<bool?> _existingLoanBorrowerReceivesCashOutIndicator;
+        private DirtyValue<bool?> _existingLoanBorrowerReceivesCashOutIndicator;
         public bool? ExistingLoanBorrowerReceivesCashOutIndicator { get { return _existingLoanBorrowerReceivesCashOutIndicator; } set { _existingLoanBorrowerReceivesCashOutIndicator = value; } }
-        private Value<decimal?> _existingLoanBottomRatioPercent;
+        private DirtyValue<decimal?> _existingLoanBottomRatioPercent;
         public decimal? ExistingLoanBottomRatioPercent { get { return _existingLoanBottomRatioPercent; } set { _existingLoanBottomRatioPercent = value; } }
-        private Value<DateTime?> _existingLoanDateLoanClosed;
+        private DirtyValue<DateTime?> _existingLoanDateLoanClosed;
         public DateTime? ExistingLoanDateLoanClosed { get { return _existingLoanDateLoanClosed; } set { _existingLoanDateLoanClosed = value; } }
-        private Value<decimal?> _existingLoanFullyIndexRatePercent;
+        private DirtyValue<decimal?> _existingLoanFullyIndexRatePercent;
         public decimal? ExistingLoanFullyIndexRatePercent { get { return _existingLoanFullyIndexRatePercent; } set { _existingLoanFullyIndexRatePercent = value; } }
-        private Value<decimal?> _existingLoanInterestRatePercent;
+        private DirtyValue<decimal?> _existingLoanInterestRatePercent;
         public decimal? ExistingLoanInterestRatePercent { get { return _existingLoanInterestRatePercent; } set { _existingLoanInterestRatePercent = value; } }
-        private Value<bool?> _existingLoanIsGuaranteedIndicator;
+        private DirtyValue<bool?> _existingLoanIsGuaranteedIndicator;
         public bool? ExistingLoanIsGuaranteedIndicator { get { return _existingLoanIsGuaranteedIndicator; } set { _existingLoanIsGuaranteedIndicator = value; } }
-        private Value<bool?> _existingLoanIsLoanRefinancedAsSpecial;
+        private DirtyValue<bool?> _existingLoanIsLoanRefinancedAsSpecial;
         public bool? ExistingLoanIsLoanRefinancedAsSpecial { get { return _existingLoanIsLoanRefinancedAsSpecial; } set { _existingLoanIsLoanRefinancedAsSpecial = value; } }
-        private Value<bool?> _existingLoanIsNegativeAmortizationFeatureIndicator;
+        private DirtyValue<bool?> _existingLoanIsNegativeAmortizationFeatureIndicator;
         public bool? ExistingLoanIsNegativeAmortizationFeatureIndicator { get { return _existingLoanIsNegativeAmortizationFeatureIndicator; } set { _existingLoanIsNegativeAmortizationFeatureIndicator = value; } }
-        private Value<bool?> _existingLoanIsPrepaymentPenalty;
+        private DirtyValue<bool?> _existingLoanIsPrepaymentPenalty;
         public bool? ExistingLoanIsPrepaymentPenalty { get { return _existingLoanIsPrepaymentPenalty; } set { _existingLoanIsPrepaymentPenalty = value; } }
-        private Value<string> _existingLoanLoanAmortizationType;
+        private DirtyValue<string> _existingLoanLoanAmortizationType;
         public string ExistingLoanLoanAmortizationType { get { return _existingLoanLoanAmortizationType; } set { _existingLoanLoanAmortizationType = value; } }
-        private Value<decimal?> _existingLoanLoanAmount;
+        private DirtyValue<decimal?> _existingLoanLoanAmount;
         public decimal? ExistingLoanLoanAmount { get { return _existingLoanLoanAmount; } set { _existingLoanLoanAmount = value; } }
-        private Value<int?> _existingLoanLoanTerm;
+        private DirtyValue<int?> _existingLoanLoanTerm;
         public int? ExistingLoanLoanTerm { get { return _existingLoanLoanTerm; } set { _existingLoanLoanTerm = value; } }
-        private Value<decimal?> _existingLoanLtvPercent;
+        private DirtyValue<decimal?> _existingLoanLtvPercent;
         public decimal? ExistingLoanLtvPercent { get { return _existingLoanLtvPercent; } set { _existingLoanLtvPercent = value; } }
-        private Value<decimal?> _existingLoanMaximumRatePercent;
+        private DirtyValue<decimal?> _existingLoanMaximumRatePercent;
         public decimal? ExistingLoanMaximumRatePercent { get { return _existingLoanMaximumRatePercent; } set { _existingLoanMaximumRatePercent = value; } }
-        private Value<int?> _existingLoanMonthsRemaining;
+        private DirtyValue<int?> _existingLoanMonthsRemaining;
         public int? ExistingLoanMonthsRemaining { get { return _existingLoanMonthsRemaining; } set { _existingLoanMonthsRemaining = value; } }
-        private Value<decimal?> _existingLoanPaymentAmount;
+        private DirtyValue<decimal?> _existingLoanPaymentAmount;
         public decimal? ExistingLoanPaymentAmount { get { return _existingLoanPaymentAmount; } set { _existingLoanPaymentAmount = value; } }
-        private Value<decimal?> _existingLoanPaymentDifference;
+        private DirtyValue<decimal?> _existingLoanPaymentDifference;
         public decimal? ExistingLoanPaymentDifference { get { return _existingLoanPaymentDifference; } set { _existingLoanPaymentDifference = value; } }
-        private Value<decimal?> _existingLoanPaymentIncludeMiObligation;
+        private DirtyValue<decimal?> _existingLoanPaymentIncludeMiObligation;
         public decimal? ExistingLoanPaymentIncludeMiObligation { get { return _existingLoanPaymentIncludeMiObligation; } set { _existingLoanPaymentIncludeMiObligation = value; } }
-        private Value<decimal?> _existingLoanPaymentIncludeMortgageInsurance;
+        private DirtyValue<decimal?> _existingLoanPaymentIncludeMortgageInsurance;
         public decimal? ExistingLoanPaymentIncludeMortgageInsurance { get { return _existingLoanPaymentIncludeMortgageInsurance; } set { _existingLoanPaymentIncludeMortgageInsurance = value; } }
-        private Value<decimal?> _existingLoanPrepaymentPenaltyAmountIncludedInNewLoan;
+        private DirtyValue<decimal?> _existingLoanPrepaymentPenaltyAmountIncludedInNewLoan;
         public decimal? ExistingLoanPrepaymentPenaltyAmountIncludedInNewLoan { get { return _existingLoanPrepaymentPenaltyAmountIncludedInNewLoan; } set { _existingLoanPrepaymentPenaltyAmountIncludedInNewLoan = value; } }
-        private Value<string> _existingLoanPrepaymentPenaltyBasedOn;
+        private DirtyValue<string> _existingLoanPrepaymentPenaltyBasedOn;
         public string ExistingLoanPrepaymentPenaltyBasedOn { get { return _existingLoanPrepaymentPenaltyBasedOn; } set { _existingLoanPrepaymentPenaltyBasedOn = value; } }
-        private Value<decimal?> _existingLoanPrepaymentPenaltyPercentage;
+        private DirtyValue<decimal?> _existingLoanPrepaymentPenaltyPercentage;
         public decimal? ExistingLoanPrepaymentPenaltyPercentage { get { return _existingLoanPrepaymentPenaltyPercentage; } set { _existingLoanPrepaymentPenaltyPercentage = value; } }
-        private Value<int?> _existingLoanPrepaymentPenaltyTerm;
+        private DirtyValue<int?> _existingLoanPrepaymentPenaltyTerm;
         public int? ExistingLoanPrepaymentPenaltyTerm { get { return _existingLoanPrepaymentPenaltyTerm; } set { _existingLoanPrepaymentPenaltyTerm = value; } }
-        private Value<string> _existingLoanProvidedByLicenseeType;
+        private DirtyValue<string> _existingLoanProvidedByLicenseeType;
         public string ExistingLoanProvidedByLicenseeType { get { return _existingLoanProvidedByLicenseeType; } set { _existingLoanProvidedByLicenseeType = value; } }
-        private Value<string> _existingLoanPurposeType;
+        private DirtyValue<string> _existingLoanPurposeType;
         public string ExistingLoanPurposeType { get { return _existingLoanPurposeType; } set { _existingLoanPurposeType = value; } }
-        private Value<int?> _existingLoanRecoupCostsYears;
+        private DirtyValue<int?> _existingLoanRecoupCostsYears;
         public int? ExistingLoanRecoupCostsYears { get { return _existingLoanRecoupCostsYears; } set { _existingLoanRecoupCostsYears = value; } }
-        private Value<decimal?> _existingLoanSavingsAmount;
+        private DirtyValue<decimal?> _existingLoanSavingsAmount;
         public decimal? ExistingLoanSavingsAmount { get { return _existingLoanSavingsAmount; } set { _existingLoanSavingsAmount = value; } }
-        private Value<decimal?> _existingLoanTotalDebtPayoff;
+        private DirtyValue<decimal?> _existingLoanTotalDebtPayoff;
         public decimal? ExistingLoanTotalDebtPayoff { get { return _existingLoanTotalDebtPayoff; } set { _existingLoanTotalDebtPayoff = value; } }
-        private Value<decimal?> _existingLoanWeightedAverageInterestRatePercent;
+        private DirtyValue<decimal?> _existingLoanWeightedAverageInterestRatePercent;
         public decimal? ExistingLoanWeightedAverageInterestRatePercent { get { return _existingLoanWeightedAverageInterestRatePercent; } set { _existingLoanWeightedAverageInterestRatePercent = value; } }
-        private Value<bool?> _homeLoanComplianceWith209;
+        private DirtyValue<bool?> _homeLoanComplianceWith209;
         public bool? HomeLoanComplianceWith209 { get { return _homeLoanComplianceWith209; } set { _homeLoanComplianceWith209 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _lenderDeterminedBorrowersInterest;
+        private DirtyValue<bool?> _lenderDeterminedBorrowersInterest;
         public bool? LenderDeterminedBorrowersInterest { get { return _lenderDeterminedBorrowersInterest; } set { _lenderDeterminedBorrowersInterest = value; } }
-        private Value<bool?> _newLoanIsGuaranteedIndicator;
+        private DirtyValue<bool?> _newLoanIsGuaranteedIndicator;
         public bool? NewLoanIsGuaranteedIndicator { get { return _newLoanIsGuaranteedIndicator; } set { _newLoanIsGuaranteedIndicator = value; } }
-        private Value<bool?> _newLoanIsNegativeAmortizationFeatureIndicator;
+        private DirtyValue<bool?> _newLoanIsNegativeAmortizationFeatureIndicator;
         public bool? NewLoanIsNegativeAmortizationFeatureIndicator { get { return _newLoanIsNegativeAmortizationFeatureIndicator; } set { _newLoanIsNegativeAmortizationFeatureIndicator = value; } }
-        private Value<bool?> _newLoanIsSafeHarborQM;
+        private DirtyValue<bool?> _newLoanIsSafeHarborQM;
         public bool? NewLoanIsSafeHarborQM { get { return _newLoanIsSafeHarborQM; } set { _newLoanIsSafeHarborQM = value; } }
-        private Value<bool?> _newLoanIsSpecialMortgageOriginatedIndicator;
+        private DirtyValue<bool?> _newLoanIsSpecialMortgageOriginatedIndicator;
         public bool? NewLoanIsSpecialMortgageOriginatedIndicator { get { return _newLoanIsSpecialMortgageOriginatedIndicator; } set { _newLoanIsSpecialMortgageOriginatedIndicator = value; } }
-        private Value<decimal?> _newLoanPaymentWithMiDifference;
+        private DirtyValue<decimal?> _newLoanPaymentWithMiDifference;
         public decimal? NewLoanPaymentWithMiDifference { get { return _newLoanPaymentWithMiDifference; } set { _newLoanPaymentWithMiDifference = value; } }
-        private Value<decimal?> _newLoanPaymentWithObligationDifference;
+        private DirtyValue<decimal?> _newLoanPaymentWithObligationDifference;
         public decimal? NewLoanPaymentWithObligationDifference { get { return _newLoanPaymentWithObligationDifference; } set { _newLoanPaymentWithObligationDifference = value; } }
-        private Value<bool?> _newLoanPayOffConsolidateDebtIndicator;
+        private DirtyValue<bool?> _newLoanPayOffConsolidateDebtIndicator;
         public bool? NewLoanPayOffConsolidateDebtIndicator { get { return _newLoanPayOffConsolidateDebtIndicator; } set { _newLoanPayOffConsolidateDebtIndicator = value; } }
-        private Value<decimal?> _newLoanWeightedAverageInterestRatePercent;
+        private DirtyValue<decimal?> _newLoanWeightedAverageInterestRatePercent;
         public decimal? NewLoanWeightedAverageInterestRatePercent { get { return _newLoanWeightedAverageInterestRatePercent; } set { _newLoanWeightedAverageInterestRatePercent = value; } }
-        private Value<bool?> _obtainingLowerIntMonthlyPaymentIndicator;
+        private DirtyValue<bool?> _obtainingLowerIntMonthlyPaymentIndicator;
         public bool? ObtainingLowerIntMonthlyPaymentIndicator { get { return _obtainingLowerIntMonthlyPaymentIndicator; } set { _obtainingLowerIntMonthlyPaymentIndicator = value; } }
-        private Value<bool?> _obtainingLowerIntRateIndicator;
+        private DirtyValue<bool?> _obtainingLowerIntRateIndicator;
         public bool? ObtainingLowerIntRateIndicator { get { return _obtainingLowerIntRateIndicator; } set { _obtainingLowerIntRateIndicator = value; } }
-        private Value<bool?> _obtainingShortAmortScheduleIndicator;
+        private DirtyValue<bool?> _obtainingShortAmortScheduleIndicator;
         public bool? ObtainingShortAmortScheduleIndicator { get { return _obtainingShortAmortScheduleIndicator; } set { _obtainingShortAmortScheduleIndicator = value; } }
-        private Value<bool?> _otherReason;
+        private DirtyValue<bool?> _otherReason;
         public bool? OtherReason { get { return _otherReason; } set { _otherReason = value; } }
-        private Value<string> _otherReasonDescription;
+        private DirtyValue<string> _otherReasonDescription;
         public string OtherReasonDescription { get { return _otherReasonDescription; } set { _otherReasonDescription = value; } }
-        private Value<bool?> _printBorrowerInitialLinesIndicator;
+        private DirtyValue<bool?> _printBorrowerInitialLinesIndicator;
         public bool? PrintBorrowerInitialLinesIndicator { get { return _printBorrowerInitialLinesIndicator; } set { _printBorrowerInitialLinesIndicator = value; } }
-        private Value<bool?> _proceedsOfNewLoanWillBeUsedIndicator;
+        private DirtyValue<bool?> _proceedsOfNewLoanWillBeUsedIndicator;
         public bool? ProceedsOfNewLoanWillBeUsedIndicator { get { return _proceedsOfNewLoanWillBeUsedIndicator; } set { _proceedsOfNewLoanWillBeUsedIndicator = value; } }
-        private Value<bool?> _receivingCashOutFromNewLoanGreaterThanClosingCostIndicator;
+        private DirtyValue<bool?> _receivingCashOutFromNewLoanGreaterThanClosingCostIndicator;
         public bool? ReceivingCashOutFromNewLoanGreaterThanClosingCostIndicator { get { return _receivingCashOutFromNewLoanGreaterThanClosingCostIndicator; } set { _receivingCashOutFromNewLoanGreaterThanClosingCostIndicator = value; } }
-        private Value<bool?> _refinancingLoanIsHomeEquityIndicator;
+        private DirtyValue<bool?> _refinancingLoanIsHomeEquityIndicator;
         public bool? RefinancingLoanIsHomeEquityIndicator { get { return _refinancingLoanIsHomeEquityIndicator; } set { _refinancingLoanIsHomeEquityIndicator = value; } }
-        private Value<bool?> _refinancingRespondBonaFide;
+        private DirtyValue<bool?> _refinancingRespondBonaFide;
         public bool? RefinancingRespondBonaFide { get { return _refinancingRespondBonaFide; } set { _refinancingRespondBonaFide = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/NewYorkFee.cs
+++ b/src/EncompassRest/Loans/NewYorkFee.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class NewYorkFee : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _date;
+        private DirtyValue<DateTime?> _date;
         public DateTime? Date { get { return _date; } set { _date = value; } }
-        private Value<string> _feeType;
+        private DirtyValue<string> _feeType;
         public string FeeType { get { return _feeType; } set { _feeType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<int?> _newYorkFeeIndex;
+        private DirtyValue<int?> _newYorkFeeIndex;
         public int? NewYorkFeeIndex { get { return _newYorkFeeIndex; } set { _newYorkFeeIndex = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/NewYorkPrimaryLender.cs
+++ b/src/EncompassRest/Loans/NewYorkPrimaryLender.cs
@@ -8,21 +8,21 @@ namespace EncompassRest.Loans
 {
     public sealed partial class NewYorkPrimaryLender : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<int?> _newYorkPrimaryLenderIndex;
+        private DirtyValue<int?> _newYorkPrimaryLenderIndex;
         public int? NewYorkPrimaryLenderIndex { get { return _newYorkPrimaryLenderIndex; } set { _newYorkPrimaryLenderIndex = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/OtherTransaction.cs
+++ b/src/EncompassRest/Loans/OtherTransaction.cs
@@ -8,39 +8,39 @@ namespace EncompassRest.Loans
 {
     public sealed partial class OtherTransaction : IDirty
     {
-        private Value<string> _accountNumber;
+        private DirtyValue<string> _accountNumber;
         public string AccountNumber { get { return _accountNumber; } set { _accountNumber = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _institutionName;
+        private DirtyValue<string> _institutionName;
         public string InstitutionName { get { return _institutionName; } set { _institutionName = value; } }
-        private Value<string> _institutionRouting;
+        private DirtyValue<string> _institutionRouting;
         public string InstitutionRouting { get { return _institutionRouting; } set { _institutionRouting = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<string> _reference;
+        private DirtyValue<string> _reference;
         public string Reference { get { return _reference; } set { _reference = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PaymentReversalTransaction.cs
+++ b/src/EncompassRest/Loans/PaymentReversalTransaction.cs
@@ -8,35 +8,35 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PaymentReversalTransaction : IDirty
     {
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<string> _paymentId;
+        private DirtyValue<string> _paymentId;
         public string PaymentId { get { return _paymentId; } set { _paymentId = value; } }
-        private Value<string> _reversalType;
+        private DirtyValue<string> _reversalType;
         public string ReversalType { get { return _reversalType; } set { _reversalType = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PaymentTransaction.cs
+++ b/src/EncompassRest/Loans/PaymentTransaction.cs
@@ -8,107 +8,107 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PaymentTransaction : IDirty
     {
-        private Value<string> _accountHolder;
+        private DirtyValue<string> _accountHolder;
         public string AccountHolder { get { return _accountHolder; } set { _accountHolder = value; } }
-        private Value<string> _accountNumber;
+        private DirtyValue<string> _accountNumber;
         public string AccountNumber { get { return _accountNumber; } set { _accountNumber = value; } }
-        private Value<decimal?> _additionalEscrow;
+        private DirtyValue<decimal?> _additionalEscrow;
         public decimal? AdditionalEscrow { get { return _additionalEscrow; } set { _additionalEscrow = value; } }
-        private Value<decimal?> _additionalPrincipal;
+        private DirtyValue<decimal?> _additionalPrincipal;
         public decimal? AdditionalPrincipal { get { return _additionalPrincipal; } set { _additionalPrincipal = value; } }
-        private Value<decimal?> _buydownSubsidyAmount;
+        private DirtyValue<decimal?> _buydownSubsidyAmount;
         public decimal? BuydownSubsidyAmount { get { return _buydownSubsidyAmount; } set { _buydownSubsidyAmount = value; } }
-        private Value<string> _checkNumber;
+        private DirtyValue<string> _checkNumber;
         public string CheckNumber { get { return _checkNumber; } set { _checkNumber = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<decimal?> _commonAmount;
+        private DirtyValue<decimal?> _commonAmount;
         public decimal? CommonAmount { get { return _commonAmount; } set { _commonAmount = value; } }
-        private Value<DateTime?> _commonDate;
+        private DirtyValue<DateTime?> _commonDate;
         public DateTime? CommonDate { get { return _commonDate; } set { _commonDate = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<decimal?> _escrow;
+        private DirtyValue<decimal?> _escrow;
         public decimal? Escrow { get { return _escrow; } set { _escrow = value; } }
-        private Value<decimal?> _escrowCityPropertyTax;
+        private DirtyValue<decimal?> _escrowCityPropertyTax;
         public decimal? EscrowCityPropertyTax { get { return _escrowCityPropertyTax; } set { _escrowCityPropertyTax = value; } }
-        private Value<decimal?> _escrowFloodInsurance;
+        private DirtyValue<decimal?> _escrowFloodInsurance;
         public decimal? EscrowFloodInsurance { get { return _escrowFloodInsurance; } set { _escrowFloodInsurance = value; } }
-        private Value<decimal?> _escrowHazardInsurance;
+        private DirtyValue<decimal?> _escrowHazardInsurance;
         public decimal? EscrowHazardInsurance { get { return _escrowHazardInsurance; } set { _escrowHazardInsurance = value; } }
-        private Value<decimal?> _escrowMortgageInsurance;
+        private DirtyValue<decimal?> _escrowMortgageInsurance;
         public decimal? EscrowMortgageInsurance { get { return _escrowMortgageInsurance; } set { _escrowMortgageInsurance = value; } }
-        private Value<decimal?> _escrowOther1;
+        private DirtyValue<decimal?> _escrowOther1;
         public decimal? EscrowOther1 { get { return _escrowOther1; } set { _escrowOther1 = value; } }
-        private Value<decimal?> _escrowOther2;
+        private DirtyValue<decimal?> _escrowOther2;
         public decimal? EscrowOther2 { get { return _escrowOther2; } set { _escrowOther2 = value; } }
-        private Value<decimal?> _escrowOther3;
+        private DirtyValue<decimal?> _escrowOther3;
         public decimal? EscrowOther3 { get { return _escrowOther3; } set { _escrowOther3 = value; } }
-        private Value<decimal?> _escrowTax;
+        private DirtyValue<decimal?> _escrowTax;
         public decimal? EscrowTax { get { return _escrowTax; } set { _escrowTax = value; } }
-        private Value<decimal?> _escrowUSDAMonthlyPremium;
+        private DirtyValue<decimal?> _escrowUSDAMonthlyPremium;
         public decimal? EscrowUSDAMonthlyPremium { get { return _escrowUSDAMonthlyPremium; } set { _escrowUSDAMonthlyPremium = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _indexRate;
+        private DirtyValue<decimal?> _indexRate;
         public decimal? IndexRate { get { return _indexRate; } set { _indexRate = value; } }
-        private Value<string> _institutionName;
+        private DirtyValue<string> _institutionName;
         public string InstitutionName { get { return _institutionName; } set { _institutionName = value; } }
-        private Value<string> _institutionRouting;
+        private DirtyValue<string> _institutionRouting;
         public string InstitutionRouting { get { return _institutionRouting; } set { _institutionRouting = value; } }
-        private Value<decimal?> _interest;
+        private DirtyValue<decimal?> _interest;
         public decimal? Interest { get { return _interest; } set { _interest = value; } }
-        private Value<decimal?> _interestRate;
+        private DirtyValue<decimal?> _interestRate;
         public decimal? InterestRate { get { return _interestRate; } set { _interestRate = value; } }
-        private Value<decimal?> _lateFee;
+        private DirtyValue<decimal?> _lateFee;
         public decimal? LateFee { get { return _lateFee; } set { _lateFee = value; } }
-        private Value<decimal?> _lateFeeIfLate;
+        private DirtyValue<decimal?> _lateFeeIfLate;
         public decimal? LateFeeIfLate { get { return _lateFeeIfLate; } set { _lateFeeIfLate = value; } }
-        private Value<DateTime?> _latePaymentDate;
+        private DirtyValue<DateTime?> _latePaymentDate;
         public DateTime? LatePaymentDate { get { return _latePaymentDate; } set { _latePaymentDate = value; } }
-        private Value<decimal?> _miscFee;
+        private DirtyValue<decimal?> _miscFee;
         public decimal? MiscFee { get { return _miscFee; } set { _miscFee = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<DateTime?> _paymentDepositedDate;
+        private DirtyValue<DateTime?> _paymentDepositedDate;
         public DateTime? PaymentDepositedDate { get { return _paymentDepositedDate; } set { _paymentDepositedDate = value; } }
-        private Value<DateTime?> _paymentDueDate;
+        private DirtyValue<DateTime?> _paymentDueDate;
         public DateTime? PaymentDueDate { get { return _paymentDueDate; } set { _paymentDueDate = value; } }
-        private Value<DateTime?> _paymentIndexDate;
+        private DirtyValue<DateTime?> _paymentIndexDate;
         public DateTime? PaymentIndexDate { get { return _paymentIndexDate; } set { _paymentIndexDate = value; } }
-        private Value<int?> _paymentNumber;
+        private DirtyValue<int?> _paymentNumber;
         public int? PaymentNumber { get { return _paymentNumber; } set { _paymentNumber = value; } }
-        private Value<DateTime?> _paymentReceivedDate;
+        private DirtyValue<DateTime?> _paymentReceivedDate;
         public DateTime? PaymentReceivedDate { get { return _paymentReceivedDate; } set { _paymentReceivedDate = value; } }
-        private Value<decimal?> _principal;
+        private DirtyValue<decimal?> _principal;
         public decimal? Principal { get { return _principal; } set { _principal = value; } }
-        private Value<string> _reference;
+        private DirtyValue<string> _reference;
         public string Reference { get { return _reference; } set { _reference = value; } }
-        private Value<decimal?> _schedulePayLogMiscFee;
+        private DirtyValue<decimal?> _schedulePayLogMiscFee;
         public decimal? SchedulePayLogMiscFee { get { return _schedulePayLogMiscFee; } set { _schedulePayLogMiscFee = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<DateTime?> _statementDate;
+        private DirtyValue<DateTime?> _statementDate;
         public DateTime? StatementDate { get { return _statementDate; } set { _statementDate = value; } }
-        private Value<decimal?> _totalAmountDue;
+        private DirtyValue<decimal?> _totalAmountDue;
         public decimal? TotalAmountDue { get { return _totalAmountDue; } set { _totalAmountDue = value; } }
-        private Value<decimal?> _totalAmountReceived;
+        private DirtyValue<decimal?> _totalAmountReceived;
         public decimal? TotalAmountReceived { get { return _totalAmountReceived; } set { _totalAmountReceived = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PostClosingConditionLog.cs
+++ b/src/EncompassRest/Loans/PostClosingConditionLog.cs
@@ -10,16 +10,16 @@ namespace EncompassRest.Loans
     {
         private Value<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<bool?> _cleared;
         public bool? Cleared { get { return _cleared; } set { _cleared = value; } }
         private Value<string> _clearedBy;
         public string ClearedBy { get { return _clearedBy; } set { _clearedBy = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -100,11 +100,9 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _addedBy.Dirty
-                    || _alerts.Dirty
                     || _alertsXml.Dirty
                     || _cleared.Dirty
                     || _clearedBy.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _dateAddedUtc.Dirty
@@ -140,7 +138,9 @@ namespace EncompassRest.Loans
                     || _status.Dirty
                     || _statusDescription.Dirty
                     || _systemId.Dirty
-                    || _title.Dirty;
+                    || _title.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -148,11 +148,9 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _addedBy.Dirty = value;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _cleared.Dirty = value;
                 _clearedBy.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _dateAddedUtc.Dirty = value;
@@ -189,6 +187,8 @@ namespace EncompassRest.Loans
                 _statusDescription.Dirty = value;
                 _systemId.Dirty = value;
                 _title.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/PostClosingConditionLog.cs
+++ b/src/EncompassRest/Loans/PostClosingConditionLog.cs
@@ -8,89 +8,89 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PostClosingConditionLog : IDirty
     {
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<bool?> _cleared;
+        private DirtyValue<bool?> _cleared;
         public bool? Cleared { get { return _cleared; } set { _cleared = value; } }
-        private Value<string> _clearedBy;
+        private DirtyValue<string> _clearedBy;
         public string ClearedBy { get { return _clearedBy; } set { _clearedBy = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateAddedUtc;
+        private DirtyValue<DateTime?> _dateAddedUtc;
         public DateTime? DateAddedUtc { get { return _dateAddedUtc; } set { _dateAddedUtc = value; } }
-        private Value<DateTime?> _dateClearedUtc;
+        private DirtyValue<DateTime?> _dateClearedUtc;
         public DateTime? DateClearedUtc { get { return _dateClearedUtc; } set { _dateClearedUtc = value; } }
-        private Value<DateTime?> _dateExpected;
+        private DirtyValue<DateTime?> _dateExpected;
         public DateTime? DateExpected { get { return _dateExpected; } set { _dateExpected = value; } }
-        private Value<DateTime?> _dateReceived;
+        private DirtyValue<DateTime?> _dateReceived;
         public DateTime? DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateRequestedUtc;
+        private DirtyValue<DateTime?> _dateRequestedUtc;
         public DateTime? DateRequestedUtc { get { return _dateRequestedUtc; } set { _dateRequestedUtc = value; } }
-        private Value<DateTime?> _dateRerequestedUtc;
+        private DirtyValue<DateTime?> _dateRerequestedUtc;
         public DateTime? DateRerequestedUtc { get { return _dateRerequestedUtc; } set { _dateRerequestedUtc = value; } }
-        private Value<DateTime?> _dateSentUtc;
+        private DirtyValue<DateTime?> _dateSentUtc;
         public DateTime? DateSentUtc { get { return _dateSentUtc; } set { _dateSentUtc = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<int?> _daysTillDue;
+        private DirtyValue<int?> _daysTillDue;
         public int? DaysTillDue { get { return _daysTillDue; } set { _daysTillDue = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _details;
+        private DirtyValue<string> _details;
         public string Details { get { return _details; } set { _details = value; } }
-        private Value<bool?> _expected;
+        private DirtyValue<bool?> _expected;
         public bool? Expected { get { return _expected; } set { _expected = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isPastDue;
+        private DirtyValue<bool?> _isPastDue;
         public bool? IsPastDue { get { return _isPastDue; } set { _isPastDue = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _pairId;
+        private DirtyValue<string> _pairId;
         public string PairId { get { return _pairId; } set { _pairId = value; } }
-        private Value<bool?> _received;
+        private DirtyValue<bool?> _received;
         public bool? Received { get { return _received; } set { _received = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<string> _recipient;
+        private DirtyValue<string> _recipient;
         public string Recipient { get { return _recipient; } set { _recipient = value; } }
-        private Value<bool?> _requested;
+        private DirtyValue<bool?> _requested;
         public bool? Requested { get { return _requested; } set { _requested = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<string> _requestedFrom;
+        private DirtyValue<string> _requestedFrom;
         public string RequestedFrom { get { return _requestedFrom; } set { _requestedFrom = value; } }
-        private Value<bool?> _rerequested;
+        private DirtyValue<bool?> _rerequested;
         public bool? Rerequested { get { return _rerequested; } set { _rerequested = value; } }
-        private Value<string> _rerequestedBy;
+        private DirtyValue<string> _rerequestedBy;
         public string RerequestedBy { get { return _rerequestedBy; } set { _rerequestedBy = value; } }
-        private Value<bool?> _sent;
+        private DirtyValue<bool?> _sent;
         public bool? Sent { get { return _sent; } set { _sent = value; } }
-        private Value<string> _sentBy;
+        private DirtyValue<string> _sentBy;
         public string SentBy { get { return _sentBy; } set { _sentBy = value; } }
-        private Value<string> _source;
+        private DirtyValue<string> _source;
         public string Source { get { return _source; } set { _source = value; } }
-        private Value<string> _status;
+        private DirtyValue<string> _status;
         public string Status { get { return _status; } set { _status = value; } }
-        private Value<string> _statusDescription;
+        private DirtyValue<string> _statusDescription;
         public string StatusDescription { get { return _statusDescription; } set { _statusDescription = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PreliminaryConditionLog.cs
+++ b/src/EncompassRest/Loans/PreliminaryConditionLog.cs
@@ -10,14 +10,14 @@ namespace EncompassRest.Loans
     {
         private Value<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<string> _category;
         public string Category { get { return _category; } set { _category = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -94,10 +94,8 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _addedBy.Dirty
-                    || _alerts.Dirty
                     || _alertsXml.Dirty
                     || _category.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _dateAddedUtc.Dirty
@@ -131,7 +129,9 @@ namespace EncompassRest.Loans
                     || _statusDescription.Dirty
                     || _systemId.Dirty
                     || _title.Dirty
-                    || _underwriterAccessIndicator.Dirty;
+                    || _underwriterAccessIndicator.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -139,10 +139,8 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _addedBy.Dirty = value;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _category.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _dateAddedUtc.Dirty = value;
@@ -177,6 +175,8 @@ namespace EncompassRest.Loans
                 _systemId.Dirty = value;
                 _title.Dirty = value;
                 _underwriterAccessIndicator.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/PreliminaryConditionLog.cs
+++ b/src/EncompassRest/Loans/PreliminaryConditionLog.cs
@@ -8,83 +8,83 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PreliminaryConditionLog : IDirty
     {
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<string> _category;
+        private DirtyValue<string> _category;
         public string Category { get { return _category; } set { _category = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateAddedUtc;
+        private DirtyValue<DateTime?> _dateAddedUtc;
         public DateTime? DateAddedUtc { get { return _dateAddedUtc; } set { _dateAddedUtc = value; } }
-        private Value<DateTime?> _dateExpected;
+        private DirtyValue<DateTime?> _dateExpected;
         public DateTime? DateExpected { get { return _dateExpected; } set { _dateExpected = value; } }
-        private Value<DateTime?> _dateFulfilled;
+        private DirtyValue<DateTime?> _dateFulfilled;
         public DateTime? DateFulfilled { get { return _dateFulfilled; } set { _dateFulfilled = value; } }
-        private Value<DateTime?> _dateReceived;
+        private DirtyValue<DateTime?> _dateReceived;
         public DateTime? DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateRequestedUtc;
+        private DirtyValue<DateTime?> _dateRequestedUtc;
         public DateTime? DateRequestedUtc { get { return _dateRequestedUtc; } set { _dateRequestedUtc = value; } }
-        private Value<DateTime?> _dateRerequestedUtc;
+        private DirtyValue<DateTime?> _dateRerequestedUtc;
         public DateTime? DateRerequestedUtc { get { return _dateRerequestedUtc; } set { _dateRerequestedUtc = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _details;
+        private DirtyValue<string> _details;
         public string Details { get { return _details; } set { _details = value; } }
-        private Value<bool?> _expected;
+        private DirtyValue<bool?> _expected;
         public bool? Expected { get { return _expected; } set { _expected = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<bool?> _fulfilled;
+        private DirtyValue<bool?> _fulfilled;
         public bool? Fulfilled { get { return _fulfilled; } set { _fulfilled = value; } }
-        private Value<string> _fulfilledBy;
+        private DirtyValue<string> _fulfilledBy;
         public string FulfilledBy { get { return _fulfilledBy; } set { _fulfilledBy = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isPastDue;
+        private DirtyValue<bool?> _isPastDue;
         public bool? IsPastDue { get { return _isPastDue; } set { _isPastDue = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _pairId;
+        private DirtyValue<string> _pairId;
         public string PairId { get { return _pairId; } set { _pairId = value; } }
-        private Value<string> _priorTo;
+        private DirtyValue<string> _priorTo;
         public string PriorTo { get { return _priorTo; } set { _priorTo = value; } }
-        private Value<bool?> _received;
+        private DirtyValue<bool?> _received;
         public bool? Received { get { return _received; } set { _received = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<bool?> _requested;
+        private DirtyValue<bool?> _requested;
         public bool? Requested { get { return _requested; } set { _requested = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<bool?> _rerequested;
+        private DirtyValue<bool?> _rerequested;
         public bool? Rerequested { get { return _rerequested; } set { _rerequested = value; } }
-        private Value<string> _rerequestedBy;
+        private DirtyValue<string> _rerequestedBy;
         public string RerequestedBy { get { return _rerequestedBy; } set { _rerequestedBy = value; } }
-        private Value<string> _source;
+        private DirtyValue<string> _source;
         public string Source { get { return _source; } set { _source = value; } }
-        private Value<string> _status;
+        private DirtyValue<string> _status;
         public string Status { get { return _status; } set { _status = value; } }
-        private Value<string> _statusDescription;
+        private DirtyValue<string> _statusDescription;
         public string StatusDescription { get { return _statusDescription; } set { _statusDescription = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<bool?> _underwriterAccessIndicator;
+        private DirtyValue<bool?> _underwriterAccessIndicator;
         public bool? UnderwriterAccessIndicator { get { return _underwriterAccessIndicator; } set { _underwriterAccessIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PrepaymentPenalty.cs
+++ b/src/EncompassRest/Loans/PrepaymentPenalty.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PrepaymentPenalty : IDirty
     {
-        private Value<string> _fullPrepaymentPenaltyOptionType;
+        private DirtyValue<string> _fullPrepaymentPenaltyOptionType;
         public string FullPrepaymentPenaltyOptionType { get { return _fullPrepaymentPenaltyOptionType; } set { _fullPrepaymentPenaltyOptionType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _prepaymentPenaltyPercent;
+        private DirtyValue<decimal?> _prepaymentPenaltyPercent;
         public decimal? PrepaymentPenaltyPercent { get { return _prepaymentPenaltyPercent; } set { _prepaymentPenaltyPercent = value; } }
-        private Value<int?> _termMonthsCount;
+        private DirtyValue<int?> _termMonthsCount;
         public int? TermMonthsCount { get { return _termMonthsCount; } set { _termMonthsCount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Prequalification.cs
+++ b/src/EncompassRest/Loans/Prequalification.cs
@@ -66,8 +66,8 @@ namespace EncompassRest.Loans
         public decimal? PercentOfIncomeTax { get { return _percentOfIncomeTax; } set { _percentOfIncomeTax = value; } }
         private Value<decimal?> _percentOfInvestmentInterest;
         public decimal? PercentOfInvestmentInterest { get { return _percentOfInvestmentInterest; } set { _percentOfInvestmentInterest = value; } }
-        private Value<List<PrequalificationScenario>> _prequalificationScenarios;
-        public List<PrequalificationScenario> PrequalificationScenarios { get { return _prequalificationScenarios; } set { _prequalificationScenarios = value; } }
+        private DirtyList<PrequalificationScenario> _prequalificationScenarios;
+        public IList<PrequalificationScenario> PrequalificationScenarios { get { var v = _prequalificationScenarios; return v ?? Interlocked.CompareExchange(ref _prequalificationScenarios, (v = new DirtyList<PrequalificationScenario>()), null) ?? v; } set { _prequalificationScenarios = new DirtyList<PrequalificationScenario>(value); } }
         private Value<string> _qualificationStatus;
         public string QualificationStatus { get { return _qualificationStatus; } set { _qualificationStatus = value; } }
         private Value<decimal?> _rentalCost;
@@ -166,7 +166,6 @@ namespace EncompassRest.Loans
                     || _percentOfHomeAppreciation.Dirty
                     || _percentOfIncomeTax.Dirty
                     || _percentOfInvestmentInterest.Dirty
-                    || _prequalificationScenarios.Dirty
                     || _qualificationStatus.Dirty
                     || _rentalCost.Dirty
                     || _rentersInsurance.Dirty
@@ -197,7 +196,8 @@ namespace EncompassRest.Loans
                     || _withinLimits7.Dirty
                     || _withinLimits8.Dirty
                     || _withinLimits9.Dirty
-                    || _yearsForComparison.Dirty;
+                    || _yearsForComparison.Dirty
+                    || _prequalificationScenarios?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -233,7 +233,6 @@ namespace EncompassRest.Loans
                 _percentOfHomeAppreciation.Dirty = value;
                 _percentOfIncomeTax.Dirty = value;
                 _percentOfInvestmentInterest.Dirty = value;
-                _prequalificationScenarios.Dirty = value;
                 _qualificationStatus.Dirty = value;
                 _rentalCost.Dirty = value;
                 _rentersInsurance.Dirty = value;
@@ -265,6 +264,7 @@ namespace EncompassRest.Loans
                 _withinLimits8.Dirty = value;
                 _withinLimits9.Dirty = value;
                 _yearsForComparison.Dirty = value;
+                if (_prequalificationScenarios != null) _prequalificationScenarios.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Prequalification.cs
+++ b/src/EncompassRest/Loans/Prequalification.cs
@@ -8,127 +8,127 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Prequalification : IDirty
     {
-        private Value<decimal?> _afterTaxOwnMoSavings;
+        private DirtyValue<decimal?> _afterTaxOwnMoSavings;
         public decimal? AfterTaxOwnMoSavings { get { return _afterTaxOwnMoSavings; } set { _afterTaxOwnMoSavings = value; } }
-        private Value<decimal?> _afterTaxRentMoSavings;
+        private DirtyValue<decimal?> _afterTaxRentMoSavings;
         public decimal? AfterTaxRentMoSavings { get { return _afterTaxRentMoSavings; } set { _afterTaxRentMoSavings = value; } }
-        private Value<decimal?> _annualHomeMaintenance;
+        private DirtyValue<decimal?> _annualHomeMaintenance;
         public decimal? AnnualHomeMaintenance { get { return _annualHomeMaintenance; } set { _annualHomeMaintenance = value; } }
-        private Value<decimal?> _avgMoPmtSavings;
+        private DirtyValue<decimal?> _avgMoPmtSavings;
         public decimal? AvgMoPmtSavings { get { return _avgMoPmtSavings; } set { _avgMoPmtSavings = value; } }
-        private Value<decimal?> _beforeTaxOwnMoPmt;
+        private DirtyValue<decimal?> _beforeTaxOwnMoPmt;
         public decimal? BeforeTaxOwnMoPmt { get { return _beforeTaxOwnMoPmt; } set { _beforeTaxOwnMoPmt = value; } }
-        private Value<decimal?> _beforeTaxRentMoPmt;
+        private DirtyValue<decimal?> _beforeTaxRentMoPmt;
         public decimal? BeforeTaxRentMoPmt { get { return _beforeTaxRentMoPmt; } set { _beforeTaxRentMoPmt = value; } }
-        private Value<int?> _cashOutBalance;
+        private DirtyValue<int?> _cashOutBalance;
         public int? CashOutBalance { get { return _cashOutBalance; } set { _cashOutBalance = value; } }
-        private Value<decimal?> _combinedGain;
+        private DirtyValue<decimal?> _combinedGain;
         public decimal? CombinedGain { get { return _combinedGain; } set { _combinedGain = value; } }
-        private Value<decimal?> _costIncreasePerYear;
+        private DirtyValue<decimal?> _costIncreasePerYear;
         public decimal? CostIncreasePerYear { get { return _costIncreasePerYear; } set { _costIncreasePerYear = value; } }
-        private Value<decimal?> _downPaymentAmount;
+        private DirtyValue<decimal?> _downPaymentAmount;
         public decimal? DownPaymentAmount { get { return _downPaymentAmount; } set { _downPaymentAmount = value; } }
-        private Value<string> _favorableOption;
+        private DirtyValue<string> _favorableOption;
         public string FavorableOption { get { return _favorableOption; } set { _favorableOption = value; } }
-        private Value<decimal?> _homeSellingPriceAfterYears;
+        private DirtyValue<decimal?> _homeSellingPriceAfterYears;
         public decimal? HomeSellingPriceAfterYears { get { return _homeSellingPriceAfterYears; } set { _homeSellingPriceAfterYears = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _investmentGain;
+        private DirtyValue<decimal?> _investmentGain;
         public decimal? InvestmentGain { get { return _investmentGain; } set { _investmentGain = value; } }
-        private Value<decimal?> _maxLoanLimit;
+        private DirtyValue<decimal?> _maxLoanLimit;
         public decimal? MaxLoanLimit { get { return _maxLoanLimit; } set { _maxLoanLimit = value; } }
-        private Value<decimal?> _maxPropValue;
+        private DirtyValue<decimal?> _maxPropValue;
         public decimal? MaxPropValue { get { return _maxPropValue; } set { _maxPropValue = value; } }
-        private Value<decimal?> _minusDownPmtAndClosingCosts;
+        private DirtyValue<decimal?> _minusDownPmtAndClosingCosts;
         public decimal? MinusDownPmtAndClosingCosts { get { return _minusDownPmtAndClosingCosts; } set { _minusDownPmtAndClosingCosts = value; } }
-        private Value<decimal?> _minusLoanBalance;
+        private DirtyValue<decimal?> _minusLoanBalance;
         public decimal? MinusLoanBalance { get { return _minusLoanBalance; } set { _minusLoanBalance = value; } }
-        private Value<decimal?> _monthlyBenefit;
+        private DirtyValue<decimal?> _monthlyBenefit;
         public decimal? MonthlyBenefit { get { return _monthlyBenefit; } set { _monthlyBenefit = value; } }
-        private Value<decimal?> _monthlyHomeAppreciation;
+        private DirtyValue<decimal?> _monthlyHomeAppreciation;
         public decimal? MonthlyHomeAppreciation { get { return _monthlyHomeAppreciation; } set { _monthlyHomeAppreciation = value; } }
-        private Value<decimal?> _monthlyHomeEquity;
+        private DirtyValue<decimal?> _monthlyHomeEquity;
         public decimal? MonthlyHomeEquity { get { return _monthlyHomeEquity; } set { _monthlyHomeEquity = value; } }
-        private Value<decimal?> _monthlyIncomeTax;
+        private DirtyValue<decimal?> _monthlyIncomeTax;
         public decimal? MonthlyIncomeTax { get { return _monthlyIncomeTax; } set { _monthlyIncomeTax = value; } }
-        private Value<decimal?> _monthlyInvestmentInterest;
+        private DirtyValue<decimal?> _monthlyInvestmentInterest;
         public decimal? MonthlyInvestmentInterest { get { return _monthlyInvestmentInterest; } set { _monthlyInvestmentInterest = value; } }
-        private Value<int?> _monthlySavings;
+        private DirtyValue<int?> _monthlySavings;
         public int? MonthlySavings { get { return _monthlySavings; } set { _monthlySavings = value; } }
-        private Value<string> _numberOfMonths;
+        private DirtyValue<string> _numberOfMonths;
         public string NumberOfMonths { get { return _numberOfMonths; } set { _numberOfMonths = value; } }
-        private Value<decimal?> _percentAnnualHomeMaint;
+        private DirtyValue<decimal?> _percentAnnualHomeMaint;
         public decimal? PercentAnnualHomeMaint { get { return _percentAnnualHomeMaint; } set { _percentAnnualHomeMaint = value; } }
-        private Value<decimal?> _percentOfHomeAppreciation;
+        private DirtyValue<decimal?> _percentOfHomeAppreciation;
         public decimal? PercentOfHomeAppreciation { get { return _percentOfHomeAppreciation; } set { _percentOfHomeAppreciation = value; } }
-        private Value<decimal?> _percentOfIncomeTax;
+        private DirtyValue<decimal?> _percentOfIncomeTax;
         public decimal? PercentOfIncomeTax { get { return _percentOfIncomeTax; } set { _percentOfIncomeTax = value; } }
-        private Value<decimal?> _percentOfInvestmentInterest;
+        private DirtyValue<decimal?> _percentOfInvestmentInterest;
         public decimal? PercentOfInvestmentInterest { get { return _percentOfInvestmentInterest; } set { _percentOfInvestmentInterest = value; } }
         private DirtyList<PrequalificationScenario> _prequalificationScenarios;
         public IList<PrequalificationScenario> PrequalificationScenarios { get { var v = _prequalificationScenarios; return v ?? Interlocked.CompareExchange(ref _prequalificationScenarios, (v = new DirtyList<PrequalificationScenario>()), null) ?? v; } set { _prequalificationScenarios = new DirtyList<PrequalificationScenario>(value); } }
-        private Value<string> _qualificationStatus;
+        private DirtyValue<string> _qualificationStatus;
         public string QualificationStatus { get { return _qualificationStatus; } set { _qualificationStatus = value; } }
-        private Value<decimal?> _rentalCost;
+        private DirtyValue<decimal?> _rentalCost;
         public decimal? RentalCost { get { return _rentalCost; } set { _rentalCost = value; } }
-        private Value<decimal?> _rentersInsurance;
+        private DirtyValue<decimal?> _rentersInsurance;
         public decimal? RentersInsurance { get { return _rentersInsurance; } set { _rentersInsurance = value; } }
-        private Value<decimal?> _totalBenefit;
+        private DirtyValue<decimal?> _totalBenefit;
         public decimal? TotalBenefit { get { return _totalBenefit; } set { _totalBenefit = value; } }
-        private Value<decimal?> _totalCashFlow;
+        private DirtyValue<decimal?> _totalCashFlow;
         public decimal? TotalCashFlow { get { return _totalCashFlow; } set { _totalCashFlow = value; } }
-        private Value<decimal?> _totalGain;
+        private DirtyValue<decimal?> _totalGain;
         public decimal? TotalGain { get { return _totalGain; } set { _totalGain = value; } }
-        private Value<decimal?> _totalHomeAppreciation;
+        private DirtyValue<decimal?> _totalHomeAppreciation;
         public decimal? TotalHomeAppreciation { get { return _totalHomeAppreciation; } set { _totalHomeAppreciation = value; } }
-        private Value<decimal?> _totalHomeEquity;
+        private DirtyValue<decimal?> _totalHomeEquity;
         public decimal? TotalHomeEquity { get { return _totalHomeEquity; } set { _totalHomeEquity = value; } }
-        private Value<decimal?> _totalHousingExpense;
+        private DirtyValue<decimal?> _totalHousingExpense;
         public decimal? TotalHousingExpense { get { return _totalHousingExpense; } set { _totalHousingExpense = value; } }
-        private Value<decimal?> _totalIncomeTax;
+        private DirtyValue<decimal?> _totalIncomeTax;
         public decimal? TotalIncomeTax { get { return _totalIncomeTax; } set { _totalIncomeTax = value; } }
-        private Value<decimal?> _totalInvestmentInterest;
+        private DirtyValue<decimal?> _totalInvestmentInterest;
         public decimal? TotalInvestmentInterest { get { return _totalInvestmentInterest; } set { _totalInvestmentInterest = value; } }
-        private Value<int?> _totalLiabilityPayment;
+        private DirtyValue<int?> _totalLiabilityPayment;
         public int? TotalLiabilityPayment { get { return _totalLiabilityPayment; } set { _totalLiabilityPayment = value; } }
-        private Value<int?> _totalLiabilityUnpaid;
+        private DirtyValue<int?> _totalLiabilityUnpaid;
         public int? TotalLiabilityUnpaid { get { return _totalLiabilityUnpaid; } set { _totalLiabilityUnpaid = value; } }
-        private Value<int?> _totalLoanSavings;
+        private DirtyValue<int?> _totalLoanSavings;
         public int? TotalLoanSavings { get { return _totalLoanSavings; } set { _totalLoanSavings = value; } }
-        private Value<decimal?> _totalOtherExpenses;
+        private DirtyValue<decimal?> _totalOtherExpenses;
         public decimal? TotalOtherExpenses { get { return _totalOtherExpenses; } set { _totalOtherExpenses = value; } }
-        private Value<decimal?> _totalOwnPmtOverYears;
+        private DirtyValue<decimal?> _totalOwnPmtOverYears;
         public decimal? TotalOwnPmtOverYears { get { return _totalOwnPmtOverYears; } set { _totalOwnPmtOverYears = value; } }
-        private Value<decimal?> _totalOwnTaxSavings;
+        private DirtyValue<decimal?> _totalOwnTaxSavings;
         public decimal? TotalOwnTaxSavings { get { return _totalOwnTaxSavings; } set { _totalOwnTaxSavings = value; } }
-        private Value<int?> _totalPaidOffBalance;
+        private DirtyValue<int?> _totalPaidOffBalance;
         public int? TotalPaidOffBalance { get { return _totalPaidOffBalance; } set { _totalPaidOffBalance = value; } }
-        private Value<int?> _totalPaidOffMonthly;
+        private DirtyValue<int?> _totalPaidOffMonthly;
         public int? TotalPaidOffMonthly { get { return _totalPaidOffMonthly; } set { _totalPaidOffMonthly = value; } }
-        private Value<decimal?> _totalPmtSavings;
+        private DirtyValue<decimal?> _totalPmtSavings;
         public decimal? TotalPmtSavings { get { return _totalPmtSavings; } set { _totalPmtSavings = value; } }
-        private Value<decimal?> _totalRentPmtOverYears;
+        private DirtyValue<decimal?> _totalRentPmtOverYears;
         public decimal? TotalRentPmtOverYears { get { return _totalRentPmtOverYears; } set { _totalRentPmtOverYears = value; } }
-        private Value<string> _withinLimits1;
+        private DirtyValue<string> _withinLimits1;
         public string WithinLimits1 { get { return _withinLimits1; } set { _withinLimits1 = value; } }
-        private Value<string> _withinLimits2;
+        private DirtyValue<string> _withinLimits2;
         public string WithinLimits2 { get { return _withinLimits2; } set { _withinLimits2 = value; } }
-        private Value<string> _withinLimits3;
+        private DirtyValue<string> _withinLimits3;
         public string WithinLimits3 { get { return _withinLimits3; } set { _withinLimits3 = value; } }
-        private Value<string> _withinLimits4;
+        private DirtyValue<string> _withinLimits4;
         public string WithinLimits4 { get { return _withinLimits4; } set { _withinLimits4 = value; } }
-        private Value<string> _withinLimits5;
+        private DirtyValue<string> _withinLimits5;
         public string WithinLimits5 { get { return _withinLimits5; } set { _withinLimits5 = value; } }
-        private Value<string> _withinLimits6;
+        private DirtyValue<string> _withinLimits6;
         public string WithinLimits6 { get { return _withinLimits6; } set { _withinLimits6 = value; } }
-        private Value<string> _withinLimits7;
+        private DirtyValue<string> _withinLimits7;
         public string WithinLimits7 { get { return _withinLimits7; } set { _withinLimits7 = value; } }
-        private Value<string> _withinLimits8;
+        private DirtyValue<string> _withinLimits8;
         public string WithinLimits8 { get { return _withinLimits8; } set { _withinLimits8 = value; } }
-        private Value<string> _withinLimits9;
+        private DirtyValue<string> _withinLimits9;
         public string WithinLimits9 { get { return _withinLimits9; } set { _withinLimits9 = value; } }
-        private Value<int?> _yearsForComparison;
+        private DirtyValue<int?> _yearsForComparison;
         public int? YearsForComparison { get { return _yearsForComparison; } set { _yearsForComparison = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PrequalificationScenario.cs
+++ b/src/EncompassRest/Loans/PrequalificationScenario.cs
@@ -8,81 +8,81 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PrequalificationScenario : IDirty
     {
-        private Value<int?> _appraisedValue;
+        private DirtyValue<int?> _appraisedValue;
         public int? AppraisedValue { get { return _appraisedValue; } set { _appraisedValue = value; } }
-        private Value<decimal?> _apr;
+        private DirtyValue<decimal?> _apr;
         public decimal? Apr { get { return _apr; } set { _apr = value; } }
-        private Value<decimal?> _cashToClose;
+        private DirtyValue<decimal?> _cashToClose;
         public decimal? CashToClose { get { return _cashToClose; } set { _cashToClose = value; } }
-        private Value<decimal?> _closingCost;
+        private DirtyValue<decimal?> _closingCost;
         public decimal? ClosingCost { get { return _closingCost; } set { _closingCost = value; } }
-        private Value<decimal?> _cltv;
+        private DirtyValue<decimal?> _cltv;
         public decimal? Cltv { get { return _cltv; } set { _cltv = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _creditScore;
+        private DirtyValue<string> _creditScore;
         public string CreditScore { get { return _creditScore; } set { _creditScore = value; } }
-        private Value<string> _currentStatus;
+        private DirtyValue<string> _currentStatus;
         public string CurrentStatus { get { return _currentStatus; } set { _currentStatus = value; } }
-        private Value<decimal?> _downPaymentAmount;
+        private DirtyValue<decimal?> _downPaymentAmount;
         public decimal? DownPaymentAmount { get { return _downPaymentAmount; } set { _downPaymentAmount = value; } }
-        private Value<decimal?> _downPaymentPercent;
+        private DirtyValue<decimal?> _downPaymentPercent;
         public decimal? DownPaymentPercent { get { return _downPaymentPercent; } set { _downPaymentPercent = value; } }
-        private Value<decimal?> _fhaUpfrontMIPremiumPercent;
+        private DirtyValue<decimal?> _fhaUpfrontMIPremiumPercent;
         public decimal? FhaUpfrontMIPremiumPercent { get { return _fhaUpfrontMIPremiumPercent; } set { _fhaUpfrontMIPremiumPercent = value; } }
-        private Value<decimal?> _grossNegativeCashFlow;
+        private DirtyValue<decimal?> _grossNegativeCashFlow;
         public decimal? GrossNegativeCashFlow { get { return _grossNegativeCashFlow; } set { _grossNegativeCashFlow = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _loanAmount;
+        private DirtyValue<decimal?> _loanAmount;
         public decimal? LoanAmount { get { return _loanAmount; } set { _loanAmount = value; } }
-        private Value<decimal?> _ltv;
+        private DirtyValue<decimal?> _ltv;
         public decimal? Ltv { get { return _ltv; } set { _ltv = value; } }
-        private Value<decimal?> _maximumDebt;
+        private DirtyValue<decimal?> _maximumDebt;
         public decimal? MaximumDebt { get { return _maximumDebt; } set { _maximumDebt = value; } }
-        private Value<decimal?> _maximumLoanAmount;
+        private DirtyValue<decimal?> _maximumLoanAmount;
         public decimal? MaximumLoanAmount { get { return _maximumLoanAmount; } set { _maximumLoanAmount = value; } }
-        private Value<decimal?> _miAndFundingFeeFinancedAmount;
+        private DirtyValue<decimal?> _miAndFundingFeeFinancedAmount;
         public decimal? MiAndFundingFeeFinancedAmount { get { return _miAndFundingFeeFinancedAmount; } set { _miAndFundingFeeFinancedAmount = value; } }
-        private Value<decimal?> _minimumIncome;
+        private DirtyValue<decimal?> _minimumIncome;
         public decimal? MinimumIncome { get { return _minimumIncome; } set { _minimumIncome = value; } }
-        private Value<decimal?> _monthlyPayment;
+        private DirtyValue<decimal?> _monthlyPayment;
         public decimal? MonthlyPayment { get { return _monthlyPayment; } set { _monthlyPayment = value; } }
-        private Value<decimal?> _prepaidItemsEstimatedAmount;
+        private DirtyValue<decimal?> _prepaidItemsEstimatedAmount;
         public decimal? PrepaidItemsEstimatedAmount { get { return _prepaidItemsEstimatedAmount; } set { _prepaidItemsEstimatedAmount = value; } }
-        private Value<int?> _prequalificationScenarioIndex;
+        private DirtyValue<int?> _prequalificationScenarioIndex;
         public int? PrequalificationScenarioIndex { get { return _prequalificationScenarioIndex; } set { _prequalificationScenarioIndex = value; } }
-        private Value<decimal?> _qualBottomRatioPercent;
+        private DirtyValue<decimal?> _qualBottomRatioPercent;
         public decimal? QualBottomRatioPercent { get { return _qualBottomRatioPercent; } set { _qualBottomRatioPercent = value; } }
-        private Value<decimal?> _qualTopRatioPercent;
+        private DirtyValue<decimal?> _qualTopRatioPercent;
         public decimal? QualTopRatioPercent { get { return _qualTopRatioPercent; } set { _qualTopRatioPercent = value; } }
-        private Value<decimal?> _salesPrice;
+        private DirtyValue<decimal?> _salesPrice;
         public decimal? SalesPrice { get { return _salesPrice; } set { _salesPrice = value; } }
-        private Value<decimal?> _subordinateFin;
+        private DirtyValue<decimal?> _subordinateFin;
         public decimal? SubordinateFin { get { return _subordinateFin; } set { _subordinateFin = value; } }
-        private Value<decimal?> _totalBaseCost;
+        private DirtyValue<decimal?> _totalBaseCost;
         public decimal? TotalBaseCost { get { return _totalBaseCost; } set { _totalBaseCost = value; } }
-        private Value<decimal?> _totalCashAvailable;
+        private DirtyValue<decimal?> _totalCashAvailable;
         public decimal? TotalCashAvailable { get { return _totalCashAvailable; } set { _totalCashAvailable = value; } }
-        private Value<decimal?> _totalCashLeft;
+        private DirtyValue<decimal?> _totalCashLeft;
         public decimal? TotalCashLeft { get { return _totalCashLeft; } set { _totalCashLeft = value; } }
-        private Value<decimal?> _totalCosts;
+        private DirtyValue<decimal?> _totalCosts;
         public decimal? TotalCosts { get { return _totalCosts; } set { _totalCosts = value; } }
-        private Value<decimal?> _totalFinancing;
+        private DirtyValue<decimal?> _totalFinancing;
         public decimal? TotalFinancing { get { return _totalFinancing; } set { _totalFinancing = value; } }
-        private Value<decimal?> _totalHe;
+        private DirtyValue<decimal?> _totalHe;
         public decimal? TotalHe { get { return _totalHe; } set { _totalHe = value; } }
-        private Value<decimal?> _totalIncome;
+        private DirtyValue<decimal?> _totalIncome;
         public decimal? TotalIncome { get { return _totalIncome; } set { _totalIncome = value; } }
-        private Value<decimal?> _totalLoanAmount;
+        private DirtyValue<decimal?> _totalLoanAmount;
         public decimal? TotalLoanAmount { get { return _totalLoanAmount; } set { _totalLoanAmount = value; } }
-        private Value<decimal?> _totalOtherExpense;
+        private DirtyValue<decimal?> _totalOtherExpense;
         public decimal? TotalOtherExpense { get { return _totalOtherExpense; } set { _totalOtherExpense = value; } }
-        private Value<decimal?> _totalPaidOffMortgage;
+        private DirtyValue<decimal?> _totalPaidOffMortgage;
         public decimal? TotalPaidOffMortgage { get { return _totalPaidOffMortgage; } set { _totalPaidOffMortgage = value; } }
-        private Value<decimal?> _totalPaidOffOthers;
+        private DirtyValue<decimal?> _totalPaidOffOthers;
         public decimal? TotalPaidOffOthers { get { return _totalPaidOffOthers; } set { _totalPaidOffOthers = value; } }
-        private Value<decimal?> _totalPayments;
+        private DirtyValue<decimal?> _totalPayments;
         public decimal? TotalPayments { get { return _totalPayments; } set { _totalPayments = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PreviousVaLoan.cs
+++ b/src/EncompassRest/Loans/PreviousVaLoan.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PreviousVaLoan : IDirty
     {
-        private Value<DateTime?> _dateOfLoan;
+        private DirtyValue<DateTime?> _dateOfLoan;
         public DateTime? DateOfLoan { get { return _dateOfLoan; } set { _dateOfLoan = value; } }
-        private Value<DateTime?> _dateSold;
+        private DirtyValue<DateTime?> _dateSold;
         public DateTime? DateSold { get { return _dateSold; } set { _dateSold = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _loanType;
+        private DirtyValue<string> _loanType;
         public string LoanType { get { return _loanType; } set { _loanType = value; } }
-        private Value<int?> _previousVaLoanIndex;
+        private DirtyValue<int?> _previousVaLoanIndex;
         public int? PreviousVaLoanIndex { get { return _previousVaLoanIndex; } set { _previousVaLoanIndex = value; } }
-        private Value<string> _propertyAddress;
+        private DirtyValue<string> _propertyAddress;
         public string PropertyAddress { get { return _propertyAddress; } set { _propertyAddress = value; } }
-        private Value<string> _propertyCity;
+        private DirtyValue<string> _propertyCity;
         public string PropertyCity { get { return _propertyCity; } set { _propertyCity = value; } }
-        private Value<bool?> _propertyOwned;
+        private DirtyValue<bool?> _propertyOwned;
         public bool? PropertyOwned { get { return _propertyOwned; } set { _propertyOwned = value; } }
-        private Value<string> _propertyPostalCode;
+        private DirtyValue<string> _propertyPostalCode;
         public string PropertyPostalCode { get { return _propertyPostalCode; } set { _propertyPostalCode = value; } }
-        private Value<string> _propertyState;
+        private DirtyValue<string> _propertyState;
         public string PropertyState { get { return _propertyState; } set { _propertyState = value; } }
-        private Value<string> _vALoanNumber;
+        private DirtyValue<string> _vALoanNumber;
         public string VALoanNumber { get { return _vALoanNumber; } set { _vALoanNumber = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PriceAdjustment.cs
+++ b/src/EncompassRest/Loans/PriceAdjustment.cs
@@ -8,17 +8,17 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PriceAdjustment : IDirty
     {
-        private Value<string> _adjustmentType;
+        private DirtyValue<string> _adjustmentType;
         public string AdjustmentType { get { return _adjustmentType; } set { _adjustmentType = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _priceAdjustmentType;
+        private DirtyValue<string> _priceAdjustmentType;
         public string PriceAdjustmentType { get { return _priceAdjustmentType; } set { _priceAdjustmentType = value; } }
-        private Value<decimal?> _rate;
+        private DirtyValue<decimal?> _rate;
         public decimal? Rate { get { return _rate; } set { _rate = value; } }
-        private Value<string> _rateLockAdjustmentType;
+        private DirtyValue<string> _rateLockAdjustmentType;
         public string RateLockAdjustmentType { get { return _rateLockAdjustmentType; } set { _rateLockAdjustmentType = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PrincipalDisbursementTransaction.cs
+++ b/src/EncompassRest/Loans/PrincipalDisbursementTransaction.cs
@@ -8,35 +8,35 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PrincipalDisbursementTransaction : IDirty
     {
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<DateTime?> _disbursementDate;
+        private DirtyValue<DateTime?> _disbursementDate;
         public DateTime? DisbursementDate { get { return _disbursementDate; } set { _disbursementDate = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _institutionName;
+        private DirtyValue<string> _institutionName;
         public string InstitutionName { get { return _institutionName; } set { _institutionName = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PrintForm.cs
+++ b/src/EncompassRest/Loans/PrintForm.cs
@@ -8,9 +8,9 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PrintForm : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PrintLog.cs
+++ b/src/EncompassRest/Loans/PrintLog.cs
@@ -8,33 +8,33 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PrintLog : IDirty
     {
-        private Value<string> _action;
+        private DirtyValue<string> _action;
         public string Action { get { return _action; } set { _action = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _printedBy;
+        private DirtyValue<string> _printedBy;
         public string PrintedBy { get { return _printedBy; } set { _printedBy = value; } }
-        private Value<string> _printedByFullName;
+        private DirtyValue<string> _printedByFullName;
         public string PrintedByFullName { get { return _printedByFullName; } set { _printedByFullName = value; } }
         private DirtyList<PrintForm> _printForms;
         public IList<PrintForm> PrintForms { get { var v = _printForms; return v ?? Interlocked.CompareExchange(ref _printForms, (v = new DirtyList<PrintForm>()), null) ?? v; } set { _printForms = new DirtyList<PrintForm>(value); } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PrintLog.cs
+++ b/src/EncompassRest/Loans/PrintLog.cs
@@ -10,10 +10,10 @@ namespace EncompassRest.Loans
     {
         private Value<string> _action;
         public string Action { get { return _action; } set { _action = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -32,8 +32,8 @@ namespace EncompassRest.Loans
         public string PrintedBy { get { return _printedBy; } set { _printedBy = value; } }
         private Value<string> _printedByFullName;
         public string PrintedByFullName { get { return _printedByFullName; } set { _printedByFullName = value; } }
-        private Value<List<PrintForm>> _printForms;
-        public List<PrintForm> PrintForms { get { return _printForms; } set { _printForms = value; } }
+        private DirtyList<PrintForm> _printForms;
+        public IList<PrintForm> PrintForms { get { var v = _printForms; return v ?? Interlocked.CompareExchange(ref _printForms, (v = new DirtyList<PrintForm>()), null) ?? v; } set { _printForms = new DirtyList<PrintForm>(value); } }
         private Value<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
@@ -44,8 +44,6 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _action.Dirty
-                    || _alerts.Dirty
-                    || _commentList.Dirty
                     || _comments.Dirty
                     || _dateUtc.Dirty
                     || _fileAttachmentsMigrated.Dirty
@@ -55,8 +53,10 @@ namespace EncompassRest.Loans
                     || _logRecordIndex.Dirty
                     || _printedBy.Dirty
                     || _printedByFullName.Dirty
-                    || _printForms.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _printForms?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -64,8 +64,6 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _action.Dirty = value;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
@@ -75,8 +73,10 @@ namespace EncompassRest.Loans
                 _logRecordIndex.Dirty = value;
                 _printedBy.Dirty = value;
                 _printedByFullName.Dirty = value;
-                _printForms.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_printForms != null) _printForms.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/PrivacyPolicy.cs
+++ b/src/EncompassRest/Loans/PrivacyPolicy.cs
@@ -8,99 +8,99 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PrivacyPolicy : IDirty
     {
-        private Value<string> _additionalRightsDescription;
+        private DirtyValue<string> _additionalRightsDescription;
         public string AdditionalRightsDescription { get { return _additionalRightsDescription; } set { _additionalRightsDescription = value; } }
-        private Value<string> _affiliateType;
+        private DirtyValue<string> _affiliateType;
         public string AffiliateType { get { return _affiliateType; } set { _affiliateType = value; } }
-        private Value<string> _affiliateTypeExample1;
+        private DirtyValue<string> _affiliateTypeExample1;
         public string AffiliateTypeExample1 { get { return _affiliateTypeExample1; } set { _affiliateTypeExample1 = value; } }
-        private Value<string> _affiliateTypeExample2;
+        private DirtyValue<string> _affiliateTypeExample2;
         public string AffiliateTypeExample2 { get { return _affiliateTypeExample2; } set { _affiliateTypeExample2 = value; } }
-        private Value<string> _affiliateTypeExample3;
+        private DirtyValue<string> _affiliateTypeExample3;
         public string AffiliateTypeExample3 { get { return _affiliateTypeExample3; } set { _affiliateTypeExample3 = value; } }
-        private Value<string> _alsoCollectFrom;
+        private DirtyValue<string> _alsoCollectFrom;
         public string AlsoCollectFrom { get { return _alsoCollectFrom; } set { _alsoCollectFrom = value; } }
-        private Value<int?> _daysToUse;
+        private DirtyValue<int?> _daysToUse;
         public int? DaysToUse { get { return _daysToUse; } set { _daysToUse = value; } }
-        private Value<string> _howToShare;
+        private DirtyValue<string> _howToShare;
         public string HowToShare { get { return _howToShare; } set { _howToShare = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _informationShare1;
+        private DirtyValue<string> _informationShare1;
         public string InformationShare1 { get { return _informationShare1; } set { _informationShare1 = value; } }
-        private Value<string> _informationShare2;
+        private DirtyValue<string> _informationShare2;
         public string InformationShare2 { get { return _informationShare2; } set { _informationShare2 = value; } }
-        private Value<string> _informationShare3;
+        private DirtyValue<string> _informationShare3;
         public string InformationShare3 { get { return _informationShare3; } set { _informationShare3 = value; } }
-        private Value<string> _informationShare4;
+        private DirtyValue<string> _informationShare4;
         public string InformationShare4 { get { return _informationShare4; } set { _informationShare4 = value; } }
-        private Value<string> _informationShare5;
+        private DirtyValue<string> _informationShare5;
         public string InformationShare5 { get { return _informationShare5; } set { _informationShare5 = value; } }
-        private Value<string> _informationShare6;
+        private DirtyValue<string> _informationShare6;
         public string InformationShare6 { get { return _informationShare6; } set { _informationShare6 = value; } }
-        private Value<string> _informationShare7;
+        private DirtyValue<string> _informationShare7;
         public string InformationShare7 { get { return _informationShare7; } set { _informationShare7 = value; } }
-        private Value<string> _informationTypesWeCollect1;
+        private DirtyValue<string> _informationTypesWeCollect1;
         public string InformationTypesWeCollect1 { get { return _informationTypesWeCollect1; } set { _informationTypesWeCollect1 = value; } }
-        private Value<string> _informationTypesWeCollect2;
+        private DirtyValue<string> _informationTypesWeCollect2;
         public string InformationTypesWeCollect2 { get { return _informationTypesWeCollect2; } set { _informationTypesWeCollect2 = value; } }
-        private Value<string> _informationTypesWeCollect3;
+        private DirtyValue<string> _informationTypesWeCollect3;
         public string InformationTypesWeCollect3 { get { return _informationTypesWeCollect3; } set { _informationTypesWeCollect3 = value; } }
-        private Value<string> _informationTypesWeCollect4;
+        private DirtyValue<string> _informationTypesWeCollect4;
         public string InformationTypesWeCollect4 { get { return _informationTypesWeCollect4; } set { _informationTypesWeCollect4 = value; } }
-        private Value<string> _informationTypesWeCollect5;
+        private DirtyValue<string> _informationTypesWeCollect5;
         public string InformationTypesWeCollect5 { get { return _informationTypesWeCollect5; } set { _informationTypesWeCollect5 = value; } }
-        private Value<string> _jointMarketType;
+        private DirtyValue<string> _jointMarketType;
         public string JointMarketType { get { return _jointMarketType; } set { _jointMarketType = value; } }
-        private Value<string> _jointMarketTypeExample1;
+        private DirtyValue<string> _jointMarketTypeExample1;
         public string JointMarketTypeExample1 { get { return _jointMarketTypeExample1; } set { _jointMarketTypeExample1 = value; } }
-        private Value<string> _limitSharing1;
+        private DirtyValue<string> _limitSharing1;
         public string LimitSharing1 { get { return _limitSharing1; } set { _limitSharing1 = value; } }
-        private Value<string> _limitSharing2;
+        private DirtyValue<string> _limitSharing2;
         public string LimitSharing2 { get { return _limitSharing2; } set { _limitSharing2 = value; } }
-        private Value<string> _limitSharing3;
+        private DirtyValue<string> _limitSharing3;
         public string LimitSharing3 { get { return _limitSharing3; } set { _limitSharing3 = value; } }
-        private Value<string> _limitSharing4;
+        private DirtyValue<string> _limitSharing4;
         public string LimitSharing4 { get { return _limitSharing4; } set { _limitSharing4 = value; } }
-        private Value<string> _limitSharing5;
+        private DirtyValue<string> _limitSharing5;
         public string LimitSharing5 { get { return _limitSharing5; } set { _limitSharing5 = value; } }
-        private Value<string> _limitSharing6;
+        private DirtyValue<string> _limitSharing6;
         public string LimitSharing6 { get { return _limitSharing6; } set { _limitSharing6 = value; } }
-        private Value<string> _limitSharing7;
+        private DirtyValue<string> _limitSharing7;
         public string LimitSharing7 { get { return _limitSharing7; } set { _limitSharing7 = value; } }
-        private Value<string> _month;
+        private DirtyValue<string> _month;
         public string Month { get { return _month; } set { _month = value; } }
-        private Value<string> _nonaffiliateType;
+        private DirtyValue<string> _nonaffiliateType;
         public string NonaffiliateType { get { return _nonaffiliateType; } set { _nonaffiliateType = value; } }
-        private Value<string> _nonaffiliateTypeExample1;
+        private DirtyValue<string> _nonaffiliateTypeExample1;
         public string NonaffiliateTypeExample1 { get { return _nonaffiliateTypeExample1; } set { _nonaffiliateTypeExample1 = value; } }
-        private Value<string> _notesForProtectPrivacy;
+        private DirtyValue<string> _notesForProtectPrivacy;
         public string NotesForProtectPrivacy { get { return _notesForProtectPrivacy; } set { _notesForProtectPrivacy = value; } }
-        private Value<string> _otherInformation;
+        private DirtyValue<string> _otherInformation;
         public string OtherInformation { get { return _otherInformation; } set { _otherInformation = value; } }
-        private Value<string> _phoneForQuestion;
+        private DirtyValue<string> _phoneForQuestion;
         public string PhoneForQuestion { get { return _phoneForQuestion; } set { _phoneForQuestion = value; } }
-        private Value<string> _phoneToLimit;
+        private DirtyValue<string> _phoneToLimit;
         public string PhoneToLimit { get { return _phoneToLimit; } set { _phoneToLimit = value; } }
-        private Value<string> _printSelection;
+        private DirtyValue<string> _printSelection;
         public string PrintSelection { get { return _printSelection; } set { _printSelection = value; } }
-        private Value<string> _shareInfoWithJointMarketing;
+        private DirtyValue<string> _shareInfoWithJointMarketing;
         public string ShareInfoWithJointMarketing { get { return _shareInfoWithJointMarketing; } set { _shareInfoWithJointMarketing = value; } }
-        private Value<string> _timesToCollect1;
+        private DirtyValue<string> _timesToCollect1;
         public string TimesToCollect1 { get { return _timesToCollect1; } set { _timesToCollect1 = value; } }
-        private Value<string> _timesToCollect2;
+        private DirtyValue<string> _timesToCollect2;
         public string TimesToCollect2 { get { return _timesToCollect2; } set { _timesToCollect2 = value; } }
-        private Value<string> _timesToCollect3;
+        private DirtyValue<string> _timesToCollect3;
         public string TimesToCollect3 { get { return _timesToCollect3; } set { _timesToCollect3 = value; } }
-        private Value<string> _timesToCollect4;
+        private DirtyValue<string> _timesToCollect4;
         public string TimesToCollect4 { get { return _timesToCollect4; } set { _timesToCollect4 = value; } }
-        private Value<string> _timesToCollect5;
+        private DirtyValue<string> _timesToCollect5;
         public string TimesToCollect5 { get { return _timesToCollect5; } set { _timesToCollect5 = value; } }
-        private Value<string> _websiteForQuestion;
+        private DirtyValue<string> _websiteForQuestion;
         public string WebsiteForQuestion { get { return _websiteForQuestion; } set { _websiteForQuestion = value; } }
-        private Value<string> _websiteToLimit;
+        private DirtyValue<string> _websiteToLimit;
         public string WebsiteToLimit { get { return _websiteToLimit; } set { _websiteToLimit = value; } }
-        private Value<int?> _year;
+        private DirtyValue<int?> _year;
         public int? Year { get { return _year; } set { _year = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ProfitManagement.cs
+++ b/src/EncompassRest/Loans/ProfitManagement.cs
@@ -32,8 +32,8 @@ namespace EncompassRest.Loans
         public string Id { get { return _id; } set { _id = value; } }
         private Value<decimal?> _netProfit;
         public decimal? NetProfit { get { return _netProfit; } set { _netProfit = value; } }
-        private Value<List<ProfitManagementItem>> _profitManagementItems;
-        public List<ProfitManagementItem> ProfitManagementItems { get { return _profitManagementItems; } set { _profitManagementItems = value; } }
+        private DirtyList<ProfitManagementItem> _profitManagementItems;
+        public IList<ProfitManagementItem> ProfitManagementItems { get { var v = _profitManagementItems; return v ?? Interlocked.CompareExchange(ref _profitManagementItems, (v = new DirtyList<ProfitManagementItem>()), null) ?? v; } set { _profitManagementItems = new DirtyList<ProfitManagementItem>(value); } }
         private int _gettingDirty;
         private int _settingDirty; 
         internal bool Dirty
@@ -53,7 +53,7 @@ namespace EncompassRest.Loans
                     || _grossCheckAmount.Dirty
                     || _id.Dirty
                     || _netProfit.Dirty
-                    || _profitManagementItems.Dirty;
+                    || _profitManagementItems?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -72,7 +72,7 @@ namespace EncompassRest.Loans
                 _grossCheckAmount.Dirty = value;
                 _id.Dirty = value;
                 _netProfit.Dirty = value;
-                _profitManagementItems.Dirty = value;
+                if (_profitManagementItems != null) _profitManagementItems.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/ProfitManagement.cs
+++ b/src/EncompassRest/Loans/ProfitManagement.cs
@@ -8,29 +8,29 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ProfitManagement : IDirty
     {
-        private Value<decimal?> _commissionableGrossProfit;
+        private DirtyValue<decimal?> _commissionableGrossProfit;
         public decimal? CommissionableGrossProfit { get { return _commissionableGrossProfit; } set { _commissionableGrossProfit = value; } }
-        private Value<decimal?> _expenseAmount1;
+        private DirtyValue<decimal?> _expenseAmount1;
         public decimal? ExpenseAmount1 { get { return _expenseAmount1; } set { _expenseAmount1 = value; } }
-        private Value<decimal?> _expenseAmount2;
+        private DirtyValue<decimal?> _expenseAmount2;
         public decimal? ExpenseAmount2 { get { return _expenseAmount2; } set { _expenseAmount2 = value; } }
-        private Value<decimal?> _expenseAmount3;
+        private DirtyValue<decimal?> _expenseAmount3;
         public decimal? ExpenseAmount3 { get { return _expenseAmount3; } set { _expenseAmount3 = value; } }
-        private Value<decimal?> _expenseAmount4;
+        private DirtyValue<decimal?> _expenseAmount4;
         public decimal? ExpenseAmount4 { get { return _expenseAmount4; } set { _expenseAmount4 = value; } }
-        private Value<string> _expenseDescription1;
+        private DirtyValue<string> _expenseDescription1;
         public string ExpenseDescription1 { get { return _expenseDescription1; } set { _expenseDescription1 = value; } }
-        private Value<string> _expenseDescription2;
+        private DirtyValue<string> _expenseDescription2;
         public string ExpenseDescription2 { get { return _expenseDescription2; } set { _expenseDescription2 = value; } }
-        private Value<string> _expenseDescription3;
+        private DirtyValue<string> _expenseDescription3;
         public string ExpenseDescription3 { get { return _expenseDescription3; } set { _expenseDescription3 = value; } }
-        private Value<string> _expenseDescription4;
+        private DirtyValue<string> _expenseDescription4;
         public string ExpenseDescription4 { get { return _expenseDescription4; } set { _expenseDescription4 = value; } }
-        private Value<decimal?> _grossCheckAmount;
+        private DirtyValue<decimal?> _grossCheckAmount;
         public decimal? GrossCheckAmount { get { return _grossCheckAmount; } set { _grossCheckAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _netProfit;
+        private DirtyValue<decimal?> _netProfit;
         public decimal? NetProfit { get { return _netProfit; } set { _netProfit = value; } }
         private DirtyList<ProfitManagementItem> _profitManagementItems;
         public IList<ProfitManagementItem> ProfitManagementItems { get { var v = _profitManagementItems; return v ?? Interlocked.CompareExchange(ref _profitManagementItems, (v = new DirtyList<ProfitManagementItem>()), null) ?? v; } set { _profitManagementItems = new DirtyList<ProfitManagementItem>(value); } }

--- a/src/EncompassRest/Loans/ProfitManagementItem.cs
+++ b/src/EncompassRest/Loans/ProfitManagementItem.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ProfitManagementItem : IDirty
     {
-        private Value<decimal?> _atPercent;
+        private DirtyValue<decimal?> _atPercent;
         public decimal? AtPercent { get { return _atPercent; } set { _atPercent = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _plusAmount;
+        private DirtyValue<decimal?> _plusAmount;
         public decimal? PlusAmount { get { return _plusAmount; } set { _plusAmount = value; } }
-        private Value<int?> _profitManagementItemIndex;
+        private DirtyValue<int?> _profitManagementItemIndex;
         public int? ProfitManagementItemIndex { get { return _profitManagementItemIndex; } set { _profitManagementItemIndex = value; } }
-        private Value<decimal?> _total;
+        private DirtyValue<decimal?> _total;
         public decimal? Total { get { return _total; } set { _total = value; } }
-        private Value<string> _type;
+        private DirtyValue<string> _type;
         public string Type { get { return _type; } set { _type = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Property.cs
+++ b/src/EncompassRest/Loans/Property.cs
@@ -8,115 +8,115 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Property : IDirty
     {
-        private Value<string> _assessorsParcelIdentifier;
+        private DirtyValue<string> _assessorsParcelIdentifier;
         public string AssessorsParcelIdentifier { get { return _assessorsParcelIdentifier; } set { _assessorsParcelIdentifier = value; } }
-        private Value<string> _blockIdentifier;
+        private DirtyValue<string> _blockIdentifier;
         public string BlockIdentifier { get { return _blockIdentifier; } set { _blockIdentifier = value; } }
-        private Value<bool?> _borrowerHomesteadIndicator;
+        private DirtyValue<bool?> _borrowerHomesteadIndicator;
         public bool? BorrowerHomesteadIndicator { get { return _borrowerHomesteadIndicator; } set { _borrowerHomesteadIndicator = value; } }
-        private Value<string> _buildingStatusType;
+        private DirtyValue<string> _buildingStatusType;
         public string BuildingStatusType { get { return _buildingStatusType; } set { _buildingStatusType = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<bool?> _condotelIndicator;
+        private DirtyValue<bool?> _condotelIndicator;
         public bool? CondotelIndicator { get { return _condotelIndicator; } set { _condotelIndicator = value; } }
-        private Value<decimal?> _constructionImprovementCostsAmount;
+        private DirtyValue<decimal?> _constructionImprovementCostsAmount;
         public decimal? ConstructionImprovementCostsAmount { get { return _constructionImprovementCostsAmount; } set { _constructionImprovementCostsAmount = value; } }
-        private Value<string> _county;
+        private DirtyValue<string> _county;
         public string County { get { return _county; } set { _county = value; } }
-        private Value<int?> _financedNumberOfUnits;
+        private DirtyValue<int?> _financedNumberOfUnits;
         public int? FinancedNumberOfUnits { get { return _financedNumberOfUnits; } set { _financedNumberOfUnits = value; } }
-        private Value<string> _floodCertificationIdentifier;
+        private DirtyValue<string> _floodCertificationIdentifier;
         public string FloodCertificationIdentifier { get { return _floodCertificationIdentifier; } set { _floodCertificationIdentifier = value; } }
-        private Value<decimal?> _freCashOutAmount;
+        private DirtyValue<decimal?> _freCashOutAmount;
         public decimal? FreCashOutAmount { get { return _freCashOutAmount; } set { _freCashOutAmount = value; } }
-        private Value<string> _gseRefinancePurposeType;
+        private DirtyValue<string> _gseRefinancePurposeType;
         public string GseRefinancePurposeType { get { return _gseRefinancePurposeType; } set { _gseRefinancePurposeType = value; } }
-        private Value<string> _gseTitleMannerHeldDescription;
+        private DirtyValue<string> _gseTitleMannerHeldDescription;
         public string GseTitleMannerHeldDescription { get { return _gseTitleMannerHeldDescription; } set { _gseTitleMannerHeldDescription = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isConstructionPhaseDisclosedSeparately;
+        private DirtyValue<bool?> _isConstructionPhaseDisclosedSeparately;
         public bool? IsConstructionPhaseDisclosedSeparately { get { return _isConstructionPhaseDisclosedSeparately; } set { _isConstructionPhaseDisclosedSeparately = value; } }
-        private Value<decimal?> _landEstimatedValueAmount;
+        private DirtyValue<decimal?> _landEstimatedValueAmount;
         public decimal? LandEstimatedValueAmount { get { return _landEstimatedValueAmount; } set { _landEstimatedValueAmount = value; } }
-        private Value<string> _legalDescriptionText1;
+        private DirtyValue<string> _legalDescriptionText1;
         public string LegalDescriptionText1 { get { return _legalDescriptionText1; } set { _legalDescriptionText1 = value; } }
-        private Value<string> _legalDescriptionText2;
+        private DirtyValue<string> _legalDescriptionText2;
         public string LegalDescriptionText2 { get { return _legalDescriptionText2; } set { _legalDescriptionText2 = value; } }
-        private Value<bool?> _linkedIsConstructionPhaseDisclosedSeparately;
+        private DirtyValue<bool?> _linkedIsConstructionPhaseDisclosedSeparately;
         public bool? LinkedIsConstructionPhaseDisclosedSeparately { get { return _linkedIsConstructionPhaseDisclosedSeparately; } set { _linkedIsConstructionPhaseDisclosedSeparately = value; } }
-        private Value<string> _linkedLoanPurposeType;
+        private DirtyValue<string> _linkedLoanPurposeType;
         public string LinkedLoanPurposeType { get { return _linkedLoanPurposeType; } set { _linkedLoanPurposeType = value; } }
-        private Value<string> _loanPurposeType;
+        private DirtyValue<string> _loanPurposeType;
         public string LoanPurposeType { get { return _loanPurposeType; } set { _loanPurposeType = value; } }
-        private Value<decimal?> _lotAcres;
+        private DirtyValue<decimal?> _lotAcres;
         public decimal? LotAcres { get { return _lotAcres; } set { _lotAcres = value; } }
-        private Value<string> _lotIdentifier;
+        private DirtyValue<string> _lotIdentifier;
         public string LotIdentifier { get { return _lotIdentifier; } set { _lotIdentifier = value; } }
-        private Value<string> _nameRecordingJurisdiction;
+        private DirtyValue<string> _nameRecordingJurisdiction;
         public string NameRecordingJurisdiction { get { return _nameRecordingJurisdiction; } set { _nameRecordingJurisdiction = value; } }
-        private Value<bool?> _nonwarrantableProjectIndicator;
+        private DirtyValue<bool?> _nonwarrantableProjectIndicator;
         public bool? NonwarrantableProjectIndicator { get { return _nonwarrantableProjectIndicator; } set { _nonwarrantableProjectIndicator = value; } }
-        private Value<decimal?> _numberOfStories;
+        private DirtyValue<decimal?> _numberOfStories;
         public decimal? NumberOfStories { get { return _numberOfStories; } set { _numberOfStories = value; } }
-        private Value<string> _otherLoanPurposeDescription;
+        private DirtyValue<string> _otherLoanPurposeDescription;
         public string OtherLoanPurposeDescription { get { return _otherLoanPurposeDescription; } set { _otherLoanPurposeDescription = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _priorLoanRecordationBookNumber;
+        private DirtyValue<string> _priorLoanRecordationBookNumber;
         public string PriorLoanRecordationBookNumber { get { return _priorLoanRecordationBookNumber; } set { _priorLoanRecordationBookNumber = value; } }
-        private Value<decimal?> _priorLoanRecordationCurrentPrincipalAmount;
+        private DirtyValue<decimal?> _priorLoanRecordationCurrentPrincipalAmount;
         public decimal? PriorLoanRecordationCurrentPrincipalAmount { get { return _priorLoanRecordationCurrentPrincipalAmount; } set { _priorLoanRecordationCurrentPrincipalAmount = value; } }
-        private Value<decimal?> _priorLoanRecordationOriginalPrincipalAmount;
+        private DirtyValue<decimal?> _priorLoanRecordationOriginalPrincipalAmount;
         public decimal? PriorLoanRecordationOriginalPrincipalAmount { get { return _priorLoanRecordationOriginalPrincipalAmount; } set { _priorLoanRecordationOriginalPrincipalAmount = value; } }
-        private Value<string> _priorLoanRecordationPageNumber;
+        private DirtyValue<string> _priorLoanRecordationPageNumber;
         public string PriorLoanRecordationPageNumber { get { return _priorLoanRecordationPageNumber; } set { _priorLoanRecordationPageNumber = value; } }
-        private Value<bool?> _prodIsSpInUnderservedArea;
+        private DirtyValue<bool?> _prodIsSpInUnderservedArea;
         public bool? ProdIsSpInUnderservedArea { get { return _prodIsSpInUnderservedArea; } set { _prodIsSpInUnderservedArea = value; } }
-        private Value<string> _propertyAcquiredYear;
+        private DirtyValue<string> _propertyAcquiredYear;
         public string PropertyAcquiredYear { get { return _propertyAcquiredYear; } set { _propertyAcquiredYear = value; } }
-        private Value<decimal?> _propertyExistingLienAmount;
+        private DirtyValue<decimal?> _propertyExistingLienAmount;
         public decimal? PropertyExistingLienAmount { get { return _propertyExistingLienAmount; } set { _propertyExistingLienAmount = value; } }
-        private Value<DateTime?> _propertyLeaseholdExpirationDate;
+        private DirtyValue<DateTime?> _propertyLeaseholdExpirationDate;
         public DateTime? PropertyLeaseholdExpirationDate { get { return _propertyLeaseholdExpirationDate; } set { _propertyLeaseholdExpirationDate = value; } }
-        private Value<decimal?> _propertyOriginalCostAmount;
+        private DirtyValue<decimal?> _propertyOriginalCostAmount;
         public decimal? PropertyOriginalCostAmount { get { return _propertyOriginalCostAmount; } set { _propertyOriginalCostAmount = value; } }
-        private Value<string> _propertyRightsType;
+        private DirtyValue<string> _propertyRightsType;
         public string PropertyRightsType { get { return _propertyRightsType; } set { _propertyRightsType = value; } }
-        private Value<string> _propertyUsageType;
+        private DirtyValue<string> _propertyUsageType;
         public string PropertyUsageType { get { return _propertyUsageType; } set { _propertyUsageType = value; } }
-        private Value<decimal?> _refinanceImprovementCostsAmount;
+        private DirtyValue<decimal?> _refinanceImprovementCostsAmount;
         public decimal? RefinanceImprovementCostsAmount { get { return _refinanceImprovementCostsAmount; } set { _refinanceImprovementCostsAmount = value; } }
-        private Value<string> _refinanceImprovementsType;
+        private DirtyValue<string> _refinanceImprovementsType;
         public string RefinanceImprovementsType { get { return _refinanceImprovementsType; } set { _refinanceImprovementsType = value; } }
-        private Value<string> _refinancePropertyAcquiredYear;
+        private DirtyValue<string> _refinancePropertyAcquiredYear;
         public string RefinancePropertyAcquiredYear { get { return _refinancePropertyAcquiredYear; } set { _refinancePropertyAcquiredYear = value; } }
-        private Value<decimal?> _refinancePropertyExistingLienAmount;
+        private DirtyValue<decimal?> _refinancePropertyExistingLienAmount;
         public decimal? RefinancePropertyExistingLienAmount { get { return _refinancePropertyExistingLienAmount; } set { _refinancePropertyExistingLienAmount = value; } }
-        private Value<decimal?> _refinancePropertyOriginalCostAmount;
+        private DirtyValue<decimal?> _refinancePropertyOriginalCostAmount;
         public decimal? RefinancePropertyOriginalCostAmount { get { return _refinancePropertyOriginalCostAmount; } set { _refinancePropertyOriginalCostAmount = value; } }
-        private Value<string> _refinanceProposedImprovementsDescription;
+        private DirtyValue<string> _refinanceProposedImprovementsDescription;
         public string RefinanceProposedImprovementsDescription { get { return _refinanceProposedImprovementsDescription; } set { _refinanceProposedImprovementsDescription = value; } }
-        private Value<bool?> _ruralAreaIndicator;
+        private DirtyValue<bool?> _ruralAreaIndicator;
         public bool? RuralAreaIndicator { get { return _ruralAreaIndicator; } set { _ruralAreaIndicator = value; } }
-        private Value<string> _sectionIdentifier;
+        private DirtyValue<string> _sectionIdentifier;
         public string SectionIdentifier { get { return _sectionIdentifier; } set { _sectionIdentifier = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _streetAddress;
+        private DirtyValue<string> _streetAddress;
         public string StreetAddress { get { return _streetAddress; } set { _streetAddress = value; } }
-        private Value<string> _streetAddress2;
+        private DirtyValue<string> _streetAddress2;
         public string StreetAddress2 { get { return _streetAddress2; } set { _streetAddress2 = value; } }
-        private Value<string> _structureBuiltYear;
+        private DirtyValue<string> _structureBuiltYear;
         public string StructureBuiltYear { get { return _structureBuiltYear; } set { _structureBuiltYear = value; } }
-        private Value<bool?> _texasContinuousMoneyLoanIndicator;
+        private DirtyValue<bool?> _texasContinuousMoneyLoanIndicator;
         public bool? TexasContinuousMoneyLoanIndicator { get { return _texasContinuousMoneyLoanIndicator; } set { _texasContinuousMoneyLoanIndicator = value; } }
-        private Value<decimal?> _totalConstructionValueAmount;
+        private DirtyValue<decimal?> _totalConstructionValueAmount;
         public decimal? TotalConstructionValueAmount { get { return _totalConstructionValueAmount; } set { _totalConstructionValueAmount = value; } }
-        private Value<string> _typeRecordingJurisdiction;
+        private DirtyValue<string> _typeRecordingJurisdiction;
         public string TypeRecordingJurisdiction { get { return _typeRecordingJurisdiction; } set { _typeRecordingJurisdiction = value; } }
-        private Value<string> _unincorporatedAreaName;
+        private DirtyValue<string> _unincorporatedAreaName;
         public string UnincorporatedAreaName { get { return _unincorporatedAreaName; } set { _unincorporatedAreaName = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PurchaseAdvicePayout.cs
+++ b/src/EncompassRest/Loans/PurchaseAdvicePayout.cs
@@ -8,15 +8,15 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PurchaseAdvicePayout : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<decimal?> _diffAmount;
+        private DirtyValue<decimal?> _diffAmount;
         public decimal? DiffAmount { get { return _diffAmount; } set { _diffAmount = value; } }
-        private Value<decimal?> _expectedAmount;
+        private DirtyValue<decimal?> _expectedAmount;
         public decimal? ExpectedAmount { get { return _expectedAmount; } set { _expectedAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/PurchaseCredit.cs
+++ b/src/EncompassRest/Loans/PurchaseCredit.cs
@@ -8,11 +8,11 @@ namespace EncompassRest.Loans
 {
     public sealed partial class PurchaseCredit : IDirty
     {
-        private Value<decimal?> _amount;
+        private DirtyValue<decimal?> _amount;
         public decimal? Amount { get { return _amount; } set { _amount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _purchaseCreditType;
+        private DirtyValue<string> _purchaseCreditType;
         public string PurchaseCreditType { get { return _purchaseCreditType; } set { _purchaseCreditType = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RateLock.cs
+++ b/src/EncompassRest/Loans/RateLock.cs
@@ -38,8 +38,8 @@ namespace EncompassRest.Loans
         public string BranchApprovedby { get { return _branchApprovedby; } set { _branchApprovedby = value; } }
         private Value<decimal?> _branchPrice;
         public decimal? BranchPrice { get { return _branchPrice; } set { _branchPrice = value; } }
-        private Value<List<PriceAdjustment>> _buySideAdjustments;
-        public List<PriceAdjustment> BuySideAdjustments { get { return _buySideAdjustments; } set { _buySideAdjustments = value; } }
+        private DirtyList<PriceAdjustment> _buySideAdjustments;
+        public IList<PriceAdjustment> BuySideAdjustments { get { var v = _buySideAdjustments; return v ?? Interlocked.CompareExchange(ref _buySideAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _buySideAdjustments = new DirtyList<PriceAdjustment>(value); } }
         private Value<string> _buySideComments;
         public string BuySideComments { get { return _buySideComments; } set { _buySideComments = value; } }
         private Value<DateTime?> _buySideCommitmentDate;
@@ -164,8 +164,8 @@ namespace EncompassRest.Loans
         public string CompInvestorTemplateName { get { return _compInvestorTemplateName; } set { _compInvestorTemplateName = value; } }
         private Value<string> _compInvestorWebsite;
         public string CompInvestorWebsite { get { return _compInvestorWebsite; } set { _compInvestorWebsite = value; } }
-        private Value<List<PriceAdjustment>> _compSideAdjustments;
-        public List<PriceAdjustment> CompSideAdjustments { get { return _compSideAdjustments; } set { _compSideAdjustments = value; } }
+        private DirtyList<PriceAdjustment> _compSideAdjustments;
+        public IList<PriceAdjustment> CompSideAdjustments { get { var v = _compSideAdjustments; return v ?? Interlocked.CompareExchange(ref _compSideAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _compSideAdjustments = new DirtyList<PriceAdjustment>(value); } }
         private Value<string> _compSideComments;
         public string CompSideComments { get { return _compSideComments; } set { _compSideComments = value; } }
         private Value<string> _compSideComparisonedBy;
@@ -520,8 +520,8 @@ namespace EncompassRest.Loans
         public string CreditScoreToUse { get { return _creditScoreToUse; } set { _creditScoreToUse = value; } }
         private Value<int?> _cumulatedDaystoExtend;
         public int? CumulatedDaystoExtend { get { return _cumulatedDaystoExtend; } set { _cumulatedDaystoExtend = value; } }
-        private Value<List<PriceAdjustment>> _currentAdjustments;
-        public List<PriceAdjustment> CurrentAdjustments { get { return _currentAdjustments; } set { _currentAdjustments = value; } }
+        private DirtyList<PriceAdjustment> _currentAdjustments;
+        public IList<PriceAdjustment> CurrentAdjustments { get { var v = _currentAdjustments; return v ?? Interlocked.CompareExchange(ref _currentAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _currentAdjustments = new DirtyList<PriceAdjustment>(value); } }
         private Value<string> _currentComments;
         public string CurrentComments { get { return _currentComments; } set { _currentComments = value; } }
         private Value<DateTime?> _currentLockDate;
@@ -630,8 +630,8 @@ namespace EncompassRest.Loans
         public string ExtensionRequestPending { get { return _extensionRequestPending; } set { _extensionRequestPending = value; } }
         private Value<int?> _extensionSequenceNumber;
         public int? ExtensionSequenceNumber { get { return _extensionSequenceNumber; } set { _extensionSequenceNumber = value; } }
-        private Value<List<ExtraPayment>> _extraPayments;
-        public List<ExtraPayment> ExtraPayments { get { return _extraPayments; } set { _extraPayments = value; } }
+        private DirtyList<ExtraPayment> _extraPayments;
+        public IList<ExtraPayment> ExtraPayments { get { var v = _extraPayments; return v ?? Interlocked.CompareExchange(ref _extraPayments, (v = new DirtyList<ExtraPayment>()), null) ?? v; } set { _extraPayments = new DirtyList<ExtraPayment>(value); } }
         private Value<decimal?> _fHAUpfrontMIPremiumPercent;
         public decimal? FHAUpfrontMIPremiumPercent { get { return _fHAUpfrontMIPremiumPercent; } set { _fHAUpfrontMIPremiumPercent = value; } }
         private Value<int?> _financedNumberOfUnits;
@@ -730,10 +730,10 @@ namespace EncompassRest.Loans
         public DateTime? LoanScheduledClosingDate { get { return _loanScheduledClosingDate; } set { _loanScheduledClosingDate = value; } }
         private Value<bool?> _lockField;
         public bool? LockField { get { return _lockField; } set { _lockField = value; } }
-        private Value<List<PriceAdjustment>> _lockRequestAdjustments;
-        public List<PriceAdjustment> LockRequestAdjustments { get { return _lockRequestAdjustments; } set { _lockRequestAdjustments = value; } }
-        private Value<List<LockRequestBorrower>> _lockRequestBorrowers;
-        public List<LockRequestBorrower> LockRequestBorrowers { get { return _lockRequestBorrowers; } set { _lockRequestBorrowers = value; } }
+        private DirtyList<PriceAdjustment> _lockRequestAdjustments;
+        public IList<PriceAdjustment> LockRequestAdjustments { get { var v = _lockRequestAdjustments; return v ?? Interlocked.CompareExchange(ref _lockRequestAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _lockRequestAdjustments = new DirtyList<PriceAdjustment>(value); } }
+        private DirtyList<LockRequestBorrower> _lockRequestBorrowers;
+        public IList<LockRequestBorrower> LockRequestBorrowers { get { var v = _lockRequestBorrowers; return v ?? Interlocked.CompareExchange(ref _lockRequestBorrowers, (v = new DirtyList<LockRequestBorrower>()), null) ?? v; } set { _lockRequestBorrowers = new DirtyList<LockRequestBorrower>(value); } }
         private Value<string> _lockRequestLoanPurposeType;
         public string LockRequestLoanPurposeType { get { return _lockRequestLoanPurposeType; } set { _lockRequestLoanPurposeType = value; } }
         private Value<decimal?> _lTV;
@@ -772,8 +772,8 @@ namespace EncompassRest.Loans
         public string PrepayPenalty { get { return _prepayPenalty; } set { _prepayPenalty = value; } }
         private Value<decimal?> _priceAdjustment;
         public decimal? PriceAdjustment { get { return _priceAdjustment; } set { _priceAdjustment = value; } }
-        private Value<List<PriceAdjustment>> _priceAdjustments;
-        public List<PriceAdjustment> PriceAdjustments { get { return _priceAdjustments; } set { _priceAdjustments = value; } }
+        private DirtyList<PriceAdjustment> _priceAdjustments;
+        public IList<PriceAdjustment> PriceAdjustments { get { var v = _priceAdjustments; return v ?? Interlocked.CompareExchange(ref _priceAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _priceAdjustments = new DirtyList<PriceAdjustment>(value); } }
         private Value<string> _pricingHistoryData;
         public string PricingHistoryData { get { return _pricingHistoryData; } set { _pricingHistoryData = value; } }
         private Value<string> _pricingUpdated;
@@ -790,8 +790,8 @@ namespace EncompassRest.Loans
         public string PropertyUsageType { get { return _propertyUsageType; } set { _propertyUsageType = value; } }
         private Value<int?> _purchaseAdviceNumberOfDays;
         public int? PurchaseAdviceNumberOfDays { get { return _purchaseAdviceNumberOfDays; } set { _purchaseAdviceNumberOfDays = value; } }
-        private Value<List<PurchaseAdvicePayout>> _purchaseAdvicePayouts;
-        public List<PurchaseAdvicePayout> PurchaseAdvicePayouts { get { return _purchaseAdvicePayouts; } set { _purchaseAdvicePayouts = value; } }
+        private DirtyList<PurchaseAdvicePayout> _purchaseAdvicePayouts;
+        public IList<PurchaseAdvicePayout> PurchaseAdvicePayouts { get { var v = _purchaseAdvicePayouts; return v ?? Interlocked.CompareExchange(ref _purchaseAdvicePayouts, (v = new DirtyList<PurchaseAdvicePayout>()), null) ?? v; } set { _purchaseAdvicePayouts = new DirtyList<PurchaseAdvicePayout>(value); } }
         private Value<decimal?> _purchasePriceAmount;
         public decimal? PurchasePriceAmount { get { return _purchasePriceAmount; } set { _purchasePriceAmount = value; } }
         private Value<string> _rateRequestStatus;
@@ -820,8 +820,8 @@ namespace EncompassRest.Loans
         public string RequestFullfilledDateTime { get { return _requestFullfilledDateTime; } set { _requestFullfilledDateTime = value; } }
         private Value<string> _requestImpoundType;
         public string RequestImpoundType { get { return _requestImpoundType; } set { _requestImpoundType = value; } }
-        private Value<string> _requestImpoundWaived;
-        public string RequestImpoundWaived { get { return _requestImpoundWaived; } set { _requestImpoundWaived = value; } }
+        private Value<string> _requestImpoundWavied;
+        public string RequestImpoundWavied { get { return _requestImpoundWavied; } set { _requestImpoundWavied = value; } }
         private Value<string> _requestLockCancellationComment;
         public string RequestLockCancellationComment { get { return _requestLockCancellationComment; } set { _requestLockCancellationComment = value; } }
         private Value<DateTime?> _requestLockCancellationDate;
@@ -834,6 +834,8 @@ namespace EncompassRest.Loans
         public string RequestLockExtendComment { get { return _requestLockExtendComment; } set { _requestLockExtendComment = value; } }
         private Value<decimal?> _requestLockExtendPriceAdjustment;
         public decimal? RequestLockExtendPriceAdjustment { get { return _requestLockExtendPriceAdjustment; } set { _requestLockExtendPriceAdjustment = value; } }
+        private Value<string> _requestLockStatus;
+        public string RequestLockStatus { get { return _requestLockStatus; } set { _requestLockStatus = value; } }
         private Value<string> _requestLockType;
         public string RequestLockType { get { return _requestLockType; } set { _requestLockType = value; } }
         private Value<decimal?> _requestMarginRate;
@@ -888,8 +890,8 @@ namespace EncompassRest.Loans
         public decimal? SecondSubordinateAmount { get { return _secondSubordinateAmount; } set { _secondSubordinateAmount = value; } }
         private Value<decimal?> _sellerPaidMIPremium;
         public decimal? SellerPaidMIPremium { get { return _sellerPaidMIPremium; } set { _sellerPaidMIPremium = value; } }
-        private Value<List<PriceAdjustment>> _sellSideAdjustments;
-        public List<PriceAdjustment> SellSideAdjustments { get { return _sellSideAdjustments; } set { _sellSideAdjustments = value; } }
+        private DirtyList<PriceAdjustment> _sellSideAdjustments;
+        public IList<PriceAdjustment> SellSideAdjustments { get { var v = _sellSideAdjustments; return v ?? Interlocked.CompareExchange(ref _sellSideAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _sellSideAdjustments = new DirtyList<PriceAdjustment>(value); } }
         private Value<string> _sellSideComments;
         public string SellSideComments { get { return _sellSideComments; } set { _sellSideComments = value; } }
         private Value<string> _sellSideCommitmentContractNumber;
@@ -1034,7 +1036,6 @@ namespace EncompassRest.Loans
                     || _branchApprovalDate.Dirty
                     || _branchApprovedby.Dirty
                     || _branchPrice.Dirty
-                    || _buySideAdjustments.Dirty
                     || _buySideComments.Dirty
                     || _buySideCommitmentDate.Dirty
                     || _buySideCommitmentNumber.Dirty
@@ -1097,7 +1098,6 @@ namespace EncompassRest.Loans
                     || _compInvestorState.Dirty
                     || _compInvestorTemplateName.Dirty
                     || _compInvestorWebsite.Dirty
-                    || _compSideAdjustments.Dirty
                     || _compSideComments.Dirty
                     || _compSideComparisonedBy.Dirty
                     || _compSideCurrentRateSetDate.Dirty
@@ -1275,7 +1275,6 @@ namespace EncompassRest.Loans
                     || _correspondentWarehouseBankZip.Dirty
                     || _creditScoreToUse.Dirty
                     || _cumulatedDaystoExtend.Dirty
-                    || _currentAdjustments.Dirty
                     || _currentComments.Dirty
                     || _currentLockDate.Dirty
                     || _currentLockExpires.Dirty
@@ -1330,7 +1329,6 @@ namespace EncompassRest.Loans
                     || _expectedSRP.Dirty
                     || _extensionRequestPending.Dirty
                     || _extensionSequenceNumber.Dirty
-                    || _extraPayments.Dirty
                     || _fHAUpfrontMIPremiumPercent.Dirty
                     || _financedNumberOfUnits.Dirty
                     || _firstPaymenTo.Dirty
@@ -1380,8 +1378,6 @@ namespace EncompassRest.Loans
                     || _loanProgramFile.Dirty
                     || _loanScheduledClosingDate.Dirty
                     || _lockField.Dirty
-                    || _lockRequestAdjustments.Dirty
-                    || _lockRequestBorrowers.Dirty
                     || _lockRequestLoanPurposeType.Dirty
                     || _lTV.Dirty
                     || _minFICO.Dirty
@@ -1401,7 +1397,6 @@ namespace EncompassRest.Loans
                     || _premium.Dirty
                     || _prepayPenalty.Dirty
                     || _priceAdjustment.Dirty
-                    || _priceAdjustments.Dirty
                     || _pricingHistoryData.Dirty
                     || _pricingUpdated.Dirty
                     || _principle.Dirty
@@ -1410,7 +1405,6 @@ namespace EncompassRest.Loans
                     || _propertyEstimatedValueAmount.Dirty
                     || _propertyUsageType.Dirty
                     || _purchaseAdviceNumberOfDays.Dirty
-                    || _purchaseAdvicePayouts.Dirty
                     || _purchasePriceAmount.Dirty
                     || _rateRequestStatus.Dirty
                     || _rateStatus.Dirty
@@ -1425,13 +1419,14 @@ namespace EncompassRest.Loans
                     || _requestExtendedLockExpires.Dirty
                     || _requestFullfilledDateTime.Dirty
                     || _requestImpoundType.Dirty
-                    || _requestImpoundWaived.Dirty
+                    || _requestImpoundWavied.Dirty
                     || _requestLockCancellationComment.Dirty
                     || _requestLockCancellationDate.Dirty
                     || _requestLockDate.Dirty
                     || _requestLockExpires.Dirty
                     || _requestLockExtendComment.Dirty
                     || _requestLockExtendPriceAdjustment.Dirty
+                    || _requestLockStatus.Dirty
                     || _requestLockType.Dirty
                     || _requestMarginRate.Dirty
                     || _requestMarginRateRequested.Dirty
@@ -1459,7 +1454,6 @@ namespace EncompassRest.Loans
                     || _roundToNearest50.Dirty
                     || _secondSubordinateAmount.Dirty
                     || _sellerPaidMIPremium.Dirty
-                    || _sellSideAdjustments.Dirty
                     || _sellSideComments.Dirty
                     || _sellSideCommitmentContractNumber.Dirty
                     || _sellSideCommitmentDate.Dirty
@@ -1520,7 +1514,16 @@ namespace EncompassRest.Loans
                     || _totalSubordinateFinancing.Dirty
                     || _twelveMonthMortgageRentalHistoryIndicator.Dirty
                     || _type.Dirty
-                    || _usePoint.Dirty;
+                    || _usePoint.Dirty
+                    || _buySideAdjustments?.Dirty == true
+                    || _compSideAdjustments?.Dirty == true
+                    || _currentAdjustments?.Dirty == true
+                    || _extraPayments?.Dirty == true
+                    || _lockRequestAdjustments?.Dirty == true
+                    || _lockRequestBorrowers?.Dirty == true
+                    || _priceAdjustments?.Dirty == true
+                    || _purchaseAdvicePayouts?.Dirty == true
+                    || _sellSideAdjustments?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -1542,7 +1545,6 @@ namespace EncompassRest.Loans
                 _branchApprovalDate.Dirty = value;
                 _branchApprovedby.Dirty = value;
                 _branchPrice.Dirty = value;
-                _buySideAdjustments.Dirty = value;
                 _buySideComments.Dirty = value;
                 _buySideCommitmentDate.Dirty = value;
                 _buySideCommitmentNumber.Dirty = value;
@@ -1605,7 +1607,6 @@ namespace EncompassRest.Loans
                 _compInvestorState.Dirty = value;
                 _compInvestorTemplateName.Dirty = value;
                 _compInvestorWebsite.Dirty = value;
-                _compSideAdjustments.Dirty = value;
                 _compSideComments.Dirty = value;
                 _compSideComparisonedBy.Dirty = value;
                 _compSideCurrentRateSetDate.Dirty = value;
@@ -1783,7 +1784,6 @@ namespace EncompassRest.Loans
                 _correspondentWarehouseBankZip.Dirty = value;
                 _creditScoreToUse.Dirty = value;
                 _cumulatedDaystoExtend.Dirty = value;
-                _currentAdjustments.Dirty = value;
                 _currentComments.Dirty = value;
                 _currentLockDate.Dirty = value;
                 _currentLockExpires.Dirty = value;
@@ -1838,7 +1838,6 @@ namespace EncompassRest.Loans
                 _expectedSRP.Dirty = value;
                 _extensionRequestPending.Dirty = value;
                 _extensionSequenceNumber.Dirty = value;
-                _extraPayments.Dirty = value;
                 _fHAUpfrontMIPremiumPercent.Dirty = value;
                 _financedNumberOfUnits.Dirty = value;
                 _firstPaymenTo.Dirty = value;
@@ -1888,8 +1887,6 @@ namespace EncompassRest.Loans
                 _loanProgramFile.Dirty = value;
                 _loanScheduledClosingDate.Dirty = value;
                 _lockField.Dirty = value;
-                _lockRequestAdjustments.Dirty = value;
-                _lockRequestBorrowers.Dirty = value;
                 _lockRequestLoanPurposeType.Dirty = value;
                 _lTV.Dirty = value;
                 _minFICO.Dirty = value;
@@ -1909,7 +1906,6 @@ namespace EncompassRest.Loans
                 _premium.Dirty = value;
                 _prepayPenalty.Dirty = value;
                 _priceAdjustment.Dirty = value;
-                _priceAdjustments.Dirty = value;
                 _pricingHistoryData.Dirty = value;
                 _pricingUpdated.Dirty = value;
                 _principle.Dirty = value;
@@ -1918,7 +1914,6 @@ namespace EncompassRest.Loans
                 _propertyEstimatedValueAmount.Dirty = value;
                 _propertyUsageType.Dirty = value;
                 _purchaseAdviceNumberOfDays.Dirty = value;
-                _purchaseAdvicePayouts.Dirty = value;
                 _purchasePriceAmount.Dirty = value;
                 _rateRequestStatus.Dirty = value;
                 _rateStatus.Dirty = value;
@@ -1933,13 +1928,14 @@ namespace EncompassRest.Loans
                 _requestExtendedLockExpires.Dirty = value;
                 _requestFullfilledDateTime.Dirty = value;
                 _requestImpoundType.Dirty = value;
-                _requestImpoundWaived.Dirty = value;
+                _requestImpoundWavied.Dirty = value;
                 _requestLockCancellationComment.Dirty = value;
                 _requestLockCancellationDate.Dirty = value;
                 _requestLockDate.Dirty = value;
                 _requestLockExpires.Dirty = value;
                 _requestLockExtendComment.Dirty = value;
                 _requestLockExtendPriceAdjustment.Dirty = value;
+                _requestLockStatus.Dirty = value;
                 _requestLockType.Dirty = value;
                 _requestMarginRate.Dirty = value;
                 _requestMarginRateRequested.Dirty = value;
@@ -1967,7 +1963,6 @@ namespace EncompassRest.Loans
                 _roundToNearest50.Dirty = value;
                 _secondSubordinateAmount.Dirty = value;
                 _sellerPaidMIPremium.Dirty = value;
-                _sellSideAdjustments.Dirty = value;
                 _sellSideComments.Dirty = value;
                 _sellSideCommitmentContractNumber.Dirty = value;
                 _sellSideCommitmentDate.Dirty = value;
@@ -2029,6 +2024,15 @@ namespace EncompassRest.Loans
                 _twelveMonthMortgageRentalHistoryIndicator.Dirty = value;
                 _type.Dirty = value;
                 _usePoint.Dirty = value;
+                if (_buySideAdjustments != null) _buySideAdjustments.Dirty = value;
+                if (_compSideAdjustments != null) _compSideAdjustments.Dirty = value;
+                if (_currentAdjustments != null) _currentAdjustments.Dirty = value;
+                if (_extraPayments != null) _extraPayments.Dirty = value;
+                if (_lockRequestAdjustments != null) _lockRequestAdjustments.Dirty = value;
+                if (_lockRequestBorrowers != null) _lockRequestBorrowers.Dirty = value;
+                if (_priceAdjustments != null) _priceAdjustments.Dirty = value;
+                if (_purchaseAdvicePayouts != null) _purchaseAdvicePayouts.Dirty = value;
+                if (_sellSideAdjustments != null) _sellSideAdjustments.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/RateLock.cs
+++ b/src/EncompassRest/Loans/RateLock.cs
@@ -8,1011 +8,1011 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RateLock : IDirty
     {
-        private Value<decimal?> _actualSellAmount;
+        private DirtyValue<decimal?> _actualSellAmount;
         public decimal? ActualSellAmount { get { return _actualSellAmount; } set { _actualSellAmount = value; } }
-        private Value<decimal?> _actualSellPrice;
+        private DirtyValue<decimal?> _actualSellPrice;
         public decimal? ActualSellPrice { get { return _actualSellPrice; } set { _actualSellPrice = value; } }
-        private Value<decimal?> _actualSellSideSRP;
+        private DirtyValue<decimal?> _actualSellSideSRP;
         public decimal? ActualSellSideSRP { get { return _actualSellSideSRP; } set { _actualSellSideSRP = value; } }
-        private Value<decimal?> _actualSRPAmount;
+        private DirtyValue<decimal?> _actualSRPAmount;
         public decimal? ActualSRPAmount { get { return _actualSRPAmount; } set { _actualSRPAmount = value; } }
-        private Value<decimal?> _amountDue;
+        private DirtyValue<decimal?> _amountDue;
         public decimal? AmountDue { get { return _amountDue; } set { _amountDue = value; } }
-        private Value<string> _amountDueTo;
+        private DirtyValue<string> _amountDueTo;
         public string AmountDueTo { get { return _amountDueTo; } set { _amountDueTo = value; } }
-        private Value<decimal?> _amountPaid;
+        private DirtyValue<decimal?> _amountPaid;
         public decimal? AmountPaid { get { return _amountPaid; } set { _amountPaid = value; } }
-        private Value<string> _amountPaidTo;
+        private DirtyValue<string> _amountPaidTo;
         public string AmountPaidTo { get { return _amountPaidTo; } set { _amountPaidTo = value; } }
-        private Value<decimal?> _amountReceived;
+        private DirtyValue<decimal?> _amountReceived;
         public decimal? AmountReceived { get { return _amountReceived; } set { _amountReceived = value; } }
-        private Value<int?> _balloonLoanMaturityTermMonths;
+        private DirtyValue<int?> _balloonLoanMaturityTermMonths;
         public int? BalloonLoanMaturityTermMonths { get { return _balloonLoanMaturityTermMonths; } set { _balloonLoanMaturityTermMonths = value; } }
-        private Value<decimal?> _baseLoanAmount;
+        private DirtyValue<decimal?> _baseLoanAmount;
         public decimal? BaseLoanAmount { get { return _baseLoanAmount; } set { _baseLoanAmount = value; } }
-        private Value<decimal?> _borrowerRequestedLoanAmount;
+        private DirtyValue<decimal?> _borrowerRequestedLoanAmount;
         public decimal? BorrowerRequestedLoanAmount { get { return _borrowerRequestedLoanAmount; } set { _borrowerRequestedLoanAmount = value; } }
-        private Value<DateTime?> _branchApprovalDate;
+        private DirtyValue<DateTime?> _branchApprovalDate;
         public DateTime? BranchApprovalDate { get { return _branchApprovalDate; } set { _branchApprovalDate = value; } }
-        private Value<string> _branchApprovedby;
+        private DirtyValue<string> _branchApprovedby;
         public string BranchApprovedby { get { return _branchApprovedby; } set { _branchApprovedby = value; } }
-        private Value<decimal?> _branchPrice;
+        private DirtyValue<decimal?> _branchPrice;
         public decimal? BranchPrice { get { return _branchPrice; } set { _branchPrice = value; } }
         private DirtyList<PriceAdjustment> _buySideAdjustments;
         public IList<PriceAdjustment> BuySideAdjustments { get { var v = _buySideAdjustments; return v ?? Interlocked.CompareExchange(ref _buySideAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _buySideAdjustments = new DirtyList<PriceAdjustment>(value); } }
-        private Value<string> _buySideComments;
+        private DirtyValue<string> _buySideComments;
         public string BuySideComments { get { return _buySideComments; } set { _buySideComments = value; } }
-        private Value<DateTime?> _buySideCommitmentDate;
+        private DirtyValue<DateTime?> _buySideCommitmentDate;
         public DateTime? BuySideCommitmentDate { get { return _buySideCommitmentDate; } set { _buySideCommitmentDate = value; } }
-        private Value<string> _buySideCommitmentNumber;
+        private DirtyValue<string> _buySideCommitmentNumber;
         public string BuySideCommitmentNumber { get { return _buySideCommitmentNumber; } set { _buySideCommitmentNumber = value; } }
-        private Value<string> _buySideCommitmentType;
+        private DirtyValue<string> _buySideCommitmentType;
         public string BuySideCommitmentType { get { return _buySideCommitmentType; } set { _buySideCommitmentType = value; } }
-        private Value<DateTime?> _buySideCurrentRateSetDate;
+        private DirtyValue<DateTime?> _buySideCurrentRateSetDate;
         public DateTime? BuySideCurrentRateSetDate { get { return _buySideCurrentRateSetDate; } set { _buySideCurrentRateSetDate = value; } }
-        private Value<int?> _buySideDaystoExtend;
+        private DirtyValue<int?> _buySideDaystoExtend;
         public int? BuySideDaystoExtend { get { return _buySideDaystoExtend; } set { _buySideDaystoExtend = value; } }
-        private Value<DateTime?> _buySideDeliveryExpirationDate;
+        private DirtyValue<DateTime?> _buySideDeliveryExpirationDate;
         public DateTime? BuySideDeliveryExpirationDate { get { return _buySideDeliveryExpirationDate; } set { _buySideDeliveryExpirationDate = value; } }
-        private Value<string> _buySideDeliveryType;
+        private DirtyValue<string> _buySideDeliveryType;
         public string BuySideDeliveryType { get { return _buySideDeliveryType; } set { _buySideDeliveryType = value; } }
-        private Value<DateTime?> _buySideExpirationDate;
+        private DirtyValue<DateTime?> _buySideExpirationDate;
         public DateTime? BuySideExpirationDate { get { return _buySideExpirationDate; } set { _buySideExpirationDate = value; } }
-        private Value<DateTime?> _buySideExtendedLockExpires;
+        private DirtyValue<DateTime?> _buySideExtendedLockExpires;
         public DateTime? BuySideExtendedLockExpires { get { return _buySideExtendedLockExpires; } set { _buySideExtendedLockExpires = value; } }
-        private Value<DateTime?> _buySideLockDate;
+        private DirtyValue<DateTime?> _buySideLockDate;
         public DateTime? BuySideLockDate { get { return _buySideLockDate; } set { _buySideLockDate = value; } }
-        private Value<DateTime?> _buySideLockExpires;
+        private DirtyValue<DateTime?> _buySideLockExpires;
         public DateTime? BuySideLockExpires { get { return _buySideLockExpires; } set { _buySideLockExpires = value; } }
-        private Value<decimal?> _buySideLockExtendPriceAdjustment;
+        private DirtyValue<decimal?> _buySideLockExtendPriceAdjustment;
         public decimal? BuySideLockExtendPriceAdjustment { get { return _buySideLockExtendPriceAdjustment; } set { _buySideLockExtendPriceAdjustment = value; } }
-        private Value<decimal?> _buySideMarginNetBuyRate;
+        private DirtyValue<decimal?> _buySideMarginNetBuyRate;
         public decimal? BuySideMarginNetBuyRate { get { return _buySideMarginNetBuyRate; } set { _buySideMarginNetBuyRate = value; } }
-        private Value<decimal?> _buySideMarginRate;
+        private DirtyValue<decimal?> _buySideMarginRate;
         public decimal? BuySideMarginRate { get { return _buySideMarginRate; } set { _buySideMarginRate = value; } }
-        private Value<decimal?> _buySideMarginTotalAdjustment;
+        private DirtyValue<decimal?> _buySideMarginTotalAdjustment;
         public decimal? BuySideMarginTotalAdjustment { get { return _buySideMarginTotalAdjustment; } set { _buySideMarginTotalAdjustment = value; } }
-        private Value<string> _buySideMasterCommitmentNumber;
+        private DirtyValue<string> _buySideMasterCommitmentNumber;
         public string BuySideMasterCommitmentNumber { get { return _buySideMasterCommitmentNumber; } set { _buySideMasterCommitmentNumber = value; } }
-        private Value<int?> _buySideNumberOfDays;
+        private DirtyValue<int?> _buySideNumberOfDays;
         public int? BuySideNumberOfDays { get { return _buySideNumberOfDays; } set { _buySideNumberOfDays = value; } }
-        private Value<bool?> _buySideOnrpEligible;
+        private DirtyValue<bool?> _buySideOnrpEligible;
         public bool? BuySideOnrpEligible { get { return _buySideOnrpEligible; } set { _buySideOnrpEligible = value; } }
-        private Value<DateTime?> _buySideOnrpLockDate;
+        private DirtyValue<DateTime?> _buySideOnrpLockDate;
         public DateTime? BuySideOnrpLockDate { get { return _buySideOnrpLockDate; } set { _buySideOnrpLockDate = value; } }
-        private Value<string> _buySideOnrpLockTime;
+        private DirtyValue<string> _buySideOnrpLockTime;
         public string BuySideOnrpLockTime { get { return _buySideOnrpLockTime; } set { _buySideOnrpLockTime = value; } }
-        private Value<string> _buySideOrgID;
+        private DirtyValue<string> _buySideOrgID;
         public string BuySideOrgID { get { return _buySideOrgID; } set { _buySideOrgID = value; } }
-        private Value<DateTime?> _buySideOriginalLockExpires;
+        private DirtyValue<DateTime?> _buySideOriginalLockExpires;
         public DateTime? BuySideOriginalLockExpires { get { return _buySideOriginalLockExpires; } set { _buySideOriginalLockExpires = value; } }
-        private Value<decimal?> _buySidePriceNetBuyPrice;
+        private DirtyValue<decimal?> _buySidePriceNetBuyPrice;
         public decimal? BuySidePriceNetBuyPrice { get { return _buySidePriceNetBuyPrice; } set { _buySidePriceNetBuyPrice = value; } }
-        private Value<decimal?> _buySidePriceRate;
+        private DirtyValue<decimal?> _buySidePriceRate;
         public decimal? BuySidePriceRate { get { return _buySidePriceRate; } set { _buySidePriceRate = value; } }
-        private Value<decimal?> _buySidePriceTotalAdjustment;
+        private DirtyValue<decimal?> _buySidePriceTotalAdjustment;
         public decimal? BuySidePriceTotalAdjustment { get { return _buySidePriceTotalAdjustment; } set { _buySidePriceTotalAdjustment = value; } }
-        private Value<decimal?> _buySideRate;
+        private DirtyValue<decimal?> _buySideRate;
         public decimal? BuySideRate { get { return _buySideRate; } set { _buySideRate = value; } }
-        private Value<decimal?> _buySideRateNetBuyRate;
+        private DirtyValue<decimal?> _buySideRateNetBuyRate;
         public decimal? BuySideRateNetBuyRate { get { return _buySideRateNetBuyRate; } set { _buySideRateNetBuyRate = value; } }
-        private Value<string> _buySideRateSheetID;
+        private DirtyValue<string> _buySideRateSheetID;
         public string BuySideRateSheetID { get { return _buySideRateSheetID; } set { _buySideRateSheetID = value; } }
-        private Value<decimal?> _buySideRateTotalAdjustment;
+        private DirtyValue<decimal?> _buySideRateTotalAdjustment;
         public decimal? BuySideRateTotalAdjustment { get { return _buySideRateTotalAdjustment; } set { _buySideRateTotalAdjustment = value; } }
-        private Value<string> _buySideRequestedBy;
+        private DirtyValue<string> _buySideRequestedBy;
         public string BuySideRequestedBy { get { return _buySideRequestedBy; } set { _buySideRequestedBy = value; } }
-        private Value<decimal?> _buySideSRPPaidOut;
+        private DirtyValue<decimal?> _buySideSRPPaidOut;
         public decimal? BuySideSRPPaidOut { get { return _buySideSRPPaidOut; } set { _buySideSRPPaidOut = value; } }
-        private Value<decimal?> _buySideStartingAdjPoint;
+        private DirtyValue<decimal?> _buySideStartingAdjPoint;
         public decimal? BuySideStartingAdjPoint { get { return _buySideStartingAdjPoint; } set { _buySideStartingAdjPoint = value; } }
-        private Value<decimal?> _buySideStartingAdjPrice;
+        private DirtyValue<decimal?> _buySideStartingAdjPrice;
         public decimal? BuySideStartingAdjPrice { get { return _buySideStartingAdjPrice; } set { _buySideStartingAdjPrice = value; } }
-        private Value<decimal?> _buySideStartingAdjRate;
+        private DirtyValue<decimal?> _buySideStartingAdjRate;
         public decimal? BuySideStartingAdjRate { get { return _buySideStartingAdjRate; } set { _buySideStartingAdjRate = value; } }
-        private Value<string> _buySideTPOID;
+        private DirtyValue<string> _buySideTPOID;
         public string BuySideTPOID { get { return _buySideTPOID; } set { _buySideTPOID = value; } }
-        private Value<string> _buySideTPOName;
+        private DirtyValue<string> _buySideTPOName;
         public string BuySideTPOName { get { return _buySideTPOName; } set { _buySideTPOName = value; } }
-        private Value<string> _buySideTradeGuid;
+        private DirtyValue<string> _buySideTradeGuid;
         public string BuySideTradeGuid { get { return _buySideTradeGuid; } set { _buySideTradeGuid = value; } }
-        private Value<string> _buySideTradeNumber;
+        private DirtyValue<string> _buySideTradeNumber;
         public string BuySideTradeNumber { get { return _buySideTradeNumber; } set { _buySideTradeNumber = value; } }
-        private Value<decimal?> _buySideUnDiscountedRate;
+        private DirtyValue<decimal?> _buySideUnDiscountedRate;
         public decimal? BuySideUnDiscountedRate { get { return _buySideUnDiscountedRate; } set { _buySideUnDiscountedRate = value; } }
-        private Value<string> _cancellationRequestPending;
+        private DirtyValue<string> _cancellationRequestPending;
         public string CancellationRequestPending { get { return _cancellationRequestPending; } set { _cancellationRequestPending = value; } }
-        private Value<decimal?> _combinedLTV;
+        private DirtyValue<decimal?> _combinedLTV;
         public decimal? CombinedLTV { get { return _combinedLTV; } set { _combinedLTV = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _commitment;
+        private DirtyValue<string> _commitment;
         public string Commitment { get { return _commitment; } set { _commitment = value; } }
-        private Value<string> _commitmentType;
+        private DirtyValue<string> _commitmentType;
         public string CommitmentType { get { return _commitmentType; } set { _commitmentType = value; } }
-        private Value<decimal?> _compGainLossPercentage;
+        private DirtyValue<decimal?> _compGainLossPercentage;
         public decimal? CompGainLossPercentage { get { return _compGainLossPercentage; } set { _compGainLossPercentage = value; } }
-        private Value<decimal?> _compGainLossPrice;
+        private DirtyValue<decimal?> _compGainLossPrice;
         public decimal? CompGainLossPrice { get { return _compGainLossPrice; } set { _compGainLossPrice = value; } }
-        private Value<decimal?> _compGainLossTotalBuyPrice;
+        private DirtyValue<decimal?> _compGainLossTotalBuyPrice;
         public decimal? CompGainLossTotalBuyPrice { get { return _compGainLossTotalBuyPrice; } set { _compGainLossTotalBuyPrice = value; } }
-        private Value<decimal?> _compGainLossTotalCompPrice;
+        private DirtyValue<decimal?> _compGainLossTotalCompPrice;
         public decimal? CompGainLossTotalCompPrice { get { return _compGainLossTotalCompPrice; } set { _compGainLossTotalCompPrice = value; } }
-        private Value<string> _compInvestorAddress;
+        private DirtyValue<string> _compInvestorAddress;
         public string CompInvestorAddress { get { return _compInvestorAddress; } set { _compInvestorAddress = value; } }
-        private Value<string> _compInvestorCity;
+        private DirtyValue<string> _compInvestorCity;
         public string CompInvestorCity { get { return _compInvestorCity; } set { _compInvestorCity = value; } }
-        private Value<string> _compInvestorCommitment;
+        private DirtyValue<string> _compInvestorCommitment;
         public string CompInvestorCommitment { get { return _compInvestorCommitment; } set { _compInvestorCommitment = value; } }
-        private Value<string> _compInvestorContact;
+        private DirtyValue<string> _compInvestorContact;
         public string CompInvestorContact { get { return _compInvestorContact; } set { _compInvestorContact = value; } }
-        private Value<string> _compInvestorEmail;
+        private DirtyValue<string> _compInvestorEmail;
         public string CompInvestorEmail { get { return _compInvestorEmail; } set { _compInvestorEmail = value; } }
-        private Value<string> _compInvestorLockType;
+        private DirtyValue<string> _compInvestorLockType;
         public string CompInvestorLockType { get { return _compInvestorLockType; } set { _compInvestorLockType = value; } }
-        private Value<string> _compInvestorName;
+        private DirtyValue<string> _compInvestorName;
         public string CompInvestorName { get { return _compInvestorName; } set { _compInvestorName = value; } }
-        private Value<string> _compInvestorPhone;
+        private DirtyValue<string> _compInvestorPhone;
         public string CompInvestorPhone { get { return _compInvestorPhone; } set { _compInvestorPhone = value; } }
-        private Value<string> _compInvestorPostalCode;
+        private DirtyValue<string> _compInvestorPostalCode;
         public string CompInvestorPostalCode { get { return _compInvestorPostalCode; } set { _compInvestorPostalCode = value; } }
-        private Value<string> _compInvestorProgramCode;
+        private DirtyValue<string> _compInvestorProgramCode;
         public string CompInvestorProgramCode { get { return _compInvestorProgramCode; } set { _compInvestorProgramCode = value; } }
-        private Value<string> _compInvestorState;
+        private DirtyValue<string> _compInvestorState;
         public string CompInvestorState { get { return _compInvestorState; } set { _compInvestorState = value; } }
-        private Value<string> _compInvestorTemplateName;
+        private DirtyValue<string> _compInvestorTemplateName;
         public string CompInvestorTemplateName { get { return _compInvestorTemplateName; } set { _compInvestorTemplateName = value; } }
-        private Value<string> _compInvestorWebsite;
+        private DirtyValue<string> _compInvestorWebsite;
         public string CompInvestorWebsite { get { return _compInvestorWebsite; } set { _compInvestorWebsite = value; } }
         private DirtyList<PriceAdjustment> _compSideAdjustments;
         public IList<PriceAdjustment> CompSideAdjustments { get { var v = _compSideAdjustments; return v ?? Interlocked.CompareExchange(ref _compSideAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _compSideAdjustments = new DirtyList<PriceAdjustment>(value); } }
-        private Value<string> _compSideComments;
+        private DirtyValue<string> _compSideComments;
         public string CompSideComments { get { return _compSideComments; } set { _compSideComments = value; } }
-        private Value<string> _compSideComparisonedBy;
+        private DirtyValue<string> _compSideComparisonedBy;
         public string CompSideComparisonedBy { get { return _compSideComparisonedBy; } set { _compSideComparisonedBy = value; } }
-        private Value<DateTime?> _compSideCurrentRateSetDate;
+        private DirtyValue<DateTime?> _compSideCurrentRateSetDate;
         public DateTime? CompSideCurrentRateSetDate { get { return _compSideCurrentRateSetDate; } set { _compSideCurrentRateSetDate = value; } }
-        private Value<int?> _compSideDaystoExtend;
+        private DirtyValue<int?> _compSideDaystoExtend;
         public int? CompSideDaystoExtend { get { return _compSideDaystoExtend; } set { _compSideDaystoExtend = value; } }
-        private Value<decimal?> _compSideDiscountYSP;
+        private DirtyValue<decimal?> _compSideDiscountYSP;
         public decimal? CompSideDiscountYSP { get { return _compSideDiscountYSP; } set { _compSideDiscountYSP = value; } }
-        private Value<DateTime?> _compSideExtendedLockExpires;
+        private DirtyValue<DateTime?> _compSideExtendedLockExpires;
         public DateTime? CompSideExtendedLockExpires { get { return _compSideExtendedLockExpires; } set { _compSideExtendedLockExpires = value; } }
-        private Value<string> _compSideInvestorStatus;
+        private DirtyValue<string> _compSideInvestorStatus;
         public string CompSideInvestorStatus { get { return _compSideInvestorStatus; } set { _compSideInvestorStatus = value; } }
-        private Value<DateTime?> _compSideInvestorStatusDate;
+        private DirtyValue<DateTime?> _compSideInvestorStatusDate;
         public DateTime? CompSideInvestorStatusDate { get { return _compSideInvestorStatusDate; } set { _compSideInvestorStatusDate = value; } }
-        private Value<string> _compSideInvestorTradeNumber;
+        private DirtyValue<string> _compSideInvestorTradeNumber;
         public string CompSideInvestorTradeNumber { get { return _compSideInvestorTradeNumber; } set { _compSideInvestorTradeNumber = value; } }
-        private Value<string> _compSideLoanProgram;
+        private DirtyValue<string> _compSideLoanProgram;
         public string CompSideLoanProgram { get { return _compSideLoanProgram; } set { _compSideLoanProgram = value; } }
-        private Value<DateTime?> _compSideLockDate;
+        private DirtyValue<DateTime?> _compSideLockDate;
         public DateTime? CompSideLockDate { get { return _compSideLockDate; } set { _compSideLockDate = value; } }
-        private Value<DateTime?> _compSideLockExpires;
+        private DirtyValue<DateTime?> _compSideLockExpires;
         public DateTime? CompSideLockExpires { get { return _compSideLockExpires; } set { _compSideLockExpires = value; } }
-        private Value<decimal?> _compSideLockExtendPriceAdjustment;
+        private DirtyValue<decimal?> _compSideLockExtendPriceAdjustment;
         public decimal? CompSideLockExtendPriceAdjustment { get { return _compSideLockExtendPriceAdjustment; } set { _compSideLockExtendPriceAdjustment = value; } }
-        private Value<decimal?> _compSideMarginNetCompRate;
+        private DirtyValue<decimal?> _compSideMarginNetCompRate;
         public decimal? CompSideMarginNetCompRate { get { return _compSideMarginNetCompRate; } set { _compSideMarginNetCompRate = value; } }
-        private Value<decimal?> _compSideMarginRate;
+        private DirtyValue<decimal?> _compSideMarginRate;
         public decimal? CompSideMarginRate { get { return _compSideMarginRate; } set { _compSideMarginRate = value; } }
-        private Value<decimal?> _compSideMarginTotalAdjustment;
+        private DirtyValue<decimal?> _compSideMarginTotalAdjustment;
         public decimal? CompSideMarginTotalAdjustment { get { return _compSideMarginTotalAdjustment; } set { _compSideMarginTotalAdjustment = value; } }
-        private Value<string> _compSideMasterContractNumber;
+        private DirtyValue<string> _compSideMasterContractNumber;
         public string CompSideMasterContractNumber { get { return _compSideMasterContractNumber; } set { _compSideMasterContractNumber = value; } }
-        private Value<decimal?> _compSideNetCompPrice;
+        private DirtyValue<decimal?> _compSideNetCompPrice;
         public decimal? CompSideNetCompPrice { get { return _compSideNetCompPrice; } set { _compSideNetCompPrice = value; } }
-        private Value<decimal?> _compSideNetCompRate;
+        private DirtyValue<decimal?> _compSideNetCompRate;
         public decimal? CompSideNetCompRate { get { return _compSideNetCompRate; } set { _compSideNetCompRate = value; } }
-        private Value<int?> _compSideNumberOfDays;
+        private DirtyValue<int?> _compSideNumberOfDays;
         public int? CompSideNumberOfDays { get { return _compSideNumberOfDays; } set { _compSideNumberOfDays = value; } }
-        private Value<DateTime?> _compSideOriginalLockExpires;
+        private DirtyValue<DateTime?> _compSideOriginalLockExpires;
         public DateTime? CompSideOriginalLockExpires { get { return _compSideOriginalLockExpires; } set { _compSideOriginalLockExpires = value; } }
-        private Value<decimal?> _compSidePriceRate;
+        private DirtyValue<decimal?> _compSidePriceRate;
         public decimal? CompSidePriceRate { get { return _compSidePriceRate; } set { _compSidePriceRate = value; } }
-        private Value<decimal?> _compSidePriceTotalAdjustment;
+        private DirtyValue<decimal?> _compSidePriceTotalAdjustment;
         public decimal? CompSidePriceTotalAdjustment { get { return _compSidePriceTotalAdjustment; } set { _compSidePriceTotalAdjustment = value; } }
-        private Value<decimal?> _compSideRate;
+        private DirtyValue<decimal?> _compSideRate;
         public decimal? CompSideRate { get { return _compSideRate; } set { _compSideRate = value; } }
-        private Value<string> _compSideRateSheetID;
+        private DirtyValue<string> _compSideRateSheetID;
         public string CompSideRateSheetID { get { return _compSideRateSheetID; } set { _compSideRateSheetID = value; } }
-        private Value<decimal?> _compSideRateTotalAdjustment;
+        private DirtyValue<decimal?> _compSideRateTotalAdjustment;
         public decimal? CompSideRateTotalAdjustment { get { return _compSideRateTotalAdjustment; } set { _compSideRateTotalAdjustment = value; } }
-        private Value<string> _compSideRequestedBy;
+        private DirtyValue<string> _compSideRequestedBy;
         public string CompSideRequestedBy { get { return _compSideRequestedBy; } set { _compSideRequestedBy = value; } }
-        private Value<string> _compSideServicingType;
+        private DirtyValue<string> _compSideServicingType;
         public string CompSideServicingType { get { return _compSideServicingType; } set { _compSideServicingType = value; } }
-        private Value<decimal?> _compSideSRPPaidOut;
+        private DirtyValue<decimal?> _compSideSRPPaidOut;
         public decimal? CompSideSRPPaidOut { get { return _compSideSRPPaidOut; } set { _compSideSRPPaidOut = value; } }
-        private Value<string> _compSideTradeGuid;
+        private DirtyValue<string> _compSideTradeGuid;
         public string CompSideTradeGuid { get { return _compSideTradeGuid; } set { _compSideTradeGuid = value; } }
-        private Value<string> _compSideTradeNumber;
+        private DirtyValue<string> _compSideTradeNumber;
         public string CompSideTradeNumber { get { return _compSideTradeNumber; } set { _compSideTradeNumber = value; } }
-        private Value<string> _confirmedBy;
+        private DirtyValue<string> _confirmedBy;
         public string ConfirmedBy { get { return _confirmedBy; } set { _confirmedBy = value; } }
-        private Value<DateTime?> _confirmedDate;
+        private DirtyValue<DateTime?> _confirmedDate;
         public DateTime? ConfirmedDate { get { return _confirmedDate; } set { _confirmedDate = value; } }
-        private Value<DateTime?> _corporateApprovalDate;
+        private DirtyValue<DateTime?> _corporateApprovalDate;
         public DateTime? CorporateApprovalDate { get { return _corporateApprovalDate; } set { _corporateApprovalDate = value; } }
-        private Value<string> _corporateApprovedby;
+        private DirtyValue<string> _corporateApprovedby;
         public string CorporateApprovedby { get { return _corporateApprovedby; } set { _corporateApprovedby = value; } }
-        private Value<decimal?> _corporatePrice;
+        private DirtyValue<decimal?> _corporatePrice;
         public decimal? CorporatePrice { get { return _corporatePrice; } set { _corporatePrice = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowAdditionalEscrow;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowAdditionalEscrow;
         public decimal? CorrespondentAdditionalEscrowAdditionalEscrow { get { return _correspondentAdditionalEscrowAdditionalEscrow; } set { _correspondentAdditionalEscrowAdditionalEscrow = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowAmount1007;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowAmount1007;
         public decimal? CorrespondentAdditionalEscrowAmount1007 { get { return _correspondentAdditionalEscrowAmount1007; } set { _correspondentAdditionalEscrowAmount1007 = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowAmount1008;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowAmount1008;
         public decimal? CorrespondentAdditionalEscrowAmount1008 { get { return _correspondentAdditionalEscrowAmount1008; } set { _correspondentAdditionalEscrowAmount1008 = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowAmount1009;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowAmount1009;
         public decimal? CorrespondentAdditionalEscrowAmount1009 { get { return _correspondentAdditionalEscrowAmount1009; } set { _correspondentAdditionalEscrowAmount1009 = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowCityPropertyTax;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowCityPropertyTax;
         public decimal? CorrespondentAdditionalEscrowCityPropertyTax { get { return _correspondentAdditionalEscrowCityPropertyTax; } set { _correspondentAdditionalEscrowCityPropertyTax = value; } }
-        private Value<string> _correspondentAdditionalEscrowDescription1007;
+        private DirtyValue<string> _correspondentAdditionalEscrowDescription1007;
         public string CorrespondentAdditionalEscrowDescription1007 { get { return _correspondentAdditionalEscrowDescription1007; } set { _correspondentAdditionalEscrowDescription1007 = value; } }
-        private Value<string> _correspondentAdditionalEscrowDescription1008;
+        private DirtyValue<string> _correspondentAdditionalEscrowDescription1008;
         public string CorrespondentAdditionalEscrowDescription1008 { get { return _correspondentAdditionalEscrowDescription1008; } set { _correspondentAdditionalEscrowDescription1008 = value; } }
-        private Value<string> _correspondentAdditionalEscrowDescription1009;
+        private DirtyValue<string> _correspondentAdditionalEscrowDescription1009;
         public string CorrespondentAdditionalEscrowDescription1009 { get { return _correspondentAdditionalEscrowDescription1009; } set { _correspondentAdditionalEscrowDescription1009 = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowFloodInsurance;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowFloodInsurance;
         public decimal? CorrespondentAdditionalEscrowFloodInsurance { get { return _correspondentAdditionalEscrowFloodInsurance; } set { _correspondentAdditionalEscrowFloodInsurance = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowHomeInsurance;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowHomeInsurance;
         public decimal? CorrespondentAdditionalEscrowHomeInsurance { get { return _correspondentAdditionalEscrowHomeInsurance; } set { _correspondentAdditionalEscrowHomeInsurance = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowMIMIP;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowMIMIP;
         public decimal? CorrespondentAdditionalEscrowMIMIP { get { return _correspondentAdditionalEscrowMIMIP; } set { _correspondentAdditionalEscrowMIMIP = value; } }
-        private Value<int?> _correspondentAdditionalEscrowNumOfPayments;
+        private DirtyValue<int?> _correspondentAdditionalEscrowNumOfPayments;
         public int? CorrespondentAdditionalEscrowNumOfPayments { get { return _correspondentAdditionalEscrowNumOfPayments; } set { _correspondentAdditionalEscrowNumOfPayments = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowOption1Amount;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowOption1Amount;
         public decimal? CorrespondentAdditionalEscrowOption1Amount { get { return _correspondentAdditionalEscrowOption1Amount; } set { _correspondentAdditionalEscrowOption1Amount = value; } }
-        private Value<string> _correspondentAdditionalEscrowOption1Desc;
+        private DirtyValue<string> _correspondentAdditionalEscrowOption1Desc;
         public string CorrespondentAdditionalEscrowOption1Desc { get { return _correspondentAdditionalEscrowOption1Desc; } set { _correspondentAdditionalEscrowOption1Desc = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowOption2Amount;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowOption2Amount;
         public decimal? CorrespondentAdditionalEscrowOption2Amount { get { return _correspondentAdditionalEscrowOption2Amount; } set { _correspondentAdditionalEscrowOption2Amount = value; } }
-        private Value<string> _correspondentAdditionalEscrowOption2Desc;
+        private DirtyValue<string> _correspondentAdditionalEscrowOption2Desc;
         public string CorrespondentAdditionalEscrowOption2Desc { get { return _correspondentAdditionalEscrowOption2Desc; } set { _correspondentAdditionalEscrowOption2Desc = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowPropertyTax;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowPropertyTax;
         public decimal? CorrespondentAdditionalEscrowPropertyTax { get { return _correspondentAdditionalEscrowPropertyTax; } set { _correspondentAdditionalEscrowPropertyTax = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowSumOfPayments;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowSumOfPayments;
         public decimal? CorrespondentAdditionalEscrowSumOfPayments { get { return _correspondentAdditionalEscrowSumOfPayments; } set { _correspondentAdditionalEscrowSumOfPayments = value; } }
-        private Value<decimal?> _correspondentAdditionalEscrowUSDAAnnualFee;
+        private DirtyValue<decimal?> _correspondentAdditionalEscrowUSDAAnnualFee;
         public decimal? CorrespondentAdditionalEscrowUSDAAnnualFee { get { return _correspondentAdditionalEscrowUSDAAnnualFee; } set { _correspondentAdditionalEscrowUSDAAnnualFee = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount1;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount1;
         public decimal? CorrespondentAdditionalLineAmount1 { get { return _correspondentAdditionalLineAmount1; } set { _correspondentAdditionalLineAmount1 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount10;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount10;
         public decimal? CorrespondentAdditionalLineAmount10 { get { return _correspondentAdditionalLineAmount10; } set { _correspondentAdditionalLineAmount10 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount11;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount11;
         public decimal? CorrespondentAdditionalLineAmount11 { get { return _correspondentAdditionalLineAmount11; } set { _correspondentAdditionalLineAmount11 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount12;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount12;
         public decimal? CorrespondentAdditionalLineAmount12 { get { return _correspondentAdditionalLineAmount12; } set { _correspondentAdditionalLineAmount12 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount13;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount13;
         public decimal? CorrespondentAdditionalLineAmount13 { get { return _correspondentAdditionalLineAmount13; } set { _correspondentAdditionalLineAmount13 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount2;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount2;
         public decimal? CorrespondentAdditionalLineAmount2 { get { return _correspondentAdditionalLineAmount2; } set { _correspondentAdditionalLineAmount2 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount3;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount3;
         public decimal? CorrespondentAdditionalLineAmount3 { get { return _correspondentAdditionalLineAmount3; } set { _correspondentAdditionalLineAmount3 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount4;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount4;
         public decimal? CorrespondentAdditionalLineAmount4 { get { return _correspondentAdditionalLineAmount4; } set { _correspondentAdditionalLineAmount4 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount5;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount5;
         public decimal? CorrespondentAdditionalLineAmount5 { get { return _correspondentAdditionalLineAmount5; } set { _correspondentAdditionalLineAmount5 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount6;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount6;
         public decimal? CorrespondentAdditionalLineAmount6 { get { return _correspondentAdditionalLineAmount6; } set { _correspondentAdditionalLineAmount6 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount7;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount7;
         public decimal? CorrespondentAdditionalLineAmount7 { get { return _correspondentAdditionalLineAmount7; } set { _correspondentAdditionalLineAmount7 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount8;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount8;
         public decimal? CorrespondentAdditionalLineAmount8 { get { return _correspondentAdditionalLineAmount8; } set { _correspondentAdditionalLineAmount8 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineAmount9;
+        private DirtyValue<decimal?> _correspondentAdditionalLineAmount9;
         public decimal? CorrespondentAdditionalLineAmount9 { get { return _correspondentAdditionalLineAmount9; } set { _correspondentAdditionalLineAmount9 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription1;
+        private DirtyValue<string> _correspondentAdditionalLineDescription1;
         public string CorrespondentAdditionalLineDescription1 { get { return _correspondentAdditionalLineDescription1; } set { _correspondentAdditionalLineDescription1 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription10;
+        private DirtyValue<string> _correspondentAdditionalLineDescription10;
         public string CorrespondentAdditionalLineDescription10 { get { return _correspondentAdditionalLineDescription10; } set { _correspondentAdditionalLineDescription10 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription11;
+        private DirtyValue<string> _correspondentAdditionalLineDescription11;
         public string CorrespondentAdditionalLineDescription11 { get { return _correspondentAdditionalLineDescription11; } set { _correspondentAdditionalLineDescription11 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription12;
+        private DirtyValue<string> _correspondentAdditionalLineDescription12;
         public string CorrespondentAdditionalLineDescription12 { get { return _correspondentAdditionalLineDescription12; } set { _correspondentAdditionalLineDescription12 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription2;
+        private DirtyValue<string> _correspondentAdditionalLineDescription2;
         public string CorrespondentAdditionalLineDescription2 { get { return _correspondentAdditionalLineDescription2; } set { _correspondentAdditionalLineDescription2 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription3;
+        private DirtyValue<string> _correspondentAdditionalLineDescription3;
         public string CorrespondentAdditionalLineDescription3 { get { return _correspondentAdditionalLineDescription3; } set { _correspondentAdditionalLineDescription3 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription4;
+        private DirtyValue<string> _correspondentAdditionalLineDescription4;
         public string CorrespondentAdditionalLineDescription4 { get { return _correspondentAdditionalLineDescription4; } set { _correspondentAdditionalLineDescription4 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription5;
+        private DirtyValue<string> _correspondentAdditionalLineDescription5;
         public string CorrespondentAdditionalLineDescription5 { get { return _correspondentAdditionalLineDescription5; } set { _correspondentAdditionalLineDescription5 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription6;
+        private DirtyValue<string> _correspondentAdditionalLineDescription6;
         public string CorrespondentAdditionalLineDescription6 { get { return _correspondentAdditionalLineDescription6; } set { _correspondentAdditionalLineDescription6 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription7;
+        private DirtyValue<string> _correspondentAdditionalLineDescription7;
         public string CorrespondentAdditionalLineDescription7 { get { return _correspondentAdditionalLineDescription7; } set { _correspondentAdditionalLineDescription7 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription8;
+        private DirtyValue<string> _correspondentAdditionalLineDescription8;
         public string CorrespondentAdditionalLineDescription8 { get { return _correspondentAdditionalLineDescription8; } set { _correspondentAdditionalLineDescription8 = value; } }
-        private Value<string> _correspondentAdditionalLineDescription9;
+        private DirtyValue<string> _correspondentAdditionalLineDescription9;
         public string CorrespondentAdditionalLineDescription9 { get { return _correspondentAdditionalLineDescription9; } set { _correspondentAdditionalLineDescription9 = value; } }
-        private Value<decimal?> _correspondentAdditionalLineTotalAmount;
+        private DirtyValue<decimal?> _correspondentAdditionalLineTotalAmount;
         public decimal? CorrespondentAdditionalLineTotalAmount { get { return _correspondentAdditionalLineTotalAmount; } set { _correspondentAdditionalLineTotalAmount = value; } }
-        private Value<decimal?> _correspondentAdjusterAmount1;
+        private DirtyValue<decimal?> _correspondentAdjusterAmount1;
         public decimal? CorrespondentAdjusterAmount1 { get { return _correspondentAdjusterAmount1; } set { _correspondentAdjusterAmount1 = value; } }
-        private Value<decimal?> _correspondentAdjusterAmount2;
+        private DirtyValue<decimal?> _correspondentAdjusterAmount2;
         public decimal? CorrespondentAdjusterAmount2 { get { return _correspondentAdjusterAmount2; } set { _correspondentAdjusterAmount2 = value; } }
-        private Value<decimal?> _correspondentAdjusterAmount3;
+        private DirtyValue<decimal?> _correspondentAdjusterAmount3;
         public decimal? CorrespondentAdjusterAmount3 { get { return _correspondentAdjusterAmount3; } set { _correspondentAdjusterAmount3 = value; } }
-        private Value<string> _correspondentAdjusterDescription1;
+        private DirtyValue<string> _correspondentAdjusterDescription1;
         public string CorrespondentAdjusterDescription1 { get { return _correspondentAdjusterDescription1; } set { _correspondentAdjusterDescription1 = value; } }
-        private Value<string> _correspondentAdjusterDescription2;
+        private DirtyValue<string> _correspondentAdjusterDescription2;
         public string CorrespondentAdjusterDescription2 { get { return _correspondentAdjusterDescription2; } set { _correspondentAdjusterDescription2 = value; } }
-        private Value<string> _correspondentAdjusterDescription3;
+        private DirtyValue<string> _correspondentAdjusterDescription3;
         public string CorrespondentAdjusterDescription3 { get { return _correspondentAdjusterDescription3; } set { _correspondentAdjusterDescription3 = value; } }
-        private Value<string> _correspondentConfirmedBy;
+        private DirtyValue<string> _correspondentConfirmedBy;
         public string CorrespondentConfirmedBy { get { return _correspondentConfirmedBy; } set { _correspondentConfirmedBy = value; } }
-        private Value<DateTime?> _correspondentConfirmedDate;
+        private DirtyValue<DateTime?> _correspondentConfirmedDate;
         public DateTime? CorrespondentConfirmedDate { get { return _correspondentConfirmedDate; } set { _correspondentConfirmedDate = value; } }
-        private Value<decimal?> _correspondentCurrentImpounds;
+        private DirtyValue<decimal?> _correspondentCurrentImpounds;
         public decimal? CorrespondentCurrentImpounds { get { return _correspondentCurrentImpounds; } set { _correspondentCurrentImpounds = value; } }
-        private Value<decimal?> _correspondentCurrentPrincipal;
+        private DirtyValue<decimal?> _correspondentCurrentPrincipal;
         public decimal? CorrespondentCurrentPrincipal { get { return _correspondentCurrentPrincipal; } set { _correspondentCurrentPrincipal = value; } }
-        private Value<DateTime?> _correspondentDate;
+        private DirtyValue<DateTime?> _correspondentDate;
         public DateTime? CorrespondentDate { get { return _correspondentDate; } set { _correspondentDate = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsAmount1007;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsAmount1007;
         public decimal? CorrespondentEscrowDisbursementsAmount1007 { get { return _correspondentEscrowDisbursementsAmount1007; } set { _correspondentEscrowDisbursementsAmount1007 = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsAmount1008;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsAmount1008;
         public decimal? CorrespondentEscrowDisbursementsAmount1008 { get { return _correspondentEscrowDisbursementsAmount1008; } set { _correspondentEscrowDisbursementsAmount1008 = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsAmount1009;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsAmount1009;
         public decimal? CorrespondentEscrowDisbursementsAmount1009 { get { return _correspondentEscrowDisbursementsAmount1009; } set { _correspondentEscrowDisbursementsAmount1009 = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsCityPropertyTax;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsCityPropertyTax;
         public decimal? CorrespondentEscrowDisbursementsCityPropertyTax { get { return _correspondentEscrowDisbursementsCityPropertyTax; } set { _correspondentEscrowDisbursementsCityPropertyTax = value; } }
-        private Value<string> _correspondentEscrowDisbursementsDescription1007;
+        private DirtyValue<string> _correspondentEscrowDisbursementsDescription1007;
         public string CorrespondentEscrowDisbursementsDescription1007 { get { return _correspondentEscrowDisbursementsDescription1007; } set { _correspondentEscrowDisbursementsDescription1007 = value; } }
-        private Value<string> _correspondentEscrowDisbursementsDescription1008;
+        private DirtyValue<string> _correspondentEscrowDisbursementsDescription1008;
         public string CorrespondentEscrowDisbursementsDescription1008 { get { return _correspondentEscrowDisbursementsDescription1008; } set { _correspondentEscrowDisbursementsDescription1008 = value; } }
-        private Value<string> _correspondentEscrowDisbursementsDescription1009;
+        private DirtyValue<string> _correspondentEscrowDisbursementsDescription1009;
         public string CorrespondentEscrowDisbursementsDescription1009 { get { return _correspondentEscrowDisbursementsDescription1009; } set { _correspondentEscrowDisbursementsDescription1009 = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsEscrowsToBePaidBySeller;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsEscrowsToBePaidBySeller;
         public decimal? CorrespondentEscrowDisbursementsEscrowsToBePaidBySeller { get { return _correspondentEscrowDisbursementsEscrowsToBePaidBySeller; } set { _correspondentEscrowDisbursementsEscrowsToBePaidBySeller = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsEsrowFundedByInvestor;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsEsrowFundedByInvestor;
         public decimal? CorrespondentEscrowDisbursementsEsrowFundedByInvestor { get { return _correspondentEscrowDisbursementsEsrowFundedByInvestor; } set { _correspondentEscrowDisbursementsEsrowFundedByInvestor = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsFloodInsurance;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsFloodInsurance;
         public decimal? CorrespondentEscrowDisbursementsFloodInsurance { get { return _correspondentEscrowDisbursementsFloodInsurance; } set { _correspondentEscrowDisbursementsFloodInsurance = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsHomeInsurance;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsHomeInsurance;
         public decimal? CorrespondentEscrowDisbursementsHomeInsurance { get { return _correspondentEscrowDisbursementsHomeInsurance; } set { _correspondentEscrowDisbursementsHomeInsurance = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsMortgageInsurance;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsMortgageInsurance;
         public decimal? CorrespondentEscrowDisbursementsMortgageInsurance { get { return _correspondentEscrowDisbursementsMortgageInsurance; } set { _correspondentEscrowDisbursementsMortgageInsurance = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsOption1Amount;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsOption1Amount;
         public decimal? CorrespondentEscrowDisbursementsOption1Amount { get { return _correspondentEscrowDisbursementsOption1Amount; } set { _correspondentEscrowDisbursementsOption1Amount = value; } }
-        private Value<string> _correspondentEscrowDisbursementsOption1Desc;
+        private DirtyValue<string> _correspondentEscrowDisbursementsOption1Desc;
         public string CorrespondentEscrowDisbursementsOption1Desc { get { return _correspondentEscrowDisbursementsOption1Desc; } set { _correspondentEscrowDisbursementsOption1Desc = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsOption2Amount;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsOption2Amount;
         public decimal? CorrespondentEscrowDisbursementsOption2Amount { get { return _correspondentEscrowDisbursementsOption2Amount; } set { _correspondentEscrowDisbursementsOption2Amount = value; } }
-        private Value<string> _correspondentEscrowDisbursementsOption2Desc;
+        private DirtyValue<string> _correspondentEscrowDisbursementsOption2Desc;
         public string CorrespondentEscrowDisbursementsOption2Desc { get { return _correspondentEscrowDisbursementsOption2Desc; } set { _correspondentEscrowDisbursementsOption2Desc = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsPropertyTax;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsPropertyTax;
         public decimal? CorrespondentEscrowDisbursementsPropertyTax { get { return _correspondentEscrowDisbursementsPropertyTax; } set { _correspondentEscrowDisbursementsPropertyTax = value; } }
-        private Value<decimal?> _correspondentEscrowDisbursementsUSDAAnnualFee;
+        private DirtyValue<decimal?> _correspondentEscrowDisbursementsUSDAAnnualFee;
         public decimal? CorrespondentEscrowDisbursementsUSDAAnnualFee { get { return _correspondentEscrowDisbursementsUSDAAnnualFee; } set { _correspondentEscrowDisbursementsUSDAAnnualFee = value; } }
-        private Value<decimal?> _correspondentFinalBuyAmount;
+        private DirtyValue<decimal?> _correspondentFinalBuyAmount;
         public decimal? CorrespondentFinalBuyAmount { get { return _correspondentFinalBuyAmount; } set { _correspondentFinalBuyAmount = value; } }
-        private Value<decimal?> _correspondentFinalBuyPrice;
+        private DirtyValue<decimal?> _correspondentFinalBuyPrice;
         public decimal? CorrespondentFinalBuyPrice { get { return _correspondentFinalBuyPrice; } set { _correspondentFinalBuyPrice = value; } }
-        private Value<decimal?> _correspondentFinalCDAggAdjAmount;
+        private DirtyValue<decimal?> _correspondentFinalCDAggAdjAmount;
         public decimal? CorrespondentFinalCDAggAdjAmount { get { return _correspondentFinalCDAggAdjAmount; } set { _correspondentFinalCDAggAdjAmount = value; } }
-        private Value<decimal?> _correspondentFinalCDAmount1007;
+        private DirtyValue<decimal?> _correspondentFinalCDAmount1007;
         public decimal? CorrespondentFinalCDAmount1007 { get { return _correspondentFinalCDAmount1007; } set { _correspondentFinalCDAmount1007 = value; } }
-        private Value<decimal?> _correspondentFinalCDAmount1008;
+        private DirtyValue<decimal?> _correspondentFinalCDAmount1008;
         public decimal? CorrespondentFinalCDAmount1008 { get { return _correspondentFinalCDAmount1008; } set { _correspondentFinalCDAmount1008 = value; } }
-        private Value<decimal?> _correspondentFinalCDAmount1009;
+        private DirtyValue<decimal?> _correspondentFinalCDAmount1009;
         public decimal? CorrespondentFinalCDAmount1009 { get { return _correspondentFinalCDAmount1009; } set { _correspondentFinalCDAmount1009 = value; } }
-        private Value<decimal?> _correspondentFinalCDCityPropertyTax;
+        private DirtyValue<decimal?> _correspondentFinalCDCityPropertyTax;
         public decimal? CorrespondentFinalCDCityPropertyTax { get { return _correspondentFinalCDCityPropertyTax; } set { _correspondentFinalCDCityPropertyTax = value; } }
-        private Value<string> _correspondentFinalCDDescription1007;
+        private DirtyValue<string> _correspondentFinalCDDescription1007;
         public string CorrespondentFinalCDDescription1007 { get { return _correspondentFinalCDDescription1007; } set { _correspondentFinalCDDescription1007 = value; } }
-        private Value<string> _correspondentFinalCDDescription1008;
+        private DirtyValue<string> _correspondentFinalCDDescription1008;
         public string CorrespondentFinalCDDescription1008 { get { return _correspondentFinalCDDescription1008; } set { _correspondentFinalCDDescription1008 = value; } }
-        private Value<string> _correspondentFinalCDDescription1009;
+        private DirtyValue<string> _correspondentFinalCDDescription1009;
         public string CorrespondentFinalCDDescription1009 { get { return _correspondentFinalCDDescription1009; } set { _correspondentFinalCDDescription1009 = value; } }
-        private Value<decimal?> _correspondentFinalCDFloodInsurance;
+        private DirtyValue<decimal?> _correspondentFinalCDFloodInsurance;
         public decimal? CorrespondentFinalCDFloodInsurance { get { return _correspondentFinalCDFloodInsurance; } set { _correspondentFinalCDFloodInsurance = value; } }
-        private Value<decimal?> _correspondentFinalCDHomeInsurance;
+        private DirtyValue<decimal?> _correspondentFinalCDHomeInsurance;
         public decimal? CorrespondentFinalCDHomeInsurance { get { return _correspondentFinalCDHomeInsurance; } set { _correspondentFinalCDHomeInsurance = value; } }
-        private Value<decimal?> _correspondentFinalCDMortgageInsurance;
+        private DirtyValue<decimal?> _correspondentFinalCDMortgageInsurance;
         public decimal? CorrespondentFinalCDMortgageInsurance { get { return _correspondentFinalCDMortgageInsurance; } set { _correspondentFinalCDMortgageInsurance = value; } }
-        private Value<decimal?> _correspondentFinalCDOption1Amount;
+        private DirtyValue<decimal?> _correspondentFinalCDOption1Amount;
         public decimal? CorrespondentFinalCDOption1Amount { get { return _correspondentFinalCDOption1Amount; } set { _correspondentFinalCDOption1Amount = value; } }
-        private Value<string> _correspondentFinalCDOption1Desc;
+        private DirtyValue<string> _correspondentFinalCDOption1Desc;
         public string CorrespondentFinalCDOption1Desc { get { return _correspondentFinalCDOption1Desc; } set { _correspondentFinalCDOption1Desc = value; } }
-        private Value<decimal?> _correspondentFinalCDOption2Amount;
+        private DirtyValue<decimal?> _correspondentFinalCDOption2Amount;
         public decimal? CorrespondentFinalCDOption2Amount { get { return _correspondentFinalCDOption2Amount; } set { _correspondentFinalCDOption2Amount = value; } }
-        private Value<string> _correspondentFinalCDOption2Desc;
+        private DirtyValue<string> _correspondentFinalCDOption2Desc;
         public string CorrespondentFinalCDOption2Desc { get { return _correspondentFinalCDOption2Desc; } set { _correspondentFinalCDOption2Desc = value; } }
-        private Value<decimal?> _correspondentFinalCDPropertyTax;
+        private DirtyValue<decimal?> _correspondentFinalCDPropertyTax;
         public decimal? CorrespondentFinalCDPropertyTax { get { return _correspondentFinalCDPropertyTax; } set { _correspondentFinalCDPropertyTax = value; } }
-        private Value<decimal?> _correspondentFinalCDReservesCollectedAtClosing;
+        private DirtyValue<decimal?> _correspondentFinalCDReservesCollectedAtClosing;
         public decimal? CorrespondentFinalCDReservesCollectedAtClosing { get { return _correspondentFinalCDReservesCollectedAtClosing; } set { _correspondentFinalCDReservesCollectedAtClosing = value; } }
-        private Value<decimal?> _correspondentFinalCDUSDAAnnualFee;
+        private DirtyValue<decimal?> _correspondentFinalCDUSDAAnnualFee;
         public decimal? CorrespondentFinalCDUSDAAnnualFee { get { return _correspondentFinalCDUSDAAnnualFee; } set { _correspondentFinalCDUSDAAnnualFee = value; } }
-        private Value<DateTime?> _correspondentFirstPaymentDate;
+        private DirtyValue<DateTime?> _correspondentFirstPaymentDate;
         public DateTime? CorrespondentFirstPaymentDate { get { return _correspondentFirstPaymentDate; } set { _correspondentFirstPaymentDate = value; } }
-        private Value<decimal?> _correspondentImpounds;
+        private DirtyValue<decimal?> _correspondentImpounds;
         public decimal? CorrespondentImpounds { get { return _correspondentImpounds; } set { _correspondentImpounds = value; } }
-        private Value<decimal?> _correspondentInterest;
+        private DirtyValue<decimal?> _correspondentInterest;
         public decimal? CorrespondentInterest { get { return _correspondentInterest; } set { _correspondentInterest = value; } }
-        private Value<int?> _correspondentInterestDays;
+        private DirtyValue<int?> _correspondentInterestDays;
         public int? CorrespondentInterestDays { get { return _correspondentInterestDays; } set { _correspondentInterestDays = value; } }
-        private Value<decimal?> _correspondentLateFeeAmount;
+        private DirtyValue<decimal?> _correspondentLateFeeAmount;
         public decimal? CorrespondentLateFeeAmount { get { return _correspondentLateFeeAmount; } set { _correspondentLateFeeAmount = value; } }
-        private Value<decimal?> _correspondentLateFeePriceAdjustment;
+        private DirtyValue<decimal?> _correspondentLateFeePriceAdjustment;
         public decimal? CorrespondentLateFeePriceAdjustment { get { return _correspondentLateFeePriceAdjustment; } set { _correspondentLateFeePriceAdjustment = value; } }
-        private Value<DateTime?> _correspondentPaidToDate;
+        private DirtyValue<DateTime?> _correspondentPaidToDate;
         public DateTime? CorrespondentPaidToDate { get { return _correspondentPaidToDate; } set { _correspondentPaidToDate = value; } }
-        private Value<DateTime?> _correspondentPaymentHistoryAnticipatedPurchaseDate;
+        private DirtyValue<DateTime?> _correspondentPaymentHistoryAnticipatedPurchaseDate;
         public DateTime? CorrespondentPaymentHistoryAnticipatedPurchaseDate { get { return _correspondentPaymentHistoryAnticipatedPurchaseDate; } set { _correspondentPaymentHistoryAnticipatedPurchaseDate = value; } }
-        private Value<decimal?> _correspondentPaymentHistoryCalculatedPurchasedPrincipal;
+        private DirtyValue<decimal?> _correspondentPaymentHistoryCalculatedPurchasedPrincipal;
         public decimal? CorrespondentPaymentHistoryCalculatedPurchasedPrincipal { get { return _correspondentPaymentHistoryCalculatedPurchasedPrincipal; } set { _correspondentPaymentHistoryCalculatedPurchasedPrincipal = value; } }
-        private Value<DateTime?> _correspondentPaymentHistoryFirstBorrowerPaymentDueDate;
+        private DirtyValue<DateTime?> _correspondentPaymentHistoryFirstBorrowerPaymentDueDate;
         public DateTime? CorrespondentPaymentHistoryFirstBorrowerPaymentDueDate { get { return _correspondentPaymentHistoryFirstBorrowerPaymentDueDate; } set { _correspondentPaymentHistoryFirstBorrowerPaymentDueDate = value; } }
-        private Value<DateTime?> _correspondentPaymentHistoryFirstInvestorPaymentDate;
+        private DirtyValue<DateTime?> _correspondentPaymentHistoryFirstInvestorPaymentDate;
         public DateTime? CorrespondentPaymentHistoryFirstInvestorPaymentDate { get { return _correspondentPaymentHistoryFirstInvestorPaymentDate; } set { _correspondentPaymentHistoryFirstInvestorPaymentDate = value; } }
-        private Value<DateTime?> _correspondentPaymentHistoryNoteDate;
+        private DirtyValue<DateTime?> _correspondentPaymentHistoryNoteDate;
         public DateTime? CorrespondentPaymentHistoryNoteDate { get { return _correspondentPaymentHistoryNoteDate; } set { _correspondentPaymentHistoryNoteDate = value; } }
-        private Value<decimal?> _correspondentPaymentHistoryPricipalReduction;
+        private DirtyValue<decimal?> _correspondentPaymentHistoryPricipalReduction;
         public decimal? CorrespondentPaymentHistoryPricipalReduction { get { return _correspondentPaymentHistoryPricipalReduction; } set { _correspondentPaymentHistoryPricipalReduction = value; } }
-        private Value<decimal?> _correspondentPurchasedPrincipal;
+        private DirtyValue<decimal?> _correspondentPurchasedPrincipal;
         public decimal? CorrespondentPurchasedPrincipal { get { return _correspondentPurchasedPrincipal; } set { _correspondentPurchasedPrincipal = value; } }
-        private Value<string> _correspondentReconcilationComments;
+        private DirtyValue<string> _correspondentReconcilationComments;
         public string CorrespondentReconcilationComments { get { return _correspondentReconcilationComments; } set { _correspondentReconcilationComments = value; } }
-        private Value<decimal?> _correspondentRemainingBuydownAmount;
+        private DirtyValue<decimal?> _correspondentRemainingBuydownAmount;
         public decimal? CorrespondentRemainingBuydownAmount { get { return _correspondentRemainingBuydownAmount; } set { _correspondentRemainingBuydownAmount = value; } }
-        private Value<decimal?> _correspondentSRPAmount;
+        private DirtyValue<decimal?> _correspondentSRPAmount;
         public decimal? CorrespondentSRPAmount { get { return _correspondentSRPAmount; } set { _correspondentSRPAmount = value; } }
-        private Value<decimal?> _correspondentTotalBuyAmount;
+        private DirtyValue<decimal?> _correspondentTotalBuyAmount;
         public decimal? CorrespondentTotalBuyAmount { get { return _correspondentTotalBuyAmount; } set { _correspondentTotalBuyAmount = value; } }
-        private Value<decimal?> _correspondentTotalFees;
+        private DirtyValue<decimal?> _correspondentTotalFees;
         public decimal? CorrespondentTotalFees { get { return _correspondentTotalFees; } set { _correspondentTotalFees = value; } }
-        private Value<string> _correspondentWarehouseBankABANum;
+        private DirtyValue<string> _correspondentWarehouseBankABANum;
         public string CorrespondentWarehouseBankABANum { get { return _correspondentWarehouseBankABANum; } set { _correspondentWarehouseBankABANum = value; } }
-        private Value<string> _correspondentWarehouseBankAcctName;
+        private DirtyValue<string> _correspondentWarehouseBankAcctName;
         public string CorrespondentWarehouseBankAcctName { get { return _correspondentWarehouseBankAcctName; } set { _correspondentWarehouseBankAcctName = value; } }
-        private Value<string> _correspondentWarehouseBankAcctNum;
+        private DirtyValue<string> _correspondentWarehouseBankAcctNum;
         public string CorrespondentWarehouseBankAcctNum { get { return _correspondentWarehouseBankAcctNum; } set { _correspondentWarehouseBankAcctNum = value; } }
-        private Value<string> _correspondentWarehouseBankAddress;
+        private DirtyValue<string> _correspondentWarehouseBankAddress;
         public string CorrespondentWarehouseBankAddress { get { return _correspondentWarehouseBankAddress; } set { _correspondentWarehouseBankAddress = value; } }
-        private Value<string> _correspondentWarehouseBankAddress1;
+        private DirtyValue<string> _correspondentWarehouseBankAddress1;
         public string CorrespondentWarehouseBankAddress1 { get { return _correspondentWarehouseBankAddress1; } set { _correspondentWarehouseBankAddress1 = value; } }
-        private Value<DateTime?> _correspondentWarehouseBankBaileeExpirationDate;
+        private DirtyValue<DateTime?> _correspondentWarehouseBankBaileeExpirationDate;
         public DateTime? CorrespondentWarehouseBankBaileeExpirationDate { get { return _correspondentWarehouseBankBaileeExpirationDate; } set { _correspondentWarehouseBankBaileeExpirationDate = value; } }
-        private Value<bool?> _correspondentWarehouseBankBaileeLetterReceivedIndicator;
+        private DirtyValue<bool?> _correspondentWarehouseBankBaileeLetterReceivedIndicator;
         public bool? CorrespondentWarehouseBankBaileeLetterReceivedIndicator { get { return _correspondentWarehouseBankBaileeLetterReceivedIndicator; } set { _correspondentWarehouseBankBaileeLetterReceivedIndicator = value; } }
-        private Value<bool?> _correspondentWarehouseBankBaileeLetterReqIndicator;
+        private DirtyValue<bool?> _correspondentWarehouseBankBaileeLetterReqIndicator;
         public bool? CorrespondentWarehouseBankBaileeLetterReqIndicator { get { return _correspondentWarehouseBankBaileeLetterReqIndicator; } set { _correspondentWarehouseBankBaileeLetterReqIndicator = value; } }
-        private Value<string> _correspondentWarehouseBankCity;
+        private DirtyValue<string> _correspondentWarehouseBankCity;
         public string CorrespondentWarehouseBankCity { get { return _correspondentWarehouseBankCity; } set { _correspondentWarehouseBankCity = value; } }
-        private Value<string> _correspondentWarehouseBankContactEmail;
+        private DirtyValue<string> _correspondentWarehouseBankContactEmail;
         public string CorrespondentWarehouseBankContactEmail { get { return _correspondentWarehouseBankContactEmail; } set { _correspondentWarehouseBankContactEmail = value; } }
-        private Value<string> _correspondentWarehouseBankContactFax;
+        private DirtyValue<string> _correspondentWarehouseBankContactFax;
         public string CorrespondentWarehouseBankContactFax { get { return _correspondentWarehouseBankContactFax; } set { _correspondentWarehouseBankContactFax = value; } }
-        private Value<string> _correspondentWarehouseBankContactName;
+        private DirtyValue<string> _correspondentWarehouseBankContactName;
         public string CorrespondentWarehouseBankContactName { get { return _correspondentWarehouseBankContactName; } set { _correspondentWarehouseBankContactName = value; } }
-        private Value<string> _correspondentWarehouseBankContactPhone;
+        private DirtyValue<string> _correspondentWarehouseBankContactPhone;
         public string CorrespondentWarehouseBankContactPhone { get { return _correspondentWarehouseBankContactPhone; } set { _correspondentWarehouseBankContactPhone = value; } }
-        private Value<string> _correspondentWarehouseBankDescription;
+        private DirtyValue<string> _correspondentWarehouseBankDescription;
         public string CorrespondentWarehouseBankDescription { get { return _correspondentWarehouseBankDescription; } set { _correspondentWarehouseBankDescription = value; } }
-        private Value<string> _correspondentWarehouseBankFurtherCreditAcctName;
+        private DirtyValue<string> _correspondentWarehouseBankFurtherCreditAcctName;
         public string CorrespondentWarehouseBankFurtherCreditAcctName { get { return _correspondentWarehouseBankFurtherCreditAcctName; } set { _correspondentWarehouseBankFurtherCreditAcctName = value; } }
-        private Value<string> _correspondentWarehouseBankFurtherCreditAcctNum;
+        private DirtyValue<string> _correspondentWarehouseBankFurtherCreditAcctNum;
         public string CorrespondentWarehouseBankFurtherCreditAcctNum { get { return _correspondentWarehouseBankFurtherCreditAcctNum; } set { _correspondentWarehouseBankFurtherCreditAcctNum = value; } }
-        private Value<int?> _correspondentWarehouseBankId;
+        private DirtyValue<int?> _correspondentWarehouseBankId;
         public int? CorrespondentWarehouseBankId { get { return _correspondentWarehouseBankId; } set { _correspondentWarehouseBankId = value; } }
-        private Value<string> _correspondentWarehouseBankName;
+        private DirtyValue<string> _correspondentWarehouseBankName;
         public string CorrespondentWarehouseBankName { get { return _correspondentWarehouseBankName; } set { _correspondentWarehouseBankName = value; } }
-        private Value<string> _correspondentWarehouseBankNotes;
+        private DirtyValue<string> _correspondentWarehouseBankNotes;
         public string CorrespondentWarehouseBankNotes { get { return _correspondentWarehouseBankNotes; } set { _correspondentWarehouseBankNotes = value; } }
-        private Value<bool?> _correspondentWarehouseBankSelfFunderIndicator;
+        private DirtyValue<bool?> _correspondentWarehouseBankSelfFunderIndicator;
         public bool? CorrespondentWarehouseBankSelfFunderIndicator { get { return _correspondentWarehouseBankSelfFunderIndicator; } set { _correspondentWarehouseBankSelfFunderIndicator = value; } }
-        private Value<string> _correspondentWarehouseBankState;
+        private DirtyValue<string> _correspondentWarehouseBankState;
         public string CorrespondentWarehouseBankState { get { return _correspondentWarehouseBankState; } set { _correspondentWarehouseBankState = value; } }
-        private Value<bool?> _correspondentWarehouseBankTriPartyContractIndicator;
+        private DirtyValue<bool?> _correspondentWarehouseBankTriPartyContractIndicator;
         public bool? CorrespondentWarehouseBankTriPartyContractIndicator { get { return _correspondentWarehouseBankTriPartyContractIndicator; } set { _correspondentWarehouseBankTriPartyContractIndicator = value; } }
-        private Value<bool?> _correspondentWarehouseBankUseDefaultContactIndicator;
+        private DirtyValue<bool?> _correspondentWarehouseBankUseDefaultContactIndicator;
         public bool? CorrespondentWarehouseBankUseDefaultContactIndicator { get { return _correspondentWarehouseBankUseDefaultContactIndicator; } set { _correspondentWarehouseBankUseDefaultContactIndicator = value; } }
-        private Value<string> _correspondentWarehouseBankWireConfirmationNumber;
+        private DirtyValue<string> _correspondentWarehouseBankWireConfirmationNumber;
         public string CorrespondentWarehouseBankWireConfirmationNumber { get { return _correspondentWarehouseBankWireConfirmationNumber; } set { _correspondentWarehouseBankWireConfirmationNumber = value; } }
-        private Value<bool?> _correspondentWarehouseBankWireInstructionsReceivedIndicator;
+        private DirtyValue<bool?> _correspondentWarehouseBankWireInstructionsReceivedIndicator;
         public bool? CorrespondentWarehouseBankWireInstructionsReceivedIndicator { get { return _correspondentWarehouseBankWireInstructionsReceivedIndicator; } set { _correspondentWarehouseBankWireInstructionsReceivedIndicator = value; } }
-        private Value<string> _correspondentWarehouseBankZip;
+        private DirtyValue<string> _correspondentWarehouseBankZip;
         public string CorrespondentWarehouseBankZip { get { return _correspondentWarehouseBankZip; } set { _correspondentWarehouseBankZip = value; } }
-        private Value<string> _creditScoreToUse;
+        private DirtyValue<string> _creditScoreToUse;
         public string CreditScoreToUse { get { return _creditScoreToUse; } set { _creditScoreToUse = value; } }
-        private Value<int?> _cumulatedDaystoExtend;
+        private DirtyValue<int?> _cumulatedDaystoExtend;
         public int? CumulatedDaystoExtend { get { return _cumulatedDaystoExtend; } set { _cumulatedDaystoExtend = value; } }
         private DirtyList<PriceAdjustment> _currentAdjustments;
         public IList<PriceAdjustment> CurrentAdjustments { get { var v = _currentAdjustments; return v ?? Interlocked.CompareExchange(ref _currentAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _currentAdjustments = new DirtyList<PriceAdjustment>(value); } }
-        private Value<string> _currentComments;
+        private DirtyValue<string> _currentComments;
         public string CurrentComments { get { return _currentComments; } set { _currentComments = value; } }
-        private Value<DateTime?> _currentLockDate;
+        private DirtyValue<DateTime?> _currentLockDate;
         public DateTime? CurrentLockDate { get { return _currentLockDate; } set { _currentLockDate = value; } }
-        private Value<DateTime?> _currentLockExpires;
+        private DirtyValue<DateTime?> _currentLockExpires;
         public DateTime? CurrentLockExpires { get { return _currentLockExpires; } set { _currentLockExpires = value; } }
-        private Value<decimal?> _currentMarginRate;
+        private DirtyValue<decimal?> _currentMarginRate;
         public decimal? CurrentMarginRate { get { return _currentMarginRate; } set { _currentMarginRate = value; } }
-        private Value<decimal?> _currentMarginRateRequested;
+        private DirtyValue<decimal?> _currentMarginRateRequested;
         public decimal? CurrentMarginRateRequested { get { return _currentMarginRateRequested; } set { _currentMarginRateRequested = value; } }
-        private Value<decimal?> _currentMarginTotalAdjustment;
+        private DirtyValue<decimal?> _currentMarginTotalAdjustment;
         public decimal? CurrentMarginTotalAdjustment { get { return _currentMarginTotalAdjustment; } set { _currentMarginTotalAdjustment = value; } }
-        private Value<int?> _currentNumberOfDays;
+        private DirtyValue<int?> _currentNumberOfDays;
         public int? CurrentNumberOfDays { get { return _currentNumberOfDays; } set { _currentNumberOfDays = value; } }
-        private Value<decimal?> _currentPriceRate;
+        private DirtyValue<decimal?> _currentPriceRate;
         public decimal? CurrentPriceRate { get { return _currentPriceRate; } set { _currentPriceRate = value; } }
-        private Value<decimal?> _currentPriceRateRequested;
+        private DirtyValue<decimal?> _currentPriceRateRequested;
         public decimal? CurrentPriceRateRequested { get { return _currentPriceRateRequested; } set { _currentPriceRateRequested = value; } }
-        private Value<decimal?> _currentPriceTotalAdjustment;
+        private DirtyValue<decimal?> _currentPriceTotalAdjustment;
         public decimal? CurrentPriceTotalAdjustment { get { return _currentPriceTotalAdjustment; } set { _currentPriceTotalAdjustment = value; } }
-        private Value<decimal?> _currentRate;
+        private DirtyValue<decimal?> _currentRate;
         public decimal? CurrentRate { get { return _currentRate; } set { _currentRate = value; } }
-        private Value<decimal?> _currentRateRequested;
+        private DirtyValue<decimal?> _currentRateRequested;
         public decimal? CurrentRateRequested { get { return _currentRateRequested; } set { _currentRateRequested = value; } }
-        private Value<DateTime?> _currentRateSetDate;
+        private DirtyValue<DateTime?> _currentRateSetDate;
         public DateTime? CurrentRateSetDate { get { return _currentRateSetDate; } set { _currentRateSetDate = value; } }
-        private Value<string> _currentRateSheetID;
+        private DirtyValue<string> _currentRateSheetID;
         public string CurrentRateSheetID { get { return _currentRateSheetID; } set { _currentRateSheetID = value; } }
-        private Value<decimal?> _currentRateTotalAdjustment;
+        private DirtyValue<decimal?> _currentRateTotalAdjustment;
         public decimal? CurrentRateTotalAdjustment { get { return _currentRateTotalAdjustment; } set { _currentRateTotalAdjustment = value; } }
-        private Value<DateTime?> _date;
+        private DirtyValue<DateTime?> _date;
         public DateTime? Date { get { return _date; } set { _date = value; } }
-        private Value<DateTime?> _dateFirstPaymentToInvestor;
+        private DirtyValue<DateTime?> _dateFirstPaymentToInvestor;
         public DateTime? DateFirstPaymentToInvestor { get { return _dateFirstPaymentToInvestor; } set { _dateFirstPaymentToInvestor = value; } }
-        private Value<DateTime?> _dateLockedWithInvestor;
+        private DirtyValue<DateTime?> _dateLockedWithInvestor;
         public DateTime? DateLockedWithInvestor { get { return _dateLockedWithInvestor; } set { _dateLockedWithInvestor = value; } }
-        private Value<DateTime?> _dateSold;
+        private DirtyValue<DateTime?> _dateSold;
         public DateTime? DateSold { get { return _dateSold; } set { _dateSold = value; } }
-        private Value<DateTime?> _dateWarehoused;
+        private DirtyValue<DateTime?> _dateWarehoused;
         public DateTime? DateWarehoused { get { return _dateWarehoused; } set { _dateWarehoused = value; } }
-        private Value<int?> _daysToExtend;
+        private DirtyValue<int?> _daysToExtend;
         public int? DaysToExtend { get { return _daysToExtend; } set { _daysToExtend = value; } }
-        private Value<string> _deliveryType;
+        private DirtyValue<string> _deliveryType;
         public string DeliveryType { get { return _deliveryType; } set { _deliveryType = value; } }
-        private Value<decimal?> _diffAmountReceived;
+        private DirtyValue<decimal?> _diffAmountReceived;
         public decimal? DiffAmountReceived { get { return _diffAmountReceived; } set { _diffAmountReceived = value; } }
-        private Value<decimal?> _diffImpounds;
+        private DirtyValue<decimal?> _diffImpounds;
         public decimal? DiffImpounds { get { return _diffImpounds; } set { _diffImpounds = value; } }
-        private Value<decimal?> _diffInterest;
+        private DirtyValue<decimal?> _diffInterest;
         public decimal? DiffInterest { get { return _diffInterest; } set { _diffInterest = value; } }
-        private Value<decimal?> _diffPremium;
+        private DirtyValue<decimal?> _diffPremium;
         public decimal? DiffPremium { get { return _diffPremium; } set { _diffPremium = value; } }
-        private Value<decimal?> _diffPrinciple;
+        private DirtyValue<decimal?> _diffPrinciple;
         public decimal? DiffPrinciple { get { return _diffPrinciple; } set { _diffPrinciple = value; } }
-        private Value<decimal?> _diffRemainingBuydownFunds;
+        private DirtyValue<decimal?> _diffRemainingBuydownFunds;
         public decimal? DiffRemainingBuydownFunds { get { return _diffRemainingBuydownFunds; } set { _diffRemainingBuydownFunds = value; } }
-        private Value<decimal?> _diffSellAmount;
+        private DirtyValue<decimal?> _diffSellAmount;
         public decimal? DiffSellAmount { get { return _diffSellAmount; } set { _diffSellAmount = value; } }
-        private Value<decimal?> _diffSellPrice;
+        private DirtyValue<decimal?> _diffSellPrice;
         public decimal? DiffSellPrice { get { return _diffSellPrice; } set { _diffSellPrice = value; } }
-        private Value<decimal?> _diffSellSideSRP;
+        private DirtyValue<decimal?> _diffSellSideSRP;
         public decimal? DiffSellSideSRP { get { return _diffSellSideSRP; } set { _diffSellSideSRP = value; } }
-        private Value<decimal?> _diffSRP;
+        private DirtyValue<decimal?> _diffSRP;
         public decimal? DiffSRP { get { return _diffSRP; } set { _diffSRP = value; } }
-        private Value<decimal?> _diffSRPAmount;
+        private DirtyValue<decimal?> _diffSRPAmount;
         public decimal? DiffSRPAmount { get { return _diffSRPAmount; } set { _diffSRPAmount = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator1;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator1;
         public bool? EmploymentBorrowerSelfEmployedIndicator1 { get { return _employmentBorrowerSelfEmployedIndicator1; } set { _employmentBorrowerSelfEmployedIndicator1 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator10;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator10;
         public bool? EmploymentBorrowerSelfEmployedIndicator10 { get { return _employmentBorrowerSelfEmployedIndicator10; } set { _employmentBorrowerSelfEmployedIndicator10 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator11;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator11;
         public bool? EmploymentBorrowerSelfEmployedIndicator11 { get { return _employmentBorrowerSelfEmployedIndicator11; } set { _employmentBorrowerSelfEmployedIndicator11 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator12;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator12;
         public bool? EmploymentBorrowerSelfEmployedIndicator12 { get { return _employmentBorrowerSelfEmployedIndicator12; } set { _employmentBorrowerSelfEmployedIndicator12 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator2;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator2;
         public bool? EmploymentBorrowerSelfEmployedIndicator2 { get { return _employmentBorrowerSelfEmployedIndicator2; } set { _employmentBorrowerSelfEmployedIndicator2 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator3;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator3;
         public bool? EmploymentBorrowerSelfEmployedIndicator3 { get { return _employmentBorrowerSelfEmployedIndicator3; } set { _employmentBorrowerSelfEmployedIndicator3 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator4;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator4;
         public bool? EmploymentBorrowerSelfEmployedIndicator4 { get { return _employmentBorrowerSelfEmployedIndicator4; } set { _employmentBorrowerSelfEmployedIndicator4 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator5;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator5;
         public bool? EmploymentBorrowerSelfEmployedIndicator5 { get { return _employmentBorrowerSelfEmployedIndicator5; } set { _employmentBorrowerSelfEmployedIndicator5 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator6;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator6;
         public bool? EmploymentBorrowerSelfEmployedIndicator6 { get { return _employmentBorrowerSelfEmployedIndicator6; } set { _employmentBorrowerSelfEmployedIndicator6 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator7;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator7;
         public bool? EmploymentBorrowerSelfEmployedIndicator7 { get { return _employmentBorrowerSelfEmployedIndicator7; } set { _employmentBorrowerSelfEmployedIndicator7 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator8;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator8;
         public bool? EmploymentBorrowerSelfEmployedIndicator8 { get { return _employmentBorrowerSelfEmployedIndicator8; } set { _employmentBorrowerSelfEmployedIndicator8 = value; } }
-        private Value<bool?> _employmentBorrowerSelfEmployedIndicator9;
+        private DirtyValue<bool?> _employmentBorrowerSelfEmployedIndicator9;
         public bool? EmploymentBorrowerSelfEmployedIndicator9 { get { return _employmentBorrowerSelfEmployedIndicator9; } set { _employmentBorrowerSelfEmployedIndicator9 = value; } }
-        private Value<decimal?> _expectedAmountReceived;
+        private DirtyValue<decimal?> _expectedAmountReceived;
         public decimal? ExpectedAmountReceived { get { return _expectedAmountReceived; } set { _expectedAmountReceived = value; } }
-        private Value<decimal?> _expectedImpounds;
+        private DirtyValue<decimal?> _expectedImpounds;
         public decimal? ExpectedImpounds { get { return _expectedImpounds; } set { _expectedImpounds = value; } }
-        private Value<decimal?> _expectedInterest;
+        private DirtyValue<decimal?> _expectedInterest;
         public decimal? ExpectedInterest { get { return _expectedInterest; } set { _expectedInterest = value; } }
-        private Value<decimal?> _expectedPremium;
+        private DirtyValue<decimal?> _expectedPremium;
         public decimal? ExpectedPremium { get { return _expectedPremium; } set { _expectedPremium = value; } }
-        private Value<decimal?> _expectedPrinciple;
+        private DirtyValue<decimal?> _expectedPrinciple;
         public decimal? ExpectedPrinciple { get { return _expectedPrinciple; } set { _expectedPrinciple = value; } }
-        private Value<decimal?> _expectedRemainingBuydownFunds;
+        private DirtyValue<decimal?> _expectedRemainingBuydownFunds;
         public decimal? ExpectedRemainingBuydownFunds { get { return _expectedRemainingBuydownFunds; } set { _expectedRemainingBuydownFunds = value; } }
-        private Value<decimal?> _expectedSRP;
+        private DirtyValue<decimal?> _expectedSRP;
         public decimal? ExpectedSRP { get { return _expectedSRP; } set { _expectedSRP = value; } }
-        private Value<string> _extensionRequestPending;
+        private DirtyValue<string> _extensionRequestPending;
         public string ExtensionRequestPending { get { return _extensionRequestPending; } set { _extensionRequestPending = value; } }
-        private Value<int?> _extensionSequenceNumber;
+        private DirtyValue<int?> _extensionSequenceNumber;
         public int? ExtensionSequenceNumber { get { return _extensionSequenceNumber; } set { _extensionSequenceNumber = value; } }
         private DirtyList<ExtraPayment> _extraPayments;
         public IList<ExtraPayment> ExtraPayments { get { var v = _extraPayments; return v ?? Interlocked.CompareExchange(ref _extraPayments, (v = new DirtyList<ExtraPayment>()), null) ?? v; } set { _extraPayments = new DirtyList<ExtraPayment>(value); } }
-        private Value<decimal?> _fHAUpfrontMIPremiumPercent;
+        private DirtyValue<decimal?> _fHAUpfrontMIPremiumPercent;
         public decimal? FHAUpfrontMIPremiumPercent { get { return _fHAUpfrontMIPremiumPercent; } set { _fHAUpfrontMIPremiumPercent = value; } }
-        private Value<int?> _financedNumberOfUnits;
+        private DirtyValue<int?> _financedNumberOfUnits;
         public int? FinancedNumberOfUnits { get { return _financedNumberOfUnits; } set { _financedNumberOfUnits = value; } }
-        private Value<string> _firstPaymenTo;
+        private DirtyValue<string> _firstPaymenTo;
         public string FirstPaymenTo { get { return _firstPaymenTo; } set { _firstPaymenTo = value; } }
-        private Value<decimal?> _firstSubordinateAmount;
+        private DirtyValue<decimal?> _firstSubordinateAmount;
         public decimal? FirstSubordinateAmount { get { return _firstSubordinateAmount; } set { _firstSubordinateAmount = value; } }
-        private Value<bool?> _firstTimeHomebuyersIndicator;
+        private DirtyValue<bool?> _firstTimeHomebuyersIndicator;
         public bool? FirstTimeHomebuyersIndicator { get { return _firstTimeHomebuyersIndicator; } set { _firstTimeHomebuyersIndicator = value; } }
-        private Value<string> _fNMProductPlanIdentifier;
+        private DirtyValue<string> _fNMProductPlanIdentifier;
         public string FNMProductPlanIdentifier { get { return _fNMProductPlanIdentifier; } set { _fNMProductPlanIdentifier = value; } }
-        private Value<decimal?> _fundingAmount;
+        private DirtyValue<decimal?> _fundingAmount;
         public decimal? FundingAmount { get { return _fundingAmount; } set { _fundingAmount = value; } }
-        private Value<decimal?> _gainLossPercentage;
+        private DirtyValue<decimal?> _gainLossPercentage;
         public decimal? GainLossPercentage { get { return _gainLossPercentage; } set { _gainLossPercentage = value; } }
-        private Value<decimal?> _gainLossPrice;
+        private DirtyValue<decimal?> _gainLossPrice;
         public decimal? GainLossPrice { get { return _gainLossPrice; } set { _gainLossPrice = value; } }
-        private Value<decimal?> _gainLossTotalBuyPrice;
+        private DirtyValue<decimal?> _gainLossTotalBuyPrice;
         public decimal? GainLossTotalBuyPrice { get { return _gainLossTotalBuyPrice; } set { _gainLossTotalBuyPrice = value; } }
-        private Value<decimal?> _gPMRate;
+        private DirtyValue<decimal?> _gPMRate;
         public decimal? GPMRate { get { return _gPMRate; } set { _gPMRate = value; } }
-        private Value<int?> _gPMYears;
+        private DirtyValue<int?> _gPMYears;
         public int? GPMYears { get { return _gPMYears; } set { _gPMYears = value; } }
-        private Value<string> _gSEPropertyType;
+        private DirtyValue<string> _gSEPropertyType;
         public string GSEPropertyType { get { return _gSEPropertyType; } set { _gSEPropertyType = value; } }
-        private Value<string> _hedging;
+        private DirtyValue<string> _hedging;
         public string Hedging { get { return _hedging; } set { _hedging = value; } }
-        private Value<string> _hELOCActualBalance;
+        private DirtyValue<string> _hELOCActualBalance;
         public string HELOCActualBalance { get { return _hELOCActualBalance; } set { _hELOCActualBalance = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _impounds;
+        private DirtyValue<decimal?> _impounds;
         public decimal? Impounds { get { return _impounds; } set { _impounds = value; } }
-        private Value<string> _impoundType;
+        private DirtyValue<string> _impoundType;
         public string ImpoundType { get { return _impoundType; } set { _impoundType = value; } }
-        private Value<string> _impoundWavied;
+        private DirtyValue<string> _impoundWavied;
         public string ImpoundWavied { get { return _impoundWavied; } set { _impoundWavied = value; } }
-        private Value<decimal?> _interest;
+        private DirtyValue<decimal?> _interest;
         public decimal? Interest { get { return _interest; } set { _interest = value; } }
-        private Value<string> _investorAddress;
+        private DirtyValue<string> _investorAddress;
         public string InvestorAddress { get { return _investorAddress; } set { _investorAddress = value; } }
-        private Value<string> _investorCity;
+        private DirtyValue<string> _investorCity;
         public string InvestorCity { get { return _investorCity; } set { _investorCity = value; } }
-        private Value<string> _investorCommitment;
+        private DirtyValue<string> _investorCommitment;
         public string InvestorCommitment { get { return _investorCommitment; } set { _investorCommitment = value; } }
-        private Value<string> _investorContact;
+        private DirtyValue<string> _investorContact;
         public string InvestorContact { get { return _investorContact; } set { _investorContact = value; } }
-        private Value<DateTime?> _investorDeliveryDate;
+        private DirtyValue<DateTime?> _investorDeliveryDate;
         public DateTime? InvestorDeliveryDate { get { return _investorDeliveryDate; } set { _investorDeliveryDate = value; } }
-        private Value<string> _investorEmail;
+        private DirtyValue<string> _investorEmail;
         public string InvestorEmail { get { return _investorEmail; } set { _investorEmail = value; } }
-        private Value<string> _investorLoanNumber;
+        private DirtyValue<string> _investorLoanNumber;
         public string InvestorLoanNumber { get { return _investorLoanNumber; } set { _investorLoanNumber = value; } }
-        private Value<string> _investorLockType;
+        private DirtyValue<string> _investorLockType;
         public string InvestorLockType { get { return _investorLockType; } set { _investorLockType = value; } }
-        private Value<string> _investorMERSNumber;
+        private DirtyValue<string> _investorMERSNumber;
         public string InvestorMERSNumber { get { return _investorMERSNumber; } set { _investorMERSNumber = value; } }
-        private Value<string> _investorName;
+        private DirtyValue<string> _investorName;
         public string InvestorName { get { return _investorName; } set { _investorName = value; } }
-        private Value<string> _investorPhone;
+        private DirtyValue<string> _investorPhone;
         public string InvestorPhone { get { return _investorPhone; } set { _investorPhone = value; } }
-        private Value<string> _investorPostalCode;
+        private DirtyValue<string> _investorPostalCode;
         public string InvestorPostalCode { get { return _investorPostalCode; } set { _investorPostalCode = value; } }
-        private Value<string> _investorProgramCode;
+        private DirtyValue<string> _investorProgramCode;
         public string InvestorProgramCode { get { return _investorProgramCode; } set { _investorProgramCode = value; } }
-        private Value<string> _investorState;
+        private DirtyValue<string> _investorState;
         public string InvestorState { get { return _investorState; } set { _investorState = value; } }
-        private Value<DateTime?> _investorTargetDeliveryDate;
+        private DirtyValue<DateTime?> _investorTargetDeliveryDate;
         public DateTime? InvestorTargetDeliveryDate { get { return _investorTargetDeliveryDate; } set { _investorTargetDeliveryDate = value; } }
-        private Value<string> _investorTemplateName;
+        private DirtyValue<string> _investorTemplateName;
         public string InvestorTemplateName { get { return _investorTemplateName; } set { _investorTemplateName = value; } }
-        private Value<string> _investorWebsite;
+        private DirtyValue<string> _investorWebsite;
         public string InvestorWebsite { get { return _investorWebsite; } set { _investorWebsite = value; } }
-        private Value<string> _isCancelled;
+        private DirtyValue<string> _isCancelled;
         public string IsCancelled { get { return _isCancelled; } set { _isCancelled = value; } }
-        private Value<bool?> _isDeliveryType;
+        private DirtyValue<bool?> _isDeliveryType;
         public bool? IsDeliveryType { get { return _isDeliveryType; } set { _isDeliveryType = value; } }
-        private Value<bool?> _lenderPaidMortgageInsuranceIndicator;
+        private DirtyValue<bool?> _lenderPaidMortgageInsuranceIndicator;
         public bool? LenderPaidMortgageInsuranceIndicator { get { return _lenderPaidMortgageInsuranceIndicator; } set { _lenderPaidMortgageInsuranceIndicator = value; } }
-        private Value<string> _lienPriorityType;
+        private DirtyValue<string> _lienPriorityType;
         public string LienPriorityType { get { return _lienPriorityType; } set { _lienPriorityType = value; } }
-        private Value<int?> _loanAmortizationTermMonths;
+        private DirtyValue<int?> _loanAmortizationTermMonths;
         public int? LoanAmortizationTermMonths { get { return _loanAmortizationTermMonths; } set { _loanAmortizationTermMonths = value; } }
-        private Value<string> _loanAmortizationType;
+        private DirtyValue<string> _loanAmortizationType;
         public string LoanAmortizationType { get { return _loanAmortizationType; } set { _loanAmortizationType = value; } }
-        private Value<string> _loanDocumentationType;
+        private DirtyValue<string> _loanDocumentationType;
         public string LoanDocumentationType { get { return _loanDocumentationType; } set { _loanDocumentationType = value; } }
-        private Value<bool?> _loanFor203K;
+        private DirtyValue<bool?> _loanFor203K;
         public bool? LoanFor203K { get { return _loanFor203K; } set { _loanFor203K = value; } }
-        private Value<string> _loanProgram;
+        private DirtyValue<string> _loanProgram;
         public string LoanProgram { get { return _loanProgram; } set { _loanProgram = value; } }
-        private Value<string> _loanProgramFile;
+        private DirtyValue<string> _loanProgramFile;
         public string LoanProgramFile { get { return _loanProgramFile; } set { _loanProgramFile = value; } }
-        private Value<DateTime?> _loanScheduledClosingDate;
+        private DirtyValue<DateTime?> _loanScheduledClosingDate;
         public DateTime? LoanScheduledClosingDate { get { return _loanScheduledClosingDate; } set { _loanScheduledClosingDate = value; } }
-        private Value<bool?> _lockField;
+        private DirtyValue<bool?> _lockField;
         public bool? LockField { get { return _lockField; } set { _lockField = value; } }
         private DirtyList<PriceAdjustment> _lockRequestAdjustments;
         public IList<PriceAdjustment> LockRequestAdjustments { get { var v = _lockRequestAdjustments; return v ?? Interlocked.CompareExchange(ref _lockRequestAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _lockRequestAdjustments = new DirtyList<PriceAdjustment>(value); } }
         private DirtyList<LockRequestBorrower> _lockRequestBorrowers;
         public IList<LockRequestBorrower> LockRequestBorrowers { get { var v = _lockRequestBorrowers; return v ?? Interlocked.CompareExchange(ref _lockRequestBorrowers, (v = new DirtyList<LockRequestBorrower>()), null) ?? v; } set { _lockRequestBorrowers = new DirtyList<LockRequestBorrower>(value); } }
-        private Value<string> _lockRequestLoanPurposeType;
+        private DirtyValue<string> _lockRequestLoanPurposeType;
         public string LockRequestLoanPurposeType { get { return _lockRequestLoanPurposeType; } set { _lockRequestLoanPurposeType = value; } }
-        private Value<decimal?> _lTV;
+        private DirtyValue<decimal?> _lTV;
         public decimal? LTV { get { return _lTV; } set { _lTV = value; } }
-        private Value<string> _minFICO;
+        private DirtyValue<string> _minFICO;
         public string MinFICO { get { return _minFICO; } set { _minFICO = value; } }
-        private Value<string> _minFICO2;
+        private DirtyValue<string> _minFICO2;
         public string MinFICO2 { get { return _minFICO2; } set { _minFICO2 = value; } }
-        private Value<decimal?> _mIPPaidInCash;
+        private DirtyValue<decimal?> _mIPPaidInCash;
         public decimal? MIPPaidInCash { get { return _mIPPaidInCash; } set { _mIPPaidInCash = value; } }
-        private Value<string> _mortgageType;
+        private DirtyValue<string> _mortgageType;
         public string MortgageType { get { return _mortgageType; } set { _mortgageType = value; } }
-        private Value<decimal?> _netSellAmount;
+        private DirtyValue<decimal?> _netSellAmount;
         public decimal? NetSellAmount { get { return _netSellAmount; } set { _netSellAmount = value; } }
-        private Value<decimal?> _netSellPrice;
+        private DirtyValue<decimal?> _netSellPrice;
         public decimal? NetSellPrice { get { return _netSellPrice; } set { _netSellPrice = value; } }
-        private Value<DateTime?> _nextPaymentDate;
+        private DirtyValue<DateTime?> _nextPaymentDate;
         public DateTime? NextPaymentDate { get { return _nextPaymentDate; } set { _nextPaymentDate = value; } }
-        private Value<bool?> _noClosingCostOption;
+        private DirtyValue<bool?> _noClosingCostOption;
         public bool? NoClosingCostOption { get { return _noClosingCostOption; } set { _noClosingCostOption = value; } }
-        private Value<string> _oNRPLock;
+        private DirtyValue<string> _oNRPLock;
         public string ONRPLock { get { return _oNRPLock; } set { _oNRPLock = value; } }
-        private Value<string> _otherAmortizationTypeDescription;
+        private DirtyValue<string> _otherAmortizationTypeDescription;
         public string OtherAmortizationTypeDescription { get { return _otherAmortizationTypeDescription; } set { _otherAmortizationTypeDescription = value; } }
-        private Value<decimal?> _otherSubordinateAmount;
+        private DirtyValue<decimal?> _otherSubordinateAmount;
         public decimal? OtherSubordinateAmount { get { return _otherSubordinateAmount; } set { _otherSubordinateAmount = value; } }
-        private Value<string> _penaltyTerm;
+        private DirtyValue<string> _penaltyTerm;
         public string PenaltyTerm { get { return _penaltyTerm; } set { _penaltyTerm = value; } }
-        private Value<string> _perDiemInterestRoundingType;
+        private DirtyValue<string> _perDiemInterestRoundingType;
         public string PerDiemInterestRoundingType { get { return _perDiemInterestRoundingType; } set { _perDiemInterestRoundingType = value; } }
-        private Value<string> _planCode;
+        private DirtyValue<string> _planCode;
         public string PlanCode { get { return _planCode; } set { _planCode = value; } }
-        private Value<decimal?> _premium;
+        private DirtyValue<decimal?> _premium;
         public decimal? Premium { get { return _premium; } set { _premium = value; } }
-        private Value<string> _prepayPenalty;
+        private DirtyValue<string> _prepayPenalty;
         public string PrepayPenalty { get { return _prepayPenalty; } set { _prepayPenalty = value; } }
-        private Value<decimal?> _priceAdjustment;
+        private DirtyValue<decimal?> _priceAdjustment;
         public decimal? PriceAdjustment { get { return _priceAdjustment; } set { _priceAdjustment = value; } }
         private DirtyList<PriceAdjustment> _priceAdjustments;
         public IList<PriceAdjustment> PriceAdjustments { get { var v = _priceAdjustments; return v ?? Interlocked.CompareExchange(ref _priceAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _priceAdjustments = new DirtyList<PriceAdjustment>(value); } }
-        private Value<string> _pricingHistoryData;
+        private DirtyValue<string> _pricingHistoryData;
         public string PricingHistoryData { get { return _pricingHistoryData; } set { _pricingHistoryData = value; } }
-        private Value<string> _pricingUpdated;
+        private DirtyValue<string> _pricingUpdated;
         public string PricingUpdated { get { return _pricingUpdated; } set { _pricingUpdated = value; } }
-        private Value<decimal?> _principle;
+        private DirtyValue<decimal?> _principle;
         public decimal? Principle { get { return _principle; } set { _principle = value; } }
-        private Value<decimal?> _profitMarginAdjustedBuyPrice;
+        private DirtyValue<decimal?> _profitMarginAdjustedBuyPrice;
         public decimal? ProfitMarginAdjustedBuyPrice { get { return _profitMarginAdjustedBuyPrice; } set { _profitMarginAdjustedBuyPrice = value; } }
-        private Value<int?> _propertyAppraisedValueAmount;
+        private DirtyValue<int?> _propertyAppraisedValueAmount;
         public int? PropertyAppraisedValueAmount { get { return _propertyAppraisedValueAmount; } set { _propertyAppraisedValueAmount = value; } }
-        private Value<int?> _propertyEstimatedValueAmount;
+        private DirtyValue<int?> _propertyEstimatedValueAmount;
         public int? PropertyEstimatedValueAmount { get { return _propertyEstimatedValueAmount; } set { _propertyEstimatedValueAmount = value; } }
-        private Value<string> _propertyUsageType;
+        private DirtyValue<string> _propertyUsageType;
         public string PropertyUsageType { get { return _propertyUsageType; } set { _propertyUsageType = value; } }
-        private Value<int?> _purchaseAdviceNumberOfDays;
+        private DirtyValue<int?> _purchaseAdviceNumberOfDays;
         public int? PurchaseAdviceNumberOfDays { get { return _purchaseAdviceNumberOfDays; } set { _purchaseAdviceNumberOfDays = value; } }
         private DirtyList<PurchaseAdvicePayout> _purchaseAdvicePayouts;
         public IList<PurchaseAdvicePayout> PurchaseAdvicePayouts { get { var v = _purchaseAdvicePayouts; return v ?? Interlocked.CompareExchange(ref _purchaseAdvicePayouts, (v = new DirtyList<PurchaseAdvicePayout>()), null) ?? v; } set { _purchaseAdvicePayouts = new DirtyList<PurchaseAdvicePayout>(value); } }
-        private Value<decimal?> _purchasePriceAmount;
+        private DirtyValue<decimal?> _purchasePriceAmount;
         public decimal? PurchasePriceAmount { get { return _purchasePriceAmount; } set { _purchasePriceAmount = value; } }
-        private Value<string> _rateRequestStatus;
+        private DirtyValue<string> _rateRequestStatus;
         public string RateRequestStatus { get { return _rateRequestStatus; } set { _rateRequestStatus = value; } }
-        private Value<string> _rateStatus;
+        private DirtyValue<string> _rateStatus;
         public string RateStatus { get { return _rateStatus; } set { _rateStatus = value; } }
-        private Value<string> _reasonforBranchApproval;
+        private DirtyValue<string> _reasonforBranchApproval;
         public string ReasonforBranchApproval { get { return _reasonforBranchApproval; } set { _reasonforBranchApproval = value; } }
-        private Value<string> _reasonforCorporateApproval;
+        private DirtyValue<string> _reasonforCorporateApproval;
         public string ReasonforCorporateApproval { get { return _reasonforCorporateApproval; } set { _reasonforCorporateApproval = value; } }
-        private Value<decimal?> _reconciledDiff;
+        private DirtyValue<decimal?> _reconciledDiff;
         public decimal? ReconciledDiff { get { return _reconciledDiff; } set { _reconciledDiff = value; } }
-        private Value<string> _reLockRequestPending;
+        private DirtyValue<string> _reLockRequestPending;
         public string ReLockRequestPending { get { return _reLockRequestPending; } set { _reLockRequestPending = value; } }
-        private Value<decimal?> _remainingBuydownFunds;
+        private DirtyValue<decimal?> _remainingBuydownFunds;
         public decimal? RemainingBuydownFunds { get { return _remainingBuydownFunds; } set { _remainingBuydownFunds = value; } }
-        private Value<string> _requestComments;
+        private DirtyValue<string> _requestComments;
         public string RequestComments { get { return _requestComments; } set { _requestComments = value; } }
-        private Value<DateTime?> _requestCurrentRateSetDate;
+        private DirtyValue<DateTime?> _requestCurrentRateSetDate;
         public DateTime? RequestCurrentRateSetDate { get { return _requestCurrentRateSetDate; } set { _requestCurrentRateSetDate = value; } }
-        private Value<int?> _requestDaystoExtend;
+        private DirtyValue<int?> _requestDaystoExtend;
         public int? RequestDaystoExtend { get { return _requestDaystoExtend; } set { _requestDaystoExtend = value; } }
-        private Value<DateTime?> _requestExtendedLockExpires;
+        private DirtyValue<DateTime?> _requestExtendedLockExpires;
         public DateTime? RequestExtendedLockExpires { get { return _requestExtendedLockExpires; } set { _requestExtendedLockExpires = value; } }
-        private Value<string> _requestFullfilledDateTime;
+        private DirtyValue<string> _requestFullfilledDateTime;
         public string RequestFullfilledDateTime { get { return _requestFullfilledDateTime; } set { _requestFullfilledDateTime = value; } }
-        private Value<string> _requestImpoundType;
+        private DirtyValue<string> _requestImpoundType;
         public string RequestImpoundType { get { return _requestImpoundType; } set { _requestImpoundType = value; } }
-        private Value<string> _requestImpoundWavied;
+        private DirtyValue<string> _requestImpoundWavied;
         public string RequestImpoundWavied { get { return _requestImpoundWavied; } set { _requestImpoundWavied = value; } }
-        private Value<string> _requestLockCancellationComment;
+        private DirtyValue<string> _requestLockCancellationComment;
         public string RequestLockCancellationComment { get { return _requestLockCancellationComment; } set { _requestLockCancellationComment = value; } }
-        private Value<DateTime?> _requestLockCancellationDate;
+        private DirtyValue<DateTime?> _requestLockCancellationDate;
         public DateTime? RequestLockCancellationDate { get { return _requestLockCancellationDate; } set { _requestLockCancellationDate = value; } }
-        private Value<DateTime?> _requestLockDate;
+        private DirtyValue<DateTime?> _requestLockDate;
         public DateTime? RequestLockDate { get { return _requestLockDate; } set { _requestLockDate = value; } }
-        private Value<DateTime?> _requestLockExpires;
+        private DirtyValue<DateTime?> _requestLockExpires;
         public DateTime? RequestLockExpires { get { return _requestLockExpires; } set { _requestLockExpires = value; } }
-        private Value<string> _requestLockExtendComment;
+        private DirtyValue<string> _requestLockExtendComment;
         public string RequestLockExtendComment { get { return _requestLockExtendComment; } set { _requestLockExtendComment = value; } }
-        private Value<decimal?> _requestLockExtendPriceAdjustment;
+        private DirtyValue<decimal?> _requestLockExtendPriceAdjustment;
         public decimal? RequestLockExtendPriceAdjustment { get { return _requestLockExtendPriceAdjustment; } set { _requestLockExtendPriceAdjustment = value; } }
-        private Value<string> _requestLockStatus;
+        private DirtyValue<string> _requestLockStatus;
         public string RequestLockStatus { get { return _requestLockStatus; } set { _requestLockStatus = value; } }
-        private Value<string> _requestLockType;
+        private DirtyValue<string> _requestLockType;
         public string RequestLockType { get { return _requestLockType; } set { _requestLockType = value; } }
-        private Value<decimal?> _requestMarginRate;
+        private DirtyValue<decimal?> _requestMarginRate;
         public decimal? RequestMarginRate { get { return _requestMarginRate; } set { _requestMarginRate = value; } }
-        private Value<decimal?> _requestMarginRateRequested;
+        private DirtyValue<decimal?> _requestMarginRateRequested;
         public decimal? RequestMarginRateRequested { get { return _requestMarginRateRequested; } set { _requestMarginRateRequested = value; } }
-        private Value<decimal?> _requestMarginSRPPaidOut;
+        private DirtyValue<decimal?> _requestMarginSRPPaidOut;
         public decimal? RequestMarginSRPPaidOut { get { return _requestMarginSRPPaidOut; } set { _requestMarginSRPPaidOut = value; } }
-        private Value<decimal?> _requestMarginTotalAdjustment;
+        private DirtyValue<decimal?> _requestMarginTotalAdjustment;
         public decimal? RequestMarginTotalAdjustment { get { return _requestMarginTotalAdjustment; } set { _requestMarginTotalAdjustment = value; } }
-        private Value<int?> _requestNumberOfDays;
+        private DirtyValue<int?> _requestNumberOfDays;
         public int? RequestNumberOfDays { get { return _requestNumberOfDays; } set { _requestNumberOfDays = value; } }
-        private Value<bool?> _requestOnrpEligible;
+        private DirtyValue<bool?> _requestOnrpEligible;
         public bool? RequestOnrpEligible { get { return _requestOnrpEligible; } set { _requestOnrpEligible = value; } }
-        private Value<DateTime?> _requestOnrpLockDate;
+        private DirtyValue<DateTime?> _requestOnrpLockDate;
         public DateTime? RequestOnrpLockDate { get { return _requestOnrpLockDate; } set { _requestOnrpLockDate = value; } }
-        private Value<string> _requestOnrpLockTime;
+        private DirtyValue<string> _requestOnrpLockTime;
         public string RequestOnrpLockTime { get { return _requestOnrpLockTime; } set { _requestOnrpLockTime = value; } }
-        private Value<DateTime?> _requestOriginalLockExpires;
+        private DirtyValue<DateTime?> _requestOriginalLockExpires;
         public DateTime? RequestOriginalLockExpires { get { return _requestOriginalLockExpires; } set { _requestOriginalLockExpires = value; } }
-        private Value<string> _requestPenaltyTerm;
+        private DirtyValue<string> _requestPenaltyTerm;
         public string RequestPenaltyTerm { get { return _requestPenaltyTerm; } set { _requestPenaltyTerm = value; } }
-        private Value<string> _requestPending;
+        private DirtyValue<string> _requestPending;
         public string RequestPending { get { return _requestPending; } set { _requestPending = value; } }
-        private Value<string> _requestPrepayPenalty;
+        private DirtyValue<string> _requestPrepayPenalty;
         public string RequestPrepayPenalty { get { return _requestPrepayPenalty; } set { _requestPrepayPenalty = value; } }
-        private Value<decimal?> _requestPriceRate;
+        private DirtyValue<decimal?> _requestPriceRate;
         public decimal? RequestPriceRate { get { return _requestPriceRate; } set { _requestPriceRate = value; } }
-        private Value<decimal?> _requestPriceRateRequested;
+        private DirtyValue<decimal?> _requestPriceRateRequested;
         public decimal? RequestPriceRateRequested { get { return _requestPriceRateRequested; } set { _requestPriceRateRequested = value; } }
-        private Value<decimal?> _requestPriceTotalAdjustment;
+        private DirtyValue<decimal?> _requestPriceTotalAdjustment;
         public decimal? RequestPriceTotalAdjustment { get { return _requestPriceTotalAdjustment; } set { _requestPriceTotalAdjustment = value; } }
-        private Value<decimal?> _requestRate;
+        private DirtyValue<decimal?> _requestRate;
         public decimal? RequestRate { get { return _requestRate; } set { _requestRate = value; } }
-        private Value<decimal?> _requestRateRequested;
+        private DirtyValue<decimal?> _requestRateRequested;
         public decimal? RequestRateRequested { get { return _requestRateRequested; } set { _requestRateRequested = value; } }
-        private Value<string> _requestRateSheetID;
+        private DirtyValue<string> _requestRateSheetID;
         public string RequestRateSheetID { get { return _requestRateSheetID; } set { _requestRateSheetID = value; } }
-        private Value<decimal?> _requestRateTotalAdjustment;
+        private DirtyValue<decimal?> _requestRateTotalAdjustment;
         public decimal? RequestRateTotalAdjustment { get { return _requestRateTotalAdjustment; } set { _requestRateTotalAdjustment = value; } }
-        private Value<decimal?> _requestStartingAdjPoint;
+        private DirtyValue<decimal?> _requestStartingAdjPoint;
         public decimal? RequestStartingAdjPoint { get { return _requestStartingAdjPoint; } set { _requestStartingAdjPoint = value; } }
-        private Value<decimal?> _requestStartingAdjRate;
+        private DirtyValue<decimal?> _requestStartingAdjRate;
         public decimal? RequestStartingAdjRate { get { return _requestStartingAdjRate; } set { _requestStartingAdjRate = value; } }
-        private Value<string> _requestType;
+        private DirtyValue<string> _requestType;
         public string RequestType { get { return _requestType; } set { _requestType = value; } }
-        private Value<decimal?> _requestUnDiscountedRate;
+        private DirtyValue<decimal?> _requestUnDiscountedRate;
         public decimal? RequestUnDiscountedRate { get { return _requestUnDiscountedRate; } set { _requestUnDiscountedRate = value; } }
-        private Value<bool?> _roundToNearest50;
+        private DirtyValue<bool?> _roundToNearest50;
         public bool? RoundToNearest50 { get { return _roundToNearest50; } set { _roundToNearest50 = value; } }
-        private Value<decimal?> _secondSubordinateAmount;
+        private DirtyValue<decimal?> _secondSubordinateAmount;
         public decimal? SecondSubordinateAmount { get { return _secondSubordinateAmount; } set { _secondSubordinateAmount = value; } }
-        private Value<decimal?> _sellerPaidMIPremium;
+        private DirtyValue<decimal?> _sellerPaidMIPremium;
         public decimal? SellerPaidMIPremium { get { return _sellerPaidMIPremium; } set { _sellerPaidMIPremium = value; } }
         private DirtyList<PriceAdjustment> _sellSideAdjustments;
         public IList<PriceAdjustment> SellSideAdjustments { get { var v = _sellSideAdjustments; return v ?? Interlocked.CompareExchange(ref _sellSideAdjustments, (v = new DirtyList<PriceAdjustment>()), null) ?? v; } set { _sellSideAdjustments = new DirtyList<PriceAdjustment>(value); } }
-        private Value<string> _sellSideComments;
+        private DirtyValue<string> _sellSideComments;
         public string SellSideComments { get { return _sellSideComments; } set { _sellSideComments = value; } }
-        private Value<string> _sellSideCommitmentContractNumber;
+        private DirtyValue<string> _sellSideCommitmentContractNumber;
         public string SellSideCommitmentContractNumber { get { return _sellSideCommitmentContractNumber; } set { _sellSideCommitmentContractNumber = value; } }
-        private Value<DateTime?> _sellSideCommitmentDate;
+        private DirtyValue<DateTime?> _sellSideCommitmentDate;
         public DateTime? SellSideCommitmentDate { get { return _sellSideCommitmentDate; } set { _sellSideCommitmentDate = value; } }
-        private Value<DateTime?> _sellSideCurrentRateSetDate;
+        private DirtyValue<DateTime?> _sellSideCurrentRateSetDate;
         public DateTime? SellSideCurrentRateSetDate { get { return _sellSideCurrentRateSetDate; } set { _sellSideCurrentRateSetDate = value; } }
-        private Value<int?> _sellSideDaystoExtend;
+        private DirtyValue<int?> _sellSideDaystoExtend;
         public int? SellSideDaystoExtend { get { return _sellSideDaystoExtend; } set { _sellSideDaystoExtend = value; } }
-        private Value<decimal?> _sellSideDiscountYSP;
+        private DirtyValue<decimal?> _sellSideDiscountYSP;
         public decimal? SellSideDiscountYSP { get { return _sellSideDiscountYSP; } set { _sellSideDiscountYSP = value; } }
-        private Value<DateTime?> _sellSideExtendedLockExpires;
+        private DirtyValue<DateTime?> _sellSideExtendedLockExpires;
         public DateTime? SellSideExtendedLockExpires { get { return _sellSideExtendedLockExpires; } set { _sellSideExtendedLockExpires = value; } }
-        private Value<decimal?> _sellSideGuaranteeFee;
+        private DirtyValue<decimal?> _sellSideGuaranteeFee;
         public decimal? SellSideGuaranteeFee { get { return _sellSideGuaranteeFee; } set { _sellSideGuaranteeFee = value; } }
-        private Value<decimal?> _sellSideGuarantyBaseFee;
+        private DirtyValue<decimal?> _sellSideGuarantyBaseFee;
         public decimal? SellSideGuarantyBaseFee { get { return _sellSideGuarantyBaseFee; } set { _sellSideGuarantyBaseFee = value; } }
-        private Value<string> _sellSideInvestorStatus;
+        private DirtyValue<string> _sellSideInvestorStatus;
         public string SellSideInvestorStatus { get { return _sellSideInvestorStatus; } set { _sellSideInvestorStatus = value; } }
-        private Value<DateTime?> _sellSideInvestorStatusDate;
+        private DirtyValue<DateTime?> _sellSideInvestorStatusDate;
         public DateTime? SellSideInvestorStatusDate { get { return _sellSideInvestorStatusDate; } set { _sellSideInvestorStatusDate = value; } }
-        private Value<string> _sellSideInvestorTradeNumber;
+        private DirtyValue<string> _sellSideInvestorTradeNumber;
         public string SellSideInvestorTradeNumber { get { return _sellSideInvestorTradeNumber; } set { _sellSideInvestorTradeNumber = value; } }
-        private Value<string> _sellSideLoanProgram;
+        private DirtyValue<string> _sellSideLoanProgram;
         public string SellSideLoanProgram { get { return _sellSideLoanProgram; } set { _sellSideLoanProgram = value; } }
-        private Value<DateTime?> _sellSideLockDate;
+        private DirtyValue<DateTime?> _sellSideLockDate;
         public DateTime? SellSideLockDate { get { return _sellSideLockDate; } set { _sellSideLockDate = value; } }
-        private Value<DateTime?> _sellSideLockExpires;
+        private DirtyValue<DateTime?> _sellSideLockExpires;
         public DateTime? SellSideLockExpires { get { return _sellSideLockExpires; } set { _sellSideLockExpires = value; } }
-        private Value<decimal?> _sellSideLockExtendPriceAdjustment;
+        private DirtyValue<decimal?> _sellSideLockExtendPriceAdjustment;
         public decimal? SellSideLockExtendPriceAdjustment { get { return _sellSideLockExtendPriceAdjustment; } set { _sellSideLockExtendPriceAdjustment = value; } }
-        private Value<decimal?> _sellSideMarginNetSellRate;
+        private DirtyValue<decimal?> _sellSideMarginNetSellRate;
         public decimal? SellSideMarginNetSellRate { get { return _sellSideMarginNetSellRate; } set { _sellSideMarginNetSellRate = value; } }
-        private Value<decimal?> _sellSideMarginRate;
+        private DirtyValue<decimal?> _sellSideMarginRate;
         public decimal? SellSideMarginRate { get { return _sellSideMarginRate; } set { _sellSideMarginRate = value; } }
-        private Value<decimal?> _sellSideMarginTotalAdjustment;
+        private DirtyValue<decimal?> _sellSideMarginTotalAdjustment;
         public decimal? SellSideMarginTotalAdjustment { get { return _sellSideMarginTotalAdjustment; } set { _sellSideMarginTotalAdjustment = value; } }
-        private Value<string> _sellSideMasterContractNumber;
+        private DirtyValue<string> _sellSideMasterContractNumber;
         public string SellSideMasterContractNumber { get { return _sellSideMasterContractNumber; } set { _sellSideMasterContractNumber = value; } }
-        private Value<decimal?> _sellSideMSRValue;
+        private DirtyValue<decimal?> _sellSideMSRValue;
         public decimal? SellSideMSRValue { get { return _sellSideMSRValue; } set { _sellSideMSRValue = value; } }
-        private Value<decimal?> _sellSideNetSellPrice;
+        private DirtyValue<decimal?> _sellSideNetSellPrice;
         public decimal? SellSideNetSellPrice { get { return _sellSideNetSellPrice; } set { _sellSideNetSellPrice = value; } }
-        private Value<decimal?> _sellSideNetSellRate;
+        private DirtyValue<decimal?> _sellSideNetSellRate;
         public decimal? SellSideNetSellRate { get { return _sellSideNetSellRate; } set { _sellSideNetSellRate = value; } }
-        private Value<int?> _sellSideNumberOfDays;
+        private DirtyValue<int?> _sellSideNumberOfDays;
         public int? SellSideNumberOfDays { get { return _sellSideNumberOfDays; } set { _sellSideNumberOfDays = value; } }
-        private Value<DateTime?> _sellSideOriginalLockExpires;
+        private DirtyValue<DateTime?> _sellSideOriginalLockExpires;
         public DateTime? SellSideOriginalLockExpires { get { return _sellSideOriginalLockExpires; } set { _sellSideOriginalLockExpires = value; } }
-        private Value<string> _sellSidePoolID;
+        private DirtyValue<string> _sellSidePoolID;
         public string SellSidePoolID { get { return _sellSidePoolID; } set { _sellSidePoolID = value; } }
-        private Value<string> _sellSidePoolNumber;
+        private DirtyValue<string> _sellSidePoolNumber;
         public string SellSidePoolNumber { get { return _sellSidePoolNumber; } set { _sellSidePoolNumber = value; } }
-        private Value<decimal?> _sellSidePriceRate;
+        private DirtyValue<decimal?> _sellSidePriceRate;
         public decimal? SellSidePriceRate { get { return _sellSidePriceRate; } set { _sellSidePriceRate = value; } }
-        private Value<decimal?> _sellSidePriceTotalAdjustment;
+        private DirtyValue<decimal?> _sellSidePriceTotalAdjustment;
         public decimal? SellSidePriceTotalAdjustment { get { return _sellSidePriceTotalAdjustment; } set { _sellSidePriceTotalAdjustment = value; } }
-        private Value<string> _sellSideProductName;
+        private DirtyValue<string> _sellSideProductName;
         public string SellSideProductName { get { return _sellSideProductName; } set { _sellSideProductName = value; } }
-        private Value<decimal?> _sellSideRate;
+        private DirtyValue<decimal?> _sellSideRate;
         public decimal? SellSideRate { get { return _sellSideRate; } set { _sellSideRate = value; } }
-        private Value<string> _sellSideRateSheetID;
+        private DirtyValue<string> _sellSideRateSheetID;
         public string SellSideRateSheetID { get { return _sellSideRateSheetID; } set { _sellSideRateSheetID = value; } }
-        private Value<decimal?> _sellSideRateTotalAdjustment;
+        private DirtyValue<decimal?> _sellSideRateTotalAdjustment;
         public decimal? SellSideRateTotalAdjustment { get { return _sellSideRateTotalAdjustment; } set { _sellSideRateTotalAdjustment = value; } }
-        private Value<string> _sellSideRequestedBy;
+        private DirtyValue<string> _sellSideRequestedBy;
         public string SellSideRequestedBy { get { return _sellSideRequestedBy; } set { _sellSideRequestedBy = value; } }
-        private Value<string> _sellSideServicer;
+        private DirtyValue<string> _sellSideServicer;
         public string SellSideServicer { get { return _sellSideServicer; } set { _sellSideServicer = value; } }
-        private Value<decimal?> _sellSideServicingFee;
+        private DirtyValue<decimal?> _sellSideServicingFee;
         public decimal? SellSideServicingFee { get { return _sellSideServicingFee; } set { _sellSideServicingFee = value; } }
-        private Value<string> _sellSideServicingType;
+        private DirtyValue<string> _sellSideServicingType;
         public string SellSideServicingType { get { return _sellSideServicingType; } set { _sellSideServicingType = value; } }
-        private Value<decimal?> _sellSideSRP;
+        private DirtyValue<decimal?> _sellSideSRP;
         public decimal? SellSideSRP { get { return _sellSideSRP; } set { _sellSideSRP = value; } }
-        private Value<decimal?> _sellSideSRPPaidOut;
+        private DirtyValue<decimal?> _sellSideSRPPaidOut;
         public decimal? SellSideSRPPaidOut { get { return _sellSideSRPPaidOut; } set { _sellSideSRPPaidOut = value; } }
-        private Value<string> _sellSideTradeGuid;
+        private DirtyValue<string> _sellSideTradeGuid;
         public string SellSideTradeGuid { get { return _sellSideTradeGuid; } set { _sellSideTradeGuid = value; } }
-        private Value<string> _sellSideTradeMgmtPrevConfirmedLockGuid;
+        private DirtyValue<string> _sellSideTradeMgmtPrevConfirmedLockGuid;
         public string SellSideTradeMgmtPrevConfirmedLockGuid { get { return _sellSideTradeMgmtPrevConfirmedLockGuid; } set { _sellSideTradeMgmtPrevConfirmedLockGuid = value; } }
-        private Value<string> _sellSideTradeNumber;
+        private DirtyValue<string> _sellSideTradeNumber;
         public string SellSideTradeNumber { get { return _sellSideTradeNumber; } set { _sellSideTradeNumber = value; } }
-        private Value<bool?> _servicingReleaseIndicator;
+        private DirtyValue<bool?> _servicingReleaseIndicator;
         public bool? ServicingReleaseIndicator { get { return _servicingReleaseIndicator; } set { _servicingReleaseIndicator = value; } }
-        private Value<decimal?> _sRP;
+        private DirtyValue<decimal?> _sRP;
         public decimal? SRP { get { return _sRP; } set { _sRP = value; } }
-        private Value<decimal?> _sRPAmount;
+        private DirtyValue<decimal?> _sRPAmount;
         public decimal? SRPAmount { get { return _sRPAmount; } set { _sRPAmount = value; } }
-        private Value<decimal?> _sRPPaidOut;
+        private DirtyValue<decimal?> _sRPPaidOut;
         public decimal? SRPPaidOut { get { return _sRPPaidOut; } set { _sRPPaidOut = value; } }
-        private Value<string> _subjectPropertyCity;
+        private DirtyValue<string> _subjectPropertyCity;
         public string SubjectPropertyCity { get { return _subjectPropertyCity; } set { _subjectPropertyCity = value; } }
-        private Value<bool?> _subjectPropertyCondotelIndicator;
+        private DirtyValue<bool?> _subjectPropertyCondotelIndicator;
         public bool? SubjectPropertyCondotelIndicator { get { return _subjectPropertyCondotelIndicator; } set { _subjectPropertyCondotelIndicator = value; } }
-        private Value<string> _subjectPropertyCounty;
+        private DirtyValue<string> _subjectPropertyCounty;
         public string SubjectPropertyCounty { get { return _subjectPropertyCounty; } set { _subjectPropertyCounty = value; } }
-        private Value<bool?> _subjectPropertyNonWarrantableProjectIndicator;
+        private DirtyValue<bool?> _subjectPropertyNonWarrantableProjectIndicator;
         public bool? SubjectPropertyNonWarrantableProjectIndicator { get { return _subjectPropertyNonWarrantableProjectIndicator; } set { _subjectPropertyNonWarrantableProjectIndicator = value; } }
-        private Value<string> _subjectPropertyPostalCode;
+        private DirtyValue<string> _subjectPropertyPostalCode;
         public string SubjectPropertyPostalCode { get { return _subjectPropertyPostalCode; } set { _subjectPropertyPostalCode = value; } }
-        private Value<string> _subjectPropertyState;
+        private DirtyValue<string> _subjectPropertyState;
         public string SubjectPropertyState { get { return _subjectPropertyState; } set { _subjectPropertyState = value; } }
-        private Value<string> _subjectPropertyStreetAddress;
+        private DirtyValue<string> _subjectPropertyStreetAddress;
         public string SubjectPropertyStreetAddress { get { return _subjectPropertyStreetAddress; } set { _subjectPropertyStreetAddress = value; } }
-        private Value<string> _timeLockedWithInvestor;
+        private DirtyValue<string> _timeLockedWithInvestor;
         public string TimeLockedWithInvestor { get { return _timeLockedWithInvestor; } set { _timeLockedWithInvestor = value; } }
-        private Value<decimal?> _totalBuyPrice;
+        private DirtyValue<decimal?> _totalBuyPrice;
         public decimal? TotalBuyPrice { get { return _totalBuyPrice; } set { _totalBuyPrice = value; } }
-        private Value<decimal?> _totalForLesserOfSumAsIs;
+        private DirtyValue<decimal?> _totalForLesserOfSumAsIs;
         public decimal? TotalForLesserOfSumAsIs { get { return _totalForLesserOfSumAsIs; } set { _totalForLesserOfSumAsIs = value; } }
-        private Value<decimal?> _totalPrice;
+        private DirtyValue<decimal?> _totalPrice;
         public decimal? TotalPrice { get { return _totalPrice; } set { _totalPrice = value; } }
-        private Value<decimal?> _totalSubordinateFinancing;
+        private DirtyValue<decimal?> _totalSubordinateFinancing;
         public decimal? TotalSubordinateFinancing { get { return _totalSubordinateFinancing; } set { _totalSubordinateFinancing = value; } }
-        private Value<bool?> _twelveMonthMortgageRentalHistoryIndicator;
+        private DirtyValue<bool?> _twelveMonthMortgageRentalHistoryIndicator;
         public bool? TwelveMonthMortgageRentalHistoryIndicator { get { return _twelveMonthMortgageRentalHistoryIndicator; } set { _twelveMonthMortgageRentalHistoryIndicator = value; } }
-        private Value<string> _type;
+        private DirtyValue<string> _type;
         public string Type { get { return _type; } set { _type = value; } }
-        private Value<bool?> _usePoint;
+        private DirtyValue<bool?> _usePoint;
         public bool? UsePoint { get { return _usePoint; } set { _usePoint = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RegistrationLog.cs
+++ b/src/EncompassRest/Loans/RegistrationLog.cs
@@ -12,35 +12,35 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<bool?> _currentIndicator;
+        private DirtyValue<bool?> _currentIndicator;
         public bool? CurrentIndicator { get { return _currentIndicator; } set { _currentIndicator = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<DateTime?> _expiredDate;
+        private DirtyValue<DateTime?> _expiredDate;
         public DateTime? ExpiredDate { get { return _expiredDate; } set { _expiredDate = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _investorName;
+        private DirtyValue<string> _investorName;
         public string InvestorName { get { return _investorName; } set { _investorName = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _reference;
+        private DirtyValue<string> _reference;
         public string Reference { get { return _reference; } set { _reference = value; } }
-        private Value<string> _registeredById;
+        private DirtyValue<string> _registeredById;
         public string RegisteredById { get { return _registeredById; } set { _registeredById = value; } }
-        private Value<string> _registeredByName;
+        private DirtyValue<string> _registeredByName;
         public string RegisteredByName { get { return _registeredByName; } set { _registeredByName = value; } }
-        private Value<DateTime?> _registeredDate;
+        private DirtyValue<DateTime?> _registeredDate;
         public DateTime? RegisteredDate { get { return _registeredDate; } set { _registeredDate = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RegistrationLog.cs
+++ b/src/EncompassRest/Loans/RegistrationLog.cs
@@ -8,10 +8,10 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RegistrationLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<bool?> _currentIndicator;
@@ -49,9 +49,7 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _currentIndicator.Dirty
                     || _dateUtc.Dirty
                     || _expiredDate.Dirty
@@ -65,15 +63,15 @@ namespace EncompassRest.Loans
                     || _registeredById.Dirty
                     || _registeredByName.Dirty
                     || _registeredDate.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _currentIndicator.Dirty = value;
                 _dateUtc.Dirty = value;
@@ -89,6 +87,8 @@ namespace EncompassRest.Loans
                 _registeredByName.Dirty = value;
                 _registeredDate.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/RegulationZ.cs
+++ b/src/EncompassRest/Loans/RegulationZ.cs
@@ -8,491 +8,491 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RegulationZ : IDirty
     {
-        private Value<string> _acknowledgedDay;
+        private DirtyValue<string> _acknowledgedDay;
         public string AcknowledgedDay { get { return _acknowledgedDay; } set { _acknowledgedDay = value; } }
-        private Value<string> _acknowledgedMonth;
+        private DirtyValue<string> _acknowledgedMonth;
         public string AcknowledgedMonth { get { return _acknowledgedMonth; } set { _acknowledgedMonth = value; } }
-        private Value<string> _acknowledgedYear;
+        private DirtyValue<string> _acknowledgedYear;
         public string AcknowledgedYear { get { return _acknowledgedYear; } set { _acknowledgedYear = value; } }
-        private Value<bool?> _acquisition;
+        private DirtyValue<bool?> _acquisition;
         public bool? Acquisition { get { return _acquisition; } set { _acquisition = value; } }
-        private Value<string> _additionalArmInformation;
+        private DirtyValue<string> _additionalArmInformation;
         public string AdditionalArmInformation { get { return _additionalArmInformation; } set { _additionalArmInformation = value; } }
-        private Value<bool?> _allDateAndNumericalDisclosuresIndicator;
+        private DirtyValue<bool?> _allDateAndNumericalDisclosuresIndicator;
         public bool? AllDateAndNumericalDisclosuresIndicator { get { return _allDateAndNumericalDisclosuresIndicator; } set { _allDateAndNumericalDisclosuresIndicator = value; } }
-        private Value<decimal?> _amountFinanced;
+        private DirtyValue<decimal?> _amountFinanced;
         public decimal? AmountFinanced { get { return _amountFinanced; } set { _amountFinanced = value; } }
-        private Value<decimal?> _aprPercent;
+        private DirtyValue<decimal?> _aprPercent;
         public decimal? AprPercent { get { return _aprPercent; } set { _aprPercent = value; } }
-        private Value<string> _armDisclosureDescription;
+        private DirtyValue<string> _armDisclosureDescription;
         public string ArmDisclosureDescription { get { return _armDisclosureDescription; } set { _armDisclosureDescription = value; } }
-        private Value<string> _assumptionOnYourProperty;
+        private DirtyValue<string> _assumptionOnYourProperty;
         public string AssumptionOnYourProperty { get { return _assumptionOnYourProperty; } set { _assumptionOnYourProperty = value; } }
-        private Value<DateTime?> _borrowerIntendToContinueDate;
+        private DirtyValue<DateTime?> _borrowerIntendToContinueDate;
         public DateTime? BorrowerIntendToContinueDate { get { return _borrowerIntendToContinueDate; } set { _borrowerIntendToContinueDate = value; } }
-        private Value<bool?> _borrowerIntendToContinueIndicator;
+        private DirtyValue<bool?> _borrowerIntendToContinueIndicator;
         public bool? BorrowerIntendToContinueIndicator { get { return _borrowerIntendToContinueIndicator; } set { _borrowerIntendToContinueIndicator = value; } }
-        private Value<string> _borrowerMiTerminationDate;
+        private DirtyValue<string> _borrowerMiTerminationDate;
         public string BorrowerMiTerminationDate { get { return _borrowerMiTerminationDate; } set { _borrowerMiTerminationDate = value; } }
-        private Value<string> _calculateBasedOnRemainingBalance;
+        private DirtyValue<string> _calculateBasedOnRemainingBalance;
         public string CalculateBasedOnRemainingBalance { get { return _calculateBasedOnRemainingBalance; } set { _calculateBasedOnRemainingBalance = value; } }
-        private Value<bool?> _chargesAddedToPaymentsIndicator;
+        private DirtyValue<bool?> _chargesAddedToPaymentsIndicator;
         public bool? ChargesAddedToPaymentsIndicator { get { return _chargesAddedToPaymentsIndicator; } set { _chargesAddedToPaymentsIndicator = value; } }
-        private Value<bool?> _chargesAtLoanClosingIndicator;
+        private DirtyValue<bool?> _chargesAtLoanClosingIndicator;
         public bool? ChargesAtLoanClosingIndicator { get { return _chargesAtLoanClosingIndicator; } set { _chargesAtLoanClosingIndicator = value; } }
-        private Value<string> _circumstanceChangeReason;
+        private DirtyValue<string> _circumstanceChangeReason;
         public string CircumstanceChangeReason { get { return _circumstanceChangeReason; } set { _circumstanceChangeReason = value; } }
-        private Value<DateTime?> _circumstanceChangeReceivedDate;
+        private DirtyValue<DateTime?> _circumstanceChangeReceivedDate;
         public DateTime? CircumstanceChangeReceivedDate { get { return _circumstanceChangeReceivedDate; } set { _circumstanceChangeReceivedDate = value; } }
-        private Value<DateTime?> _closingDisclosureReceivedDate;
+        private DirtyValue<DateTime?> _closingDisclosureReceivedDate;
         public DateTime? ClosingDisclosureReceivedDate { get { return _closingDisclosureReceivedDate; } set { _closingDisclosureReceivedDate = value; } }
-        private Value<DateTime?> _closingDisclosureSentDate;
+        private DirtyValue<DateTime?> _closingDisclosureSentDate;
         public DateTime? ClosingDisclosureSentDate { get { return _closingDisclosureSentDate; } set { _closingDisclosureSentDate = value; } }
-        private Value<string> _constructionFirstIntChangeAdjType;
+        private DirtyValue<string> _constructionFirstIntChangeAdjType;
         public string ConstructionFirstIntChangeAdjType { get { return _constructionFirstIntChangeAdjType; } set { _constructionFirstIntChangeAdjType = value; } }
-        private Value<string> _constructionLoanDescription;
+        private DirtyValue<string> _constructionLoanDescription;
         public string ConstructionLoanDescription { get { return _constructionLoanDescription; } set { _constructionLoanDescription = value; } }
-        private Value<string> _constructionLoanMethod;
+        private DirtyValue<string> _constructionLoanMethod;
         public string ConstructionLoanMethod { get { return _constructionLoanMethod; } set { _constructionLoanMethod = value; } }
-        private Value<int?> _constructionPeriodMonths;
+        private DirtyValue<int?> _constructionPeriodMonths;
         public int? ConstructionPeriodMonths { get { return _constructionPeriodMonths; } set { _constructionPeriodMonths = value; } }
-        private Value<decimal?> _constructionRatePercent;
+        private DirtyValue<decimal?> _constructionRatePercent;
         public decimal? ConstructionRatePercent { get { return _constructionRatePercent; } set { _constructionRatePercent = value; } }
-        private Value<bool?> _constructionRefinanceIndicator;
+        private DirtyValue<bool?> _constructionRefinanceIndicator;
         public bool? ConstructionRefinanceIndicator { get { return _constructionRefinanceIndicator; } set { _constructionRefinanceIndicator = value; } }
-        private Value<decimal?> _creditDisability;
+        private DirtyValue<decimal?> _creditDisability;
         public decimal? CreditDisability { get { return _creditDisability; } set { _creditDisability = value; } }
-        private Value<bool?> _creditDisabilityIndicator;
+        private DirtyValue<bool?> _creditDisabilityIndicator;
         public bool? CreditDisabilityIndicator { get { return _creditDisabilityIndicator; } set { _creditDisabilityIndicator = value; } }
-        private Value<decimal?> _creditLife;
+        private DirtyValue<decimal?> _creditLife;
         public decimal? CreditLife { get { return _creditLife; } set { _creditLife = value; } }
-        private Value<decimal?> _creditLifeAndCreditDisability;
+        private DirtyValue<decimal?> _creditLifeAndCreditDisability;
         public decimal? CreditLifeAndCreditDisability { get { return _creditLifeAndCreditDisability; } set { _creditLifeAndCreditDisability = value; } }
-        private Value<bool?> _creditLifeInsuranceIndicator;
+        private DirtyValue<bool?> _creditLifeInsuranceIndicator;
         public bool? CreditLifeInsuranceIndicator { get { return _creditLifeInsuranceIndicator; } set { _creditLifeInsuranceIndicator = value; } }
-        private Value<bool?> _customizePaymentScheduleIndicator;
+        private DirtyValue<bool?> _customizePaymentScheduleIndicator;
         public bool? CustomizePaymentScheduleIndicator { get { return _customizePaymentScheduleIndicator; } set { _customizePaymentScheduleIndicator = value; } }
-        private Value<bool?> _demandFeatureIndicator;
+        private DirtyValue<bool?> _demandFeatureIndicator;
         public bool? DemandFeatureIndicator { get { return _demandFeatureIndicator; } set { _demandFeatureIndicator = value; } }
-        private Value<decimal?> _disclosedAprPercent;
+        private DirtyValue<decimal?> _disclosedAprPercent;
         public decimal? DisclosedAprPercent { get { return _disclosedAprPercent; } set { _disclosedAprPercent = value; } }
-        private Value<bool?> _disclosedByBrokerIndicator;
+        private DirtyValue<bool?> _disclosedByBrokerIndicator;
         public bool? DisclosedByBrokerIndicator { get { return _disclosedByBrokerIndicator; } set { _disclosedByBrokerIndicator = value; } }
-        private Value<string> _disclosedComments;
+        private DirtyValue<string> _disclosedComments;
         public string DisclosedComments { get { return _disclosedComments; } set { _disclosedComments = value; } }
-        private Value<decimal?> _disclosedDailyInterestCharge;
+        private DirtyValue<decimal?> _disclosedDailyInterestCharge;
         public decimal? DisclosedDailyInterestCharge { get { return _disclosedDailyInterestCharge; } set { _disclosedDailyInterestCharge = value; } }
-        private Value<decimal?> _disclosedFinanceCharge;
+        private DirtyValue<decimal?> _disclosedFinanceCharge;
         public decimal? DisclosedFinanceCharge { get { return _disclosedFinanceCharge; } set { _disclosedFinanceCharge = value; } }
-        private Value<bool?> _disclosedPrepayment;
+        private DirtyValue<bool?> _disclosedPrepayment;
         public bool? DisclosedPrepayment { get { return _disclosedPrepayment; } set { _disclosedPrepayment = value; } }
-        private Value<string> _disclosedProduct;
+        private DirtyValue<string> _disclosedProduct;
         public string DisclosedProduct { get { return _disclosedProduct; } set { _disclosedProduct = value; } }
-        private Value<string> _disclosureMethod;
+        private DirtyValue<string> _disclosureMethod;
         public string DisclosureMethod { get { return _disclosureMethod; } set { _disclosureMethod = value; } }
-        private Value<string> _disclosureType;
+        private DirtyValue<string> _disclosureType;
         public string DisclosureType { get { return _disclosureType; } set { _disclosureType = value; } }
-        private Value<int?> _discountPeriod;
+        private DirtyValue<int?> _discountPeriod;
         public int? DiscountPeriod { get { return _discountPeriod; } set { _discountPeriod = value; } }
-        private Value<decimal?> _discountRatePercent;
+        private DirtyValue<decimal?> _discountRatePercent;
         public decimal? DiscountRatePercent { get { return _discountRatePercent; } set { _discountRatePercent = value; } }
-        private Value<string> _discountType;
+        private DirtyValue<string> _discountType;
         public string DiscountType { get { return _discountType; } set { _discountType = value; } }
-        private Value<DateTime?> _dueDate;
+        private DirtyValue<DateTime?> _dueDate;
         public DateTime? DueDate { get { return _dueDate; } set { _dueDate = value; } }
-        private Value<DateTime?> _earliestClosingDate;
+        private DirtyValue<DateTime?> _earliestClosingDate;
         public DateTime? EarliestClosingDate { get { return _earliestClosingDate; } set { _earliestClosingDate = value; } }
-        private Value<DateTime?> _earliestFeeCollectionDate;
+        private DirtyValue<DateTime?> _earliestFeeCollectionDate;
         public DateTime? EarliestFeeCollectionDate { get { return _earliestFeeCollectionDate; } set { _earliestFeeCollectionDate = value; } }
-        private Value<DateTime?> _eSignConsentBorrowerDateAccepted1;
+        private DirtyValue<DateTime?> _eSignConsentBorrowerDateAccepted1;
         public DateTime? eSignConsentBorrowerDateAccepted1 { get { return _eSignConsentBorrowerDateAccepted1; } set { _eSignConsentBorrowerDateAccepted1 = value; } }
-        private Value<DateTime?> _eSignConsentBorrowerDateAccepted2;
+        private DirtyValue<DateTime?> _eSignConsentBorrowerDateAccepted2;
         public DateTime? eSignConsentBorrowerDateAccepted2 { get { return _eSignConsentBorrowerDateAccepted2; } set { _eSignConsentBorrowerDateAccepted2 = value; } }
-        private Value<DateTime?> _eSignConsentBorrowerDateAccepted3;
+        private DirtyValue<DateTime?> _eSignConsentBorrowerDateAccepted3;
         public DateTime? eSignConsentBorrowerDateAccepted3 { get { return _eSignConsentBorrowerDateAccepted3; } set { _eSignConsentBorrowerDateAccepted3 = value; } }
-        private Value<DateTime?> _eSignConsentBorrowerDateAccepted4;
+        private DirtyValue<DateTime?> _eSignConsentBorrowerDateAccepted4;
         public DateTime? eSignConsentBorrowerDateAccepted4 { get { return _eSignConsentBorrowerDateAccepted4; } set { _eSignConsentBorrowerDateAccepted4 = value; } }
-        private Value<DateTime?> _eSignConsentBorrowerDateAccepted5;
+        private DirtyValue<DateTime?> _eSignConsentBorrowerDateAccepted5;
         public DateTime? eSignConsentBorrowerDateAccepted5 { get { return _eSignConsentBorrowerDateAccepted5; } set { _eSignConsentBorrowerDateAccepted5 = value; } }
-        private Value<DateTime?> _eSignConsentBorrowerDateAccepted6;
+        private DirtyValue<DateTime?> _eSignConsentBorrowerDateAccepted6;
         public DateTime? eSignConsentBorrowerDateAccepted6 { get { return _eSignConsentBorrowerDateAccepted6; } set { _eSignConsentBorrowerDateAccepted6 = value; } }
-        private Value<string> _eSignConsentBorrowerIPAddress1;
+        private DirtyValue<string> _eSignConsentBorrowerIPAddress1;
         public string eSignConsentBorrowerIPAddress1 { get { return _eSignConsentBorrowerIPAddress1; } set { _eSignConsentBorrowerIPAddress1 = value; } }
-        private Value<string> _eSignConsentBorrowerIPAddress2;
+        private DirtyValue<string> _eSignConsentBorrowerIPAddress2;
         public string eSignConsentBorrowerIPAddress2 { get { return _eSignConsentBorrowerIPAddress2; } set { _eSignConsentBorrowerIPAddress2 = value; } }
-        private Value<string> _eSignConsentBorrowerIPAddress3;
+        private DirtyValue<string> _eSignConsentBorrowerIPAddress3;
         public string eSignConsentBorrowerIPAddress3 { get { return _eSignConsentBorrowerIPAddress3; } set { _eSignConsentBorrowerIPAddress3 = value; } }
-        private Value<string> _eSignConsentBorrowerIPAddress4;
+        private DirtyValue<string> _eSignConsentBorrowerIPAddress4;
         public string eSignConsentBorrowerIPAddress4 { get { return _eSignConsentBorrowerIPAddress4; } set { _eSignConsentBorrowerIPAddress4 = value; } }
-        private Value<string> _eSignConsentBorrowerIPAddress5;
+        private DirtyValue<string> _eSignConsentBorrowerIPAddress5;
         public string eSignConsentBorrowerIPAddress5 { get { return _eSignConsentBorrowerIPAddress5; } set { _eSignConsentBorrowerIPAddress5 = value; } }
-        private Value<string> _eSignConsentBorrowerIPAddress6;
+        private DirtyValue<string> _eSignConsentBorrowerIPAddress6;
         public string eSignConsentBorrowerIPAddress6 { get { return _eSignConsentBorrowerIPAddress6; } set { _eSignConsentBorrowerIPAddress6 = value; } }
-        private Value<string> _eSignConsentBorrowerSource1;
+        private DirtyValue<string> _eSignConsentBorrowerSource1;
         public string eSignConsentBorrowerSource1 { get { return _eSignConsentBorrowerSource1; } set { _eSignConsentBorrowerSource1 = value; } }
-        private Value<string> _eSignConsentBorrowerSource2;
+        private DirtyValue<string> _eSignConsentBorrowerSource2;
         public string eSignConsentBorrowerSource2 { get { return _eSignConsentBorrowerSource2; } set { _eSignConsentBorrowerSource2 = value; } }
-        private Value<string> _eSignConsentBorrowerSource3;
+        private DirtyValue<string> _eSignConsentBorrowerSource3;
         public string eSignConsentBorrowerSource3 { get { return _eSignConsentBorrowerSource3; } set { _eSignConsentBorrowerSource3 = value; } }
-        private Value<string> _eSignConsentBorrowerSource4;
+        private DirtyValue<string> _eSignConsentBorrowerSource4;
         public string eSignConsentBorrowerSource4 { get { return _eSignConsentBorrowerSource4; } set { _eSignConsentBorrowerSource4 = value; } }
-        private Value<string> _eSignConsentBorrowerSource5;
+        private DirtyValue<string> _eSignConsentBorrowerSource5;
         public string eSignConsentBorrowerSource5 { get { return _eSignConsentBorrowerSource5; } set { _eSignConsentBorrowerSource5 = value; } }
-        private Value<string> _eSignConsentBorrowerSource6;
+        private DirtyValue<string> _eSignConsentBorrowerSource6;
         public string eSignConsentBorrowerSource6 { get { return _eSignConsentBorrowerSource6; } set { _eSignConsentBorrowerSource6 = value; } }
-        private Value<string> _eSignConsentBorrowerStatus1;
+        private DirtyValue<string> _eSignConsentBorrowerStatus1;
         public string eSignConsentBorrowerStatus1 { get { return _eSignConsentBorrowerStatus1; } set { _eSignConsentBorrowerStatus1 = value; } }
-        private Value<string> _eSignConsentBorrowerStatus2;
+        private DirtyValue<string> _eSignConsentBorrowerStatus2;
         public string eSignConsentBorrowerStatus2 { get { return _eSignConsentBorrowerStatus2; } set { _eSignConsentBorrowerStatus2 = value; } }
-        private Value<string> _eSignConsentBorrowerStatus3;
+        private DirtyValue<string> _eSignConsentBorrowerStatus3;
         public string eSignConsentBorrowerStatus3 { get { return _eSignConsentBorrowerStatus3; } set { _eSignConsentBorrowerStatus3 = value; } }
-        private Value<string> _eSignConsentBorrowerStatus4;
+        private DirtyValue<string> _eSignConsentBorrowerStatus4;
         public string eSignConsentBorrowerStatus4 { get { return _eSignConsentBorrowerStatus4; } set { _eSignConsentBorrowerStatus4 = value; } }
-        private Value<string> _eSignConsentBorrowerStatus5;
+        private DirtyValue<string> _eSignConsentBorrowerStatus5;
         public string eSignConsentBorrowerStatus5 { get { return _eSignConsentBorrowerStatus5; } set { _eSignConsentBorrowerStatus5 = value; } }
-        private Value<string> _eSignConsentBorrowerStatus6;
+        private DirtyValue<string> _eSignConsentBorrowerStatus6;
         public string eSignConsentBorrowerStatus6 { get { return _eSignConsentBorrowerStatus6; } set { _eSignConsentBorrowerStatus6 = value; } }
-        private Value<DateTime?> _eSignConsentCoBorrowerDateAccepted1;
+        private DirtyValue<DateTime?> _eSignConsentCoBorrowerDateAccepted1;
         public DateTime? eSignConsentCoBorrowerDateAccepted1 { get { return _eSignConsentCoBorrowerDateAccepted1; } set { _eSignConsentCoBorrowerDateAccepted1 = value; } }
-        private Value<DateTime?> _eSignConsentCoBorrowerDateAccepted2;
+        private DirtyValue<DateTime?> _eSignConsentCoBorrowerDateAccepted2;
         public DateTime? eSignConsentCoBorrowerDateAccepted2 { get { return _eSignConsentCoBorrowerDateAccepted2; } set { _eSignConsentCoBorrowerDateAccepted2 = value; } }
-        private Value<DateTime?> _eSignConsentCoBorrowerDateAccepted3;
+        private DirtyValue<DateTime?> _eSignConsentCoBorrowerDateAccepted3;
         public DateTime? eSignConsentCoBorrowerDateAccepted3 { get { return _eSignConsentCoBorrowerDateAccepted3; } set { _eSignConsentCoBorrowerDateAccepted3 = value; } }
-        private Value<DateTime?> _eSignConsentCoBorrowerDateAccepted4;
+        private DirtyValue<DateTime?> _eSignConsentCoBorrowerDateAccepted4;
         public DateTime? eSignConsentCoBorrowerDateAccepted4 { get { return _eSignConsentCoBorrowerDateAccepted4; } set { _eSignConsentCoBorrowerDateAccepted4 = value; } }
-        private Value<DateTime?> _eSignConsentCoBorrowerDateAccepted5;
+        private DirtyValue<DateTime?> _eSignConsentCoBorrowerDateAccepted5;
         public DateTime? eSignConsentCoBorrowerDateAccepted5 { get { return _eSignConsentCoBorrowerDateAccepted5; } set { _eSignConsentCoBorrowerDateAccepted5 = value; } }
-        private Value<DateTime?> _eSignConsentCoBorrowerDateAccepted6;
+        private DirtyValue<DateTime?> _eSignConsentCoBorrowerDateAccepted6;
         public DateTime? eSignConsentCoBorrowerDateAccepted6 { get { return _eSignConsentCoBorrowerDateAccepted6; } set { _eSignConsentCoBorrowerDateAccepted6 = value; } }
-        private Value<string> _eSignConsentCoBorrowerIPAddress1;
+        private DirtyValue<string> _eSignConsentCoBorrowerIPAddress1;
         public string eSignConsentCoBorrowerIPAddress1 { get { return _eSignConsentCoBorrowerIPAddress1; } set { _eSignConsentCoBorrowerIPAddress1 = value; } }
-        private Value<string> _eSignConsentCoBorrowerIPAddress2;
+        private DirtyValue<string> _eSignConsentCoBorrowerIPAddress2;
         public string eSignConsentCoBorrowerIPAddress2 { get { return _eSignConsentCoBorrowerIPAddress2; } set { _eSignConsentCoBorrowerIPAddress2 = value; } }
-        private Value<string> _eSignConsentCoBorrowerIPAddress3;
+        private DirtyValue<string> _eSignConsentCoBorrowerIPAddress3;
         public string eSignConsentCoBorrowerIPAddress3 { get { return _eSignConsentCoBorrowerIPAddress3; } set { _eSignConsentCoBorrowerIPAddress3 = value; } }
-        private Value<string> _eSignConsentCoBorrowerIPAddress4;
+        private DirtyValue<string> _eSignConsentCoBorrowerIPAddress4;
         public string eSignConsentCoBorrowerIPAddress4 { get { return _eSignConsentCoBorrowerIPAddress4; } set { _eSignConsentCoBorrowerIPAddress4 = value; } }
-        private Value<string> _eSignConsentCoBorrowerIPAddress5;
+        private DirtyValue<string> _eSignConsentCoBorrowerIPAddress5;
         public string eSignConsentCoBorrowerIPAddress5 { get { return _eSignConsentCoBorrowerIPAddress5; } set { _eSignConsentCoBorrowerIPAddress5 = value; } }
-        private Value<string> _eSignConsentCoBorrowerIPAddress6;
+        private DirtyValue<string> _eSignConsentCoBorrowerIPAddress6;
         public string eSignConsentCoBorrowerIPAddress6 { get { return _eSignConsentCoBorrowerIPAddress6; } set { _eSignConsentCoBorrowerIPAddress6 = value; } }
-        private Value<string> _eSignConsentCoBorrowerSource1;
+        private DirtyValue<string> _eSignConsentCoBorrowerSource1;
         public string eSignConsentCoBorrowerSource1 { get { return _eSignConsentCoBorrowerSource1; } set { _eSignConsentCoBorrowerSource1 = value; } }
-        private Value<string> _eSignConsentCoBorrowerSource2;
+        private DirtyValue<string> _eSignConsentCoBorrowerSource2;
         public string eSignConsentCoBorrowerSource2 { get { return _eSignConsentCoBorrowerSource2; } set { _eSignConsentCoBorrowerSource2 = value; } }
-        private Value<string> _eSignConsentCoBorrowerSource3;
+        private DirtyValue<string> _eSignConsentCoBorrowerSource3;
         public string eSignConsentCoBorrowerSource3 { get { return _eSignConsentCoBorrowerSource3; } set { _eSignConsentCoBorrowerSource3 = value; } }
-        private Value<string> _eSignConsentCoBorrowerSource4;
+        private DirtyValue<string> _eSignConsentCoBorrowerSource4;
         public string eSignConsentCoBorrowerSource4 { get { return _eSignConsentCoBorrowerSource4; } set { _eSignConsentCoBorrowerSource4 = value; } }
-        private Value<string> _eSignConsentCoBorrowerSource5;
+        private DirtyValue<string> _eSignConsentCoBorrowerSource5;
         public string eSignConsentCoBorrowerSource5 { get { return _eSignConsentCoBorrowerSource5; } set { _eSignConsentCoBorrowerSource5 = value; } }
-        private Value<string> _eSignConsentCoBorrowerSource6;
+        private DirtyValue<string> _eSignConsentCoBorrowerSource6;
         public string eSignConsentCoBorrowerSource6 { get { return _eSignConsentCoBorrowerSource6; } set { _eSignConsentCoBorrowerSource6 = value; } }
-        private Value<string> _eSignConsentCoBorrowerStatus1;
+        private DirtyValue<string> _eSignConsentCoBorrowerStatus1;
         public string eSignConsentCoBorrowerStatus1 { get { return _eSignConsentCoBorrowerStatus1; } set { _eSignConsentCoBorrowerStatus1 = value; } }
-        private Value<string> _eSignConsentCoBorrowerStatus2;
+        private DirtyValue<string> _eSignConsentCoBorrowerStatus2;
         public string eSignConsentCoBorrowerStatus2 { get { return _eSignConsentCoBorrowerStatus2; } set { _eSignConsentCoBorrowerStatus2 = value; } }
-        private Value<string> _eSignConsentCoBorrowerStatus3;
+        private DirtyValue<string> _eSignConsentCoBorrowerStatus3;
         public string eSignConsentCoBorrowerStatus3 { get { return _eSignConsentCoBorrowerStatus3; } set { _eSignConsentCoBorrowerStatus3 = value; } }
-        private Value<string> _eSignConsentCoBorrowerStatus4;
+        private DirtyValue<string> _eSignConsentCoBorrowerStatus4;
         public string eSignConsentCoBorrowerStatus4 { get { return _eSignConsentCoBorrowerStatus4; } set { _eSignConsentCoBorrowerStatus4 = value; } }
-        private Value<string> _eSignConsentCoBorrowerStatus5;
+        private DirtyValue<string> _eSignConsentCoBorrowerStatus5;
         public string eSignConsentCoBorrowerStatus5 { get { return _eSignConsentCoBorrowerStatus5; } set { _eSignConsentCoBorrowerStatus5 = value; } }
-        private Value<string> _eSignConsentCoBorrowerStatus6;
+        private DirtyValue<string> _eSignConsentCoBorrowerStatus6;
         public string eSignConsentCoBorrowerStatus6 { get { return _eSignConsentCoBorrowerStatus6; } set { _eSignConsentCoBorrowerStatus6 = value; } }
-        private Value<DateTime?> _eSignConsentDate;
+        private DirtyValue<DateTime?> _eSignConsentDate;
         public DateTime? eSignConsentDate { get { return _eSignConsentDate; } set { _eSignConsentDate = value; } }
-        private Value<decimal?> _extraPaymentForEarlyPayOff;
+        private DirtyValue<decimal?> _extraPaymentForEarlyPayOff;
         public decimal? ExtraPaymentForEarlyPayOff { get { return _extraPaymentForEarlyPayOff; } set { _extraPaymentForEarlyPayOff = value; } }
-        private Value<DateTime?> _feeCollectedDate;
+        private DirtyValue<DateTime?> _feeCollectedDate;
         public DateTime? FeeCollectedDate { get { return _feeCollectedDate; } set { _feeCollectedDate = value; } }
-        private Value<decimal?> _filingFees;
+        private DirtyValue<decimal?> _filingFees;
         public decimal? FilingFees { get { return _filingFees; } set { _filingFees = value; } }
-        private Value<DateTime?> _finalPaymentDate;
+        private DirtyValue<DateTime?> _finalPaymentDate;
         public DateTime? FinalPaymentDate { get { return _finalPaymentDate; } set { _finalPaymentDate = value; } }
-        private Value<decimal?> _financeCharge;
+        private DirtyValue<decimal?> _financeCharge;
         public decimal? FinanceCharge { get { return _financeCharge; } set { _financeCharge = value; } }
-        private Value<decimal?> _financedAllGuaranteeFeeAmount;
+        private DirtyValue<decimal?> _financedAllGuaranteeFeeAmount;
         public decimal? FinancedAllGuaranteeFeeAmount { get { return _financedAllGuaranteeFeeAmount; } set { _financedAllGuaranteeFeeAmount = value; } }
-        private Value<decimal?> _financedAllGuaranteeFeePercent;
+        private DirtyValue<decimal?> _financedAllGuaranteeFeePercent;
         public decimal? FinancedAllGuaranteeFeePercent { get { return _financedAllGuaranteeFeePercent; } set { _financedAllGuaranteeFeePercent = value; } }
-        private Value<decimal?> _financedAllTotalLoanAmount;
+        private DirtyValue<decimal?> _financedAllTotalLoanAmount;
         public decimal? FinancedAllTotalLoanAmount { get { return _financedAllTotalLoanAmount; } set { _financedAllTotalLoanAmount = value; } }
-        private Value<decimal?> _financedPortionGuaranteeFeeAmount;
+        private DirtyValue<decimal?> _financedPortionGuaranteeFeeAmount;
         public decimal? FinancedPortionGuaranteeFeeAmount { get { return _financedPortionGuaranteeFeeAmount; } set { _financedPortionGuaranteeFeeAmount = value; } }
-        private Value<decimal?> _financedPortionGuaranteeFeePercent;
+        private DirtyValue<decimal?> _financedPortionGuaranteeFeePercent;
         public decimal? FinancedPortionGuaranteeFeePercent { get { return _financedPortionGuaranteeFeePercent; } set { _financedPortionGuaranteeFeePercent = value; } }
-        private Value<decimal?> _financedPortionTotalLoanAmount;
+        private DirtyValue<decimal?> _financedPortionTotalLoanAmount;
         public decimal? FinancedPortionTotalLoanAmount { get { return _financedPortionTotalLoanAmount; } set { _financedPortionTotalLoanAmount = value; } }
-        private Value<string> _financingType;
+        private DirtyValue<string> _financingType;
         public string FinancingType { get { return _financingType; } set { _financingType = value; } }
-        private Value<DateTime?> _firstAmortizationPaymentDate;
+        private DirtyValue<DateTime?> _firstAmortizationPaymentDate;
         public DateTime? FirstAmortizationPaymentDate { get { return _firstAmortizationPaymentDate; } set { _firstAmortizationPaymentDate = value; } }
-        private Value<bool?> _floodInsuranceIndicator;
+        private DirtyValue<bool?> _floodInsuranceIndicator;
         public bool? FloodInsuranceIndicator { get { return _floodInsuranceIndicator; } set { _floodInsuranceIndicator = value; } }
-        private Value<DateTime?> _gfeApplicationDate;
+        private DirtyValue<DateTime?> _gfeApplicationDate;
         public DateTime? GfeApplicationDate { get { return _gfeApplicationDate; } set { _gfeApplicationDate = value; } }
-        private Value<bool?> _gfeChangedCircumstanceIndicator;
+        private DirtyValue<bool?> _gfeChangedCircumstanceIndicator;
         public bool? GfeChangedCircumstanceIndicator { get { return _gfeChangedCircumstanceIndicator; } set { _gfeChangedCircumstanceIndicator = value; } }
-        private Value<string> _gfeChangedCircumstanceItem;
+        private DirtyValue<string> _gfeChangedCircumstanceItem;
         public string GfeChangedCircumstanceItem { get { return _gfeChangedCircumstanceItem; } set { _gfeChangedCircumstanceItem = value; } }
-        private Value<string> _gFEChangedCirsumstanceItemCode;
+        private DirtyValue<string> _gFEChangedCirsumstanceItemCode;
         public string GFEChangedCirsumstanceItemCode { get { return _gFEChangedCirsumstanceItemCode; } set { _gFEChangedCirsumstanceItemCode = value; } }
-        private Value<DateTime?> _gfeDate;
+        private DirtyValue<DateTime?> _gfeDate;
         public DateTime? GfeDate { get { return _gfeDate; } set { _gfeDate = value; } }
-        private Value<DateTime?> _gfeExpirationDate;
+        private DirtyValue<DateTime?> _gfeExpirationDate;
         public DateTime? GfeExpirationDate { get { return _gfeExpirationDate; } set { _gfeExpirationDate = value; } }
-        private Value<string> _gfeExpirationPeriod;
+        private DirtyValue<string> _gfeExpirationPeriod;
         public string GfeExpirationPeriod { get { return _gfeExpirationPeriod; } set { _gfeExpirationPeriod = value; } }
-        private Value<bool?> _gfeRateLockRedisclosureRequiredIndicator;
+        private DirtyValue<bool?> _gfeRateLockRedisclosureRequiredIndicator;
         public bool? GfeRateLockRedisclosureRequiredIndicator { get { return _gfeRateLockRedisclosureRequiredIndicator; } set { _gfeRateLockRedisclosureRequiredIndicator = value; } }
-        private Value<DateTime?> _gfeRedisclosureProvidedDate;
+        private DirtyValue<DateTime?> _gfeRedisclosureProvidedDate;
         public DateTime? GfeRedisclosureProvidedDate { get { return _gfeRedisclosureProvidedDate; } set { _gfeRedisclosureProvidedDate = value; } }
-        private Value<DateTime?> _gfeRedisclosureReceivedDate;
+        private DirtyValue<DateTime?> _gfeRedisclosureReceivedDate;
         public DateTime? GfeRedisclosureReceivedDate { get { return _gfeRedisclosureReceivedDate; } set { _gfeRedisclosureReceivedDate = value; } }
-        private Value<DateTime?> _highCostDisclosure;
+        private DirtyValue<DateTime?> _highCostDisclosure;
         public DateTime? HighCostDisclosure { get { return _highCostDisclosure; } set { _highCostDisclosure = value; } }
-        private Value<DateTime?> _homeCounselingProvidedDate;
+        private DirtyValue<DateTime?> _homeCounselingProvidedDate;
         public DateTime? HomeCounselingProvidedDate { get { return _homeCounselingProvidedDate; } set { _homeCounselingProvidedDate = value; } }
-        private Value<bool?> _hud1ToleranceViolatedIndicator;
+        private DirtyValue<bool?> _hud1ToleranceViolatedIndicator;
         public bool? Hud1ToleranceViolatedIndicator { get { return _hud1ToleranceViolatedIndicator; } set { _hud1ToleranceViolatedIndicator = value; } }
-        private Value<string> _hudToleranceResolutionComments;
+        private DirtyValue<string> _hudToleranceResolutionComments;
         public string HudToleranceResolutionComments { get { return _hudToleranceResolutionComments; } set { _hudToleranceResolutionComments = value; } }
-        private Value<DateTime?> _hudToleranceResolutionDate;
+        private DirtyValue<DateTime?> _hudToleranceResolutionDate;
         public DateTime? HudToleranceResolutionDate { get { return _hudToleranceResolutionDate; } set { _hudToleranceResolutionDate = value; } }
-        private Value<string> _hudToleranceResolvedBy;
+        private DirtyValue<string> _hudToleranceResolvedBy;
         public string HudToleranceResolvedBy { get { return _hudToleranceResolvedBy; } set { _hudToleranceResolvedBy = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _ifYouPurchaseIndicator;
+        private DirtyValue<bool?> _ifYouPurchaseIndicator;
         public bool? IfYouPurchaseIndicator { get { return _ifYouPurchaseIndicator; } set { _ifYouPurchaseIndicator = value; } }
-        private Value<string> _ifYouPurchaseType;
+        private DirtyValue<string> _ifYouPurchaseType;
         public string IfYouPurchaseType { get { return _ifYouPurchaseType; } set { _ifYouPurchaseType = value; } }
-        private Value<bool?> _includeMiIndicator;
+        private DirtyValue<bool?> _includeMiIndicator;
         public bool? IncludeMiIndicator { get { return _includeMiIndicator; } set { _includeMiIndicator = value; } }
-        private Value<bool?> _includePmiIndicator;
+        private DirtyValue<bool?> _includePmiIndicator;
         public bool? IncludePmiIndicator { get { return _includePmiIndicator; } set { _includePmiIndicator = value; } }
-        private Value<bool?> _includeTaxesInsuranceIndicator;
+        private DirtyValue<bool?> _includeTaxesInsuranceIndicator;
         public bool? IncludeTaxesInsuranceIndicator { get { return _includeTaxesInsuranceIndicator; } set { _includeTaxesInsuranceIndicator = value; } }
-        private Value<DateTime?> _initialAVMProvidedDate;
+        private DirtyValue<DateTime?> _initialAVMProvidedDate;
         public DateTime? InitialAVMProvidedDate { get { return _initialAVMProvidedDate; } set { _initialAVMProvidedDate = value; } }
-        private Value<DateTime?> _initialDisclosureDueDate;
+        private DirtyValue<DateTime?> _initialDisclosureDueDate;
         public DateTime? InitialDisclosureDueDate { get { return _initialDisclosureDueDate; } set { _initialDisclosureDueDate = value; } }
-        private Value<DateTime?> _initialDisclosureProvidedDate;
+        private DirtyValue<DateTime?> _initialDisclosureProvidedDate;
         public DateTime? InitialDisclosureProvidedDate { get { return _initialDisclosureProvidedDate; } set { _initialDisclosureProvidedDate = value; } }
-        private Value<DateTime?> _initialGfeAffiliatedBusinessProvidedDate;
+        private DirtyValue<DateTime?> _initialGfeAffiliatedBusinessProvidedDate;
         public DateTime? InitialGfeAffiliatedBusinessProvidedDate { get { return _initialGfeAffiliatedBusinessProvidedDate; } set { _initialGfeAffiliatedBusinessProvidedDate = value; } }
-        private Value<DateTime?> _initialGFEAppraisalProvidedDate;
+        private DirtyValue<DateTime?> _initialGFEAppraisalProvidedDate;
         public DateTime? InitialGFEAppraisalProvidedDate { get { return _initialGFEAppraisalProvidedDate; } set { _initialGFEAppraisalProvidedDate = value; } }
-        private Value<DateTime?> _initialGfeCharmBookletProvidedDate;
+        private DirtyValue<DateTime?> _initialGfeCharmBookletProvidedDate;
         public DateTime? InitialGfeCharmBookletProvidedDate { get { return _initialGfeCharmBookletProvidedDate; } set { _initialGfeCharmBookletProvidedDate = value; } }
-        private Value<DateTime?> _initialGfeDisclosureProvidedDate;
+        private DirtyValue<DateTime?> _initialGfeDisclosureProvidedDate;
         public DateTime? InitialGfeDisclosureProvidedDate { get { return _initialGfeDisclosureProvidedDate; } set { _initialGfeDisclosureProvidedDate = value; } }
-        private Value<DateTime?> _initialGfeDisclosureReceivedDate;
+        private DirtyValue<DateTime?> _initialGfeDisclosureReceivedDate;
         public DateTime? InitialGfeDisclosureReceivedDate { get { return _initialGfeDisclosureReceivedDate; } set { _initialGfeDisclosureReceivedDate = value; } }
-        private Value<DateTime?> _initialGfeHelocBrochureProvidedDate;
+        private DirtyValue<DateTime?> _initialGfeHelocBrochureProvidedDate;
         public DateTime? InitialGfeHelocBrochureProvidedDate { get { return _initialGfeHelocBrochureProvidedDate; } set { _initialGfeHelocBrochureProvidedDate = value; } }
-        private Value<DateTime?> _initialGfeHudSpecialBookletProvidedDate;
+        private DirtyValue<DateTime?> _initialGfeHudSpecialBookletProvidedDate;
         public DateTime? InitialGfeHudSpecialBookletProvidedDate { get { return _initialGfeHudSpecialBookletProvidedDate; } set { _initialGfeHudSpecialBookletProvidedDate = value; } }
-        private Value<DateTime?> _initialSubsequentAppraisalProvidedDate;
+        private DirtyValue<DateTime?> _initialSubsequentAppraisalProvidedDate;
         public DateTime? InitialSubsequentAppraisalProvidedDate { get { return _initialSubsequentAppraisalProvidedDate; } set { _initialSubsequentAppraisalProvidedDate = value; } }
-        private Value<DateTime?> _initialTilDisclosureProvidedDate;
+        private DirtyValue<DateTime?> _initialTilDisclosureProvidedDate;
         public DateTime? InitialTilDisclosureProvidedDate { get { return _initialTilDisclosureProvidedDate; } set { _initialTilDisclosureProvidedDate = value; } }
-        private Value<DateTime?> _initialTilDisclosureReceivedDate;
+        private DirtyValue<DateTime?> _initialTilDisclosureReceivedDate;
         public DateTime? InitialTilDisclosureReceivedDate { get { return _initialTilDisclosureReceivedDate; } set { _initialTilDisclosureReceivedDate = value; } }
-        private Value<string> _insuranceRequiredDescription;
+        private DirtyValue<string> _insuranceRequiredDescription;
         public string InsuranceRequiredDescription { get { return _insuranceRequiredDescription; } set { _insuranceRequiredDescription = value; } }
-        private Value<string> _interestInNameOf;
+        private DirtyValue<string> _interestInNameOf;
         public string InterestInNameOf { get { return _interestInNameOf; } set { _interestInNameOf = value; } }
-        private Value<bool?> _interestOnly;
+        private DirtyValue<bool?> _interestOnly;
         public bool? InterestOnly { get { return _interestOnly; } set { _interestOnly = value; } }
-        private Value<bool?> _interestOnlyIndicator;
+        private DirtyValue<bool?> _interestOnlyIndicator;
         public bool? InterestOnlyIndicator { get { return _interestOnlyIndicator; } set { _interestOnlyIndicator = value; } }
-        private Value<int?> _interestOnlyMonths;
+        private DirtyValue<int?> _interestOnlyMonths;
         public int? InterestOnlyMonths { get { return _interestOnlyMonths; } set { _interestOnlyMonths = value; } }
-        private Value<string> _interestRateType;
+        private DirtyValue<string> _interestRateType;
         public string InterestRateType { get { return _interestRateType; } set { _interestRateType = value; } }
-        private Value<decimal?> _interestReserveAmount;
+        private DirtyValue<decimal?> _interestReserveAmount;
         public decimal? InterestReserveAmount { get { return _interestReserveAmount; } set { _interestReserveAmount = value; } }
-        private Value<string> _lastDisclosedBy;
+        private DirtyValue<string> _lastDisclosedBy;
         public string LastDisclosedBy { get { return _lastDisclosedBy; } set { _lastDisclosedBy = value; } }
-        private Value<DateTime?> _lastDisclosedDate;
+        private DirtyValue<DateTime?> _lastDisclosedDate;
         public DateTime? LastDisclosedDate { get { return _lastDisclosedDate; } set { _lastDisclosedDate = value; } }
-        private Value<DateTime?> _lastDisclosedGfeReceivedDate;
+        private DirtyValue<DateTime?> _lastDisclosedGfeReceivedDate;
         public DateTime? LastDisclosedGfeReceivedDate { get { return _lastDisclosedGfeReceivedDate; } set { _lastDisclosedGfeReceivedDate = value; } }
-        private Value<decimal?> _lateChargeBasis;
+        private DirtyValue<decimal?> _lateChargeBasis;
         public decimal? LateChargeBasis { get { return _lateChargeBasis; } set { _lateChargeBasis = value; } }
-        private Value<string> _lateChargeComments;
+        private DirtyValue<string> _lateChargeComments;
         public string LateChargeComments { get { return _lateChargeComments; } set { _lateChargeComments = value; } }
-        private Value<int?> _lateChargeDays;
+        private DirtyValue<int?> _lateChargeDays;
         public int? LateChargeDays { get { return _lateChargeDays; } set { _lateChargeDays = value; } }
-        private Value<decimal?> _lateChargePercent;
+        private DirtyValue<decimal?> _lateChargePercent;
         public decimal? LateChargePercent { get { return _lateChargePercent; } set { _lateChargePercent = value; } }
-        private Value<string> _lateChargeType;
+        private DirtyValue<string> _lateChargeType;
         public string LateChargeType { get { return _lateChargeType; } set { _lateChargeType = value; } }
-        private Value<decimal?> _lateFee;
+        private DirtyValue<decimal?> _lateFee;
         public decimal? LateFee { get { return _lateFee; } set { _lateFee = value; } }
-        private Value<string> _lEIntentToProceedComment;
+        private DirtyValue<string> _lEIntentToProceedComment;
         public string LEIntentToProceedComment { get { return _lEIntentToProceedComment; } set { _lEIntentToProceedComment = value; } }
-        private Value<bool?> _lenderPaidMortgageInsuranceIndicator;
+        private DirtyValue<bool?> _lenderPaidMortgageInsuranceIndicator;
         public bool? LenderPaidMortgageInsuranceIndicator { get { return _lenderPaidMortgageInsuranceIndicator; } set { _lenderPaidMortgageInsuranceIndicator = value; } }
-        private Value<decimal?> _lendersInspectionFee;
+        private DirtyValue<decimal?> _lendersInspectionFee;
         public decimal? LendersInspectionFee { get { return _lendersInspectionFee; } set { _lendersInspectionFee = value; } }
-        private Value<string> _lEReceivedBy;
+        private DirtyValue<string> _lEReceivedBy;
         public string LEReceivedBy { get { return _lEReceivedBy; } set { _lEReceivedBy = value; } }
-        private Value<string> _lEReceivedMethod;
+        private DirtyValue<string> _lEReceivedMethod;
         public string LEReceivedMethod { get { return _lEReceivedMethod; } set { _lEReceivedMethod = value; } }
-        private Value<string> _lEReceivedMethodOther;
+        private DirtyValue<string> _lEReceivedMethodOther;
         public string LEReceivedMethodOther { get { return _lEReceivedMethodOther; } set { _lEReceivedMethodOther = value; } }
-        private Value<DateTime?> _lESentOnDate;
+        private DirtyValue<DateTime?> _lESentOnDate;
         public DateTime? LESentOnDate { get { return _lESentOnDate; } set { _lESentOnDate = value; } }
-        private Value<decimal?> _marginPlusIndexPercent;
+        private DirtyValue<decimal?> _marginPlusIndexPercent;
         public decimal? MarginPlusIndexPercent { get { return _marginPlusIndexPercent; } set { _marginPlusIndexPercent = value; } }
-        private Value<decimal?> _maximumLateCharge;
+        private DirtyValue<decimal?> _maximumLateCharge;
         public decimal? MaximumLateCharge { get { return _maximumLateCharge; } set { _maximumLateCharge = value; } }
-        private Value<decimal?> _maximumPayment;
+        private DirtyValue<decimal?> _maximumPayment;
         public decimal? MaximumPayment { get { return _maximumPayment; } set { _maximumPayment = value; } }
-        private Value<bool?> _meansAnEstimateIndicator;
+        private DirtyValue<bool?> _meansAnEstimateIndicator;
         public bool? MeansAnEstimateIndicator { get { return _meansAnEstimateIndicator; } set { _meansAnEstimateIndicator = value; } }
-        private Value<decimal?> _miAdjustmentFactorLevel2;
+        private DirtyValue<decimal?> _miAdjustmentFactorLevel2;
         public decimal? MiAdjustmentFactorLevel2 { get { return _miAdjustmentFactorLevel2; } set { _miAdjustmentFactorLevel2 = value; } }
-        private Value<bool?> _miDecliningRenewalsIndicator;
+        private DirtyValue<bool?> _miDecliningRenewalsIndicator;
         public bool? MiDecliningRenewalsIndicator { get { return _miDecliningRenewalsIndicator; } set { _miDecliningRenewalsIndicator = value; } }
-        private Value<string> _midpointCancellation;
+        private DirtyValue<string> _midpointCancellation;
         public string MidpointCancellation { get { return _midpointCancellation; } set { _midpointCancellation = value; } }
-        private Value<decimal?> _miMonthlyPaymentLevel1;
+        private DirtyValue<decimal?> _miMonthlyPaymentLevel1;
         public decimal? MiMonthlyPaymentLevel1 { get { return _miMonthlyPaymentLevel1; } set { _miMonthlyPaymentLevel1 = value; } }
-        private Value<decimal?> _miMonthlyPaymentLevel2;
+        private DirtyValue<decimal?> _miMonthlyPaymentLevel2;
         public decimal? MiMonthlyPaymentLevel2 { get { return _miMonthlyPaymentLevel2; } set { _miMonthlyPaymentLevel2 = value; } }
-        private Value<int?> _miMonthsOfAdjustmentLevel1;
+        private DirtyValue<int?> _miMonthsOfAdjustmentLevel1;
         public int? MiMonthsOfAdjustmentLevel1 { get { return _miMonthsOfAdjustmentLevel1; } set { _miMonthsOfAdjustmentLevel1 = value; } }
-        private Value<int?> _miMonthsOfAdjustmentLevel2;
+        private DirtyValue<int?> _miMonthsOfAdjustmentLevel2;
         public int? MiMonthsOfAdjustmentLevel2 { get { return _miMonthsOfAdjustmentLevel2; } set { _miMonthsOfAdjustmentLevel2 = value; } }
-        private Value<decimal?> _minimumLateCharge;
+        private DirtyValue<decimal?> _minimumLateCharge;
         public decimal? MinimumLateCharge { get { return _minimumLateCharge; } set { _minimumLateCharge = value; } }
-        private Value<decimal?> _minimumPayment;
+        private DirtyValue<decimal?> _minimumPayment;
         public decimal? MinimumPayment { get { return _minimumPayment; } set { _minimumPayment = value; } }
-        private Value<bool?> _mIPFactorLocked;
+        private DirtyValue<bool?> _mIPFactorLocked;
         public bool? MIPFactorLocked { get { return _mIPFactorLocked; } set { _mIPFactorLocked = value; } }
-        private Value<decimal?> _mIPrepaidAmount;
+        private DirtyValue<decimal?> _mIPrepaidAmount;
         public decimal? MIPrepaidAmount { get { return _mIPrepaidAmount; } set { _mIPrepaidAmount = value; } }
-        private Value<bool?> _miPrepaidIndicator;
+        private DirtyValue<bool?> _miPrepaidIndicator;
         public bool? MiPrepaidIndicator { get { return _miPrepaidIndicator; } set { _miPrepaidIndicator = value; } }
-        private Value<string> _miScheduledTerminationDate;
+        private DirtyValue<string> _miScheduledTerminationDate;
         public string MiScheduledTerminationDate { get { return _miScheduledTerminationDate; } set { _miScheduledTerminationDate = value; } }
-        private Value<bool?> _mmiIndicator;
+        private DirtyValue<bool?> _mmiIndicator;
         public bool? MmiIndicator { get { return _mmiIndicator; } set { _mmiIndicator = value; } }
-        private Value<decimal?> _monthlyTerm;
+        private DirtyValue<decimal?> _monthlyTerm;
         public decimal? MonthlyTerm { get { return _monthlyTerm; } set { _monthlyTerm = value; } }
-        private Value<int?> _monthsOfMiPrepaid;
+        private DirtyValue<int?> _monthsOfMiPrepaid;
         public int? MonthsOfMiPrepaid { get { return _monthsOfMiPrepaid; } set { _monthsOfMiPrepaid = value; } }
-        private Value<decimal?> _mortgageInsuranceCancelPercent;
+        private DirtyValue<decimal?> _mortgageInsuranceCancelPercent;
         public decimal? MortgageInsuranceCancelPercent { get { return _mortgageInsuranceCancelPercent; } set { _mortgageInsuranceCancelPercent = value; } }
-        private Value<string> _namePreparedBy;
+        private DirtyValue<string> _namePreparedBy;
         public string NamePreparedBy { get { return _namePreparedBy; } set { _namePreparedBy = value; } }
-        private Value<string> _newConstructionIndicator;
+        private DirtyValue<string> _newConstructionIndicator;
         public string NewConstructionIndicator { get { return _newConstructionIndicator; } set { _newConstructionIndicator = value; } }
-        private Value<int?> _numberOfPayments;
+        private DirtyValue<int?> _numberOfPayments;
         public int? NumberOfPayments { get { return _numberOfPayments; } set { _numberOfPayments = value; } }
-        private Value<DateTime?> _occupancyCertDate;
+        private DirtyValue<DateTime?> _occupancyCertDate;
         public DateTime? OccupancyCertDate { get { return _occupancyCertDate; } set { _occupancyCertDate = value; } }
-        private Value<DateTime?> _originalContractDate;
+        private DirtyValue<DateTime?> _originalContractDate;
         public DateTime? OriginalContractDate { get { return _originalContractDate; } set { _originalContractDate = value; } }
-        private Value<decimal?> _outstandingBalance;
+        private DirtyValue<decimal?> _outstandingBalance;
         public decimal? OutstandingBalance { get { return _outstandingBalance; } set { _outstandingBalance = value; } }
-        private Value<string> _paymentFrequencyType;
+        private DirtyValue<string> _paymentFrequencyType;
         public string PaymentFrequencyType { get { return _paymentFrequencyType; } set { _paymentFrequencyType = value; } }
-        private Value<decimal?> _paymentIncreasePercent;
+        private DirtyValue<decimal?> _paymentIncreasePercent;
         public decimal? PaymentIncreasePercent { get { return _paymentIncreasePercent; } set { _paymentIncreasePercent = value; } }
-        private Value<string> _phonePreparedBy;
+        private DirtyValue<string> _phonePreparedBy;
         public string PhonePreparedBy { get { return _phonePreparedBy; } set { _phonePreparedBy = value; } }
-        private Value<bool?> _pmiIndicator;
+        private DirtyValue<bool?> _pmiIndicator;
         public bool? PmiIndicator { get { return _pmiIndicator; } set { _pmiIndicator = value; } }
-        private Value<DateTime?> _pmiMidpointCancelationDate;
+        private DirtyValue<DateTime?> _pmiMidpointCancelationDate;
         public DateTime? PmiMidpointCancelationDate { get { return _pmiMidpointCancelationDate; } set { _pmiMidpointCancelationDate = value; } }
-        private Value<DateTime?> _postConsummationDisclosureReceivedDate;
+        private DirtyValue<DateTime?> _postConsummationDisclosureReceivedDate;
         public DateTime? PostConsummationDisclosureReceivedDate { get { return _postConsummationDisclosureReceivedDate; } set { _postConsummationDisclosureReceivedDate = value; } }
-        private Value<DateTime?> _postConsummationDisclosureSentDate;
+        private DirtyValue<DateTime?> _postConsummationDisclosureSentDate;
         public DateTime? PostConsummationDisclosureSentDate { get { return _postConsummationDisclosureSentDate; } set { _postConsummationDisclosureSentDate = value; } }
-        private Value<decimal?> _prepaidFinanceCharge;
+        private DirtyValue<decimal?> _prepaidFinanceCharge;
         public decimal? PrepaidFinanceCharge { get { return _prepaidFinanceCharge; } set { _prepaidFinanceCharge = value; } }
-        private Value<bool?> _propertyInsuranceIndicator;
+        private DirtyValue<bool?> _propertyInsuranceIndicator;
         public bool? PropertyInsuranceIndicator { get { return _propertyInsuranceIndicator; } set { _propertyInsuranceIndicator = value; } }
-        private Value<DateTime?> _rateLockGfeDueDate;
+        private DirtyValue<DateTime?> _rateLockGfeDueDate;
         public DateTime? RateLockGfeDueDate { get { return _rateLockGfeDueDate; } set { _rateLockGfeDueDate = value; } }
-        private Value<decimal?> _ratePercent;
+        private DirtyValue<decimal?> _ratePercent;
         public decimal? RatePercent { get { return _ratePercent; } set { _ratePercent = value; } }
-        private Value<int?> _recastPaidMonths;
+        private DirtyValue<int?> _recastPaidMonths;
         public int? RecastPaidMonths { get { return _recastPaidMonths; } set { _recastPaidMonths = value; } }
-        private Value<int?> _recastStopMonths;
+        private DirtyValue<int?> _recastStopMonths;
         public int? RecastStopMonths { get { return _recastStopMonths; } set { _recastStopMonths = value; } }
-        private Value<bool?> _refundPaymentIndicator;
+        private DirtyValue<bool?> _refundPaymentIndicator;
         public bool? RefundPaymentIndicator { get { return _refundPaymentIndicator; } set { _refundPaymentIndicator = value; } }
-        private Value<bool?> _refundUnearnedMipIndicator;
+        private DirtyValue<bool?> _refundUnearnedMipIndicator;
         public bool? RefundUnearnedMipIndicator { get { return _refundUnearnedMipIndicator; } set { _refundUnearnedMipIndicator = value; } }
         private DirtyList<RegulationZInterestRatePeriod> _regulationZInterestRatePeriods;
         public IList<RegulationZInterestRatePeriod> RegulationZInterestRatePeriods { get { var v = _regulationZInterestRatePeriods; return v ?? Interlocked.CompareExchange(ref _regulationZInterestRatePeriods, (v = new DirtyList<RegulationZInterestRatePeriod>()), null) ?? v; } set { _regulationZInterestRatePeriods = new DirtyList<RegulationZInterestRatePeriod>(value); } }
         private DirtyList<RegulationZPayment> _regulationZPayments;
         public IList<RegulationZPayment> RegulationZPayments { get { var v = _regulationZPayments; return v ?? Interlocked.CompareExchange(ref _regulationZPayments, (v = new DirtyList<RegulationZPayment>()), null) ?? v; } set { _regulationZPayments = new DirtyList<RegulationZPayment>(value); } }
-        private Value<string> _regzTableType;
+        private DirtyValue<string> _regzTableType;
         public string RegzTableType { get { return _regzTableType; } set { _regzTableType = value; } }
-        private Value<bool?> _requiredDepositIndicator;
+        private DirtyValue<bool?> _requiredDepositIndicator;
         public bool? RequiredDepositIndicator { get { return _requiredDepositIndicator; } set { _requiredDepositIndicator = value; } }
-        private Value<DateTime?> _revisedClosingDisclosureReceivedDate;
+        private DirtyValue<DateTime?> _revisedClosingDisclosureReceivedDate;
         public DateTime? RevisedClosingDisclosureReceivedDate { get { return _revisedClosingDisclosureReceivedDate; } set { _revisedClosingDisclosureReceivedDate = value; } }
-        private Value<DateTime?> _revisedClosingDisclosureSentDate;
+        private DirtyValue<DateTime?> _revisedClosingDisclosureSentDate;
         public DateTime? RevisedClosingDisclosureSentDate { get { return _revisedClosingDisclosureSentDate; } set { _revisedClosingDisclosureSentDate = value; } }
-        private Value<DateTime?> _revisedGfeDueDate;
+        private DirtyValue<DateTime?> _revisedGfeDueDate;
         public DateTime? RevisedGfeDueDate { get { return _revisedGfeDueDate; } set { _revisedGfeDueDate = value; } }
-        private Value<decimal?> _roundedMarginPlusIndexPercent;
+        private DirtyValue<decimal?> _roundedMarginPlusIndexPercent;
         public decimal? RoundedMarginPlusIndexPercent { get { return _roundedMarginPlusIndexPercent; } set { _roundedMarginPlusIndexPercent = value; } }
-        private Value<DateTime?> _safeHarborSentDate;
+        private DirtyValue<DateTime?> _safeHarborSentDate;
         public DateTime? SafeHarborSentDate { get { return _safeHarborSentDate; } set { _safeHarborSentDate = value; } }
-        private Value<decimal?> _samplePayments;
+        private DirtyValue<decimal?> _samplePayments;
         public decimal? SamplePayments { get { return _samplePayments; } set { _samplePayments = value; } }
-        private Value<string> _securityType;
+        private DirtyValue<string> _securityType;
         public string SecurityType { get { return _securityType; } set { _securityType = value; } }
-        private Value<DateTime?> _sSPLSentDate;
+        private DirtyValue<DateTime?> _sSPLSentDate;
         public DateTime? SSPLSentDate { get { return _sSPLSentDate; } set { _sSPLSentDate = value; } }
-        private Value<DateTime?> _tilDate;
+        private DirtyValue<DateTime?> _tilDate;
         public DateTime? TilDate { get { return _tilDate; } set { _tilDate = value; } }
-        private Value<string> _tilDisclosedComments;
+        private DirtyValue<string> _tilDisclosedComments;
         public string TilDisclosedComments { get { return _tilDisclosedComments; } set { _tilDisclosedComments = value; } }
-        private Value<string> _tilDisclosureMethod;
+        private DirtyValue<string> _tilDisclosureMethod;
         public string TilDisclosureMethod { get { return _tilDisclosureMethod; } set { _tilDisclosureMethod = value; } }
-        private Value<DateTime?> _tilLastDisclosedBorrowerReceivedDate;
+        private DirtyValue<DateTime?> _tilLastDisclosedBorrowerReceivedDate;
         public DateTime? TilLastDisclosedBorrowerReceivedDate { get { return _tilLastDisclosedBorrowerReceivedDate; } set { _tilLastDisclosedBorrowerReceivedDate = value; } }
-        private Value<string> _tilLastDisclosedBy;
+        private DirtyValue<string> _tilLastDisclosedBy;
         public string TilLastDisclosedBy { get { return _tilLastDisclosedBy; } set { _tilLastDisclosedBy = value; } }
-        private Value<DateTime?> _tilLastDisclosedDate;
+        private DirtyValue<DateTime?> _tilLastDisclosedDate;
         public DateTime? TilLastDisclosedDate { get { return _tilLastDisclosedDate; } set { _tilLastDisclosedDate = value; } }
-        private Value<DateTime?> _tilRedisclosureProvidedDate;
+        private DirtyValue<DateTime?> _tilRedisclosureProvidedDate;
         public DateTime? TilRedisclosureProvidedDate { get { return _tilRedisclosureProvidedDate; } set { _tilRedisclosureProvidedDate = value; } }
-        private Value<DateTime?> _tilRedisclosureReceivedDate;
+        private DirtyValue<DateTime?> _tilRedisclosureReceivedDate;
         public DateTime? TilRedisclosureReceivedDate { get { return _tilRedisclosureReceivedDate; } set { _tilRedisclosureReceivedDate = value; } }
-        private Value<decimal?> _totalBrokerFees;
+        private DirtyValue<decimal?> _totalBrokerFees;
         public decimal? TotalBrokerFees { get { return _totalBrokerFees; } set { _totalBrokerFees = value; } }
-        private Value<decimal?> _totalLatePayment;
+        private DirtyValue<decimal?> _totalLatePayment;
         public decimal? TotalLatePayment { get { return _totalLatePayment; } set { _totalLatePayment = value; } }
-        private Value<decimal?> _totalLenderFees;
+        private DirtyValue<decimal?> _totalLenderFees;
         public decimal? TotalLenderFees { get { return _totalLenderFees; } set { _totalLenderFees = value; } }
-        private Value<decimal?> _totalOfPayments;
+        private DirtyValue<decimal?> _totalOfPayments;
         public decimal? TotalOfPayments { get { return _totalOfPayments; } set { _totalOfPayments = value; } }
-        private Value<decimal?> _totalOfPrincipalAndInterest;
+        private DirtyValue<decimal?> _totalOfPrincipalAndInterest;
         public decimal? TotalOfPrincipalAndInterest { get { return _totalOfPrincipalAndInterest; } set { _totalOfPrincipalAndInterest = value; } }
-        private Value<bool?> _useCustomLenderProfile;
+        private DirtyValue<bool?> _useCustomLenderProfile;
         public bool? UseCustomLenderProfile { get { return _useCustomLenderProfile; } set { _useCustomLenderProfile = value; } }
-        private Value<string> _useDaysInYears;
+        private DirtyValue<string> _useDaysInYears;
         public string UseDaysInYears { get { return _useDaysInYears; } set { _useDaysInYears = value; } }
-        private Value<bool?> _usePitiForRatioIndicator;
+        private DirtyValue<bool?> _usePitiForRatioIndicator;
         public bool? UsePitiForRatioIndicator { get { return _usePitiForRatioIndicator; } set { _usePitiForRatioIndicator = value; } }
-        private Value<bool?> _variableRateFeatureIndicator;
+        private DirtyValue<bool?> _variableRateFeatureIndicator;
         public bool? VariableRateFeatureIndicator { get { return _variableRateFeatureIndicator; } set { _variableRateFeatureIndicator = value; } }
-        private Value<decimal?> _yearlyTerm;
+        private DirtyValue<decimal?> _yearlyTerm;
         public decimal? YearlyTerm { get { return _yearlyTerm; } set { _yearlyTerm = value; } }
-        private Value<string> _yearOfMaximumPayment;
+        private DirtyValue<string> _yearOfMaximumPayment;
         public string YearOfMaximumPayment { get { return _yearOfMaximumPayment; } set { _yearOfMaximumPayment = value; } }
-        private Value<int?> _years;
+        private DirtyValue<int?> _years;
         public int? Years { get { return _years; } set { _years = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RegulationZ.cs
+++ b/src/EncompassRest/Loans/RegulationZ.cs
@@ -430,10 +430,10 @@ namespace EncompassRest.Loans
         public bool? RefundPaymentIndicator { get { return _refundPaymentIndicator; } set { _refundPaymentIndicator = value; } }
         private Value<bool?> _refundUnearnedMipIndicator;
         public bool? RefundUnearnedMipIndicator { get { return _refundUnearnedMipIndicator; } set { _refundUnearnedMipIndicator = value; } }
-        private Value<List<RegulationZInterestRatePeriod>> _regulationZInterestRatePeriods;
-        public List<RegulationZInterestRatePeriod> RegulationZInterestRatePeriods { get { return _regulationZInterestRatePeriods; } set { _regulationZInterestRatePeriods = value; } }
-        private Value<List<RegulationZPayment>> _regulationZPayments;
-        public List<RegulationZPayment> RegulationZPayments { get { return _regulationZPayments; } set { _regulationZPayments = value; } }
+        private DirtyList<RegulationZInterestRatePeriod> _regulationZInterestRatePeriods;
+        public IList<RegulationZInterestRatePeriod> RegulationZInterestRatePeriods { get { var v = _regulationZInterestRatePeriods; return v ?? Interlocked.CompareExchange(ref _regulationZInterestRatePeriods, (v = new DirtyList<RegulationZInterestRatePeriod>()), null) ?? v; } set { _regulationZInterestRatePeriods = new DirtyList<RegulationZInterestRatePeriod>(value); } }
+        private DirtyList<RegulationZPayment> _regulationZPayments;
+        public IList<RegulationZPayment> RegulationZPayments { get { var v = _regulationZPayments; return v ?? Interlocked.CompareExchange(ref _regulationZPayments, (v = new DirtyList<RegulationZPayment>()), null) ?? v; } set { _regulationZPayments = new DirtyList<RegulationZPayment>(value); } }
         private Value<string> _regzTableType;
         public string RegzTableType { get { return _regzTableType; } set { _regzTableType = value; } }
         private Value<bool?> _requiredDepositIndicator;
@@ -712,8 +712,6 @@ namespace EncompassRest.Loans
                     || _recastStopMonths.Dirty
                     || _refundPaymentIndicator.Dirty
                     || _refundUnearnedMipIndicator.Dirty
-                    || _regulationZInterestRatePeriods.Dirty
-                    || _regulationZPayments.Dirty
                     || _regzTableType.Dirty
                     || _requiredDepositIndicator.Dirty
                     || _revisedClosingDisclosureReceivedDate.Dirty
@@ -743,7 +741,9 @@ namespace EncompassRest.Loans
                     || _variableRateFeatureIndicator.Dirty
                     || _yearlyTerm.Dirty
                     || _yearOfMaximumPayment.Dirty
-                    || _years.Dirty;
+                    || _years.Dirty
+                    || _regulationZInterestRatePeriods?.Dirty == true
+                    || _regulationZPayments?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -961,8 +961,6 @@ namespace EncompassRest.Loans
                 _recastStopMonths.Dirty = value;
                 _refundPaymentIndicator.Dirty = value;
                 _refundUnearnedMipIndicator.Dirty = value;
-                _regulationZInterestRatePeriods.Dirty = value;
-                _regulationZPayments.Dirty = value;
                 _regzTableType.Dirty = value;
                 _requiredDepositIndicator.Dirty = value;
                 _revisedClosingDisclosureReceivedDate.Dirty = value;
@@ -993,6 +991,8 @@ namespace EncompassRest.Loans
                 _yearlyTerm.Dirty = value;
                 _yearOfMaximumPayment.Dirty = value;
                 _years.Dirty = value;
+                if (_regulationZInterestRatePeriods != null) _regulationZInterestRatePeriods.Dirty = value;
+                if (_regulationZPayments != null) _regulationZPayments.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/RegulationZInterestRatePeriod.cs
+++ b/src/EncompassRest/Loans/RegulationZInterestRatePeriod.cs
@@ -8,27 +8,27 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RegulationZInterestRatePeriod : IDirty
     {
-        private Value<DateTime?> _adjustmentDate;
+        private DirtyValue<DateTime?> _adjustmentDate;
         public DateTime? AdjustmentDate { get { return _adjustmentDate; } set { _adjustmentDate = value; } }
-        private Value<int?> _adjustmentMonths;
+        private DirtyValue<int?> _adjustmentMonths;
         public int? AdjustmentMonths { get { return _adjustmentMonths; } set { _adjustmentMonths = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _interestPayment;
+        private DirtyValue<decimal?> _interestPayment;
         public decimal? InterestPayment { get { return _interestPayment; } set { _interestPayment = value; } }
-        private Value<decimal?> _interestPrincipalPayment;
+        private DirtyValue<decimal?> _interestPrincipalPayment;
         public decimal? InterestPrincipalPayment { get { return _interestPrincipalPayment; } set { _interestPrincipalPayment = value; } }
-        private Value<decimal?> _interestRatePercent;
+        private DirtyValue<decimal?> _interestRatePercent;
         public decimal? InterestRatePercent { get { return _interestRatePercent; } set { _interestRatePercent = value; } }
-        private Value<decimal?> _monthlyPayment;
+        private DirtyValue<decimal?> _monthlyPayment;
         public decimal? MonthlyPayment { get { return _monthlyPayment; } set { _monthlyPayment = value; } }
-        private Value<decimal?> _principalPayment;
+        private DirtyValue<decimal?> _principalPayment;
         public decimal? PrincipalPayment { get { return _principalPayment; } set { _principalPayment = value; } }
-        private Value<string> _regulationZInterestRatePeriodType;
+        private DirtyValue<string> _regulationZInterestRatePeriodType;
         public string RegulationZInterestRatePeriodType { get { return _regulationZInterestRatePeriodType; } set { _regulationZInterestRatePeriodType = value; } }
-        private Value<decimal?> _taxInsuranceAmount;
+        private DirtyValue<decimal?> _taxInsuranceAmount;
         public decimal? TaxInsuranceAmount { get { return _taxInsuranceAmount; } set { _taxInsuranceAmount = value; } }
-        private Value<decimal?> _totalPayment;
+        private DirtyValue<decimal?> _totalPayment;
         public decimal? TotalPayment { get { return _totalPayment; } set { _totalPayment = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RegulationZPayment.cs
+++ b/src/EncompassRest/Loans/RegulationZPayment.cs
@@ -8,19 +8,19 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RegulationZPayment : IDirty
     {
-        private Value<decimal?> _balance;
+        private DirtyValue<decimal?> _balance;
         public decimal? Balance { get { return _balance; } set { _balance = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _interestRatePercent;
+        private DirtyValue<decimal?> _interestRatePercent;
         public decimal? InterestRatePercent { get { return _interestRatePercent; } set { _interestRatePercent = value; } }
-        private Value<decimal?> _monthlyPayment;
+        private DirtyValue<decimal?> _monthlyPayment;
         public decimal? MonthlyPayment { get { return _monthlyPayment; } set { _monthlyPayment = value; } }
-        private Value<int?> _numberOfPayments;
+        private DirtyValue<int?> _numberOfPayments;
         public int? NumberOfPayments { get { return _numberOfPayments; } set { _numberOfPayments = value; } }
-        private Value<DateTime?> _paymentDate;
+        private DirtyValue<DateTime?> _paymentDate;
         public DateTime? PaymentDate { get { return _paymentDate; } set { _paymentDate = value; } }
-        private Value<int?> _regulationZPaymentIndex;
+        private DirtyValue<int?> _regulationZPaymentIndex;
         public int? RegulationZPaymentIndex { get { return _regulationZPaymentIndex; } set { _regulationZPaymentIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RemovedLogRecord.cs
+++ b/src/EncompassRest/Loans/RemovedLogRecord.cs
@@ -8,8 +8,8 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RemovedLogRecord : IDirty
     {
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<DateTime?> _dateUtc;
@@ -33,22 +33,21 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _dateUtc.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _guid.Dirty
                     || _id.Dirty
                     || _isSystemSpecificIndicator.Dirty
                     || _logRecordIndex.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _dateUtc.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
@@ -57,6 +56,7 @@ namespace EncompassRest.Loans
                 _isSystemSpecificIndicator.Dirty = value;
                 _logRecordIndex.Dirty = value;
                 _systemId.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/RemovedLogRecord.cs
+++ b/src/EncompassRest/Loans/RemovedLogRecord.cs
@@ -10,21 +10,21 @@ namespace EncompassRest.Loans
     {
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ReoProperty.cs
+++ b/src/EncompassRest/Loans/ReoProperty.cs
@@ -8,67 +8,67 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ReoProperty : IDirty
     {
-        private Value<DateTime?> _acquiredDate;
+        private DirtyValue<DateTime?> _acquiredDate;
         public DateTime? AcquiredDate { get { return _acquiredDate; } set { _acquiredDate = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _dispositionStatusType;
+        private DirtyValue<string> _dispositionStatusType;
         public string DispositionStatusType { get { return _dispositionStatusType; } set { _dispositionStatusType = value; } }
-        private Value<bool?> _entityDeleted;
+        private DirtyValue<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
-        private Value<string> _gsePropertyType;
+        private DirtyValue<string> _gsePropertyType;
         public string GsePropertyType { get { return _gsePropertyType; } set { _gsePropertyType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEmpty;
+        private DirtyValue<bool?> _isEmpty;
         public bool? IsEmpty { get { return _isEmpty; } set { _isEmpty = value; } }
-        private Value<decimal?> _lienInstallmentAmount;
+        private DirtyValue<decimal?> _lienInstallmentAmount;
         public decimal? LienInstallmentAmount { get { return _lienInstallmentAmount; } set { _lienInstallmentAmount = value; } }
-        private Value<decimal?> _lienUpbAmount;
+        private DirtyValue<decimal?> _lienUpbAmount;
         public decimal? LienUpbAmount { get { return _lienUpbAmount; } set { _lienUpbAmount = value; } }
-        private Value<string> _maintenanceExpenseAmount;
+        private DirtyValue<string> _maintenanceExpenseAmount;
         public string MaintenanceExpenseAmount { get { return _maintenanceExpenseAmount; } set { _maintenanceExpenseAmount = value; } }
-        private Value<decimal?> _marketValueAmount;
+        private DirtyValue<decimal?> _marketValueAmount;
         public decimal? MarketValueAmount { get { return _marketValueAmount; } set { _marketValueAmount = value; } }
-        private Value<bool?> _noLinkToDocTrackIndicator;
+        private DirtyValue<bool?> _noLinkToDocTrackIndicator;
         public bool? NoLinkToDocTrackIndicator { get { return _noLinkToDocTrackIndicator; } set { _noLinkToDocTrackIndicator = value; } }
-        private Value<decimal?> _participationPercentage;
+        private DirtyValue<decimal?> _participationPercentage;
         public decimal? ParticipationPercentage { get { return _participationPercentage; } set { _participationPercentage = value; } }
-        private Value<decimal?> _percentageofRental;
+        private DirtyValue<decimal?> _percentageofRental;
         public decimal? PercentageofRental { get { return _percentageofRental; } set { _percentageofRental = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<bool?> _printAttachIndicator;
+        private DirtyValue<bool?> _printAttachIndicator;
         public bool? PrintAttachIndicator { get { return _printAttachIndicator; } set { _printAttachIndicator = value; } }
-        private Value<bool?> _printUserNameIndicator;
+        private DirtyValue<bool?> _printUserNameIndicator;
         public bool? PrintUserNameIndicator { get { return _printUserNameIndicator; } set { _printUserNameIndicator = value; } }
-        private Value<string> _propertyUsageType;
+        private DirtyValue<string> _propertyUsageType;
         public string PropertyUsageType { get { return _propertyUsageType; } set { _propertyUsageType = value; } }
-        private Value<int?> _purchasePrice;
+        private DirtyValue<int?> _purchasePrice;
         public int? PurchasePrice { get { return _purchasePrice; } set { _purchasePrice = value; } }
-        private Value<decimal?> _rentalIncomeGrossAmount;
+        private DirtyValue<decimal?> _rentalIncomeGrossAmount;
         public decimal? RentalIncomeGrossAmount { get { return _rentalIncomeGrossAmount; } set { _rentalIncomeGrossAmount = value; } }
-        private Value<decimal?> _rentalIncomeNetAmount;
+        private DirtyValue<decimal?> _rentalIncomeNetAmount;
         public decimal? RentalIncomeNetAmount { get { return _rentalIncomeNetAmount; } set { _rentalIncomeNetAmount = value; } }
-        private Value<string> _reoComments;
+        private DirtyValue<string> _reoComments;
         public string ReoComments { get { return _reoComments; } set { _reoComments = value; } }
-        private Value<string> _reoId;
+        private DirtyValue<string> _reoId;
         public string ReoId { get { return _reoId; } set { _reoId = value; } }
-        private Value<int?> _reoPropertyIndex;
+        private DirtyValue<int?> _reoPropertyIndex;
         public int? ReoPropertyIndex { get { return _reoPropertyIndex; } set { _reoPropertyIndex = value; } }
-        private Value<DateTime?> _requestDate;
+        private DirtyValue<DateTime?> _requestDate;
         public DateTime? RequestDate { get { return _requestDate; } set { _requestDate = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _streetAddress;
+        private DirtyValue<string> _streetAddress;
         public string StreetAddress { get { return _streetAddress; } set { _streetAddress = value; } }
-        private Value<bool?> _subjectIndicator;
+        private DirtyValue<bool?> _subjectIndicator;
         public bool? SubjectIndicator { get { return _subjectIndicator; } set { _subjectIndicator = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _titleFax;
+        private DirtyValue<string> _titleFax;
         public string TitleFax { get { return _titleFax; } set { _titleFax = value; } }
-        private Value<string> _titlePhone;
+        private DirtyValue<string> _titlePhone;
         public string TitlePhone { get { return _titlePhone; } set { _titlePhone = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Residence.cs
+++ b/src/EncompassRest/Loans/Residence.cs
@@ -8,71 +8,71 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Residence : IDirty
     {
-        private Value<string> _accountName;
+        private DirtyValue<string> _accountName;
         public string AccountName { get { return _accountName; } set { _accountName = value; } }
-        private Value<string> _addressCity;
+        private DirtyValue<string> _addressCity;
         public string AddressCity { get { return _addressCity; } set { _addressCity = value; } }
-        private Value<string> _addressPostalCode;
+        private DirtyValue<string> _addressPostalCode;
         public string AddressPostalCode { get { return _addressPostalCode; } set { _addressPostalCode = value; } }
-        private Value<string> _addressState;
+        private DirtyValue<string> _addressState;
         public string AddressState { get { return _addressState; } set { _addressState = value; } }
-        private Value<string> _addressStreetLine1;
+        private DirtyValue<string> _addressStreetLine1;
         public string AddressStreetLine1 { get { return _addressStreetLine1; } set { _addressStreetLine1 = value; } }
-        private Value<string> _altId;
+        private DirtyValue<string> _altId;
         public string AltId { get { return _altId; } set { _altId = value; } }
-        private Value<string> _applicantType;
+        private DirtyValue<string> _applicantType;
         public string ApplicantType { get { return _applicantType; } set { _applicantType = value; } }
-        private Value<string> _county;
+        private DirtyValue<string> _county;
         public string County { get { return _county; } set { _county = value; } }
-        private Value<int?> _durationTermMonths;
+        private DirtyValue<int?> _durationTermMonths;
         public int? DurationTermMonths { get { return _durationTermMonths; } set { _durationTermMonths = value; } }
-        private Value<int?> _durationTermYears;
+        private DirtyValue<int?> _durationTermYears;
         public int? DurationTermYears { get { return _durationTermYears; } set { _durationTermYears = value; } }
-        private Value<bool?> _entityDeleted;
+        private DirtyValue<bool?> _entityDeleted;
         public bool? EntityDeleted { get { return _entityDeleted; } set { _entityDeleted = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _landlordAttention;
+        private DirtyValue<string> _landlordAttention;
         public string LandlordAttention { get { return _landlordAttention; } set { _landlordAttention = value; } }
-        private Value<string> _landlordCity;
+        private DirtyValue<string> _landlordCity;
         public string LandlordCity { get { return _landlordCity; } set { _landlordCity = value; } }
-        private Value<string> _landlordComments;
+        private DirtyValue<string> _landlordComments;
         public string LandlordComments { get { return _landlordComments; } set { _landlordComments = value; } }
-        private Value<string> _landlordEmail;
+        private DirtyValue<string> _landlordEmail;
         public string LandlordEmail { get { return _landlordEmail; } set { _landlordEmail = value; } }
-        private Value<string> _landlordFax;
+        private DirtyValue<string> _landlordFax;
         public string LandlordFax { get { return _landlordFax; } set { _landlordFax = value; } }
-        private Value<string> _landlordName;
+        private DirtyValue<string> _landlordName;
         public string LandlordName { get { return _landlordName; } set { _landlordName = value; } }
-        private Value<string> _landlordPhone;
+        private DirtyValue<string> _landlordPhone;
         public string LandlordPhone { get { return _landlordPhone; } set { _landlordPhone = value; } }
-        private Value<string> _landlordPostalCode;
+        private DirtyValue<string> _landlordPostalCode;
         public string LandlordPostalCode { get { return _landlordPostalCode; } set { _landlordPostalCode = value; } }
-        private Value<string> _landlordState;
+        private DirtyValue<string> _landlordState;
         public string LandlordState { get { return _landlordState; } set { _landlordState = value; } }
-        private Value<string> _landlordStreet;
+        private DirtyValue<string> _landlordStreet;
         public string LandlordStreet { get { return _landlordStreet; } set { _landlordStreet = value; } }
-        private Value<bool?> _mailingAddressIndicator;
+        private DirtyValue<bool?> _mailingAddressIndicator;
         public bool? MailingAddressIndicator { get { return _mailingAddressIndicator; } set { _mailingAddressIndicator = value; } }
-        private Value<bool?> _noLinkToDocTrackIndicator;
+        private DirtyValue<bool?> _noLinkToDocTrackIndicator;
         public bool? NoLinkToDocTrackIndicator { get { return _noLinkToDocTrackIndicator; } set { _noLinkToDocTrackIndicator = value; } }
-        private Value<bool?> _printAttachmentIndicator;
+        private DirtyValue<bool?> _printAttachmentIndicator;
         public bool? PrintAttachmentIndicator { get { return _printAttachmentIndicator; } set { _printAttachmentIndicator = value; } }
-        private Value<bool?> _printUserNameIndicator;
+        private DirtyValue<bool?> _printUserNameIndicator;
         public bool? PrintUserNameIndicator { get { return _printUserNameIndicator; } set { _printUserNameIndicator = value; } }
-        private Value<int?> _rent;
+        private DirtyValue<int?> _rent;
         public int? Rent { get { return _rent; } set { _rent = value; } }
-        private Value<DateTime?> _requestDate;
+        private DirtyValue<DateTime?> _requestDate;
         public DateTime? RequestDate { get { return _requestDate; } set { _requestDate = value; } }
-        private Value<string> _residencyBasisType;
+        private DirtyValue<string> _residencyBasisType;
         public string ResidencyBasisType { get { return _residencyBasisType; } set { _residencyBasisType = value; } }
-        private Value<string> _residencyType;
+        private DirtyValue<string> _residencyType;
         public string ResidencyType { get { return _residencyType; } set { _residencyType = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _titleFax;
+        private DirtyValue<string> _titleFax;
         public string TitleFax { get { return _titleFax; } set { _titleFax = value; } }
-        private Value<string> _titlePhone;
+        private DirtyValue<string> _titlePhone;
         public string TitlePhone { get { return _titlePhone; } set { _titlePhone = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/RespaHudDetail.cs
+++ b/src/EncompassRest/Loans/RespaHudDetail.cs
@@ -8,23 +8,23 @@ namespace EncompassRest.Loans
 {
     public sealed partial class RespaHudDetail : IDirty
     {
-        private Value<string> _creditDebt;
+        private DirtyValue<string> _creditDebt;
         public string CreditDebt { get { return _creditDebt; } set { _creditDebt = value; } }
-        private Value<string> _fWBC;
+        private DirtyValue<string> _fWBC;
         public string FWBC { get { return _fWBC; } set { _fWBC = value; } }
-        private Value<DateTime?> _hUD1LineItemFromDate;
+        private DirtyValue<DateTime?> _hUD1LineItemFromDate;
         public DateTime? HUD1LineItemFromDate { get { return _hUD1LineItemFromDate; } set { _hUD1LineItemFromDate = value; } }
-        private Value<DateTime?> _hUD1LineItemToDate;
+        private DirtyValue<DateTime?> _hUD1LineItemToDate;
         public DateTime? HUD1LineItemToDate { get { return _hUD1LineItemToDate; } set { _hUD1LineItemToDate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _lineItemAmount;
+        private DirtyValue<decimal?> _lineItemAmount;
         public decimal? LineItemAmount { get { return _lineItemAmount; } set { _lineItemAmount = value; } }
-        private Value<string> _lineItemDescription;
+        private DirtyValue<string> _lineItemDescription;
         public string LineItemDescription { get { return _lineItemDescription; } set { _lineItemDescription = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
-        private Value<decimal?> _realValue;
+        private DirtyValue<decimal?> _realValue;
         public decimal? RealValue { get { return _realValue; } set { _realValue = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/SchedulePaymentTransaction.cs
+++ b/src/EncompassRest/Loans/SchedulePaymentTransaction.cs
@@ -8,107 +8,107 @@ namespace EncompassRest.Loans
 {
     public sealed partial class SchedulePaymentTransaction : IDirty
     {
-        private Value<decimal?> _additionalEscrow;
+        private DirtyValue<decimal?> _additionalEscrow;
         public decimal? AdditionalEscrow { get { return _additionalEscrow; } set { _additionalEscrow = value; } }
-        private Value<decimal?> _additionalPrincipal;
+        private DirtyValue<decimal?> _additionalPrincipal;
         public decimal? AdditionalPrincipal { get { return _additionalPrincipal; } set { _additionalPrincipal = value; } }
-        private Value<decimal?> _buydownSubsidyAmount;
+        private DirtyValue<decimal?> _buydownSubsidyAmount;
         public decimal? BuydownSubsidyAmount { get { return _buydownSubsidyAmount; } set { _buydownSubsidyAmount = value; } }
-        private Value<decimal?> _buydownSubsidyAmountDue;
+        private DirtyValue<decimal?> _buydownSubsidyAmountDue;
         public decimal? BuydownSubsidyAmountDue { get { return _buydownSubsidyAmountDue; } set { _buydownSubsidyAmountDue = value; } }
-        private Value<decimal?> _cityPropertyTax;
+        private DirtyValue<decimal?> _cityPropertyTax;
         public decimal? CityPropertyTax { get { return _cityPropertyTax; } set { _cityPropertyTax = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _createdById;
+        private DirtyValue<string> _createdById;
         public string CreatedById { get { return _createdById; } set { _createdById = value; } }
-        private Value<string> _createdByName;
+        private DirtyValue<string> _createdByName;
         public string CreatedByName { get { return _createdByName; } set { _createdByName = value; } }
-        private Value<DateTime?> _createdDateTimeUtc;
+        private DirtyValue<DateTime?> _createdDateTimeUtc;
         public DateTime? CreatedDateTimeUtc { get { return _createdDateTimeUtc; } set { _createdDateTimeUtc = value; } }
-        private Value<decimal?> _escrow;
+        private DirtyValue<decimal?> _escrow;
         public decimal? Escrow { get { return _escrow; } set { _escrow = value; } }
-        private Value<decimal?> _escrowCityPropertyTaxDue;
+        private DirtyValue<decimal?> _escrowCityPropertyTaxDue;
         public decimal? EscrowCityPropertyTaxDue { get { return _escrowCityPropertyTaxDue; } set { _escrowCityPropertyTaxDue = value; } }
-        private Value<decimal?> _escrowDue;
+        private DirtyValue<decimal?> _escrowDue;
         public decimal? EscrowDue { get { return _escrowDue; } set { _escrowDue = value; } }
-        private Value<decimal?> _escrowFloodInsuranceDue;
+        private DirtyValue<decimal?> _escrowFloodInsuranceDue;
         public decimal? EscrowFloodInsuranceDue { get { return _escrowFloodInsuranceDue; } set { _escrowFloodInsuranceDue = value; } }
-        private Value<decimal?> _escrowHazardInsuranceDue;
+        private DirtyValue<decimal?> _escrowHazardInsuranceDue;
         public decimal? EscrowHazardInsuranceDue { get { return _escrowHazardInsuranceDue; } set { _escrowHazardInsuranceDue = value; } }
-        private Value<decimal?> _escrowMortgageInsuranceDue;
+        private DirtyValue<decimal?> _escrowMortgageInsuranceDue;
         public decimal? EscrowMortgageInsuranceDue { get { return _escrowMortgageInsuranceDue; } set { _escrowMortgageInsuranceDue = value; } }
-        private Value<decimal?> _escrowOther1Due;
+        private DirtyValue<decimal?> _escrowOther1Due;
         public decimal? EscrowOther1Due { get { return _escrowOther1Due; } set { _escrowOther1Due = value; } }
-        private Value<decimal?> _escrowOther2Due;
+        private DirtyValue<decimal?> _escrowOther2Due;
         public decimal? EscrowOther2Due { get { return _escrowOther2Due; } set { _escrowOther2Due = value; } }
-        private Value<decimal?> _escrowOther3Due;
+        private DirtyValue<decimal?> _escrowOther3Due;
         public decimal? EscrowOther3Due { get { return _escrowOther3Due; } set { _escrowOther3Due = value; } }
-        private Value<decimal?> _escrowTaxDue;
+        private DirtyValue<decimal?> _escrowTaxDue;
         public decimal? EscrowTaxDue { get { return _escrowTaxDue; } set { _escrowTaxDue = value; } }
-        private Value<decimal?> _escrowUSDAMonthlyPremiumDue;
+        private DirtyValue<decimal?> _escrowUSDAMonthlyPremiumDue;
         public decimal? EscrowUSDAMonthlyPremiumDue { get { return _escrowUSDAMonthlyPremiumDue; } set { _escrowUSDAMonthlyPremiumDue = value; } }
-        private Value<decimal?> _floodInsurance;
+        private DirtyValue<decimal?> _floodInsurance;
         public decimal? FloodInsurance { get { return _floodInsurance; } set { _floodInsurance = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<decimal?> _hazardInsurance;
+        private DirtyValue<decimal?> _hazardInsurance;
         public decimal? HazardInsurance { get { return _hazardInsurance; } set { _hazardInsurance = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _indexRate;
+        private DirtyValue<decimal?> _indexRate;
         public decimal? IndexRate { get { return _indexRate; } set { _indexRate = value; } }
-        private Value<decimal?> _interest;
+        private DirtyValue<decimal?> _interest;
         public decimal? Interest { get { return _interest; } set { _interest = value; } }
-        private Value<decimal?> _interestDue;
+        private DirtyValue<decimal?> _interestDue;
         public decimal? InterestDue { get { return _interestDue; } set { _interestDue = value; } }
-        private Value<decimal?> _interestRate;
+        private DirtyValue<decimal?> _interestRate;
         public decimal? InterestRate { get { return _interestRate; } set { _interestRate = value; } }
-        private Value<decimal?> _lateFee;
+        private DirtyValue<decimal?> _lateFee;
         public decimal? LateFee { get { return _lateFee; } set { _lateFee = value; } }
-        private Value<DateTime?> _latePaymentDate;
+        private DirtyValue<DateTime?> _latePaymentDate;
         public DateTime? LatePaymentDate { get { return _latePaymentDate; } set { _latePaymentDate = value; } }
-        private Value<decimal?> _miscFee;
+        private DirtyValue<decimal?> _miscFee;
         public decimal? MiscFee { get { return _miscFee; } set { _miscFee = value; } }
-        private Value<decimal?> _miscFeeDue;
+        private DirtyValue<decimal?> _miscFeeDue;
         public decimal? MiscFeeDue { get { return _miscFeeDue; } set { _miscFeeDue = value; } }
-        private Value<string> _modifiedById;
+        private DirtyValue<string> _modifiedById;
         public string ModifiedById { get { return _modifiedById; } set { _modifiedById = value; } }
-        private Value<string> _modifiedByName;
+        private DirtyValue<string> _modifiedByName;
         public string ModifiedByName { get { return _modifiedByName; } set { _modifiedByName = value; } }
-        private Value<DateTime?> _modifiedDateTimeUtc;
+        private DirtyValue<DateTime?> _modifiedDateTimeUtc;
         public DateTime? ModifiedDateTimeUtc { get { return _modifiedDateTimeUtc; } set { _modifiedDateTimeUtc = value; } }
-        private Value<decimal?> _mortgageInsurance;
+        private DirtyValue<decimal?> _mortgageInsurance;
         public decimal? MortgageInsurance { get { return _mortgageInsurance; } set { _mortgageInsurance = value; } }
-        private Value<decimal?> _other1Escrow;
+        private DirtyValue<decimal?> _other1Escrow;
         public decimal? Other1Escrow { get { return _other1Escrow; } set { _other1Escrow = value; } }
-        private Value<decimal?> _other2Escrow;
+        private DirtyValue<decimal?> _other2Escrow;
         public decimal? Other2Escrow { get { return _other2Escrow; } set { _other2Escrow = value; } }
-        private Value<decimal?> _other3Escrow;
+        private DirtyValue<decimal?> _other3Escrow;
         public decimal? Other3Escrow { get { return _other3Escrow; } set { _other3Escrow = value; } }
-        private Value<int?> _paymentNumber;
+        private DirtyValue<int?> _paymentNumber;
         public int? PaymentNumber { get { return _paymentNumber; } set { _paymentNumber = value; } }
-        private Value<DateTime?> _paymentReceiveDate;
+        private DirtyValue<DateTime?> _paymentReceiveDate;
         public DateTime? PaymentReceiveDate { get { return _paymentReceiveDate; } set { _paymentReceiveDate = value; } }
-        private Value<decimal?> _principal;
+        private DirtyValue<decimal?> _principal;
         public decimal? Principal { get { return _principal; } set { _principal = value; } }
-        private Value<decimal?> _principalDue;
+        private DirtyValue<decimal?> _principalDue;
         public decimal? PrincipalDue { get { return _principalDue; } set { _principalDue = value; } }
-        private Value<string> _servicingPaymentMethod;
+        private DirtyValue<string> _servicingPaymentMethod;
         public string ServicingPaymentMethod { get { return _servicingPaymentMethod; } set { _servicingPaymentMethod = value; } }
-        private Value<string> _servicingTransactionType;
+        private DirtyValue<string> _servicingTransactionType;
         public string ServicingTransactionType { get { return _servicingTransactionType; } set { _servicingTransactionType = value; } }
-        private Value<decimal?> _taxes;
+        private DirtyValue<decimal?> _taxes;
         public decimal? Taxes { get { return _taxes; } set { _taxes = value; } }
-        private Value<decimal?> _totalPastDue;
+        private DirtyValue<decimal?> _totalPastDue;
         public decimal? TotalPastDue { get { return _totalPastDue; } set { _totalPastDue = value; } }
-        private Value<decimal?> _transactionAmount;
+        private DirtyValue<decimal?> _transactionAmount;
         public decimal? TransactionAmount { get { return _transactionAmount; } set { _transactionAmount = value; } }
-        private Value<DateTime?> _transactionDate;
+        private DirtyValue<DateTime?> _transactionDate;
         public DateTime? TransactionDate { get { return _transactionDate; } set { _transactionDate = value; } }
-        private Value<decimal?> _unpaidLateFeeDue;
+        private DirtyValue<decimal?> _unpaidLateFeeDue;
         public decimal? UnpaidLateFeeDue { get { return _unpaidLateFeeDue; } set { _unpaidLateFeeDue = value; } }
-        private Value<decimal?> _uSDAMonthlyPremium;
+        private DirtyValue<decimal?> _uSDAMonthlyPremium;
         public decimal? USDAMonthlyPremium { get { return _uSDAMonthlyPremium; } set { _uSDAMonthlyPremium = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/SecondaryFinancingProvider.cs
+++ b/src/EncompassRest/Loans/SecondaryFinancingProvider.cs
@@ -8,25 +8,25 @@ namespace EncompassRest.Loans
 {
     public sealed partial class SecondaryFinancingProvider : IDirty
     {
-        private Value<decimal?> _financingAmount;
+        private DirtyValue<decimal?> _financingAmount;
         public decimal? FinancingAmount { get { return _financingAmount; } set { _financingAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _secondaryFinancingProviderType;
+        private DirtyValue<string> _secondaryFinancingProviderType;
         public string SecondaryFinancingProviderType { get { return _secondaryFinancingProviderType; } set { _secondaryFinancingProviderType = value; } }
-        private Value<bool?> _sellerFundedDapIndicator;
+        private DirtyValue<bool?> _sellerFundedDapIndicator;
         public bool? SellerFundedDapIndicator { get { return _sellerFundedDapIndicator; } set { _sellerFundedDapIndicator = value; } }
-        private Value<string> _source;
+        private DirtyValue<string> _source;
         public string Source { get { return _source; } set { _source = value; } }
-        private Value<bool?> _sourceFromFamilyIndicator;
+        private DirtyValue<bool?> _sourceFromFamilyIndicator;
         public bool? SourceFromFamilyIndicator { get { return _sourceFromFamilyIndicator; } set { _sourceFromFamilyIndicator = value; } }
-        private Value<bool?> _sourceFromGovernmentIndicator;
+        private DirtyValue<bool?> _sourceFromGovernmentIndicator;
         public bool? SourceFromGovernmentIndicator { get { return _sourceFromGovernmentIndicator; } set { _sourceFromGovernmentIndicator = value; } }
-        private Value<bool?> _sourceFromNPIndicator;
+        private DirtyValue<bool?> _sourceFromNPIndicator;
         public bool? SourceFromNPIndicator { get { return _sourceFromNPIndicator; } set { _sourceFromNPIndicator = value; } }
-        private Value<bool?> _sourceFromOtherIndicator;
+        private DirtyValue<bool?> _sourceFromOtherIndicator;
         public bool? SourceFromOtherIndicator { get { return _sourceFromOtherIndicator; } set { _sourceFromOtherIndicator = value; } }
-        private Value<string> _sourceOtherDetail;
+        private DirtyValue<string> _sourceOtherDetail;
         public string SourceOtherDetail { get { return _sourceOtherDetail; } set { _sourceOtherDetail = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Section32.cs
+++ b/src/EncompassRest/Loans/Section32.cs
@@ -8,277 +8,277 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Section32 : IDirty
     {
-        private Value<bool?> _appraisalFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _appraisalFeeToBeFinancedIndicator;
         public bool? AppraisalFeeToBeFinancedIndicator { get { return _appraisalFeeToBeFinancedIndicator; } set { _appraisalFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _appraisalPortionOfFeeIndicator;
+        private DirtyValue<bool?> _appraisalPortionOfFeeIndicator;
         public bool? AppraisalPortionOfFeeIndicator { get { return _appraisalPortionOfFeeIndicator; } set { _appraisalPortionOfFeeIndicator = value; } }
-        private Value<decimal?> _aprExceedsTsyForFirstMortgage;
+        private DirtyValue<decimal?> _aprExceedsTsyForFirstMortgage;
         public decimal? AprExceedsTsyForFirstMortgage { get { return _aprExceedsTsyForFirstMortgage; } set { _aprExceedsTsyForFirstMortgage = value; } }
-        private Value<decimal?> _aprExceedsTsyForSubordinateMortgage;
+        private DirtyValue<decimal?> _aprExceedsTsyForSubordinateMortgage;
         public decimal? AprExceedsTsyForSubordinateMortgage { get { return _aprExceedsTsyForSubordinateMortgage; } set { _aprExceedsTsyForSubordinateMortgage = value; } }
-        private Value<bool?> _assumptionFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _assumptionFeeToBeFinancedIndicator;
         public bool? AssumptionFeeToBeFinancedIndicator { get { return _assumptionFeeToBeFinancedIndicator; } set { _assumptionFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _assumptionPortionOfFeeIndicator;
+        private DirtyValue<bool?> _assumptionPortionOfFeeIndicator;
         public bool? AssumptionPortionOfFeeIndicator { get { return _assumptionPortionOfFeeIndicator; } set { _assumptionPortionOfFeeIndicator = value; } }
-        private Value<bool?> _attorneyFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _attorneyFeeToBeFinancedIndicator;
         public bool? AttorneyFeeToBeFinancedIndicator { get { return _attorneyFeeToBeFinancedIndicator; } set { _attorneyFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _attorneyPortionOfFeeIndicator;
+        private DirtyValue<bool?> _attorneyPortionOfFeeIndicator;
         public bool? AttorneyPortionOfFeeIndicator { get { return _attorneyPortionOfFeeIndicator; } set { _attorneyPortionOfFeeIndicator = value; } }
-        private Value<bool?> _cityCountyTaxStampsFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _cityCountyTaxStampsFeeToBeFinancedIndicator;
         public bool? CityCountyTaxStampsFeeToBeFinancedIndicator { get { return _cityCountyTaxStampsFeeToBeFinancedIndicator; } set { _cityCountyTaxStampsFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _cityCountyTaxStampsPortionOfFeeIndicator;
+        private DirtyValue<bool?> _cityCountyTaxStampsPortionOfFeeIndicator;
         public bool? CityCountyTaxStampsPortionOfFeeIndicator { get { return _cityCountyTaxStampsPortionOfFeeIndicator; } set { _cityCountyTaxStampsPortionOfFeeIndicator = value; } }
-        private Value<bool?> _closingFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _closingFeeToBeFinancedIndicator;
         public bool? ClosingFeeToBeFinancedIndicator { get { return _closingFeeToBeFinancedIndicator; } set { _closingFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _closingPortionOfFeeIndicator;
+        private DirtyValue<bool?> _closingPortionOfFeeIndicator;
         public bool? ClosingPortionOfFeeIndicator { get { return _closingPortionOfFeeIndicator; } set { _closingPortionOfFeeIndicator = value; } }
-        private Value<bool?> _creditReportFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _creditReportFeeToBeFinancedIndicator;
         public bool? CreditReportFeeToBeFinancedIndicator { get { return _creditReportFeeToBeFinancedIndicator; } set { _creditReportFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _creditReportPortionOfFeeIndicator;
+        private DirtyValue<bool?> _creditReportPortionOfFeeIndicator;
         public bool? CreditReportPortionOfFeeIndicator { get { return _creditReportPortionOfFeeIndicator; } set { _creditReportPortionOfFeeIndicator = value; } }
-        private Value<bool?> _docPrepFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _docPrepFeeToBeFinancedIndicator;
         public bool? DocPrepFeeToBeFinancedIndicator { get { return _docPrepFeeToBeFinancedIndicator; } set { _docPrepFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _docPrepPortionOfFeeIndicator;
+        private DirtyValue<bool?> _docPrepPortionOfFeeIndicator;
         public bool? DocPrepPortionOfFeeIndicator { get { return _docPrepPortionOfFeeIndicator; } set { _docPrepPortionOfFeeIndicator = value; } }
-        private Value<string> _exceed2PercentPrepayPenalty;
+        private DirtyValue<string> _exceed2PercentPrepayPenalty;
         public string Exceed2PercentPrepayPenalty { get { return _exceed2PercentPrepayPenalty; } set { _exceed2PercentPrepayPenalty = value; } }
-        private Value<decimal?> _hoepaAPR;
+        private DirtyValue<decimal?> _hoepaAPR;
         public decimal? HoepaAPR { get { return _hoepaAPR; } set { _hoepaAPR = value; } }
-        private Value<decimal?> _hoepaFee;
+        private DirtyValue<decimal?> _hoepaFee;
         public decimal? HoepaFee { get { return _hoepaFee; } set { _hoepaFee = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _jurisdications;
+        private DirtyValue<string> _jurisdications;
         public string Jurisdications { get { return _jurisdications; } set { _jurisdications = value; } }
-        private Value<bool?> _lendersInspectionFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _lendersInspectionFeeToBeFinancedIndicator;
         public bool? LendersInspectionFeeToBeFinancedIndicator { get { return _lendersInspectionFeeToBeFinancedIndicator; } set { _lendersInspectionFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _lendersInspectionPortionOfFeeIndicator;
+        private DirtyValue<bool?> _lendersInspectionPortionOfFeeIndicator;
         public bool? LendersInspectionPortionOfFeeIndicator { get { return _lendersInspectionPortionOfFeeIndicator; } set { _lendersInspectionPortionOfFeeIndicator = value; } }
-        private Value<bool?> _loanDiscountFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _loanDiscountFeeToBeFinancedIndicator;
         public bool? LoanDiscountFeeToBeFinancedIndicator { get { return _loanDiscountFeeToBeFinancedIndicator; } set { _loanDiscountFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _loanDiscountPortionOfFeeIndicator;
+        private DirtyValue<bool?> _loanDiscountPortionOfFeeIndicator;
         public bool? LoanDiscountPortionOfFeeIndicator { get { return _loanDiscountPortionOfFeeIndicator; } set { _loanDiscountPortionOfFeeIndicator = value; } }
-        private Value<bool?> _loanOriginationFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _loanOriginationFeeToBeFinancedIndicator;
         public bool? LoanOriginationFeeToBeFinancedIndicator { get { return _loanOriginationFeeToBeFinancedIndicator; } set { _loanOriginationFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _loanOriginationPortionOfFeeIndicator;
+        private DirtyValue<bool?> _loanOriginationPortionOfFeeIndicator;
         public bool? LoanOriginationPortionOfFeeIndicator { get { return _loanOriginationPortionOfFeeIndicator; } set { _loanOriginationPortionOfFeeIndicator = value; } }
-        private Value<string> _loanQualifyAsHighCostMortgage;
+        private DirtyValue<string> _loanQualifyAsHighCostMortgage;
         public string LoanQualifyAsHighCostMortgage { get { return _loanQualifyAsHighCostMortgage; } set { _loanQualifyAsHighCostMortgage = value; } }
-        private Value<decimal?> _maximumPercentageOfLoan;
+        private DirtyValue<decimal?> _maximumPercentageOfLoan;
         public decimal? MaximumPercentageOfLoan { get { return _maximumPercentageOfLoan; } set { _maximumPercentageOfLoan = value; } }
-        private Value<decimal?> _maximumPointsAndFees;
+        private DirtyValue<decimal?> _maximumPointsAndFees;
         public decimal? MaximumPointsAndFees { get { return _maximumPointsAndFees; } set { _maximumPointsAndFees = value; } }
-        private Value<bool?> _mortgageBrokerFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _mortgageBrokerFeeToBeFinancedIndicator;
         public bool? MortgageBrokerFeeToBeFinancedIndicator { get { return _mortgageBrokerFeeToBeFinancedIndicator; } set { _mortgageBrokerFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _mortgageBrokerPortionOfFeeIndicator;
+        private DirtyValue<bool?> _mortgageBrokerPortionOfFeeIndicator;
         public bool? MortgageBrokerPortionOfFeeIndicator { get { return _mortgageBrokerPortionOfFeeIndicator; } set { _mortgageBrokerPortionOfFeeIndicator = value; } }
-        private Value<bool?> _mortgageInspectionFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _mortgageInspectionFeeToBeFinancedIndicator;
         public bool? MortgageInspectionFeeToBeFinancedIndicator { get { return _mortgageInspectionFeeToBeFinancedIndicator; } set { _mortgageInspectionFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _mortgageInspectionPortionOfFeeIndicator;
+        private DirtyValue<bool?> _mortgageInspectionPortionOfFeeIndicator;
         public bool? MortgageInspectionPortionOfFeeIndicator { get { return _mortgageInspectionPortionOfFeeIndicator; } set { _mortgageInspectionPortionOfFeeIndicator = value; } }
-        private Value<bool?> _mortgageInsuranceFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _mortgageInsuranceFeeToBeFinancedIndicator;
         public bool? MortgageInsuranceFeeToBeFinancedIndicator { get { return _mortgageInsuranceFeeToBeFinancedIndicator; } set { _mortgageInsuranceFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _mortgageInsurancePortionOfFeeIndicator;
+        private DirtyValue<bool?> _mortgageInsurancePortionOfFeeIndicator;
         public bool? MortgageInsurancePortionOfFeeIndicator { get { return _mortgageInsurancePortionOfFeeIndicator; } set { _mortgageInsurancePortionOfFeeIndicator = value; } }
-        private Value<bool?> _mortgageInsurancePremiumFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _mortgageInsurancePremiumFeeToBeFinancedIndicator;
         public bool? MortgageInsurancePremiumFeeToBeFinancedIndicator { get { return _mortgageInsurancePremiumFeeToBeFinancedIndicator; } set { _mortgageInsurancePremiumFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _mortgageInsurancePremiumPortionOfFeeIndicator;
+        private DirtyValue<bool?> _mortgageInsurancePremiumPortionOfFeeIndicator;
         public bool? MortgageInsurancePremiumPortionOfFeeIndicator { get { return _mortgageInsurancePremiumPortionOfFeeIndicator; } set { _mortgageInsurancePremiumPortionOfFeeIndicator = value; } }
-        private Value<bool?> _notaryFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _notaryFeeToBeFinancedIndicator;
         public bool? NotaryFeeToBeFinancedIndicator { get { return _notaryFeeToBeFinancedIndicator; } set { _notaryFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _notaryPortionOfFeeIndicator;
+        private DirtyValue<bool?> _notaryPortionOfFeeIndicator;
         public bool? NotaryPortionOfFeeIndicator { get { return _notaryPortionOfFeeIndicator; } set { _notaryPortionOfFeeIndicator = value; } }
-        private Value<bool?> _otherHighCostIndicator;
+        private DirtyValue<bool?> _otherHighCostIndicator;
         public bool? OtherHighCostIndicator { get { return _otherHighCostIndicator; } set { _otherHighCostIndicator = value; } }
-        private Value<string> _penaltyChargeMoreThan36Months;
+        private DirtyValue<string> _penaltyChargeMoreThan36Months;
         public string PenaltyChargeMoreThan36Months { get { return _penaltyChargeMoreThan36Months; } set { _penaltyChargeMoreThan36Months = value; } }
-        private Value<bool?> _pestInspectionFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _pestInspectionFeeToBeFinancedIndicator;
         public bool? PestInspectionFeeToBeFinancedIndicator { get { return _pestInspectionFeeToBeFinancedIndicator; } set { _pestInspectionFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _pestInspectionPortionOfFeeIndicator;
+        private DirtyValue<bool?> _pestInspectionPortionOfFeeIndicator;
         public bool? PestInspectionPortionOfFeeIndicator { get { return _pestInspectionPortionOfFeeIndicator; } set { _pestInspectionPortionOfFeeIndicator = value; } }
-        private Value<decimal?> _prepayPenaltyPercentofAmtPrepaid;
+        private DirtyValue<decimal?> _prepayPenaltyPercentofAmtPrepaid;
         public decimal? PrepayPenaltyPercentofAmtPrepaid { get { return _prepayPenaltyPercentofAmtPrepaid; } set { _prepayPenaltyPercentofAmtPrepaid = value; } }
-        private Value<bool?> _processingFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _processingFeeToBeFinancedIndicator;
         public bool? ProcessingFeeToBeFinancedIndicator { get { return _processingFeeToBeFinancedIndicator; } set { _processingFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _processingPortionOfFeeIndicator;
+        private DirtyValue<bool?> _processingPortionOfFeeIndicator;
         public bool? ProcessingPortionOfFeeIndicator { get { return _processingPortionOfFeeIndicator; } set { _processingPortionOfFeeIndicator = value; } }
-        private Value<decimal?> _rateSetIndex;
+        private DirtyValue<decimal?> _rateSetIndex;
         public decimal? RateSetIndex { get { return _rateSetIndex; } set { _rateSetIndex = value; } }
-        private Value<bool?> _recordingFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _recordingFeeToBeFinancedIndicator;
         public bool? RecordingFeeToBeFinancedIndicator { get { return _recordingFeeToBeFinancedIndicator; } set { _recordingFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _recordingPortionOfFeeIndicator;
+        private DirtyValue<bool?> _recordingPortionOfFeeIndicator;
         public bool? RecordingPortionOfFeeIndicator { get { return _recordingPortionOfFeeIndicator; } set { _recordingPortionOfFeeIndicator = value; } }
-        private Value<string> _resultOfPointAndFees;
+        private DirtyValue<string> _resultOfPointAndFees;
         public string ResultOfPointAndFees { get { return _resultOfPointAndFees; } set { _resultOfPointAndFees = value; } }
-        private Value<string> _resultOfSecurityYieldTest;
+        private DirtyValue<string> _resultOfSecurityYieldTest;
         public string ResultOfSecurityYieldTest { get { return _resultOfSecurityYieldTest; } set { _resultOfSecurityYieldTest = value; } }
-        private Value<bool?> _section32Indicator;
+        private DirtyValue<bool?> _section32Indicator;
         public bool? Section32Indicator { get { return _section32Indicator; } set { _section32Indicator = value; } }
-        private Value<decimal?> _section35AveragePrimeRate;
+        private DirtyValue<decimal?> _section35AveragePrimeRate;
         public decimal? Section35AveragePrimeRate { get { return _section35AveragePrimeRate; } set { _section35AveragePrimeRate = value; } }
-        private Value<string> _section35IsSecondAppraisalRequired;
+        private DirtyValue<string> _section35IsSecondAppraisalRequired;
         public string Section35IsSecondAppraisalRequired { get { return _section35IsSecondAppraisalRequired; } set { _section35IsSecondAppraisalRequired = value; } }
-        private Value<DateTime?> _section35PriorAcquisitionDate;
+        private DirtyValue<DateTime?> _section35PriorAcquisitionDate;
         public DateTime? Section35PriorAcquisitionDate { get { return _section35PriorAcquisitionDate; } set { _section35PriorAcquisitionDate = value; } }
-        private Value<decimal?> _section35PriorAcquisitionPrice;
+        private DirtyValue<decimal?> _section35PriorAcquisitionPrice;
         public decimal? Section35PriorAcquisitionPrice { get { return _section35PriorAcquisitionPrice; } set { _section35PriorAcquisitionPrice = value; } }
-        private Value<string> _section35PriorAcquisitionSource;
+        private DirtyValue<string> _section35PriorAcquisitionSource;
         public string Section35PriorAcquisitionSource { get { return _section35PriorAcquisitionSource; } set { _section35PriorAcquisitionSource = value; } }
-        private Value<string> _section35ResultOfSecurityYieldTest;
+        private DirtyValue<string> _section35ResultOfSecurityYieldTest;
         public string Section35ResultOfSecurityYieldTest { get { return _section35ResultOfSecurityYieldTest; } set { _section35ResultOfSecurityYieldTest = value; } }
-        private Value<DateTime?> _section35SalesContractDate;
+        private DirtyValue<DateTime?> _section35SalesContractDate;
         public DateTime? Section35SalesContractDate { get { return _section35SalesContractDate; } set { _section35SalesContractDate = value; } }
-        private Value<bool?> _stateTaxStampsFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _stateTaxStampsFeeToBeFinancedIndicator;
         public bool? StateTaxStampsFeeToBeFinancedIndicator { get { return _stateTaxStampsFeeToBeFinancedIndicator; } set { _stateTaxStampsFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _stateTaxStampsPortionOfFeeIndicator;
+        private DirtyValue<bool?> _stateTaxStampsPortionOfFeeIndicator;
         public bool? StateTaxStampsPortionOfFeeIndicator { get { return _stateTaxStampsPortionOfFeeIndicator; } set { _stateTaxStampsPortionOfFeeIndicator = value; } }
-        private Value<bool?> _surveyFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _surveyFeeToBeFinancedIndicator;
         public bool? SurveyFeeToBeFinancedIndicator { get { return _surveyFeeToBeFinancedIndicator; } set { _surveyFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _surveyPortionOfFeeIndicator;
+        private DirtyValue<bool?> _surveyPortionOfFeeIndicator;
         public bool? SurveyPortionOfFeeIndicator { get { return _surveyPortionOfFeeIndicator; } set { _surveyPortionOfFeeIndicator = value; } }
-        private Value<bool?> _taxServiceFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _taxServiceFeeToBeFinancedIndicator;
         public bool? TaxServiceFeeToBeFinancedIndicator { get { return _taxServiceFeeToBeFinancedIndicator; } set { _taxServiceFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _taxServicePortionOfFeeIndicator;
+        private DirtyValue<bool?> _taxServicePortionOfFeeIndicator;
         public bool? TaxServicePortionOfFeeIndicator { get { return _taxServicePortionOfFeeIndicator; } set { _taxServicePortionOfFeeIndicator = value; } }
-        private Value<bool?> _titleBinderFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _titleBinderFeeToBeFinancedIndicator;
         public bool? TitleBinderFeeToBeFinancedIndicator { get { return _titleBinderFeeToBeFinancedIndicator; } set { _titleBinderFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _titleBinderPortionOfFeeIndicator;
+        private DirtyValue<bool?> _titleBinderPortionOfFeeIndicator;
         public bool? TitleBinderPortionOfFeeIndicator { get { return _titleBinderPortionOfFeeIndicator; } set { _titleBinderPortionOfFeeIndicator = value; } }
-        private Value<bool?> _titleExaminationFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _titleExaminationFeeToBeFinancedIndicator;
         public bool? TitleExaminationFeeToBeFinancedIndicator { get { return _titleExaminationFeeToBeFinancedIndicator; } set { _titleExaminationFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _titleExaminationPortionOfFeeIndicator;
+        private DirtyValue<bool?> _titleExaminationPortionOfFeeIndicator;
         public bool? TitleExaminationPortionOfFeeIndicator { get { return _titleExaminationPortionOfFeeIndicator; } set { _titleExaminationPortionOfFeeIndicator = value; } }
-        private Value<bool?> _titleInsuranceFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _titleInsuranceFeeToBeFinancedIndicator;
         public bool? TitleInsuranceFeeToBeFinancedIndicator { get { return _titleInsuranceFeeToBeFinancedIndicator; } set { _titleInsuranceFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _titleInsurancePortionOfFeeIndicator;
+        private DirtyValue<bool?> _titleInsurancePortionOfFeeIndicator;
         public bool? TitleInsurancePortionOfFeeIndicator { get { return _titleInsurancePortionOfFeeIndicator; } set { _titleInsurancePortionOfFeeIndicator = value; } }
-        private Value<bool?> _titleSearchFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _titleSearchFeeToBeFinancedIndicator;
         public bool? TitleSearchFeeToBeFinancedIndicator { get { return _titleSearchFeeToBeFinancedIndicator; } set { _titleSearchFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _titleSearchPortionOfFeeIndicator;
+        private DirtyValue<bool?> _titleSearchPortionOfFeeIndicator;
         public bool? TitleSearchPortionOfFeeIndicator { get { return _titleSearchPortionOfFeeIndicator; } set { _titleSearchPortionOfFeeIndicator = value; } }
-        private Value<decimal?> _totalPointsAndFees;
+        private DirtyValue<decimal?> _totalPointsAndFees;
         public decimal? TotalPointsAndFees { get { return _totalPointsAndFees; } set { _totalPointsAndFees = value; } }
-        private Value<decimal?> _treasurySecurityYield;
+        private DirtyValue<decimal?> _treasurySecurityYield;
         public decimal? TreasurySecurityYield { get { return _treasurySecurityYield; } set { _treasurySecurityYield = value; } }
-        private Value<bool?> _underwritingFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _underwritingFeeToBeFinancedIndicator;
         public bool? UnderwritingFeeToBeFinancedIndicator { get { return _underwritingFeeToBeFinancedIndicator; } set { _underwritingFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _underwritingPortionOfFeeIndicator;
+        private DirtyValue<bool?> _underwritingPortionOfFeeIndicator;
         public bool? UnderwritingPortionOfFeeIndicator { get { return _underwritingPortionOfFeeIndicator; } set { _underwritingPortionOfFeeIndicator = value; } }
-        private Value<decimal?> _userDefined1109BorPaidAmount;
+        private DirtyValue<decimal?> _userDefined1109BorPaidAmount;
         public decimal? UserDefined1109BorPaidAmount { get { return _userDefined1109BorPaidAmount; } set { _userDefined1109BorPaidAmount = value; } }
-        private Value<bool?> _userDefined1109FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1109FeeToBeFinancedIndicator;
         public bool? UserDefined1109FeeToBeFinancedIndicator { get { return _userDefined1109FeeToBeFinancedIndicator; } set { _userDefined1109FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1109PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1109PortionOfFeeIndicator;
         public bool? UserDefined1109PortionOfFeeIndicator { get { return _userDefined1109PortionOfFeeIndicator; } set { _userDefined1109PortionOfFeeIndicator = value; } }
-        private Value<decimal?> _userDefined1110BorPaidAmount;
+        private DirtyValue<decimal?> _userDefined1110BorPaidAmount;
         public decimal? UserDefined1110BorPaidAmount { get { return _userDefined1110BorPaidAmount; } set { _userDefined1110BorPaidAmount = value; } }
-        private Value<bool?> _userDefined1110FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1110FeeToBeFinancedIndicator;
         public bool? UserDefined1110FeeToBeFinancedIndicator { get { return _userDefined1110FeeToBeFinancedIndicator; } set { _userDefined1110FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1110PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1110PortionOfFeeIndicator;
         public bool? UserDefined1110PortionOfFeeIndicator { get { return _userDefined1110PortionOfFeeIndicator; } set { _userDefined1110PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1111FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1111FeeToBeFinancedIndicator;
         public bool? UserDefined1111FeeToBeFinancedIndicator { get { return _userDefined1111FeeToBeFinancedIndicator; } set { _userDefined1111FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1111PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1111PortionOfFeeIndicator;
         public bool? UserDefined1111PortionOfFeeIndicator { get { return _userDefined1111PortionOfFeeIndicator; } set { _userDefined1111PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1112FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1112FeeToBeFinancedIndicator;
         public bool? UserDefined1112FeeToBeFinancedIndicator { get { return _userDefined1112FeeToBeFinancedIndicator; } set { _userDefined1112FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1112PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1112PortionOfFeeIndicator;
         public bool? UserDefined1112PortionOfFeeIndicator { get { return _userDefined1112PortionOfFeeIndicator; } set { _userDefined1112PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1113FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1113FeeToBeFinancedIndicator;
         public bool? UserDefined1113FeeToBeFinancedIndicator { get { return _userDefined1113FeeToBeFinancedIndicator; } set { _userDefined1113FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1113PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1113PortionOfFeeIndicator;
         public bool? UserDefined1113PortionOfFeeIndicator { get { return _userDefined1113PortionOfFeeIndicator; } set { _userDefined1113PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1114FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1114FeeToBeFinancedIndicator;
         public bool? UserDefined1114FeeToBeFinancedIndicator { get { return _userDefined1114FeeToBeFinancedIndicator; } set { _userDefined1114FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1114PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1114PortionOfFeeIndicator;
         public bool? UserDefined1114PortionOfFeeIndicator { get { return _userDefined1114PortionOfFeeIndicator; } set { _userDefined1114PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1204FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1204FeeToBeFinancedIndicator;
         public bool? UserDefined1204FeeToBeFinancedIndicator { get { return _userDefined1204FeeToBeFinancedIndicator; } set { _userDefined1204FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1204PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1204PortionOfFeeIndicator;
         public bool? UserDefined1204PortionOfFeeIndicator { get { return _userDefined1204PortionOfFeeIndicator; } set { _userDefined1204PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1205FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1205FeeToBeFinancedIndicator;
         public bool? UserDefined1205FeeToBeFinancedIndicator { get { return _userDefined1205FeeToBeFinancedIndicator; } set { _userDefined1205FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1205PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1205PortionOfFeeIndicator;
         public bool? UserDefined1205PortionOfFeeIndicator { get { return _userDefined1205PortionOfFeeIndicator; } set { _userDefined1205PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1206FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1206FeeToBeFinancedIndicator;
         public bool? UserDefined1206FeeToBeFinancedIndicator { get { return _userDefined1206FeeToBeFinancedIndicator; } set { _userDefined1206FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1206PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1206PortionOfFeeIndicator;
         public bool? UserDefined1206PortionOfFeeIndicator { get { return _userDefined1206PortionOfFeeIndicator; } set { _userDefined1206PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1303FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1303FeeToBeFinancedIndicator;
         public bool? UserDefined1303FeeToBeFinancedIndicator { get { return _userDefined1303FeeToBeFinancedIndicator; } set { _userDefined1303FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1303PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1303PortionOfFeeIndicator;
         public bool? UserDefined1303PortionOfFeeIndicator { get { return _userDefined1303PortionOfFeeIndicator; } set { _userDefined1303PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1304FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1304FeeToBeFinancedIndicator;
         public bool? UserDefined1304FeeToBeFinancedIndicator { get { return _userDefined1304FeeToBeFinancedIndicator; } set { _userDefined1304FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1304PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1304PortionOfFeeIndicator;
         public bool? UserDefined1304PortionOfFeeIndicator { get { return _userDefined1304PortionOfFeeIndicator; } set { _userDefined1304PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1305FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1305FeeToBeFinancedIndicator;
         public bool? UserDefined1305FeeToBeFinancedIndicator { get { return _userDefined1305FeeToBeFinancedIndicator; } set { _userDefined1305FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1305PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1305PortionOfFeeIndicator;
         public bool? UserDefined1305PortionOfFeeIndicator { get { return _userDefined1305PortionOfFeeIndicator; } set { _userDefined1305PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1306FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1306FeeToBeFinancedIndicator;
         public bool? UserDefined1306FeeToBeFinancedIndicator { get { return _userDefined1306FeeToBeFinancedIndicator; } set { _userDefined1306FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1306PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1306PortionOfFeeIndicator;
         public bool? UserDefined1306PortionOfFeeIndicator { get { return _userDefined1306PortionOfFeeIndicator; } set { _userDefined1306PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1307FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1307FeeToBeFinancedIndicator;
         public bool? UserDefined1307FeeToBeFinancedIndicator { get { return _userDefined1307FeeToBeFinancedIndicator; } set { _userDefined1307FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1307PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1307PortionOfFeeIndicator;
         public bool? UserDefined1307PortionOfFeeIndicator { get { return _userDefined1307PortionOfFeeIndicator; } set { _userDefined1307PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1308FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1308FeeToBeFinancedIndicator;
         public bool? UserDefined1308FeeToBeFinancedIndicator { get { return _userDefined1308FeeToBeFinancedIndicator; } set { _userDefined1308FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1308PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1308PortionOfFeeIndicator;
         public bool? UserDefined1308PortionOfFeeIndicator { get { return _userDefined1308PortionOfFeeIndicator; } set { _userDefined1308PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined1309FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined1309FeeToBeFinancedIndicator;
         public bool? UserDefined1309FeeToBeFinancedIndicator { get { return _userDefined1309FeeToBeFinancedIndicator; } set { _userDefined1309FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined1309PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined1309PortionOfFeeIndicator;
         public bool? UserDefined1309PortionOfFeeIndicator { get { return _userDefined1309PortionOfFeeIndicator; } set { _userDefined1309PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined813FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined813FeeToBeFinancedIndicator;
         public bool? UserDefined813FeeToBeFinancedIndicator { get { return _userDefined813FeeToBeFinancedIndicator; } set { _userDefined813FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined813PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined813PortionOfFeeIndicator;
         public bool? UserDefined813PortionOfFeeIndicator { get { return _userDefined813PortionOfFeeIndicator; } set { _userDefined813PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined814FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined814FeeToBeFinancedIndicator;
         public bool? UserDefined814FeeToBeFinancedIndicator { get { return _userDefined814FeeToBeFinancedIndicator; } set { _userDefined814FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined814PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined814PortionOfFeeIndicator;
         public bool? UserDefined814PortionOfFeeIndicator { get { return _userDefined814PortionOfFeeIndicator; } set { _userDefined814PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined815FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined815FeeToBeFinancedIndicator;
         public bool? UserDefined815FeeToBeFinancedIndicator { get { return _userDefined815FeeToBeFinancedIndicator; } set { _userDefined815FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined815PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined815PortionOfFeeIndicator;
         public bool? UserDefined815PortionOfFeeIndicator { get { return _userDefined815PortionOfFeeIndicator; } set { _userDefined815PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined816FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined816FeeToBeFinancedIndicator;
         public bool? UserDefined816FeeToBeFinancedIndicator { get { return _userDefined816FeeToBeFinancedIndicator; } set { _userDefined816FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined816PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined816PortionOfFeeIndicator;
         public bool? UserDefined816PortionOfFeeIndicator { get { return _userDefined816PortionOfFeeIndicator; } set { _userDefined816PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined817FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined817FeeToBeFinancedIndicator;
         public bool? UserDefined817FeeToBeFinancedIndicator { get { return _userDefined817FeeToBeFinancedIndicator; } set { _userDefined817FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined817PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined817PortionOfFeeIndicator;
         public bool? UserDefined817PortionOfFeeIndicator { get { return _userDefined817PortionOfFeeIndicator; } set { _userDefined817PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined818FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined818FeeToBeFinancedIndicator;
         public bool? UserDefined818FeeToBeFinancedIndicator { get { return _userDefined818FeeToBeFinancedIndicator; } set { _userDefined818FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined818PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined818PortionOfFeeIndicator;
         public bool? UserDefined818PortionOfFeeIndicator { get { return _userDefined818PortionOfFeeIndicator; } set { _userDefined818PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined819FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined819FeeToBeFinancedIndicator;
         public bool? UserDefined819FeeToBeFinancedIndicator { get { return _userDefined819FeeToBeFinancedIndicator; } set { _userDefined819FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined819PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined819PortionOfFeeIndicator;
         public bool? UserDefined819PortionOfFeeIndicator { get { return _userDefined819PortionOfFeeIndicator; } set { _userDefined819PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined820FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined820FeeToBeFinancedIndicator;
         public bool? UserDefined820FeeToBeFinancedIndicator { get { return _userDefined820FeeToBeFinancedIndicator; } set { _userDefined820FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined820PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined820PortionOfFeeIndicator;
         public bool? UserDefined820PortionOfFeeIndicator { get { return _userDefined820PortionOfFeeIndicator; } set { _userDefined820PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined821FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined821FeeToBeFinancedIndicator;
         public bool? UserDefined821FeeToBeFinancedIndicator { get { return _userDefined821FeeToBeFinancedIndicator; } set { _userDefined821FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined821PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined821PortionOfFeeIndicator;
         public bool? UserDefined821PortionOfFeeIndicator { get { return _userDefined821PortionOfFeeIndicator; } set { _userDefined821PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined822FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined822FeeToBeFinancedIndicator;
         public bool? UserDefined822FeeToBeFinancedIndicator { get { return _userDefined822FeeToBeFinancedIndicator; } set { _userDefined822FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined822PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined822PortionOfFeeIndicator;
         public bool? UserDefined822PortionOfFeeIndicator { get { return _userDefined822PortionOfFeeIndicator; } set { _userDefined822PortionOfFeeIndicator = value; } }
-        private Value<bool?> _userDefined823FeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _userDefined823FeeToBeFinancedIndicator;
         public bool? UserDefined823FeeToBeFinancedIndicator { get { return _userDefined823FeeToBeFinancedIndicator; } set { _userDefined823FeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _userDefined823PortionOfFeeIndicator;
+        private DirtyValue<bool?> _userDefined823PortionOfFeeIndicator;
         public bool? UserDefined823PortionOfFeeIndicator { get { return _userDefined823PortionOfFeeIndicator; } set { _userDefined823PortionOfFeeIndicator = value; } }
-        private Value<bool?> _wireTransferFeeToBeFinancedIndicator;
+        private DirtyValue<bool?> _wireTransferFeeToBeFinancedIndicator;
         public bool? WireTransferFeeToBeFinancedIndicator { get { return _wireTransferFeeToBeFinancedIndicator; } set { _wireTransferFeeToBeFinancedIndicator = value; } }
-        private Value<bool?> _wireTransferPortionOfFeeIndicator;
+        private DirtyValue<bool?> _wireTransferPortionOfFeeIndicator;
         public bool? WireTransferPortionOfFeeIndicator { get { return _wireTransferPortionOfFeeIndicator; } set { _wireTransferPortionOfFeeIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/SelectedHomeCounselingProvider.cs
+++ b/src/EncompassRest/Loans/SelectedHomeCounselingProvider.cs
@@ -8,53 +8,53 @@ namespace EncompassRest.Loans
 {
     public sealed partial class SelectedHomeCounselingProvider : IDirty
     {
-        private Value<bool?> _affiliatedWithLenderIndicator;
+        private DirtyValue<bool?> _affiliatedWithLenderIndicator;
         public bool? AffiliatedWithLenderIndicator { get { return _affiliatedWithLenderIndicator; } set { _affiliatedWithLenderIndicator = value; } }
-        private Value<string> _agencyAddress;
+        private DirtyValue<string> _agencyAddress;
         public string AgencyAddress { get { return _agencyAddress; } set { _agencyAddress = value; } }
-        private Value<string> _agencyAddressCity;
+        private DirtyValue<string> _agencyAddressCity;
         public string AgencyAddressCity { get { return _agencyAddressCity; } set { _agencyAddressCity = value; } }
-        private Value<string> _agencyAddressPostalCode;
+        private DirtyValue<string> _agencyAddressPostalCode;
         public string AgencyAddressPostalCode { get { return _agencyAddressPostalCode; } set { _agencyAddressPostalCode = value; } }
-        private Value<string> _agencyAddressState;
+        private DirtyValue<string> _agencyAddressState;
         public string AgencyAddressState { get { return _agencyAddressState; } set { _agencyAddressState = value; } }
-        private Value<string> _agencyAffiliationDescription;
+        private DirtyValue<string> _agencyAffiliationDescription;
         public string AgencyAffiliationDescription { get { return _agencyAffiliationDescription; } set { _agencyAffiliationDescription = value; } }
-        private Value<string> _agencyEmail;
+        private DirtyValue<string> _agencyEmail;
         public string AgencyEmail { get { return _agencyEmail; } set { _agencyEmail = value; } }
-        private Value<string> _agencyFax;
+        private DirtyValue<string> _agencyFax;
         public string AgencyFax { get { return _agencyFax; } set { _agencyFax = value; } }
-        private Value<string> _agencyName;
+        private DirtyValue<string> _agencyName;
         public string AgencyName { get { return _agencyName; } set { _agencyName = value; } }
-        private Value<string> _agencyPhoneDirect;
+        private DirtyValue<string> _agencyPhoneDirect;
         public string AgencyPhoneDirect { get { return _agencyPhoneDirect; } set { _agencyPhoneDirect = value; } }
-        private Value<string> _agencyPhoneTollFree;
+        private DirtyValue<string> _agencyPhoneTollFree;
         public string AgencyPhoneTollFree { get { return _agencyPhoneTollFree; } set { _agencyPhoneTollFree = value; } }
-        private Value<string> _agencyWebAddress;
+        private DirtyValue<string> _agencyWebAddress;
         public string AgencyWebAddress { get { return _agencyWebAddress; } set { _agencyWebAddress = value; } }
-        private Value<bool?> _brrowerSelectCounselorIndicator;
+        private DirtyValue<bool?> _brrowerSelectCounselorIndicator;
         public bool? BrrowerSelectCounselorIndicator { get { return _brrowerSelectCounselorIndicator; } set { _brrowerSelectCounselorIndicator = value; } }
-        private Value<bool?> _certificationIssuedIndicator;
+        private DirtyValue<bool?> _certificationIssuedIndicator;
         public bool? CertificationIssuedIndicator { get { return _certificationIssuedIndicator; } set { _certificationIssuedIndicator = value; } }
-        private Value<string> _counselingServicesProvided;
+        private DirtyValue<string> _counselingServicesProvided;
         public string CounselingServicesProvided { get { return _counselingServicesProvided; } set { _counselingServicesProvided = value; } }
-        private Value<decimal?> _distanceMiles;
+        private DirtyValue<decimal?> _distanceMiles;
         public decimal? DistanceMiles { get { return _distanceMiles; } set { _distanceMiles = value; } }
-        private Value<string> _explanation;
+        private DirtyValue<string> _explanation;
         public string Explanation { get { return _explanation; } set { _explanation = value; } }
-        private Value<DateTime?> _homeCounselingCompletionDate;
+        private DirtyValue<DateTime?> _homeCounselingCompletionDate;
         public DateTime? HomeCounselingCompletionDate { get { return _homeCounselingCompletionDate; } set { _homeCounselingCompletionDate = value; } }
-        private Value<DateTime?> _homeCounselingDisclosureDate;
+        private DirtyValue<DateTime?> _homeCounselingDisclosureDate;
         public DateTime? HomeCounselingDisclosureDate { get { return _homeCounselingDisclosureDate; } set { _homeCounselingDisclosureDate = value; } }
-        private Value<DateTime?> _homeCounselingGeneratedDate;
+        private DirtyValue<DateTime?> _homeCounselingGeneratedDate;
         public DateTime? HomeCounselingGeneratedDate { get { return _homeCounselingGeneratedDate; } set { _homeCounselingGeneratedDate = value; } }
-        private Value<bool?> _homeCounselingRequiredIndicator;
+        private DirtyValue<bool?> _homeCounselingRequiredIndicator;
         public bool? HomeCounselingRequiredIndicator { get { return _homeCounselingRequiredIndicator; } set { _homeCounselingRequiredIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _languagesSupported;
+        private DirtyValue<string> _languagesSupported;
         public string LanguagesSupported { get { return _languagesSupported; } set { _languagesSupported = value; } }
-        private Value<string> _selectedGUID;
+        private DirtyValue<string> _selectedGUID;
         public string SelectedGUID { get { return _selectedGUID; } set { _selectedGUID = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/SelfEmployedIncome.cs
+++ b/src/EncompassRest/Loans/SelfEmployedIncome.cs
@@ -8,21 +8,21 @@ namespace EncompassRest.Loans
 {
     public sealed partial class SelfEmployedIncome : IDirty
     {
-        private Value<bool?> _boolFieldValue;
+        private DirtyValue<bool?> _boolFieldValue;
         public bool? BoolFieldValue { get { return _boolFieldValue; } set { _boolFieldValue = value; } }
-        private Value<string> _businessName;
+        private DirtyValue<string> _businessName;
         public string BusinessName { get { return _businessName; } set { _businessName = value; } }
-        private Value<string> _fieldName;
+        private DirtyValue<string> _fieldName;
         public string FieldName { get { return _fieldName; } set { _fieldName = value; } }
-        private Value<decimal?> _fieldValue;
+        private DirtyValue<decimal?> _fieldValue;
         public decimal? FieldValue { get { return _fieldValue; } set { _fieldValue = value; } }
-        private Value<decimal?> _firstYearAmount;
+        private DirtyValue<decimal?> _firstYearAmount;
         public decimal? FirstYearAmount { get { return _firstYearAmount; } set { _firstYearAmount = value; } }
-        private Value<string> _formType;
+        private DirtyValue<string> _formType;
         public string FormType { get { return _formType; } set { _formType = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _secondYearAmount;
+        private DirtyValue<decimal?> _secondYearAmount;
         public decimal? SecondYearAmount { get { return _secondYearAmount; } set { _secondYearAmount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ServiceProviderContact.cs
+++ b/src/EncompassRest/Loans/ServiceProviderContact.cs
@@ -8,83 +8,83 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ServiceProviderContact : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _contactName;
+        private DirtyValue<string> _contactName;
         public string ContactName { get { return _contactName; } set { _contactName = value; } }
-        private Value<decimal?> _cost;
+        private DirtyValue<decimal?> _cost;
         public decimal? Cost { get { return _cost; } set { _cost = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<decimal?> _feeAmt1;
+        private DirtyValue<decimal?> _feeAmt1;
         public decimal? FeeAmt1 { get { return _feeAmt1; } set { _feeAmt1 = value; } }
-        private Value<decimal?> _feeAmt10;
+        private DirtyValue<decimal?> _feeAmt10;
         public decimal? FeeAmt10 { get { return _feeAmt10; } set { _feeAmt10 = value; } }
-        private Value<decimal?> _feeAmt2;
+        private DirtyValue<decimal?> _feeAmt2;
         public decimal? FeeAmt2 { get { return _feeAmt2; } set { _feeAmt2 = value; } }
-        private Value<decimal?> _feeAmt3;
+        private DirtyValue<decimal?> _feeAmt3;
         public decimal? FeeAmt3 { get { return _feeAmt3; } set { _feeAmt3 = value; } }
-        private Value<decimal?> _feeAmt4;
+        private DirtyValue<decimal?> _feeAmt4;
         public decimal? FeeAmt4 { get { return _feeAmt4; } set { _feeAmt4 = value; } }
-        private Value<decimal?> _feeAmt5;
+        private DirtyValue<decimal?> _feeAmt5;
         public decimal? FeeAmt5 { get { return _feeAmt5; } set { _feeAmt5 = value; } }
-        private Value<decimal?> _feeAmt6;
+        private DirtyValue<decimal?> _feeAmt6;
         public decimal? FeeAmt6 { get { return _feeAmt6; } set { _feeAmt6 = value; } }
-        private Value<decimal?> _feeAmt7;
+        private DirtyValue<decimal?> _feeAmt7;
         public decimal? FeeAmt7 { get { return _feeAmt7; } set { _feeAmt7 = value; } }
-        private Value<decimal?> _feeAmt8;
+        private DirtyValue<decimal?> _feeAmt8;
         public decimal? FeeAmt8 { get { return _feeAmt8; } set { _feeAmt8 = value; } }
-        private Value<decimal?> _feeAmt9;
+        private DirtyValue<decimal?> _feeAmt9;
         public decimal? FeeAmt9 { get { return _feeAmt9; } set { _feeAmt9 = value; } }
-        private Value<string> _feeDesc1;
+        private DirtyValue<string> _feeDesc1;
         public string FeeDesc1 { get { return _feeDesc1; } set { _feeDesc1 = value; } }
-        private Value<string> _feeDesc10;
+        private DirtyValue<string> _feeDesc10;
         public string FeeDesc10 { get { return _feeDesc10; } set { _feeDesc10 = value; } }
-        private Value<string> _feeDesc2;
+        private DirtyValue<string> _feeDesc2;
         public string FeeDesc2 { get { return _feeDesc2; } set { _feeDesc2 = value; } }
-        private Value<string> _feeDesc3;
+        private DirtyValue<string> _feeDesc3;
         public string FeeDesc3 { get { return _feeDesc3; } set { _feeDesc3 = value; } }
-        private Value<string> _feeDesc4;
+        private DirtyValue<string> _feeDesc4;
         public string FeeDesc4 { get { return _feeDesc4; } set { _feeDesc4 = value; } }
-        private Value<string> _feeDesc5;
+        private DirtyValue<string> _feeDesc5;
         public string FeeDesc5 { get { return _feeDesc5; } set { _feeDesc5 = value; } }
-        private Value<string> _feeDesc6;
+        private DirtyValue<string> _feeDesc6;
         public string FeeDesc6 { get { return _feeDesc6; } set { _feeDesc6 = value; } }
-        private Value<string> _feeDesc7;
+        private DirtyValue<string> _feeDesc7;
         public string FeeDesc7 { get { return _feeDesc7; } set { _feeDesc7 = value; } }
-        private Value<string> _feeDesc8;
+        private DirtyValue<string> _feeDesc8;
         public string FeeDesc8 { get { return _feeDesc8; } set { _feeDesc8 = value; } }
-        private Value<string> _feeDesc9;
+        private DirtyValue<string> _feeDesc9;
         public string FeeDesc9 { get { return _feeDesc9; } set { _feeDesc9 = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lineItemNumber;
+        private DirtyValue<string> _lineItemNumber;
         public string LineItemNumber { get { return _lineItemNumber; } set { _lineItemNumber = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<int?> _providerIndex;
+        private DirtyValue<int?> _providerIndex;
         public int? ProviderIndex { get { return _providerIndex; } set { _providerIndex = value; } }
-        private Value<string> _providerName;
+        private DirtyValue<string> _providerName;
         public string ProviderName { get { return _providerName; } set { _providerName = value; } }
-        private Value<string> _relationship;
+        private DirtyValue<string> _relationship;
         public string Relationship { get { return _relationship; } set { _relationship = value; } }
-        private Value<string> _serviceProvided;
+        private DirtyValue<string> _serviceProvided;
         public string ServiceProvided { get { return _serviceProvided; } set { _serviceProvided = value; } }
-        private Value<string> _serviceProviderId;
+        private DirtyValue<string> _serviceProviderId;
         public string ServiceProviderId { get { return _serviceProviderId; } set { _serviceProviderId = value; } }
-        private Value<string> _serviceType;
+        private DirtyValue<string> _serviceType;
         public string ServiceType { get { return _serviceType; } set { _serviceType = value; } }
-        private Value<bool?> _shopFor;
+        private DirtyValue<bool?> _shopFor;
         public bool? ShopFor { get { return _shopFor; } set { _shopFor = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<string> _webUrl;
+        private DirtyValue<string> _webUrl;
         public string WebUrl { get { return _webUrl; } set { _webUrl = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ServicingDisclosure.cs
+++ b/src/EncompassRest/Loans/ServicingDisclosure.cs
@@ -8,45 +8,45 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ServicingDisclosure : IDirty
     {
-        private Value<decimal?> _disclosurePercent1;
+        private DirtyValue<decimal?> _disclosurePercent1;
         public decimal? DisclosurePercent1 { get { return _disclosurePercent1; } set { _disclosurePercent1 = value; } }
-        private Value<decimal?> _disclosurePercent2;
+        private DirtyValue<decimal?> _disclosurePercent2;
         public decimal? DisclosurePercent2 { get { return _disclosurePercent2; } set { _disclosurePercent2 = value; } }
-        private Value<decimal?> _disclosurePercent3;
+        private DirtyValue<decimal?> _disclosurePercent3;
         public decimal? DisclosurePercent3 { get { return _disclosurePercent3; } set { _disclosurePercent3 = value; } }
-        private Value<string> _disclosureYear1;
+        private DirtyValue<string> _disclosureYear1;
         public string DisclosureYear1 { get { return _disclosureYear1; } set { _disclosureYear1 = value; } }
-        private Value<string> _disclosureYear2;
+        private DirtyValue<string> _disclosureYear2;
         public string DisclosureYear2 { get { return _disclosureYear2; } set { _disclosureYear2 = value; } }
-        private Value<string> _disclosureYear3;
+        private DirtyValue<string> _disclosureYear3;
         public string DisclosureYear3 { get { return _disclosureYear3; } set { _disclosureYear3 = value; } }
-        private Value<bool?> _fiftyOneTo75Indicator;
+        private DirtyValue<bool?> _fiftyOneTo75Indicator;
         public bool? FiftyOneTo75Indicator { get { return _fiftyOneTo75Indicator; } set { _fiftyOneTo75Indicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _seventySixTo100Indicator;
+        private DirtyValue<bool?> _seventySixTo100Indicator;
         public bool? SeventySixTo100Indicator { get { return _seventySixTo100Indicator; } set { _seventySixTo100Indicator = value; } }
-        private Value<string> _thisEstimateType;
+        private DirtyValue<string> _thisEstimateType;
         public string ThisEstimateType { get { return _thisEstimateType; } set { _thisEstimateType = value; } }
-        private Value<string> _thisInformationType;
+        private DirtyValue<string> _thisInformationType;
         public string ThisInformationType { get { return _thisInformationType; } set { _thisInformationType = value; } }
-        private Value<bool?> _thisIsOurRecordOfTransferingIndicator;
+        private DirtyValue<bool?> _thisIsOurRecordOfTransferingIndicator;
         public bool? ThisIsOurRecordOfTransferingIndicator { get { return _thisIsOurRecordOfTransferingIndicator; } set { _thisIsOurRecordOfTransferingIndicator = value; } }
-        private Value<bool?> _twentySixTo50Indicator;
+        private DirtyValue<bool?> _twentySixTo50Indicator;
         public bool? TwentySixTo50Indicator { get { return _twentySixTo50Indicator; } set { _twentySixTo50Indicator = value; } }
-        private Value<string> _weAreAbleType;
+        private DirtyValue<string> _weAreAbleType;
         public string WeAreAbleType { get { return _weAreAbleType; } set { _weAreAbleType = value; } }
-        private Value<bool?> _weDoNotSellMortgageLoansIndicator;
+        private DirtyValue<bool?> _weDoNotSellMortgageLoansIndicator;
         public bool? WeDoNotSellMortgageLoansIndicator { get { return _weDoNotSellMortgageLoansIndicator; } set { _weDoNotSellMortgageLoansIndicator = value; } }
-        private Value<bool?> _weDoNotServiceMortgageLoansIndicator;
+        private DirtyValue<bool?> _weDoNotServiceMortgageLoansIndicator;
         public bool? WeDoNotServiceMortgageLoansIndicator { get { return _weDoNotServiceMortgageLoansIndicator; } set { _weDoNotServiceMortgageLoansIndicator = value; } }
-        private Value<bool?> _weHaveNotServicedMortgLoansIn3YrsIndicator;
+        private DirtyValue<bool?> _weHaveNotServicedMortgLoansIn3YrsIndicator;
         public bool? WeHaveNotServicedMortgLoansIn3YrsIndicator { get { return _weHaveNotServicedMortgLoansIn3YrsIndicator; } set { _weHaveNotServicedMortgLoansIn3YrsIndicator = value; } }
-        private Value<bool?> _weHavePreviouslyAssignedIndicator;
+        private DirtyValue<bool?> _weHavePreviouslyAssignedIndicator;
         public bool? WeHavePreviouslyAssignedIndicator { get { return _weHavePreviouslyAssignedIndicator; } set { _weHavePreviouslyAssignedIndicator = value; } }
-        private Value<bool?> _weMayAssignIndicator;
+        private DirtyValue<bool?> _weMayAssignIndicator;
         public bool? WeMayAssignIndicator { get { return _weMayAssignIndicator; } set { _weMayAssignIndicator = value; } }
-        private Value<bool?> _zeroTo25Indicator;
+        private DirtyValue<bool?> _zeroTo25Indicator;
         public bool? ZeroTo25Indicator { get { return _zeroTo25Indicator; } set { _zeroTo25Indicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/SettlementServiceCharge.cs
+++ b/src/EncompassRest/Loans/SettlementServiceCharge.cs
@@ -8,11 +8,11 @@ namespace EncompassRest.Loans
 {
     public sealed partial class SettlementServiceCharge : IDirty
     {
-        private Value<string> _amount;
+        private DirtyValue<string> _amount;
         public string Amount { get { return _amount; } set { _amount = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Shipping.cs
+++ b/src/EncompassRest/Loans/Shipping.cs
@@ -36,8 +36,8 @@ namespace EncompassRest.Loans
         public string ShipmentMethod { get { return _shipmentMethod; } set { _shipmentMethod = value; } }
         private Value<string> _shipperName;
         public string ShipperName { get { return _shipperName; } set { _shipperName = value; } }
-        private Value<List<ShippingContact>> _shippingContacts;
-        public List<ShippingContact> ShippingContacts { get { return _shippingContacts; } set { _shippingContacts = value; } }
+        private DirtyList<ShippingContact> _shippingContacts;
+        public IList<ShippingContact> ShippingContacts { get { var v = _shippingContacts; return v ?? Interlocked.CompareExchange(ref _shippingContacts, (v = new DirtyList<ShippingContact>()), null) ?? v; } set { _shippingContacts = new DirtyList<ShippingContact>(value); } }
         private Value<DateTime?> _targetDeliveryDate;
         public DateTime? TargetDeliveryDate { get { return _targetDeliveryDate; } set { _targetDeliveryDate = value; } }
         private int _gettingDirty;
@@ -61,8 +61,8 @@ namespace EncompassRest.Loans
                     || _recordingNumber.Dirty
                     || _shipmentMethod.Dirty
                     || _shipperName.Dirty
-                    || _shippingContacts.Dirty
-                    || _targetDeliveryDate.Dirty;
+                    || _targetDeliveryDate.Dirty
+                    || _shippingContacts?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -83,8 +83,8 @@ namespace EncompassRest.Loans
                 _recordingNumber.Dirty = value;
                 _shipmentMethod.Dirty = value;
                 _shipperName.Dirty = value;
-                _shippingContacts.Dirty = value;
                 _targetDeliveryDate.Dirty = value;
+                if (_shippingContacts != null) _shippingContacts.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Shipping.cs
+++ b/src/EncompassRest/Loans/Shipping.cs
@@ -8,37 +8,37 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Shipping : IDirty
     {
-        private Value<DateTime?> _actualShipDate;
+        private DirtyValue<DateTime?> _actualShipDate;
         public DateTime? ActualShipDate { get { return _actualShipDate; } set { _actualShipDate = value; } }
-        private Value<string> _carrierName;
+        private DirtyValue<string> _carrierName;
         public string CarrierName { get { return _carrierName; } set { _carrierName = value; } }
-        private Value<decimal?> _downPaymentAmount;
+        private DirtyValue<decimal?> _downPaymentAmount;
         public decimal? DownPaymentAmount { get { return _downPaymentAmount; } set { _downPaymentAmount = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _investorDeliveryDate;
+        private DirtyValue<DateTime?> _investorDeliveryDate;
         public DateTime? InvestorDeliveryDate { get { return _investorDeliveryDate; } set { _investorDeliveryDate = value; } }
-        private Value<string> _packageTrackingNumber;
+        private DirtyValue<string> _packageTrackingNumber;
         public string PackageTrackingNumber { get { return _packageTrackingNumber; } set { _packageTrackingNumber = value; } }
-        private Value<string> _physicalFileStorageComments;
+        private DirtyValue<string> _physicalFileStorageComments;
         public string PhysicalFileStorageComments { get { return _physicalFileStorageComments; } set { _physicalFileStorageComments = value; } }
-        private Value<string> _physicalFileStorageId;
+        private DirtyValue<string> _physicalFileStorageId;
         public string PhysicalFileStorageId { get { return _physicalFileStorageId; } set { _physicalFileStorageId = value; } }
-        private Value<string> _physicalFileStorageLocation;
+        private DirtyValue<string> _physicalFileStorageLocation;
         public string PhysicalFileStorageLocation { get { return _physicalFileStorageLocation; } set { _physicalFileStorageLocation = value; } }
-        private Value<string> _poolID;
+        private DirtyValue<string> _poolID;
         public string PoolID { get { return _poolID; } set { _poolID = value; } }
-        private Value<string> _poolNumber;
+        private DirtyValue<string> _poolNumber;
         public string PoolNumber { get { return _poolNumber; } set { _poolNumber = value; } }
-        private Value<string> _recordingNumber;
+        private DirtyValue<string> _recordingNumber;
         public string RecordingNumber { get { return _recordingNumber; } set { _recordingNumber = value; } }
-        private Value<string> _shipmentMethod;
+        private DirtyValue<string> _shipmentMethod;
         public string ShipmentMethod { get { return _shipmentMethod; } set { _shipmentMethod = value; } }
-        private Value<string> _shipperName;
+        private DirtyValue<string> _shipperName;
         public string ShipperName { get { return _shipperName; } set { _shipperName = value; } }
         private DirtyList<ShippingContact> _shippingContacts;
         public IList<ShippingContact> ShippingContacts { get { var v = _shippingContacts; return v ?? Interlocked.CompareExchange(ref _shippingContacts, (v = new DirtyList<ShippingContact>()), null) ?? v; } set { _shippingContacts = new DirtyList<ShippingContact>(value); } }
-        private Value<DateTime?> _targetDeliveryDate;
+        private DirtyValue<DateTime?> _targetDeliveryDate;
         public DateTime? TargetDeliveryDate { get { return _targetDeliveryDate; } set { _targetDeliveryDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/ShippingContact.cs
+++ b/src/EncompassRest/Loans/ShippingContact.cs
@@ -8,29 +8,29 @@ namespace EncompassRest.Loans
 {
     public sealed partial class ShippingContact : IDirty
     {
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _address2;
+        private DirtyValue<string> _address2;
         public string Address2 { get { return _address2; } set { _address2 = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<string> _contactName;
+        private DirtyValue<string> _contactName;
         public string ContactName { get { return _contactName; } set { _contactName = value; } }
-        private Value<string> _email;
+        private DirtyValue<string> _email;
         public string Email { get { return _email; } set { _email = value; } }
-        private Value<string> _fax;
+        private DirtyValue<string> _fax;
         public string Fax { get { return _fax; } set { _fax = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _phone;
+        private DirtyValue<string> _phone;
         public string Phone { get { return _phone; } set { _phone = value; } }
-        private Value<string> _postalCode;
+        private DirtyValue<string> _postalCode;
         public string PostalCode { get { return _postalCode; } set { _postalCode = value; } }
-        private Value<string> _shippingContactType;
+        private DirtyValue<string> _shippingContactType;
         public string ShippingContactType { get { return _shippingContactType; } set { _shippingContactType = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/StateDisclosure.cs
+++ b/src/EncompassRest/Loans/StateDisclosure.cs
@@ -8,443 +8,443 @@ namespace EncompassRest.Loans
 {
     public sealed partial class StateDisclosure : IDirty
     {
-        private Value<bool?> _acceptedByBorrowerIndicator;
+        private DirtyValue<bool?> _acceptedByBorrowerIndicator;
         public bool? AcceptedByBorrowerIndicator { get { return _acceptedByBorrowerIndicator; } set { _acceptedByBorrowerIndicator = value; } }
-        private Value<DateTime?> _acceptedDate;
+        private DirtyValue<DateTime?> _acceptedDate;
         public DateTime? AcceptedDate { get { return _acceptedDate; } set { _acceptedDate = value; } }
-        private Value<string> _actingOtherDescription1;
+        private DirtyValue<string> _actingOtherDescription1;
         public string ActingOtherDescription1 { get { return _actingOtherDescription1; } set { _actingOtherDescription1 = value; } }
-        private Value<string> _actingOtherDescription2;
+        private DirtyValue<string> _actingOtherDescription2;
         public string ActingOtherDescription2 { get { return _actingOtherDescription2; } set { _actingOtherDescription2 = value; } }
-        private Value<bool?> _actingOthersIndicator;
+        private DirtyValue<bool?> _actingOthersIndicator;
         public bool? ActingOthersIndicator { get { return _actingOthersIndicator; } set { _actingOthersIndicator = value; } }
-        private Value<int?> _advFeeAgmtInEfctNumDay;
+        private DirtyValue<int?> _advFeeAgmtInEfctNumDay;
         public int? AdvFeeAgmtInEfctNumDay { get { return _advFeeAgmtInEfctNumDay; } set { _advFeeAgmtInEfctNumDay = value; } }
-        private Value<string> _advisoryCondition1;
+        private DirtyValue<string> _advisoryCondition1;
         public string AdvisoryCondition1 { get { return _advisoryCondition1; } set { _advisoryCondition1 = value; } }
-        private Value<string> _advisoryCondition2;
+        private DirtyValue<string> _advisoryCondition2;
         public string AdvisoryCondition2 { get { return _advisoryCondition2; } set { _advisoryCondition2 = value; } }
-        private Value<string> _advisoryCondition3;
+        private DirtyValue<string> _advisoryCondition3;
         public string AdvisoryCondition3 { get { return _advisoryCondition3; } set { _advisoryCondition3 = value; } }
-        private Value<string> _advisoryCondition4;
+        private DirtyValue<string> _advisoryCondition4;
         public string AdvisoryCondition4 { get { return _advisoryCondition4; } set { _advisoryCondition4 = value; } }
-        private Value<decimal?> _amendedAcquisitionCost;
+        private DirtyValue<decimal?> _amendedAcquisitionCost;
         public decimal? AmendedAcquisitionCost { get { return _amendedAcquisitionCost; } set { _amendedAcquisitionCost = value; } }
-        private Value<DateTime?> _applicationDate;
+        private DirtyValue<DateTime?> _applicationDate;
         public DateTime? ApplicationDate { get { return _applicationDate; } set { _applicationDate = value; } }
-        private Value<string> _appraisalContact;
+        private DirtyValue<string> _appraisalContact;
         public string AppraisalContact { get { return _appraisalContact; } set { _appraisalContact = value; } }
-        private Value<decimal?> _appraisalDeposit;
+        private DirtyValue<decimal?> _appraisalDeposit;
         public decimal? AppraisalDeposit { get { return _appraisalDeposit; } set { _appraisalDeposit = value; } }
-        private Value<string> _areas;
+        private DirtyValue<string> _areas;
         public string Areas { get { return _areas; } set { _areas = value; } }
-        private Value<bool?> _asAttorneyIndicator;
+        private DirtyValue<bool?> _asAttorneyIndicator;
         public bool? AsAttorneyIndicator { get { return _asAttorneyIndicator; } set { _asAttorneyIndicator = value; } }
-        private Value<bool?> _asRealBrokerIndicator;
+        private DirtyValue<bool?> _asRealBrokerIndicator;
         public bool? AsRealBrokerIndicator { get { return _asRealBrokerIndicator; } set { _asRealBrokerIndicator = value; } }
-        private Value<bool?> _attorneyForTheBuyerIndicator;
+        private DirtyValue<bool?> _attorneyForTheBuyerIndicator;
         public bool? AttorneyForTheBuyerIndicator { get { return _attorneyForTheBuyerIndicator; } set { _attorneyForTheBuyerIndicator = value; } }
-        private Value<bool?> _attorneyForTheLenderIndicator;
+        private DirtyValue<bool?> _attorneyForTheLenderIndicator;
         public bool? AttorneyForTheLenderIndicator { get { return _attorneyForTheLenderIndicator; } set { _attorneyForTheLenderIndicator = value; } }
-        private Value<bool?> _attorneyForTheSellerIndicator;
+        private DirtyValue<bool?> _attorneyForTheSellerIndicator;
         public bool? AttorneyForTheSellerIndicator { get { return _attorneyForTheSellerIndicator; } set { _attorneyForTheSellerIndicator = value; } }
-        private Value<string> _aZCmplBlankSpcsDoc1BlankFldDesc1;
+        private DirtyValue<string> _aZCmplBlankSpcsDoc1BlankFldDesc1;
         public string AZCmplBlankSpcsDoc1BlankFldDesc1 { get { return _aZCmplBlankSpcsDoc1BlankFldDesc1; } set { _aZCmplBlankSpcsDoc1BlankFldDesc1 = value; } }
-        private Value<string> _aZCmplBlankSpcsDoc1BlankFldDesc2;
+        private DirtyValue<string> _aZCmplBlankSpcsDoc1BlankFldDesc2;
         public string AZCmplBlankSpcsDoc1BlankFldDesc2 { get { return _aZCmplBlankSpcsDoc1BlankFldDesc2; } set { _aZCmplBlankSpcsDoc1BlankFldDesc2 = value; } }
-        private Value<string> _aZCmplBlankSpcsDoc1BlankFldDesc3;
+        private DirtyValue<string> _aZCmplBlankSpcsDoc1BlankFldDesc3;
         public string AZCmplBlankSpcsDoc1BlankFldDesc3 { get { return _aZCmplBlankSpcsDoc1BlankFldDesc3; } set { _aZCmplBlankSpcsDoc1BlankFldDesc3 = value; } }
-        private Value<string> _aZCmplBlankSpcsDoc1Nm;
+        private DirtyValue<string> _aZCmplBlankSpcsDoc1Nm;
         public string AZCmplBlankSpcsDoc1Nm { get { return _aZCmplBlankSpcsDoc1Nm; } set { _aZCmplBlankSpcsDoc1Nm = value; } }
-        private Value<string> _aZCmplBlankSpcsDoc2Nm;
+        private DirtyValue<string> _aZCmplBlankSpcsDoc2Nm;
         public string AZCmplBlankSpcsDoc2Nm { get { return _aZCmplBlankSpcsDoc2Nm; } set { _aZCmplBlankSpcsDoc2Nm = value; } }
-        private Value<string> _aZCmplBlankSpcsDoc3Nm;
+        private DirtyValue<string> _aZCmplBlankSpcsDoc3Nm;
         public string AZCmplBlankSpcsDoc3Nm { get { return _aZCmplBlankSpcsDoc3Nm; } set { _aZCmplBlankSpcsDoc3Nm = value; } }
-        private Value<string> _basedOnOthersDescription;
+        private DirtyValue<string> _basedOnOthersDescription;
         public string BasedOnOthersDescription { get { return _basedOnOthersDescription; } set { _basedOnOthersDescription = value; } }
-        private Value<bool?> _basedOnOthersIndicator;
+        private DirtyValue<bool?> _basedOnOthersIndicator;
         public bool? BasedOnOthersIndicator { get { return _basedOnOthersIndicator; } set { _basedOnOthersIndicator = value; } }
-        private Value<bool?> _basedOnWholesaleOptionsIndicator;
+        private DirtyValue<bool?> _basedOnWholesaleOptionsIndicator;
         public bool? BasedOnWholesaleOptionsIndicator { get { return _basedOnWholesaleOptionsIndicator; } set { _basedOnWholesaleOptionsIndicator = value; } }
-        private Value<decimal?> _borrowerElectsEstablishEscrowAmount;
+        private DirtyValue<decimal?> _borrowerElectsEstablishEscrowAmount;
         public decimal? BorrowerElectsEstablishEscrowAmount { get { return _borrowerElectsEstablishEscrowAmount; } set { _borrowerElectsEstablishEscrowAmount = value; } }
-        private Value<bool?> _borrowerElectsEstablishEscrowIndicator;
+        private DirtyValue<bool?> _borrowerElectsEstablishEscrowIndicator;
         public bool? BorrowerElectsEstablishEscrowIndicator { get { return _borrowerElectsEstablishEscrowIndicator; } set { _borrowerElectsEstablishEscrowIndicator = value; } }
-        private Value<decimal?> _brokerageFeeAddition1;
+        private DirtyValue<decimal?> _brokerageFeeAddition1;
         public decimal? BrokerageFeeAddition1 { get { return _brokerageFeeAddition1; } set { _brokerageFeeAddition1 = value; } }
-        private Value<decimal?> _brokerageFeeAddition2;
+        private DirtyValue<decimal?> _brokerageFeeAddition2;
         public decimal? BrokerageFeeAddition2 { get { return _brokerageFeeAddition2; } set { _brokerageFeeAddition2 = value; } }
-        private Value<decimal?> _brokerageFeeAddition3;
+        private DirtyValue<decimal?> _brokerageFeeAddition3;
         public decimal? BrokerageFeeAddition3 { get { return _brokerageFeeAddition3; } set { _brokerageFeeAddition3 = value; } }
-        private Value<decimal?> _brokerageFeeAmount1;
+        private DirtyValue<decimal?> _brokerageFeeAmount1;
         public decimal? BrokerageFeeAmount1 { get { return _brokerageFeeAmount1; } set { _brokerageFeeAmount1 = value; } }
-        private Value<decimal?> _brokerageFeeAmount2;
+        private DirtyValue<decimal?> _brokerageFeeAmount2;
         public decimal? BrokerageFeeAmount2 { get { return _brokerageFeeAmount2; } set { _brokerageFeeAmount2 = value; } }
-        private Value<decimal?> _brokerageFeeAmount3;
+        private DirtyValue<decimal?> _brokerageFeeAmount3;
         public decimal? BrokerageFeeAmount3 { get { return _brokerageFeeAmount3; } set { _brokerageFeeAmount3 = value; } }
-        private Value<int?> _brokerageFeeDays;
+        private DirtyValue<int?> _brokerageFeeDays;
         public int? BrokerageFeeDays { get { return _brokerageFeeDays; } set { _brokerageFeeDays = value; } }
-        private Value<decimal?> _brokerageFeePercent1;
+        private DirtyValue<decimal?> _brokerageFeePercent1;
         public decimal? BrokerageFeePercent1 { get { return _brokerageFeePercent1; } set { _brokerageFeePercent1 = value; } }
-        private Value<decimal?> _brokerageFeePercent2;
+        private DirtyValue<decimal?> _brokerageFeePercent2;
         public decimal? BrokerageFeePercent2 { get { return _brokerageFeePercent2; } set { _brokerageFeePercent2 = value; } }
-        private Value<decimal?> _brokerageFeePercent3;
+        private DirtyValue<decimal?> _brokerageFeePercent3;
         public decimal? BrokerageFeePercent3 { get { return _brokerageFeePercent3; } set { _brokerageFeePercent3 = value; } }
-        private Value<string> _brokerAuthorizedSigningRepName;
+        private DirtyValue<string> _brokerAuthorizedSigningRepName;
         public string BrokerAuthorizedSigningRepName { get { return _brokerAuthorizedSigningRepName; } set { _brokerAuthorizedSigningRepName = value; } }
-        private Value<string> _brokerAuthorizedSigningRepTitle;
+        private DirtyValue<string> _brokerAuthorizedSigningRepTitle;
         public string BrokerAuthorizedSigningRepTitle { get { return _brokerAuthorizedSigningRepTitle; } set { _brokerAuthorizedSigningRepTitle = value; } }
-        private Value<string> _brokerForTheSeller;
+        private DirtyValue<string> _brokerForTheSeller;
         public string BrokerForTheSeller { get { return _brokerForTheSeller; } set { _brokerForTheSeller = value; } }
-        private Value<string> _brokerLicense;
+        private DirtyValue<string> _brokerLicense;
         public string BrokerLicense { get { return _brokerLicense; } set { _brokerLicense = value; } }
-        private Value<string> _brokerName;
+        private DirtyValue<string> _brokerName;
         public string BrokerName { get { return _brokerName; } set { _brokerName = value; } }
-        private Value<decimal?> _brokerPayAddition;
+        private DirtyValue<decimal?> _brokerPayAddition;
         public decimal? BrokerPayAddition { get { return _brokerPayAddition; } set { _brokerPayAddition = value; } }
-        private Value<decimal?> _brokerPayAmount;
+        private DirtyValue<decimal?> _brokerPayAmount;
         public decimal? BrokerPayAmount { get { return _brokerPayAmount; } set { _brokerPayAmount = value; } }
-        private Value<bool?> _brokerPayIndicator;
+        private DirtyValue<bool?> _brokerPayIndicator;
         public bool? BrokerPayIndicator { get { return _brokerPayIndicator; } set { _brokerPayIndicator = value; } }
-        private Value<decimal?> _brokerPayPercent;
+        private DirtyValue<decimal?> _brokerPayPercent;
         public decimal? BrokerPayPercent { get { return _brokerPayPercent; } set { _brokerPayPercent = value; } }
-        private Value<bool?> _cHARMBookletIndicator;
+        private DirtyValue<bool?> _cHARMBookletIndicator;
         public bool? CHARMBookletIndicator { get { return _cHARMBookletIndicator; } set { _cHARMBookletIndicator = value; } }
-        private Value<string> _checkPayableTo;
+        private DirtyValue<string> _checkPayableTo;
         public string CheckPayableTo { get { return _checkPayableTo; } set { _checkPayableTo = value; } }
-        private Value<decimal?> _commitmentAmount;
+        private DirtyValue<decimal?> _commitmentAmount;
         public decimal? CommitmentAmount { get { return _commitmentAmount; } set { _commitmentAmount = value; } }
-        private Value<string> _commitmentCondition1;
+        private DirtyValue<string> _commitmentCondition1;
         public string CommitmentCondition1 { get { return _commitmentCondition1; } set { _commitmentCondition1 = value; } }
-        private Value<string> _commitmentCondition2;
+        private DirtyValue<string> _commitmentCondition2;
         public string CommitmentCondition2 { get { return _commitmentCondition2; } set { _commitmentCondition2 = value; } }
-        private Value<decimal?> _commitmentFee;
+        private DirtyValue<decimal?> _commitmentFee;
         public decimal? CommitmentFee { get { return _commitmentFee; } set { _commitmentFee = value; } }
-        private Value<decimal?> _commitmentPercent;
+        private DirtyValue<decimal?> _commitmentPercent;
         public decimal? CommitmentPercent { get { return _commitmentPercent; } set { _commitmentPercent = value; } }
-        private Value<decimal?> _compensationAddition;
+        private DirtyValue<decimal?> _compensationAddition;
         public decimal? CompensationAddition { get { return _compensationAddition; } set { _compensationAddition = value; } }
-        private Value<decimal?> _compensationPercent;
+        private DirtyValue<decimal?> _compensationPercent;
         public decimal? CompensationPercent { get { return _compensationPercent; } set { _compensationPercent = value; } }
-        private Value<decimal?> _creditDeposit;
+        private DirtyValue<decimal?> _creditDeposit;
         public decimal? CreditDeposit { get { return _creditDeposit; } set { _creditDeposit = value; } }
-        private Value<string> _creditIsUsedForReason;
+        private DirtyValue<string> _creditIsUsedForReason;
         public string CreditIsUsedForReason { get { return _creditIsUsedForReason; } set { _creditIsUsedForReason = value; } }
-        private Value<string> _creditReportContact;
+        private DirtyValue<string> _creditReportContact;
         public string CreditReportContact { get { return _creditReportContact; } set { _creditReportContact = value; } }
-        private Value<int?> _daysBeforeClosing;
+        private DirtyValue<int?> _daysBeforeClosing;
         public int? DaysBeforeClosing { get { return _daysBeforeClosing; } set { _daysBeforeClosing = value; } }
-        private Value<decimal?> _depositReceipt;
+        private DirtyValue<decimal?> _depositReceipt;
         public decimal? DepositReceipt { get { return _depositReceipt; } set { _depositReceipt = value; } }
-        private Value<bool?> _depositRefundableIndicator;
+        private DirtyValue<bool?> _depositRefundableIndicator;
         public bool? DepositRefundableIndicator { get { return _depositRefundableIndicator; } set { _depositRefundableIndicator = value; } }
-        private Value<string> _directContact;
+        private DirtyValue<string> _directContact;
         public string DirectContact { get { return _directContact; } set { _directContact = value; } }
-        private Value<decimal?> _directPayAmount;
+        private DirtyValue<decimal?> _directPayAmount;
         public decimal? DirectPayAmount { get { return _directPayAmount; } set { _directPayAmount = value; } }
-        private Value<decimal?> _directPayClosing;
+        private DirtyValue<decimal?> _directPayClosing;
         public decimal? DirectPayClosing { get { return _directPayClosing; } set { _directPayClosing = value; } }
-        private Value<decimal?> _directPayCommitment;
+        private DirtyValue<decimal?> _directPayCommitment;
         public decimal? DirectPayCommitment { get { return _directPayCommitment; } set { _directPayCommitment = value; } }
-        private Value<bool?> _directPayIndicator;
+        private DirtyValue<bool?> _directPayIndicator;
         public bool? DirectPayIndicator { get { return _directPayIndicator; } set { _directPayIndicator = value; } }
-        private Value<decimal?> _directPayPercent;
+        private DirtyValue<decimal?> _directPayPercent;
         public decimal? DirectPayPercent { get { return _directPayPercent; } set { _directPayPercent = value; } }
-        private Value<string> _disclosureDeliveredBy;
+        private DirtyValue<string> _disclosureDeliveredBy;
         public string DisclosureDeliveredBy { get { return _disclosureDeliveredBy; } set { _disclosureDeliveredBy = value; } }
-        private Value<string> _disclosureDeliveredByOtherMethod;
+        private DirtyValue<string> _disclosureDeliveredByOtherMethod;
         public string DisclosureDeliveredByOtherMethod { get { return _disclosureDeliveredByOtherMethod; } set { _disclosureDeliveredByOtherMethod = value; } }
-        private Value<DateTime?> _disclosureDeliveredDate;
+        private DirtyValue<DateTime?> _disclosureDeliveredDate;
         public DateTime? DisclosureDeliveredDate { get { return _disclosureDeliveredDate; } set { _disclosureDeliveredDate = value; } }
-        private Value<bool?> _estimatedChargeShownOnGFEIndicator;
+        private DirtyValue<bool?> _estimatedChargeShownOnGFEIndicator;
         public bool? EstimatedChargeShownOnGFEIndicator { get { return _estimatedChargeShownOnGFEIndicator; } set { _estimatedChargeShownOnGFEIndicator = value; } }
-        private Value<DateTime?> _expirationDate;
+        private DirtyValue<DateTime?> _expirationDate;
         public DateTime? ExpirationDate { get { return _expirationDate; } set { _expirationDate = value; } }
-        private Value<decimal?> _federallySubsidizedAmount;
+        private DirtyValue<decimal?> _federallySubsidizedAmount;
         public decimal? FederallySubsidizedAmount { get { return _federallySubsidizedAmount; } set { _federallySubsidizedAmount = value; } }
-        private Value<decimal?> _federallySubsidizedAmountPercentage;
+        private DirtyValue<decimal?> _federallySubsidizedAmountPercentage;
         public decimal? FederallySubsidizedAmountPercentage { get { return _federallySubsidizedAmountPercentage; } set { _federallySubsidizedAmountPercentage = value; } }
-        private Value<decimal?> _feeReceived1;
+        private DirtyValue<decimal?> _feeReceived1;
         public decimal? FeeReceived1 { get { return _feeReceived1; } set { _feeReceived1 = value; } }
-        private Value<decimal?> _feeReceived2;
+        private DirtyValue<decimal?> _feeReceived2;
         public decimal? FeeReceived2 { get { return _feeReceived2; } set { _feeReceived2 = value; } }
-        private Value<string> _feeReceivedByLender;
+        private DirtyValue<string> _feeReceivedByLender;
         public string FeeReceivedByLender { get { return _feeReceivedByLender; } set { _feeReceivedByLender = value; } }
-        private Value<decimal?> _feesReceiving;
+        private DirtyValue<decimal?> _feesReceiving;
         public decimal? FeesReceiving { get { return _feesReceiving; } set { _feesReceiving = value; } }
-        private Value<decimal?> _floridaApplicationFee;
+        private DirtyValue<decimal?> _floridaApplicationFee;
         public decimal? FloridaApplicationFee { get { return _floridaApplicationFee; } set { _floridaApplicationFee = value; } }
-        private Value<decimal?> _floridaOtherFee1;
+        private DirtyValue<decimal?> _floridaOtherFee1;
         public decimal? FloridaOtherFee1 { get { return _floridaOtherFee1; } set { _floridaOtherFee1 = value; } }
-        private Value<decimal?> _floridaOtherFee2;
+        private DirtyValue<decimal?> _floridaOtherFee2;
         public decimal? FloridaOtherFee2 { get { return _floridaOtherFee2; } set { _floridaOtherFee2 = value; } }
-        private Value<string> _floridaOtherFeeTo1;
+        private DirtyValue<string> _floridaOtherFeeTo1;
         public string FloridaOtherFeeTo1 { get { return _floridaOtherFeeTo1; } set { _floridaOtherFeeTo1 = value; } }
-        private Value<string> _floridaOtherFeeTo2;
+        private DirtyValue<string> _floridaOtherFeeTo2;
         public string FloridaOtherFeeTo2 { get { return _floridaOtherFeeTo2; } set { _floridaOtherFeeTo2 = value; } }
-        private Value<string> _floridaOtherFeeTo3;
+        private DirtyValue<string> _floridaOtherFeeTo3;
         public string FloridaOtherFeeTo3 { get { return _floridaOtherFeeTo3; } set { _floridaOtherFeeTo3 = value; } }
-        private Value<string> _floridaOtherFeeTo4;
+        private DirtyValue<string> _floridaOtherFeeTo4;
         public string FloridaOtherFeeTo4 { get { return _floridaOtherFeeTo4; } set { _floridaOtherFeeTo4 = value; } }
-        private Value<string> _furtherFeesEarnedByMortgageBroker;
+        private DirtyValue<string> _furtherFeesEarnedByMortgageBroker;
         public string FurtherFeesEarnedByMortgageBroker { get { return _furtherFeesEarnedByMortgageBroker; } set { _furtherFeesEarnedByMortgageBroker = value; } }
-        private Value<decimal?> _gFEFeeReceived1;
+        private DirtyValue<decimal?> _gFEFeeReceived1;
         public decimal? GFEFeeReceived1 { get { return _gFEFeeReceived1; } set { _gFEFeeReceived1 = value; } }
-        private Value<decimal?> _gFEFeeReceived2;
+        private DirtyValue<decimal?> _gFEFeeReceived2;
         public decimal? GFEFeeReceived2 { get { return _gFEFeeReceived2; } set { _gFEFeeReceived2 = value; } }
-        private Value<bool?> _hUDBookletIndicator;
+        private DirtyValue<bool?> _hUDBookletIndicator;
         public bool? HUDBookletIndicator { get { return _hUDBookletIndicator; } set { _hUDBookletIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _independentContractorIndicator;
+        private DirtyValue<bool?> _independentContractorIndicator;
         public bool? IndependentContractorIndicator { get { return _independentContractorIndicator; } set { _independentContractorIndicator = value; } }
-        private Value<string> _indexUsed;
+        private DirtyValue<string> _indexUsed;
         public string IndexUsed { get { return _indexUsed; } set { _indexUsed = value; } }
-        private Value<string> _informationAboutTheIndexCanBeFound;
+        private DirtyValue<string> _informationAboutTheIndexCanBeFound;
         public string InformationAboutTheIndexCanBeFound { get { return _informationAboutTheIndexCanBeFound; } set { _informationAboutTheIndexCanBeFound = value; } }
-        private Value<string> _inLicensedNo;
+        private DirtyValue<string> _inLicensedNo;
         public string InLicensedNo { get { return _inLicensedNo; } set { _inLicensedNo = value; } }
-        private Value<string> _inLicensedType;
+        private DirtyValue<string> _inLicensedType;
         public string InLicensedType { get { return _inLicensedType; } set { _inLicensedType = value; } }
-        private Value<bool?> _isEstimateIndicator;
+        private DirtyValue<bool?> _isEstimateIndicator;
         public bool? IsEstimateIndicator { get { return _isEstimateIndicator; } set { _isEstimateIndicator = value; } }
-        private Value<bool?> _ksUcccElectionIndicator;
+        private DirtyValue<bool?> _ksUcccElectionIndicator;
         public bool? KsUcccElectionIndicator { get { return _ksUcccElectionIndicator; } set { _ksUcccElectionIndicator = value; } }
-        private Value<bool?> _kyHomeSolicationLoanIndicator;
+        private DirtyValue<bool?> _kyHomeSolicationLoanIndicator;
         public bool? KyHomeSolicationLoanIndicator { get { return _kyHomeSolicationLoanIndicator; } set { _kyHomeSolicationLoanIndicator = value; } }
-        private Value<DateTime?> _leaseAgreementDate;
+        private DirtyValue<DateTime?> _leaseAgreementDate;
         public DateTime? LeaseAgreementDate { get { return _leaseAgreementDate; } set { _leaseAgreementDate = value; } }
-        private Value<DateTime?> _lenderDate;
+        private DirtyValue<DateTime?> _lenderDate;
         public DateTime? LenderDate { get { return _lenderDate; } set { _lenderDate = value; } }
-        private Value<string> _lenderName;
+        private DirtyValue<string> _lenderName;
         public string LenderName { get { return _lenderName; } set { _lenderName = value; } }
-        private Value<decimal?> _lenderPaid;
+        private DirtyValue<decimal?> _lenderPaid;
         public decimal? LenderPaid { get { return _lenderPaid; } set { _lenderPaid = value; } }
-        private Value<decimal?> _lenderPayAmount;
+        private DirtyValue<decimal?> _lenderPayAmount;
         public decimal? LenderPayAmount { get { return _lenderPayAmount; } set { _lenderPayAmount = value; } }
-        private Value<bool?> _lenderPayIndicator;
+        private DirtyValue<bool?> _lenderPayIndicator;
         public bool? LenderPayIndicator { get { return _lenderPayIndicator; } set { _lenderPayIndicator = value; } }
-        private Value<decimal?> _lenderPayMaxPoint;
+        private DirtyValue<decimal?> _lenderPayMaxPoint;
         public decimal? LenderPayMaxPoint { get { return _lenderPayMaxPoint; } set { _lenderPayMaxPoint = value; } }
-        private Value<decimal?> _lenderPayPercent;
+        private DirtyValue<decimal?> _lenderPayPercent;
         public decimal? LenderPayPercent { get { return _lenderPayPercent; } set { _lenderPayPercent = value; } }
-        private Value<decimal?> _lenderPayPoint;
+        private DirtyValue<decimal?> _lenderPayPoint;
         public decimal? LenderPayPoint { get { return _lenderPayPoint; } set { _lenderPayPoint = value; } }
-        private Value<bool?> _lenderPayUnknownIndicator;
+        private DirtyValue<bool?> _lenderPayUnknownIndicator;
         public bool? LenderPayUnknownIndicator { get { return _lenderPayUnknownIndicator; } set { _lenderPayUnknownIndicator = value; } }
-        private Value<string> _lenderStatus;
+        private DirtyValue<string> _lenderStatus;
         public string LenderStatus { get { return _lenderStatus; } set { _lenderStatus = value; } }
-        private Value<string> _lessorName;
+        private DirtyValue<string> _lessorName;
         public string LessorName { get { return _lessorName; } set { _lessorName = value; } }
-        private Value<bool?> _loanTermsFixedThroughDateofLoanClosingIndicator;
+        private DirtyValue<bool?> _loanTermsFixedThroughDateofLoanClosingIndicator;
         public bool? LoanTermsFixedThroughDateofLoanClosingIndicator { get { return _loanTermsFixedThroughDateofLoanClosingIndicator; } set { _loanTermsFixedThroughDateofLoanClosingIndicator = value; } }
-        private Value<decimal?> _lockInFee;
+        private DirtyValue<decimal?> _lockInFee;
         public decimal? LockInFee { get { return _lockInFee; } set { _lockInFee = value; } }
-        private Value<string> _methodDescription;
+        private DirtyValue<string> _methodDescription;
         public string MethodDescription { get { return _methodDescription; } set { _methodDescription = value; } }
-        private Value<string> _methodDetermine;
+        private DirtyValue<string> _methodDetermine;
         public string MethodDetermine { get { return _methodDetermine; } set { _methodDetermine = value; } }
-        private Value<bool?> _mortgageAgreementIndicator;
+        private DirtyValue<bool?> _mortgageAgreementIndicator;
         public bool? MortgageAgreementIndicator { get { return _mortgageAgreementIndicator; } set { _mortgageAgreementIndicator = value; } }
-        private Value<string> _mtgBrokerLicense;
+        private DirtyValue<string> _mtgBrokerLicense;
         public string MtgBrokerLicense { get { return _mtgBrokerLicense; } set { _mtgBrokerLicense = value; } }
-        private Value<string> _nameOfLicensee;
+        private DirtyValue<string> _nameOfLicensee;
         public string NameOfLicensee { get { return _nameOfLicensee; } set { _nameOfLicensee = value; } }
-        private Value<decimal?> _newMoneyAmount;
+        private DirtyValue<decimal?> _newMoneyAmount;
         public decimal? NewMoneyAmount { get { return _newMoneyAmount; } set { _newMoneyAmount = value; } }
-        private Value<decimal?> _newYorkApplicationFee;
+        private DirtyValue<decimal?> _newYorkApplicationFee;
         public decimal? NewYorkApplicationFee { get { return _newYorkApplicationFee; } set { _newYorkApplicationFee = value; } }
-        private Value<decimal?> _newYorkAppraisalFee;
+        private DirtyValue<decimal?> _newYorkAppraisalFee;
         public decimal? NewYorkAppraisalFee { get { return _newYorkAppraisalFee; } set { _newYorkAppraisalFee = value; } }
-        private Value<decimal?> _newYorkCreditReportFee;
+        private DirtyValue<decimal?> _newYorkCreditReportFee;
         public decimal? NewYorkCreditReportFee { get { return _newYorkCreditReportFee; } set { _newYorkCreditReportFee = value; } }
         private DirtyList<NewYorkFee> _newYorkFees;
         public IList<NewYorkFee> NewYorkFees { get { var v = _newYorkFees; return v ?? Interlocked.CompareExchange(ref _newYorkFees, (v = new DirtyList<NewYorkFee>()), null) ?? v; } set { _newYorkFees = new DirtyList<NewYorkFee>(value); } }
         private DirtyList<NewYorkPrimaryLender> _newYorkPrimaryLenders;
         public IList<NewYorkPrimaryLender> NewYorkPrimaryLenders { get { var v = _newYorkPrimaryLenders; return v ?? Interlocked.CompareExchange(ref _newYorkPrimaryLenders, (v = new DirtyList<NewYorkPrimaryLender>()), null) ?? v; } set { _newYorkPrimaryLenders = new DirtyList<NewYorkPrimaryLender>(value); } }
-        private Value<decimal?> _newYorkProcessingFee;
+        private DirtyValue<decimal?> _newYorkProcessingFee;
         public decimal? NewYorkProcessingFee { get { return _newYorkProcessingFee; } set { _newYorkProcessingFee = value; } }
-        private Value<decimal?> _notRefundableAmount;
+        private DirtyValue<decimal?> _notRefundableAmount;
         public decimal? NotRefundableAmount { get { return _notRefundableAmount; } set { _notRefundableAmount = value; } }
-        private Value<bool?> _offerRetailPriceIndicator;
+        private DirtyValue<bool?> _offerRetailPriceIndicator;
         public bool? OfferRetailPriceIndicator { get { return _offerRetailPriceIndicator; } set { _offerRetailPriceIndicator = value; } }
-        private Value<decimal?> _originalAcquisitionCost;
+        private DirtyValue<decimal?> _originalAcquisitionCost;
         public decimal? OriginalAcquisitionCost { get { return _originalAcquisitionCost; } set { _originalAcquisitionCost = value; } }
-        private Value<decimal?> _originationFeeChargedAmount;
+        private DirtyValue<decimal?> _originationFeeChargedAmount;
         public decimal? OriginationFeeChargedAmount { get { return _originationFeeChargedAmount; } set { _originationFeeChargedAmount = value; } }
-        private Value<bool?> _originationFeeChargedIndicator;
+        private DirtyValue<bool?> _originationFeeChargedIndicator;
         public bool? OriginationFeeChargedIndicator { get { return _originationFeeChargedIndicator; } set { _originationFeeChargedIndicator = value; } }
-        private Value<decimal?> _originationFeeDecreasesRate;
+        private DirtyValue<decimal?> _originationFeeDecreasesRate;
         public decimal? OriginationFeeDecreasesRate { get { return _originationFeeDecreasesRate; } set { _originationFeeDecreasesRate = value; } }
-        private Value<decimal?> _originationFeeIncreasesRate;
+        private DirtyValue<decimal?> _originationFeeIncreasesRate;
         public decimal? OriginationFeeIncreasesRate { get { return _originationFeeIncreasesRate; } set { _originationFeeIncreasesRate = value; } }
-        private Value<string> _originationFeeInterestRateImpactedStatus;
+        private DirtyValue<string> _originationFeeInterestRateImpactedStatus;
         public string OriginationFeeInterestRateImpactedStatus { get { return _originationFeeInterestRateImpactedStatus; } set { _originationFeeInterestRateImpactedStatus = value; } }
-        private Value<string> _originationFeePaidBy;
+        private DirtyValue<string> _originationFeePaidBy;
         public string OriginationFeePaidBy { get { return _originationFeePaidBy; } set { _originationFeePaidBy = value; } }
-        private Value<decimal?> _paidByBorrower;
+        private DirtyValue<decimal?> _paidByBorrower;
         public decimal? PaidByBorrower { get { return _paidByBorrower; } set { _paidByBorrower = value; } }
-        private Value<decimal?> _paidByLender;
+        private DirtyValue<decimal?> _paidByLender;
         public decimal? PaidByLender { get { return _paidByLender; } set { _paidByLender = value; } }
-        private Value<decimal?> _paidByOther1;
+        private DirtyValue<decimal?> _paidByOther1;
         public decimal? PaidByOther1 { get { return _paidByOther1; } set { _paidByOther1 = value; } }
-        private Value<decimal?> _paidByOther2;
+        private DirtyValue<decimal?> _paidByOther2;
         public decimal? PaidByOther2 { get { return _paidByOther2; } set { _paidByOther2 = value; } }
-        private Value<string> _paidByOtherDescription1;
+        private DirtyValue<string> _paidByOtherDescription1;
         public string PaidByOtherDescription1 { get { return _paidByOtherDescription1; } set { _paidByOtherDescription1 = value; } }
-        private Value<string> _paidByOtherDescription2;
+        private DirtyValue<string> _paidByOtherDescription2;
         public string PaidByOtherDescription2 { get { return _paidByOtherDescription2; } set { _paidByOtherDescription2 = value; } }
-        private Value<decimal?> _previousMortgageAmountOne;
+        private DirtyValue<decimal?> _previousMortgageAmountOne;
         public decimal? PreviousMortgageAmountOne { get { return _previousMortgageAmountOne; } set { _previousMortgageAmountOne = value; } }
-        private Value<decimal?> _previousMortgageAmountTwo;
+        private DirtyValue<decimal?> _previousMortgageAmountTwo;
         public decimal? PreviousMortgageAmountTwo { get { return _previousMortgageAmountTwo; } set { _previousMortgageAmountTwo = value; } }
-        private Value<bool?> _printCertificationOfCosts;
+        private DirtyValue<bool?> _printCertificationOfCosts;
         public bool? PrintCertificationOfCosts { get { return _printCertificationOfCosts; } set { _printCertificationOfCosts = value; } }
-        private Value<bool?> _printInterestRateReductionRider;
+        private DirtyValue<bool?> _printInterestRateReductionRider;
         public bool? PrintInterestRateReductionRider { get { return _printInterestRateReductionRider; } set { _printInterestRateReductionRider = value; } }
-        private Value<bool?> _printMDDeliveryIndicator;
+        private DirtyValue<bool?> _printMDDeliveryIndicator;
         public bool? PrintMDDeliveryIndicator { get { return _printMDDeliveryIndicator; } set { _printMDDeliveryIndicator = value; } }
-        private Value<string> _providedBy;
+        private DirtyValue<string> _providedBy;
         public string ProvidedBy { get { return _providedBy; } set { _providedBy = value; } }
-        private Value<string> _questionContact;
+        private DirtyValue<string> _questionContact;
         public string QuestionContact { get { return _questionContact; } set { _questionContact = value; } }
-        private Value<string> _questionContactPhone;
+        private DirtyValue<string> _questionContactPhone;
         public string QuestionContactPhone { get { return _questionContactPhone; } set { _questionContactPhone = value; } }
-        private Value<string> _questionContactTollFree;
+        private DirtyValue<string> _questionContactTollFree;
         public string QuestionContactTollFree { get { return _questionContactTollFree; } set { _questionContactTollFree = value; } }
-        private Value<bool?> _rateLockHonoredIndicator;
+        private DirtyValue<bool?> _rateLockHonoredIndicator;
         public bool? RateLockHonoredIndicator { get { return _rateLockHonoredIndicator; } set { _rateLockHonoredIndicator = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<decimal?> _refinancingFee;
+        private DirtyValue<decimal?> _refinancingFee;
         public decimal? RefinancingFee { get { return _refinancingFee; } set { _refinancingFee = value; } }
-        private Value<string> _refundableBy;
+        private DirtyValue<string> _refundableBy;
         public string RefundableBy { get { return _refundableBy; } set { _refundableBy = value; } }
-        private Value<bool?> _refundableIndicator;
+        private DirtyValue<bool?> _refundableIndicator;
         public bool? RefundableIndicator { get { return _refundableIndicator; } set { _refundableIndicator = value; } }
-        private Value<string> _refundableType;
+        private DirtyValue<string> _refundableType;
         public string RefundableType { get { return _refundableType; } set { _refundableType = value; } }
-        private Value<string> _refundCondition1;
+        private DirtyValue<string> _refundCondition1;
         public string RefundCondition1 { get { return _refundCondition1; } set { _refundCondition1 = value; } }
-        private Value<string> _refundCondition2;
+        private DirtyValue<string> _refundCondition2;
         public string RefundCondition2 { get { return _refundCondition2; } set { _refundCondition2 = value; } }
-        private Value<string> _refundCondition3;
+        private DirtyValue<string> _refundCondition3;
         public string RefundCondition3 { get { return _refundCondition3; } set { _refundCondition3 = value; } }
-        private Value<string> _refundCondition4;
+        private DirtyValue<string> _refundCondition4;
         public string RefundCondition4 { get { return _refundCondition4; } set { _refundCondition4 = value; } }
-        private Value<string> _refundCondition5;
+        private DirtyValue<string> _refundCondition5;
         public string RefundCondition5 { get { return _refundCondition5; } set { _refundCondition5 = value; } }
-        private Value<string> _refundCondition6;
+        private DirtyValue<string> _refundCondition6;
         public string RefundCondition6 { get { return _refundCondition6; } set { _refundCondition6 = value; } }
-        private Value<string> _regulatorAddress;
+        private DirtyValue<string> _regulatorAddress;
         public string RegulatorAddress { get { return _regulatorAddress; } set { _regulatorAddress = value; } }
-        private Value<string> _regulatorCity;
+        private DirtyValue<string> _regulatorCity;
         public string RegulatorCity { get { return _regulatorCity; } set { _regulatorCity = value; } }
-        private Value<string> _regulatorMailingAddress;
+        private DirtyValue<string> _regulatorMailingAddress;
         public string RegulatorMailingAddress { get { return _regulatorMailingAddress; } set { _regulatorMailingAddress = value; } }
-        private Value<string> _regulatorMailingCity;
+        private DirtyValue<string> _regulatorMailingCity;
         public string RegulatorMailingCity { get { return _regulatorMailingCity; } set { _regulatorMailingCity = value; } }
-        private Value<string> _regulatorMailingState;
+        private DirtyValue<string> _regulatorMailingState;
         public string RegulatorMailingState { get { return _regulatorMailingState; } set { _regulatorMailingState = value; } }
-        private Value<string> _regulatorMailingZipCode;
+        private DirtyValue<string> _regulatorMailingZipCode;
         public string RegulatorMailingZipCode { get { return _regulatorMailingZipCode; } set { _regulatorMailingZipCode = value; } }
-        private Value<string> _regulatorPhone;
+        private DirtyValue<string> _regulatorPhone;
         public string RegulatorPhone { get { return _regulatorPhone; } set { _regulatorPhone = value; } }
-        private Value<string> _regulatorState;
+        private DirtyValue<string> _regulatorState;
         public string RegulatorState { get { return _regulatorState; } set { _regulatorState = value; } }
-        private Value<string> _regulatorTollFreePhone;
+        private DirtyValue<string> _regulatorTollFreePhone;
         public string RegulatorTollFreePhone { get { return _regulatorTollFreePhone; } set { _regulatorTollFreePhone = value; } }
-        private Value<string> _regulatorWebAddress;
+        private DirtyValue<string> _regulatorWebAddress;
         public string RegulatorWebAddress { get { return _regulatorWebAddress; } set { _regulatorWebAddress = value; } }
-        private Value<string> _regulatorZipCode;
+        private DirtyValue<string> _regulatorZipCode;
         public string RegulatorZipCode { get { return _regulatorZipCode; } set { _regulatorZipCode = value; } }
-        private Value<string> _scheduleOfChargesEstimatedFinalIndicator;
+        private DirtyValue<string> _scheduleOfChargesEstimatedFinalIndicator;
         public string ScheduleOfChargesEstimatedFinalIndicator { get { return _scheduleOfChargesEstimatedFinalIndicator; } set { _scheduleOfChargesEstimatedFinalIndicator = value; } }
-        private Value<string> _scRegulatoryAgencyType;
+        private DirtyValue<string> _scRegulatoryAgencyType;
         public string ScRegulatoryAgencyType { get { return _scRegulatoryAgencyType; } set { _scRegulatoryAgencyType = value; } }
-        private Value<bool?> _selectDivisionFeesIndicator;
+        private DirtyValue<bool?> _selectDivisionFeesIndicator;
         public bool? SelectDivisionFeesIndicator { get { return _selectDivisionFeesIndicator; } set { _selectDivisionFeesIndicator = value; } }
-        private Value<bool?> _selectPrimaryLenderIndicator;
+        private DirtyValue<bool?> _selectPrimaryLenderIndicator;
         public bool? SelectPrimaryLenderIndicator { get { return _selectPrimaryLenderIndicator; } set { _selectPrimaryLenderIndicator = value; } }
-        private Value<bool?> _selectPrivateLenderIndicator;
+        private DirtyValue<bool?> _selectPrivateLenderIndicator;
         public bool? SelectPrivateLenderIndicator { get { return _selectPrivateLenderIndicator; } set { _selectPrivateLenderIndicator = value; } }
-        private Value<decimal?> _servicingFeeChargedAmount;
+        private DirtyValue<decimal?> _servicingFeeChargedAmount;
         public decimal? ServicingFeeChargedAmount { get { return _servicingFeeChargedAmount; } set { _servicingFeeChargedAmount = value; } }
-        private Value<bool?> _servicingFeeChargedIndicator;
+        private DirtyValue<bool?> _servicingFeeChargedIndicator;
         public bool? ServicingFeeChargedIndicator { get { return _servicingFeeChargedIndicator; } set { _servicingFeeChargedIndicator = value; } }
-        private Value<string> _servicingFeePaidBy;
+        private DirtyValue<string> _servicingFeePaidBy;
         public string ServicingFeePaidBy { get { return _servicingFeePaidBy; } set { _servicingFeePaidBy = value; } }
-        private Value<string> _servicingFeePaidFrequence;
+        private DirtyValue<string> _servicingFeePaidFrequence;
         public string ServicingFeePaidFrequence { get { return _servicingFeePaidFrequence; } set { _servicingFeePaidFrequence = value; } }
-        private Value<bool?> _signedByBorrowerIndicator;
+        private DirtyValue<bool?> _signedByBorrowerIndicator;
         public bool? SignedByBorrowerIndicator { get { return _signedByBorrowerIndicator; } set { _signedByBorrowerIndicator = value; } }
-        private Value<bool?> _specificARMIndicator;
+        private DirtyValue<bool?> _specificARMIndicator;
         public bool? SpecificARMIndicator { get { return _specificARMIndicator; } set { _specificARMIndicator = value; } }
-        private Value<bool?> _submitToLenderIndicator;
+        private DirtyValue<bool?> _submitToLenderIndicator;
         public bool? SubmitToLenderIndicator { get { return _submitToLenderIndicator; } set { _submitToLenderIndicator = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationAssessments;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationAssessments;
         public decimal? TaxExemptAcquisitionCostCertificationAssessments { get { return _taxExemptAcquisitionCostCertificationAssessments; } set { _taxExemptAcquisitionCostCertificationAssessments = value; } }
-        private Value<string> _taxExemptAcquisitionCostCertificationOther;
+        private DirtyValue<string> _taxExemptAcquisitionCostCertificationOther;
         public string TaxExemptAcquisitionCostCertificationOther { get { return _taxExemptAcquisitionCostCertificationOther; } set { _taxExemptAcquisitionCostCertificationOther = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationOtherAmount;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationOtherAmount;
         public decimal? TaxExemptAcquisitionCostCertificationOtherAmount { get { return _taxExemptAcquisitionCostCertificationOtherAmount; } set { _taxExemptAcquisitionCostCertificationOtherAmount = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationOwnersTitleInsurance;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationOwnersTitleInsurance;
         public decimal? TaxExemptAcquisitionCostCertificationOwnersTitleInsurance { get { return _taxExemptAcquisitionCostCertificationOwnersTitleInsurance; } set { _taxExemptAcquisitionCostCertificationOwnersTitleInsurance = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationRealEstateCommission;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationRealEstateCommission;
         public decimal? TaxExemptAcquisitionCostCertificationRealEstateCommission { get { return _taxExemptAcquisitionCostCertificationRealEstateCommission; } set { _taxExemptAcquisitionCostCertificationRealEstateCommission = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationRepairsImprovements;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationRepairsImprovements;
         public decimal? TaxExemptAcquisitionCostCertificationRepairsImprovements { get { return _taxExemptAcquisitionCostCertificationRepairsImprovements; } set { _taxExemptAcquisitionCostCertificationRepairsImprovements = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationSurvey;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationSurvey;
         public decimal? TaxExemptAcquisitionCostCertificationSurvey { get { return _taxExemptAcquisitionCostCertificationSurvey; } set { _taxExemptAcquisitionCostCertificationSurvey = value; } }
-        private Value<decimal?> _taxExemptAcquisitionCostCertificationTotalAdjustments;
+        private DirtyValue<decimal?> _taxExemptAcquisitionCostCertificationTotalAdjustments;
         public decimal? TaxExemptAcquisitionCostCertificationTotalAdjustments { get { return _taxExemptAcquisitionCostCertificationTotalAdjustments; } set { _taxExemptAcquisitionCostCertificationTotalAdjustments = value; } }
-        private Value<string> _termsChange;
+        private DirtyValue<string> _termsChange;
         public string TermsChange { get { return _termsChange; } set { _termsChange = value; } }
-        private Value<decimal?> _texasApplicationFee;
+        private DirtyValue<decimal?> _texasApplicationFee;
         public decimal? TexasApplicationFee { get { return _texasApplicationFee; } set { _texasApplicationFee = value; } }
-        private Value<decimal?> _texasAppraisalFee;
+        private DirtyValue<decimal?> _texasAppraisalFee;
         public decimal? TexasAppraisalFee { get { return _texasAppraisalFee; } set { _texasAppraisalFee = value; } }
-        private Value<decimal?> _texasCreditReportFee;
+        private DirtyValue<decimal?> _texasCreditReportFee;
         public decimal? TexasCreditReportFee { get { return _texasCreditReportFee; } set { _texasCreditReportFee = value; } }
-        private Value<decimal?> _texasOtherFee1;
+        private DirtyValue<decimal?> _texasOtherFee1;
         public decimal? TexasOtherFee1 { get { return _texasOtherFee1; } set { _texasOtherFee1 = value; } }
-        private Value<decimal?> _texasOtherFee2;
+        private DirtyValue<decimal?> _texasOtherFee2;
         public decimal? TexasOtherFee2 { get { return _texasOtherFee2; } set { _texasOtherFee2 = value; } }
-        private Value<string> _texasOtherFeeContact1;
+        private DirtyValue<string> _texasOtherFeeContact1;
         public string TexasOtherFeeContact1 { get { return _texasOtherFeeContact1; } set { _texasOtherFeeContact1 = value; } }
-        private Value<string> _texasOtherFeeContact2;
+        private DirtyValue<string> _texasOtherFeeContact2;
         public string TexasOtherFeeContact2 { get { return _texasOtherFeeContact2; } set { _texasOtherFeeContact2 = value; } }
-        private Value<decimal?> _texasProcessingFee;
+        private DirtyValue<decimal?> _texasProcessingFee;
         public decimal? TexasProcessingFee { get { return _texasProcessingFee; } set { _texasProcessingFee = value; } }
-        private Value<decimal?> _thirdPartyFee;
+        private DirtyValue<decimal?> _thirdPartyFee;
         public decimal? ThirdPartyFee { get { return _thirdPartyFee; } set { _thirdPartyFee = value; } }
-        private Value<decimal?> _totalFee;
+        private DirtyValue<decimal?> _totalFee;
         public decimal? TotalFee { get { return _totalFee; } set { _totalFee = value; } }
-        private Value<decimal?> _transferFeeChargedAmount;
+        private DirtyValue<decimal?> _transferFeeChargedAmount;
         public decimal? TransferFeeChargedAmount { get { return _transferFeeChargedAmount; } set { _transferFeeChargedAmount = value; } }
-        private Value<bool?> _transferFeeChargedIndicator;
+        private DirtyValue<bool?> _transferFeeChargedIndicator;
         public bool? TransferFeeChargedIndicator { get { return _transferFeeChargedIndicator; } set { _transferFeeChargedIndicator = value; } }
-        private Value<string> _transferFeePaidBy;
+        private DirtyValue<string> _transferFeePaidBy;
         public string TransferFeePaidBy { get { return _transferFeePaidBy; } set { _transferFeePaidBy = value; } }
-        private Value<bool?> _txVeteransLandBoardIndicator;
+        private DirtyValue<bool?> _txVeteransLandBoardIndicator;
         public bool? TxVeteransLandBoardIndicator { get { return _txVeteransLandBoardIndicator; } set { _txVeteransLandBoardIndicator = value; } }
-        private Value<string> _typeOfProperty;
+        private DirtyValue<string> _typeOfProperty;
         public string TypeOfProperty { get { return _typeOfProperty; } set { _typeOfProperty = value; } }
-        private Value<string> _underwritingContact;
+        private DirtyValue<string> _underwritingContact;
         public string UnderwritingContact { get { return _underwritingContact; } set { _underwritingContact = value; } }
-        private Value<decimal?> _underwritingFee;
+        private DirtyValue<decimal?> _underwritingFee;
         public decimal? UnderwritingFee { get { return _underwritingFee; } set { _underwritingFee = value; } }
-        private Value<decimal?> _ySPChargedAmount;
+        private DirtyValue<decimal?> _ySPChargedAmount;
         public decimal? YSPChargedAmount { get { return _ySPChargedAmount; } set { _ySPChargedAmount = value; } }
-        private Value<bool?> _ySPChargedIndicator;
+        private DirtyValue<bool?> _ySPChargedIndicator;
         public bool? YSPChargedIndicator { get { return _ySPChargedIndicator; } set { _ySPChargedIndicator = value; } }
-        private Value<decimal?> _ySPDecreasesRate;
+        private DirtyValue<decimal?> _ySPDecreasesRate;
         public decimal? YSPDecreasesRate { get { return _ySPDecreasesRate; } set { _ySPDecreasesRate = value; } }
-        private Value<decimal?> _ySPIncreasesRate;
+        private DirtyValue<decimal?> _ySPIncreasesRate;
         public decimal? YSPIncreasesRate { get { return _ySPIncreasesRate; } set { _ySPIncreasesRate = value; } }
-        private Value<string> _ySPInterestRateImpactedStatus;
+        private DirtyValue<string> _ySPInterestRateImpactedStatus;
         public string YSPInterestRateImpactedStatus { get { return _ySPInterestRateImpactedStatus; } set { _ySPInterestRateImpactedStatus = value; } }
-        private Value<string> _ySPPaidBy;
+        private DirtyValue<string> _ySPPaidBy;
         public string YSPPaidBy { get { return _ySPPaidBy; } set { _ySPPaidBy = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/StateDisclosure.cs
+++ b/src/EncompassRest/Loans/StateDisclosure.cs
@@ -258,10 +258,10 @@ namespace EncompassRest.Loans
         public decimal? NewYorkAppraisalFee { get { return _newYorkAppraisalFee; } set { _newYorkAppraisalFee = value; } }
         private Value<decimal?> _newYorkCreditReportFee;
         public decimal? NewYorkCreditReportFee { get { return _newYorkCreditReportFee; } set { _newYorkCreditReportFee = value; } }
-        private Value<List<NewYorkFee>> _newYorkFees;
-        public List<NewYorkFee> NewYorkFees { get { return _newYorkFees; } set { _newYorkFees = value; } }
-        private Value<List<NewYorkPrimaryLender>> _newYorkPrimaryLenders;
-        public List<NewYorkPrimaryLender> NewYorkPrimaryLenders { get { return _newYorkPrimaryLenders; } set { _newYorkPrimaryLenders = value; } }
+        private DirtyList<NewYorkFee> _newYorkFees;
+        public IList<NewYorkFee> NewYorkFees { get { var v = _newYorkFees; return v ?? Interlocked.CompareExchange(ref _newYorkFees, (v = new DirtyList<NewYorkFee>()), null) ?? v; } set { _newYorkFees = new DirtyList<NewYorkFee>(value); } }
+        private DirtyList<NewYorkPrimaryLender> _newYorkPrimaryLenders;
+        public IList<NewYorkPrimaryLender> NewYorkPrimaryLenders { get { var v = _newYorkPrimaryLenders; return v ?? Interlocked.CompareExchange(ref _newYorkPrimaryLenders, (v = new DirtyList<NewYorkPrimaryLender>()), null) ?? v; } set { _newYorkPrimaryLenders = new DirtyList<NewYorkPrimaryLender>(value); } }
         private Value<decimal?> _newYorkProcessingFee;
         public decimal? NewYorkProcessingFee { get { return _newYorkProcessingFee; } set { _newYorkProcessingFee = value; } }
         private Value<decimal?> _notRefundableAmount;
@@ -578,8 +578,6 @@ namespace EncompassRest.Loans
                     || _newYorkApplicationFee.Dirty
                     || _newYorkAppraisalFee.Dirty
                     || _newYorkCreditReportFee.Dirty
-                    || _newYorkFees.Dirty
-                    || _newYorkPrimaryLenders.Dirty
                     || _newYorkProcessingFee.Dirty
                     || _notRefundableAmount.Dirty
                     || _offerRetailPriceIndicator.Dirty
@@ -671,7 +669,9 @@ namespace EncompassRest.Loans
                     || _ySPDecreasesRate.Dirty
                     || _ySPIncreasesRate.Dirty
                     || _ySPInterestRateImpactedStatus.Dirty
-                    || _ySPPaidBy.Dirty;
+                    || _ySPPaidBy.Dirty
+                    || _newYorkFees?.Dirty == true
+                    || _newYorkPrimaryLenders?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -803,8 +803,6 @@ namespace EncompassRest.Loans
                 _newYorkApplicationFee.Dirty = value;
                 _newYorkAppraisalFee.Dirty = value;
                 _newYorkCreditReportFee.Dirty = value;
-                _newYorkFees.Dirty = value;
-                _newYorkPrimaryLenders.Dirty = value;
                 _newYorkProcessingFee.Dirty = value;
                 _notRefundableAmount.Dirty = value;
                 _offerRetailPriceIndicator.Dirty = value;
@@ -897,6 +895,8 @@ namespace EncompassRest.Loans
                 _ySPIncreasesRate.Dirty = value;
                 _ySPInterestRateImpactedStatus.Dirty = value;
                 _ySPPaidBy.Dirty = value;
+                if (_newYorkFees != null) _newYorkFees.Dirty = value;
+                if (_newYorkPrimaryLenders != null) _newYorkPrimaryLenders.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/StateLicense.cs
+++ b/src/EncompassRest/Loans/StateLicense.cs
@@ -8,117 +8,117 @@ namespace EncompassRest.Loans
 {
     public sealed partial class StateLicense : IDirty
     {
-        private Value<string> _aK;
+        private DirtyValue<string> _aK;
         public string AK { get { return _aK; } set { _aK = value; } }
-        private Value<string> _aL;
+        private DirtyValue<string> _aL;
         public string AL { get { return _aL; } set { _aL = value; } }
-        private Value<string> _aR;
+        private DirtyValue<string> _aR;
         public string AR { get { return _aR; } set { _aR = value; } }
-        private Value<string> _aZ;
+        private DirtyValue<string> _aZ;
         public string AZ { get { return _aZ; } set { _aZ = value; } }
-        private Value<string> _cA;
+        private DirtyValue<string> _cA;
         public string CA { get { return _cA; } set { _cA = value; } }
-        private Value<string> _cO;
+        private DirtyValue<string> _cO;
         public string CO { get { return _cO; } set { _cO = value; } }
-        private Value<string> _cT;
+        private DirtyValue<string> _cT;
         public string CT { get { return _cT; } set { _cT = value; } }
-        private Value<string> _dC;
+        private DirtyValue<string> _dC;
         public string DC { get { return _dC; } set { _dC = value; } }
-        private Value<string> _dE;
+        private DirtyValue<string> _dE;
         public string DE { get { return _dE; } set { _dE = value; } }
-        private Value<string> _fL;
+        private DirtyValue<string> _fL;
         public string FL { get { return _fL; } set { _fL = value; } }
-        private Value<string> _gA;
+        private DirtyValue<string> _gA;
         public string GA { get { return _gA; } set { _gA = value; } }
-        private Value<string> _gU;
+        private DirtyValue<string> _gU;
         public string GU { get { return _gU; } set { _gU = value; } }
-        private Value<string> _hI;
+        private DirtyValue<string> _hI;
         public string HI { get { return _hI; } set { _hI = value; } }
-        private Value<string> _iA;
+        private DirtyValue<string> _iA;
         public string IA { get { return _iA; } set { _iA = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _idaho;
+        private DirtyValue<string> _idaho;
         public string Idaho { get { return _idaho; } set { _idaho = value; } }
-        private Value<string> _iL;
+        private DirtyValue<string> _iL;
         public string IL { get { return _iL; } set { _iL = value; } }
-        private Value<string> _iN;
+        private DirtyValue<string> _iN;
         public string IN { get { return _iN; } set { _iN = value; } }
-        private Value<string> _kS;
+        private DirtyValue<string> _kS;
         public string KS { get { return _kS; } set { _kS = value; } }
-        private Value<string> _kY;
+        private DirtyValue<string> _kY;
         public string KY { get { return _kY; } set { _kY = value; } }
-        private Value<string> _lA;
+        private DirtyValue<string> _lA;
         public string LA { get { return _lA; } set { _lA = value; } }
-        private Value<string> _mA;
+        private DirtyValue<string> _mA;
         public string MA { get { return _mA; } set { _mA = value; } }
-        private Value<string> _mD;
+        private DirtyValue<string> _mD;
         public string MD { get { return _mD; } set { _mD = value; } }
-        private Value<string> _mE;
+        private DirtyValue<string> _mE;
         public string ME { get { return _mE; } set { _mE = value; } }
-        private Value<string> _mI;
+        private DirtyValue<string> _mI;
         public string MI { get { return _mI; } set { _mI = value; } }
-        private Value<string> _mN;
+        private DirtyValue<string> _mN;
         public string MN { get { return _mN; } set { _mN = value; } }
-        private Value<string> _mO;
+        private DirtyValue<string> _mO;
         public string MO { get { return _mO; } set { _mO = value; } }
-        private Value<string> _mS;
+        private DirtyValue<string> _mS;
         public string MS { get { return _mS; } set { _mS = value; } }
-        private Value<string> _mT;
+        private DirtyValue<string> _mT;
         public string MT { get { return _mT; } set { _mT = value; } }
-        private Value<string> _nC;
+        private DirtyValue<string> _nC;
         public string NC { get { return _nC; } set { _nC = value; } }
-        private Value<string> _nD;
+        private DirtyValue<string> _nD;
         public string ND { get { return _nD; } set { _nD = value; } }
-        private Value<string> _nE;
+        private DirtyValue<string> _nE;
         public string NE { get { return _nE; } set { _nE = value; } }
-        private Value<string> _nH;
+        private DirtyValue<string> _nH;
         public string NH { get { return _nH; } set { _nH = value; } }
-        private Value<string> _nJ;
+        private DirtyValue<string> _nJ;
         public string NJ { get { return _nJ; } set { _nJ = value; } }
-        private Value<string> _nM;
+        private DirtyValue<string> _nM;
         public string NM { get { return _nM; } set { _nM = value; } }
-        private Value<string> _nV;
+        private DirtyValue<string> _nV;
         public string NV { get { return _nV; } set { _nV = value; } }
-        private Value<string> _nY;
+        private DirtyValue<string> _nY;
         public string NY { get { return _nY; } set { _nY = value; } }
-        private Value<string> _oH;
+        private DirtyValue<string> _oH;
         public string OH { get { return _oH; } set { _oH = value; } }
-        private Value<string> _oK;
+        private DirtyValue<string> _oK;
         public string OK { get { return _oK; } set { _oK = value; } }
-        private Value<string> _oR;
+        private DirtyValue<string> _oR;
         public string OR { get { return _oR; } set { _oR = value; } }
-        private Value<string> _pA;
+        private DirtyValue<string> _pA;
         public string PA { get { return _pA; } set { _pA = value; } }
-        private Value<string> _pR;
+        private DirtyValue<string> _pR;
         public string PR { get { return _pR; } set { _pR = value; } }
-        private Value<string> _rI;
+        private DirtyValue<string> _rI;
         public string RI { get { return _rI; } set { _rI = value; } }
-        private Value<string> _sC;
+        private DirtyValue<string> _sC;
         public string SC { get { return _sC; } set { _sC = value; } }
-        private Value<string> _sD;
+        private DirtyValue<string> _sD;
         public string SD { get { return _sD; } set { _sD = value; } }
-        private Value<string> _stateLicenseType;
+        private DirtyValue<string> _stateLicenseType;
         public string StateLicenseType { get { return _stateLicenseType; } set { _stateLicenseType = value; } }
-        private Value<string> _tN;
+        private DirtyValue<string> _tN;
         public string TN { get { return _tN; } set { _tN = value; } }
-        private Value<string> _tX;
+        private DirtyValue<string> _tX;
         public string TX { get { return _tX; } set { _tX = value; } }
-        private Value<string> _uT;
+        private DirtyValue<string> _uT;
         public string UT { get { return _uT; } set { _uT = value; } }
-        private Value<string> _vA;
+        private DirtyValue<string> _vA;
         public string VA { get { return _vA; } set { _vA = value; } }
-        private Value<string> _vI;
+        private DirtyValue<string> _vI;
         public string VI { get { return _vI; } set { _vI = value; } }
-        private Value<string> _vT;
+        private DirtyValue<string> _vT;
         public string VT { get { return _vT; } set { _vT = value; } }
-        private Value<string> _wA;
+        private DirtyValue<string> _wA;
         public string WA { get { return _wA; } set { _wA = value; } }
-        private Value<string> _wI;
+        private DirtyValue<string> _wI;
         public string WI { get { return _wI; } set { _wI = value; } }
-        private Value<string> _wV;
+        private DirtyValue<string> _wV;
         public string WV { get { return _wV; } set { _wV = value; } }
-        private Value<string> _wY;
+        private DirtyValue<string> _wY;
         public string WY { get { return _wY; } set { _wY = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/StatementCreditDenial.cs
+++ b/src/EncompassRest/Loans/StatementCreditDenial.cs
@@ -8,145 +8,145 @@ namespace EncompassRest.Loans
 {
     public sealed partial class StatementCreditDenial : IDirty
     {
-        private Value<bool?> _additionalStatement;
+        private DirtyValue<bool?> _additionalStatement;
         public bool? AdditionalStatement { get { return _additionalStatement; } set { _additionalStatement = value; } }
-        private Value<bool?> _bankruptcy;
+        private DirtyValue<bool?> _bankruptcy;
         public bool? Bankruptcy { get { return _bankruptcy; } set { _bankruptcy = value; } }
-        private Value<bool?> _collateralNotSufficient;
+        private DirtyValue<bool?> _collateralNotSufficient;
         public bool? CollateralNotSufficient { get { return _collateralNotSufficient; } set { _collateralNotSufficient = value; } }
-        private Value<bool?> _creditApplicationIncomplete;
+        private DirtyValue<bool?> _creditApplicationIncomplete;
         public bool? CreditApplicationIncomplete { get { return _creditApplicationIncomplete; } set { _creditApplicationIncomplete = value; } }
-        private Value<bool?> _creditReportObtainedFromConsumerReportingAgency;
+        private DirtyValue<bool?> _creditReportObtainedFromConsumerReportingAgency;
         public bool? CreditReportObtainedFromConsumerReportingAgency { get { return _creditReportObtainedFromConsumerReportingAgency; } set { _creditReportObtainedFromConsumerReportingAgency = value; } }
-        private Value<bool?> _delinquentCreditObligations;
+        private DirtyValue<bool?> _delinquentCreditObligations;
         public bool? DelinquentCreditObligations { get { return _delinquentCreditObligations; } set { _delinquentCreditObligations = value; } }
-        private Value<DateTime?> _denialDate;
+        private DirtyValue<DateTime?> _denialDate;
         public DateTime? DenialDate { get { return _denialDate; } set { _denialDate = value; } }
-        private Value<string> _denialDescription;
+        private DirtyValue<string> _denialDescription;
         public string DenialDescription { get { return _denialDescription; } set { _denialDescription = value; } }
-        private Value<DateTime?> _denialMailedOn;
+        private DirtyValue<DateTime?> _denialMailedOn;
         public DateTime? DenialMailedOn { get { return _denialMailedOn; } set { _denialMailedOn = value; } }
-        private Value<bool?> _denialOther1;
+        private DirtyValue<bool?> _denialOther1;
         public bool? DenialOther1 { get { return _denialOther1; } set { _denialOther1 = value; } }
-        private Value<bool?> _denialOther2;
+        private DirtyValue<bool?> _denialOther2;
         public bool? DenialOther2 { get { return _denialOther2; } set { _denialOther2 = value; } }
-        private Value<string> _denialOtherDesc1;
+        private DirtyValue<string> _denialOtherDesc1;
         public string DenialOtherDesc1 { get { return _denialOtherDesc1; } set { _denialOtherDesc1 = value; } }
-        private Value<string> _denialOtherDesc2;
+        private DirtyValue<string> _denialOtherDesc2;
         public string DenialOtherDesc2 { get { return _denialOtherDesc2; } set { _denialOtherDesc2 = value; } }
-        private Value<string> _deniedBy;
+        private DirtyValue<string> _deniedBy;
         public string DeniedBy { get { return _deniedBy; } set { _deniedBy = value; } }
-        private Value<bool?> _deniedByFhlmc;
+        private DirtyValue<bool?> _deniedByFhlmc;
         public bool? DeniedByFhlmc { get { return _deniedByFhlmc; } set { _deniedByFhlmc = value; } }
-        private Value<bool?> _deniedByFnma;
+        private DirtyValue<bool?> _deniedByFnma;
         public bool? DeniedByFnma { get { return _deniedByFnma; } set { _deniedByFnma = value; } }
-        private Value<bool?> _deniedByHud;
+        private DirtyValue<bool?> _deniedByHud;
         public bool? DeniedByHud { get { return _deniedByHud; } set { _deniedByHud = value; } }
-        private Value<bool?> _deniedByOther;
+        private DirtyValue<bool?> _deniedByOther;
         public bool? DeniedByOther { get { return _deniedByOther; } set { _deniedByOther = value; } }
-        private Value<bool?> _deniedByVa;
+        private DirtyValue<bool?> _deniedByVa;
         public bool? DeniedByVa { get { return _deniedByVa; } set { _deniedByVa = value; } }
-        private Value<string> _descriptionofAccount1;
+        private DirtyValue<string> _descriptionofAccount1;
         public string DescriptionofAccount1 { get { return _descriptionofAccount1; } set { _descriptionofAccount1 = value; } }
-        private Value<string> _descriptionofAccount2;
+        private DirtyValue<string> _descriptionofAccount2;
         public string DescriptionofAccount2 { get { return _descriptionofAccount2; } set { _descriptionofAccount2 = value; } }
-        private Value<string> _descriptionofAccount3;
+        private DirtyValue<string> _descriptionofAccount3;
         public string DescriptionofAccount3 { get { return _descriptionofAccount3; } set { _descriptionofAccount3 = value; } }
-        private Value<string> _descriptionofActionTaken1;
+        private DirtyValue<string> _descriptionofActionTaken1;
         public string DescriptionofActionTaken1 { get { return _descriptionofActionTaken1; } set { _descriptionofActionTaken1 = value; } }
-        private Value<string> _descriptionofActionTaken2;
+        private DirtyValue<string> _descriptionofActionTaken2;
         public string DescriptionofActionTaken2 { get { return _descriptionofActionTaken2; } set { _descriptionofActionTaken2 = value; } }
-        private Value<string> _ecoaAddress;
+        private DirtyValue<string> _ecoaAddress;
         public string EcoaAddress { get { return _ecoaAddress; } set { _ecoaAddress = value; } }
-        private Value<string> _ecoaAddress2;
+        private DirtyValue<string> _ecoaAddress2;
         public string EcoaAddress2 { get { return _ecoaAddress2; } set { _ecoaAddress2 = value; } }
-        private Value<string> _ecoaCity;
+        private DirtyValue<string> _ecoaCity;
         public string EcoaCity { get { return _ecoaCity; } set { _ecoaCity = value; } }
-        private Value<string> _ecoaName;
+        private DirtyValue<string> _ecoaName;
         public string EcoaName { get { return _ecoaName; } set { _ecoaName = value; } }
-        private Value<string> _ecoaPhone;
+        private DirtyValue<string> _ecoaPhone;
         public string EcoaPhone { get { return _ecoaPhone; } set { _ecoaPhone = value; } }
-        private Value<string> _ecoaPostalCode;
+        private DirtyValue<string> _ecoaPostalCode;
         public string EcoaPostalCode { get { return _ecoaPostalCode; } set { _ecoaPostalCode = value; } }
-        private Value<string> _ecoaState;
+        private DirtyValue<string> _ecoaState;
         public string EcoaState { get { return _ecoaState; } set { _ecoaState = value; } }
-        private Value<bool?> _excessiveObligations;
+        private DirtyValue<bool?> _excessiveObligations;
         public bool? ExcessiveObligations { get { return _excessiveObligations; } set { _excessiveObligations = value; } }
-        private Value<bool?> _garnishment;
+        private DirtyValue<bool?> _garnishment;
         public bool? Garnishment { get { return _garnishment; } set { _garnishment = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _inadequateCollateral;
+        private DirtyValue<bool?> _inadequateCollateral;
         public bool? InadequateCollateral { get { return _inadequateCollateral; } set { _inadequateCollateral = value; } }
-        private Value<bool?> _informationFromAConsumerReportingAgency;
+        private DirtyValue<bool?> _informationFromAConsumerReportingAgency;
         public bool? InformationFromAConsumerReportingAgency { get { return _informationFromAConsumerReportingAgency; } set { _informationFromAConsumerReportingAgency = value; } }
-        private Value<bool?> _informationObtainedFromOutsideSource;
+        private DirtyValue<bool?> _informationObtainedFromOutsideSource;
         public bool? InformationObtainedFromOutsideSource { get { return _informationObtainedFromOutsideSource; } set { _informationObtainedFromOutsideSource = value; } }
-        private Value<bool?> _informationObtainedInReportFromCra;
+        private DirtyValue<bool?> _informationObtainedInReportFromCra;
         public bool? InformationObtainedInReportFromCra { get { return _informationObtainedInReportFromCra; } set { _informationObtainedInReportFromCra = value; } }
-        private Value<bool?> _insufficientCreditFile;
+        private DirtyValue<bool?> _insufficientCreditFile;
         public bool? InsufficientCreditFile { get { return _insufficientCreditFile; } set { _insufficientCreditFile = value; } }
-        private Value<bool?> _insufficientCreditReference;
+        private DirtyValue<bool?> _insufficientCreditReference;
         public bool? InsufficientCreditReference { get { return _insufficientCreditReference; } set { _insufficientCreditReference = value; } }
-        private Value<bool?> _insufficientData;
+        private DirtyValue<bool?> _insufficientData;
         public bool? InsufficientData { get { return _insufficientData; } set { _insufficientData = value; } }
-        private Value<bool?> _insufficientFundsToCloseLoan;
+        private DirtyValue<bool?> _insufficientFundsToCloseLoan;
         public bool? InsufficientFundsToCloseLoan { get { return _insufficientFundsToCloseLoan; } set { _insufficientFundsToCloseLoan = value; } }
-        private Value<bool?> _insufficientIncomeForTotalObligations;
+        private DirtyValue<bool?> _insufficientIncomeForTotalObligations;
         public bool? InsufficientIncomeForTotalObligations { get { return _insufficientIncomeForTotalObligations; } set { _insufficientIncomeForTotalObligations = value; } }
-        private Value<bool?> _insufficientStabilityOfIncome;
+        private DirtyValue<bool?> _insufficientStabilityOfIncome;
         public bool? InsufficientStabilityOfIncome { get { return _insufficientStabilityOfIncome; } set { _insufficientStabilityOfIncome = value; } }
-        private Value<bool?> _lackOfCashReserves;
+        private DirtyValue<bool?> _lackOfCashReserves;
         public bool? LackOfCashReserves { get { return _lackOfCashReserves; } set { _lackOfCashReserves = value; } }
-        private Value<string> _lenderInvestorAddress;
+        private DirtyValue<string> _lenderInvestorAddress;
         public string LenderInvestorAddress { get { return _lenderInvestorAddress; } set { _lenderInvestorAddress = value; } }
-        private Value<string> _lenderInvestorCity;
+        private DirtyValue<string> _lenderInvestorCity;
         public string LenderInvestorCity { get { return _lenderInvestorCity; } set { _lenderInvestorCity = value; } }
-        private Value<string> _lenderInvestorName;
+        private DirtyValue<string> _lenderInvestorName;
         public string LenderInvestorName { get { return _lenderInvestorName; } set { _lenderInvestorName = value; } }
-        private Value<string> _lenderInvestorPhone;
+        private DirtyValue<string> _lenderInvestorPhone;
         public string LenderInvestorPhone { get { return _lenderInvestorPhone; } set { _lenderInvestorPhone = value; } }
-        private Value<string> _lenderInvestorPostalCode;
+        private DirtyValue<string> _lenderInvestorPostalCode;
         public string LenderInvestorPostalCode { get { return _lenderInvestorPostalCode; } set { _lenderInvestorPostalCode = value; } }
-        private Value<string> _lenderInvestorState;
+        private DirtyValue<string> _lenderInvestorState;
         public string LenderInvestorState { get { return _lenderInvestorState; } set { _lenderInvestorState = value; } }
-        private Value<bool?> _lengthOfEmployment;
+        private DirtyValue<bool?> _lengthOfEmployment;
         public bool? LengthOfEmployment { get { return _lengthOfEmployment; } set { _lengthOfEmployment = value; } }
-        private Value<bool?> _noCreditFile;
+        private DirtyValue<bool?> _noCreditFile;
         public bool? NoCreditFile { get { return _noCreditFile; } set { _noCreditFile = value; } }
-        private Value<bool?> _numberRecentInquiriesCredit;
+        private DirtyValue<bool?> _numberRecentInquiriesCredit;
         public bool? NumberRecentInquiriesCredit { get { return _numberRecentInquiriesCredit; } set { _numberRecentInquiriesCredit = value; } }
-        private Value<string> _otherDescription;
+        private DirtyValue<string> _otherDescription;
         public string OtherDescription { get { return _otherDescription; } set { _otherDescription = value; } }
-        private Value<bool?> _poorCreditPerformance;
+        private DirtyValue<bool?> _poorCreditPerformance;
         public bool? PoorCreditPerformance { get { return _poorCreditPerformance; } set { _poorCreditPerformance = value; } }
-        private Value<bool?> _temporaryOrIrregularEmployment;
+        private DirtyValue<bool?> _temporaryOrIrregularEmployment;
         public bool? TemporaryOrIrregularEmployment { get { return _temporaryOrIrregularEmployment; } set { _temporaryOrIrregularEmployment = value; } }
-        private Value<bool?> _temporaryResidence;
+        private DirtyValue<bool?> _temporaryResidence;
         public bool? TemporaryResidence { get { return _temporaryResidence; } set { _temporaryResidence = value; } }
-        private Value<bool?> _toShortPeriodOfResidence;
+        private DirtyValue<bool?> _toShortPeriodOfResidence;
         public bool? ToShortPeriodOfResidence { get { return _toShortPeriodOfResidence; } set { _toShortPeriodOfResidence = value; } }
-        private Value<bool?> _unableToVerifyCreditReferences;
+        private DirtyValue<bool?> _unableToVerifyCreditReferences;
         public bool? UnableToVerifyCreditReferences { get { return _unableToVerifyCreditReferences; } set { _unableToVerifyCreditReferences = value; } }
-        private Value<bool?> _unableToVerifyEmployment;
+        private DirtyValue<bool?> _unableToVerifyEmployment;
         public bool? UnableToVerifyEmployment { get { return _unableToVerifyEmployment; } set { _unableToVerifyEmployment = value; } }
-        private Value<bool?> _unableToVerifyIncome;
+        private DirtyValue<bool?> _unableToVerifyIncome;
         public bool? UnableToVerifyIncome { get { return _unableToVerifyIncome; } set { _unableToVerifyIncome = value; } }
-        private Value<bool?> _unableToVerifyResidence;
+        private DirtyValue<bool?> _unableToVerifyResidence;
         public bool? UnableToVerifyResidence { get { return _unableToVerifyResidence; } set { _unableToVerifyResidence = value; } }
-        private Value<bool?> _unacceptableAppraisal;
+        private DirtyValue<bool?> _unacceptableAppraisal;
         public bool? UnacceptableAppraisal { get { return _unacceptableAppraisal; } set { _unacceptableAppraisal = value; } }
-        private Value<bool?> _unacceptableCreditReferencesProvided;
+        private DirtyValue<bool?> _unacceptableCreditReferencesProvided;
         public bool? UnacceptableCreditReferencesProvided { get { return _unacceptableCreditReferencesProvided; } set { _unacceptableCreditReferencesProvided = value; } }
-        private Value<bool?> _unacceptableLeaseholdEstate;
+        private DirtyValue<bool?> _unacceptableLeaseholdEstate;
         public bool? UnacceptableLeaseholdEstate { get { return _unacceptableLeaseholdEstate; } set { _unacceptableLeaseholdEstate = value; } }
-        private Value<bool?> _unacceptablePaymentRecordOnPreviousMtg;
+        private DirtyValue<bool?> _unacceptablePaymentRecordOnPreviousMtg;
         public bool? UnacceptablePaymentRecordOnPreviousMtg { get { return _unacceptablePaymentRecordOnPreviousMtg; } set { _unacceptablePaymentRecordOnPreviousMtg = value; } }
-        private Value<bool?> _unacceptableProperty;
+        private DirtyValue<bool?> _unacceptableProperty;
         public bool? UnacceptableProperty { get { return _unacceptableProperty; } set { _unacceptableProperty = value; } }
-        private Value<bool?> _weDoNotGrantCredit;
+        private DirtyValue<bool?> _weDoNotGrantCredit;
         public bool? WeDoNotGrantCredit { get { return _weDoNotGrantCredit; } set { _weDoNotGrantCredit = value; } }
-        private Value<bool?> _withdrawnByApplicant;
+        private DirtyValue<bool?> _withdrawnByApplicant;
         public bool? WithdrawnByApplicant { get { return _withdrawnByApplicant; } set { _withdrawnByApplicant = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/StatusOnlineEvent.cs
+++ b/src/EncompassRest/Loans/StatusOnlineEvent.cs
@@ -8,11 +8,11 @@ namespace EncompassRest.Loans
 {
     public sealed partial class StatusOnlineEvent : IDirty
     {
-        private Value<string> _dateText;
+        private DirtyValue<string> _dateText;
         public string DateText { get { return _dateText; } set { _dateText = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/StatusOnlineLog.cs
+++ b/src/EncompassRest/Loans/StatusOnlineLog.cs
@@ -12,25 +12,25 @@ namespace EncompassRest.Loans
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _creator;
+        private DirtyValue<string> _creator;
         public string Creator { get { return _creator; } set { _creator = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
         private DirtyList<StatusOnlineEvent> _events;
         public IList<StatusOnlineEvent> Events { get { var v = _events; return v ?? Interlocked.CompareExchange(ref _events, (v = new DirtyList<StatusOnlineEvent>()), null) ?? v; } set { _events = new DirtyList<StatusOnlineEvent>(value); } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/StatusOnlineLog.cs
+++ b/src/EncompassRest/Loans/StatusOnlineLog.cs
@@ -8,18 +8,18 @@ namespace EncompassRest.Loans
 {
     public sealed partial class StatusOnlineLog : IDirty
     {
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _creator;
         public string Creator { get { return _creator; } set { _creator = value; } }
         private Value<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<List<StatusOnlineEvent>> _events;
-        public List<StatusOnlineEvent> Events { get { return _events; } set { _events = value; } }
+        private DirtyList<StatusOnlineEvent> _events;
+        public IList<StatusOnlineEvent> Events { get { var v = _events; return v ?? Interlocked.CompareExchange(ref _events, (v = new DirtyList<StatusOnlineEvent>()), null) ?? v; } set { _events = new DirtyList<StatusOnlineEvent>(value); } }
         private Value<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
         private Value<string> _guid;
@@ -39,36 +39,36 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _alerts.Dirty
-                    || _commentList.Dirty
-                    || _comments.Dirty
+                var dirty = _comments.Dirty
                     || _creator.Dirty
                     || _dateUtc.Dirty
-                    || _events.Dirty
                     || _fileAttachmentsMigrated.Dirty
                     || _guid.Dirty
                     || _id.Dirty
                     || _isSystemSpecificIndicator.Dirty
                     || _logRecordIndex.Dirty
-                    || _systemId.Dirty;
+                    || _systemId.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _events?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
-                _alerts.Dirty = value;
-                _commentList.Dirty = value;
                 _comments.Dirty = value;
                 _creator.Dirty = value;
                 _dateUtc.Dirty = value;
-                _events.Dirty = value;
                 _fileAttachmentsMigrated.Dirty = value;
                 _guid.Dirty = value;
                 _id.Dirty = value;
                 _isSystemSpecificIndicator.Dirty = value;
                 _logRecordIndex.Dirty = value;
                 _systemId.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_events != null) _events.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/TPO.cs
+++ b/src/EncompassRest/Loans/TPO.cs
@@ -8,191 +8,191 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TPO : IDirty
     {
-        private Value<bool?> _archived;
+        private DirtyValue<bool?> _archived;
         public bool? Archived { get { return _archived; } set { _archived = value; } }
-        private Value<string> _branchAddress;
+        private DirtyValue<string> _branchAddress;
         public string BranchAddress { get { return _branchAddress; } set { _branchAddress = value; } }
-        private Value<string> _branchAEName;
+        private DirtyValue<string> _branchAEName;
         public string BranchAEName { get { return _branchAEName; } set { _branchAEName = value; } }
-        private Value<string> _branchAEUserName;
+        private DirtyValue<string> _branchAEUserName;
         public string BranchAEUserName { get { return _branchAEUserName; } set { _branchAEUserName = value; } }
-        private Value<string> _branchCity;
+        private DirtyValue<string> _branchCity;
         public string BranchCity { get { return _branchCity; } set { _branchCity = value; } }
-        private Value<string> _branchDBAName;
+        private DirtyValue<string> _branchDBAName;
         public string BranchDBAName { get { return _branchDBAName; } set { _branchDBAName = value; } }
-        private Value<string> _branchFax;
+        private DirtyValue<string> _branchFax;
         public string BranchFax { get { return _branchFax; } set { _branchFax = value; } }
-        private Value<string> _branchID;
+        private DirtyValue<string> _branchID;
         public string BranchID { get { return _branchID; } set { _branchID = value; } }
-        private Value<string> _branchLegalName;
+        private DirtyValue<string> _branchLegalName;
         public string BranchLegalName { get { return _branchLegalName; } set { _branchLegalName = value; } }
-        private Value<string> _branchManagerEmail;
+        private DirtyValue<string> _branchManagerEmail;
         public string BranchManagerEmail { get { return _branchManagerEmail; } set { _branchManagerEmail = value; } }
-        private Value<string> _branchManagerName;
+        private DirtyValue<string> _branchManagerName;
         public string BranchManagerName { get { return _branchManagerName; } set { _branchManagerName = value; } }
-        private Value<string> _branchName;
+        private DirtyValue<string> _branchName;
         public string BranchName { get { return _branchName; } set { _branchName = value; } }
-        private Value<string> _branchOrganizationID;
+        private DirtyValue<string> _branchOrganizationID;
         public string BranchOrganizationID { get { return _branchOrganizationID; } set { _branchOrganizationID = value; } }
-        private Value<string> _branchPhone;
+        private DirtyValue<string> _branchPhone;
         public string BranchPhone { get { return _branchPhone; } set { _branchPhone = value; } }
-        private Value<string> _branchRating;
+        private DirtyValue<string> _branchRating;
         public string BranchRating { get { return _branchRating; } set { _branchRating = value; } }
-        private Value<string> _branchState;
+        private DirtyValue<string> _branchState;
         public string BranchState { get { return _branchState; } set { _branchState = value; } }
-        private Value<string> _branchZip;
+        private DirtyValue<string> _branchZip;
         public string BranchZip { get { return _branchZip; } set { _branchZip = value; } }
-        private Value<string> _cFCAddress;
+        private DirtyValue<string> _cFCAddress;
         public string CFCAddress { get { return _cFCAddress; } set { _cFCAddress = value; } }
-        private Value<string> _cFCBusinessFax;
+        private DirtyValue<string> _cFCBusinessFax;
         public string CFCBusinessFax { get { return _cFCBusinessFax; } set { _cFCBusinessFax = value; } }
-        private Value<string> _cFCBusinessPhone;
+        private DirtyValue<string> _cFCBusinessPhone;
         public string CFCBusinessPhone { get { return _cFCBusinessPhone; } set { _cFCBusinessPhone = value; } }
-        private Value<string> _cFCCellPhone;
+        private DirtyValue<string> _cFCCellPhone;
         public string CFCCellPhone { get { return _cFCCellPhone; } set { _cFCCellPhone = value; } }
-        private Value<string> _cFCCity;
+        private DirtyValue<string> _cFCCity;
         public string CFCCity { get { return _cFCCity; } set { _cFCCity = value; } }
-        private Value<string> _cFCEmail;
+        private DirtyValue<string> _cFCEmail;
         public string CFCEmail { get { return _cFCEmail; } set { _cFCEmail = value; } }
-        private Value<string> _cFCName;
+        private DirtyValue<string> _cFCName;
         public string CFCName { get { return _cFCName; } set { _cFCName = value; } }
-        private Value<string> _cFCNotes;
+        private DirtyValue<string> _cFCNotes;
         public string CFCNotes { get { return _cFCNotes; } set { _cFCNotes = value; } }
-        private Value<string> _cFCRepAE;
+        private DirtyValue<string> _cFCRepAE;
         public string CFCRepAE { get { return _cFCRepAE; } set { _cFCRepAE = value; } }
-        private Value<string> _cFCSRAEUserName;
+        private DirtyValue<string> _cFCSRAEUserName;
         public string CFCSRAEUserName { get { return _cFCSRAEUserName; } set { _cFCSRAEUserName = value; } }
-        private Value<string> _cFCState;
+        private DirtyValue<string> _cFCState;
         public string CFCState { get { return _cFCState; } set { _cFCState = value; } }
-        private Value<string> _cFCStatus;
+        private DirtyValue<string> _cFCStatus;
         public string CFCStatus { get { return _cFCStatus; } set { _cFCStatus = value; } }
-        private Value<string> _cFCUserID;
+        private DirtyValue<string> _cFCUserID;
         public string CFCUserID { get { return _cFCUserID; } set { _cFCUserID = value; } }
-        private Value<string> _cFCZip;
+        private DirtyValue<string> _cFCZip;
         public string CFCZip { get { return _cFCZip; } set { _cFCZip = value; } }
-        private Value<string> _companyAddress;
+        private DirtyValue<string> _companyAddress;
         public string CompanyAddress { get { return _companyAddress; } set { _companyAddress = value; } }
-        private Value<string> _companyAEName;
+        private DirtyValue<string> _companyAEName;
         public string CompanyAEName { get { return _companyAEName; } set { _companyAEName = value; } }
-        private Value<string> _companyAEUserName;
+        private DirtyValue<string> _companyAEUserName;
         public string CompanyAEUserName { get { return _companyAEUserName; } set { _companyAEUserName = value; } }
-        private Value<string> _companyCity;
+        private DirtyValue<string> _companyCity;
         public string CompanyCity { get { return _companyCity; } set { _companyCity = value; } }
-        private Value<string> _companyDBAName;
+        private DirtyValue<string> _companyDBAName;
         public string CompanyDBAName { get { return _companyDBAName; } set { _companyDBAName = value; } }
-        private Value<string> _companyFax;
+        private DirtyValue<string> _companyFax;
         public string CompanyFax { get { return _companyFax; } set { _companyFax = value; } }
-        private Value<string> _companyID;
+        private DirtyValue<string> _companyID;
         public string CompanyID { get { return _companyID; } set { _companyID = value; } }
-        private Value<string> _companyLegalName;
+        private DirtyValue<string> _companyLegalName;
         public string CompanyLegalName { get { return _companyLegalName; } set { _companyLegalName = value; } }
-        private Value<string> _companyManagerEmail;
+        private DirtyValue<string> _companyManagerEmail;
         public string CompanyManagerEmail { get { return _companyManagerEmail; } set { _companyManagerEmail = value; } }
-        private Value<string> _companyManagerName;
+        private DirtyValue<string> _companyManagerName;
         public string CompanyManagerName { get { return _companyManagerName; } set { _companyManagerName = value; } }
-        private Value<string> _companyName;
+        private DirtyValue<string> _companyName;
         public string CompanyName { get { return _companyName; } set { _companyName = value; } }
-        private Value<string> _companyOrganizationID;
+        private DirtyValue<string> _companyOrganizationID;
         public string CompanyOrganizationID { get { return _companyOrganizationID; } set { _companyOrganizationID = value; } }
-        private Value<string> _companyPhone;
+        private DirtyValue<string> _companyPhone;
         public string CompanyPhone { get { return _companyPhone; } set { _companyPhone = value; } }
-        private Value<string> _companyRating;
+        private DirtyValue<string> _companyRating;
         public string CompanyRating { get { return _companyRating; } set { _companyRating = value; } }
-        private Value<string> _companyState;
+        private DirtyValue<string> _companyState;
         public string CompanyState { get { return _companyState; } set { _companyState = value; } }
-        private Value<string> _companyZip;
+        private DirtyValue<string> _companyZip;
         public string CompanyZip { get { return _companyZip; } set { _companyZip = value; } }
-        private Value<DateTime?> _documentsReadyDate;
+        private DirtyValue<DateTime?> _documentsReadyDate;
         public DateTime? DocumentsReadyDate { get { return _documentsReadyDate; } set { _documentsReadyDate = value; } }
-        private Value<string> _feeReviewComments;
+        private DirtyValue<string> _feeReviewComments;
         public string FeeReviewComments { get { return _feeReviewComments; } set { _feeReviewComments = value; } }
-        private Value<string> _feeReviewStatus;
+        private DirtyValue<string> _feeReviewStatus;
         public string FeeReviewStatus { get { return _feeReviewStatus; } set { _feeReviewStatus = value; } }
-        private Value<DateTime?> _feeReviewStatusDate;
+        private DirtyValue<DateTime?> _feeReviewStatusDate;
         public DateTime? FeeReviewStatusDate { get { return _feeReviewStatusDate; } set { _feeReviewStatusDate = value; } }
-        private Value<string> _importSource;
+        private DirtyValue<string> _importSource;
         public string ImportSource { get { return _importSource; } set { _importSource = value; } }
-        private Value<DateTime?> _initialApplicationDate;
+        private DirtyValue<DateTime?> _initialApplicationDate;
         public DateTime? InitialApplicationDate { get { return _initialApplicationDate; } set { _initialApplicationDate = value; } }
-        private Value<DateTime?> _initialSubmitDate;
+        private DirtyValue<DateTime?> _initialSubmitDate;
         public DateTime? InitialSubmitDate { get { return _initialSubmitDate; } set { _initialSubmitDate = value; } }
-        private Value<string> _lOAddress;
+        private DirtyValue<string> _lOAddress;
         public string LOAddress { get { return _lOAddress; } set { _lOAddress = value; } }
-        private Value<string> _lOAEName;
+        private DirtyValue<string> _lOAEName;
         public string LOAEName { get { return _lOAEName; } set { _lOAEName = value; } }
-        private Value<string> _lOAEUserName;
+        private DirtyValue<string> _lOAEUserName;
         public string LOAEUserName { get { return _lOAEUserName; } set { _lOAEUserName = value; } }
-        private Value<string> _lOBusinessFax;
+        private DirtyValue<string> _lOBusinessFax;
         public string LOBusinessFax { get { return _lOBusinessFax; } set { _lOBusinessFax = value; } }
-        private Value<string> _lOBusinessPhone;
+        private DirtyValue<string> _lOBusinessPhone;
         public string LOBusinessPhone { get { return _lOBusinessPhone; } set { _lOBusinessPhone = value; } }
-        private Value<string> _lOCellPhone;
+        private DirtyValue<string> _lOCellPhone;
         public string LOCellPhone { get { return _lOCellPhone; } set { _lOCellPhone = value; } }
-        private Value<string> _lOCity;
+        private DirtyValue<string> _lOCity;
         public string LOCity { get { return _lOCity; } set { _lOCity = value; } }
-        private Value<string> _lOEmail;
+        private DirtyValue<string> _lOEmail;
         public string LOEmail { get { return _lOEmail; } set { _lOEmail = value; } }
-        private Value<string> _lOID;
+        private DirtyValue<string> _lOID;
         public string LOID { get { return _lOID; } set { _lOID = value; } }
-        private Value<string> _lOName;
+        private DirtyValue<string> _lOName;
         public string LOName { get { return _lOName; } set { _lOName = value; } }
-        private Value<string> _lONotes;
+        private DirtyValue<string> _lONotes;
         public string LONotes { get { return _lONotes; } set { _lONotes = value; } }
-        private Value<string> _lOState;
+        private DirtyValue<string> _lOState;
         public string LOState { get { return _lOState; } set { _lOState = value; } }
-        private Value<string> _lOStatus;
+        private DirtyValue<string> _lOStatus;
         public string LOStatus { get { return _lOStatus; } set { _lOStatus = value; } }
-        private Value<string> _lOZip;
+        private DirtyValue<string> _lOZip;
         public string LOZip { get { return _lOZip; } set { _lOZip = value; } }
-        private Value<string> _lPAddress;
+        private DirtyValue<string> _lPAddress;
         public string LPAddress { get { return _lPAddress; } set { _lPAddress = value; } }
-        private Value<string> _lPAEName;
+        private DirtyValue<string> _lPAEName;
         public string LPAEName { get { return _lPAEName; } set { _lPAEName = value; } }
-        private Value<string> _lPAEUserName;
+        private DirtyValue<string> _lPAEUserName;
         public string LPAEUserName { get { return _lPAEUserName; } set { _lPAEUserName = value; } }
-        private Value<string> _lPBusinessFax;
+        private DirtyValue<string> _lPBusinessFax;
         public string LPBusinessFax { get { return _lPBusinessFax; } set { _lPBusinessFax = value; } }
-        private Value<string> _lPBusinessPhone;
+        private DirtyValue<string> _lPBusinessPhone;
         public string LPBusinessPhone { get { return _lPBusinessPhone; } set { _lPBusinessPhone = value; } }
-        private Value<string> _lPCellPhone;
+        private DirtyValue<string> _lPCellPhone;
         public string LPCellPhone { get { return _lPCellPhone; } set { _lPCellPhone = value; } }
-        private Value<string> _lPCity;
+        private DirtyValue<string> _lPCity;
         public string LPCity { get { return _lPCity; } set { _lPCity = value; } }
-        private Value<string> _lPEmail;
+        private DirtyValue<string> _lPEmail;
         public string LPEmail { get { return _lPEmail; } set { _lPEmail = value; } }
-        private Value<string> _lPID;
+        private DirtyValue<string> _lPID;
         public string LPID { get { return _lPID; } set { _lPID = value; } }
-        private Value<string> _lPName;
+        private DirtyValue<string> _lPName;
         public string LPName { get { return _lPName; } set { _lPName = value; } }
-        private Value<string> _lPNotes;
+        private DirtyValue<string> _lPNotes;
         public string LPNotes { get { return _lPNotes; } set { _lPNotes = value; } }
-        private Value<string> _lPState;
+        private DirtyValue<string> _lPState;
         public string LPState { get { return _lPState; } set { _lPState = value; } }
-        private Value<string> _lPStatus;
+        private DirtyValue<string> _lPStatus;
         public string LPStatus { get { return _lPStatus; } set { _lPStatus = value; } }
-        private Value<string> _lPZip;
+        private DirtyValue<string> _lPZip;
         public string LPZip { get { return _lPZip; } set { _lPZip = value; } }
-        private Value<DateTime?> _purchaseStipsReadyDate;
+        private DirtyValue<DateTime?> _purchaseStipsReadyDate;
         public DateTime? PurchaseStipsReadyDate { get { return _purchaseStipsReadyDate; } set { _purchaseStipsReadyDate = value; } }
-        private Value<bool?> _purchaseStipsReviewed;
+        private DirtyValue<bool?> _purchaseStipsReviewed;
         public bool? PurchaseStipsReviewed { get { return _purchaseStipsReviewed; } set { _purchaseStipsReviewed = value; } }
-        private Value<DateTime?> _readytoDiscloseDateUtc;
+        private DirtyValue<DateTime?> _readytoDiscloseDateUtc;
         public DateTime? ReadytoDiscloseDateUtc { get { return _readytoDiscloseDateUtc; } set { _readytoDiscloseDateUtc = value; } }
-        private Value<DateTime?> _registerDate;
+        private DirtyValue<DateTime?> _registerDate;
         public DateTime? RegisterDate { get { return _registerDate; } set { _registerDate = value; } }
-        private Value<string> _sITEID;
+        private DirtyValue<string> _sITEID;
         public string SITEID { get { return _sITEID; } set { _sITEID = value; } }
-        private Value<DateTime?> _submitDate;
+        private DirtyValue<DateTime?> _submitDate;
         public DateTime? SubmitDate { get { return _submitDate; } set { _submitDate = value; } }
-        private Value<bool?> _testAccountField;
+        private DirtyValue<bool?> _testAccountField;
         public bool? TestAccountField { get { return _testAccountField; } set { _testAccountField = value; } }
-        private Value<bool?> _underwriterReviewed;
+        private DirtyValue<bool?> _underwriterReviewed;
         public bool? UnderwriterReviewed { get { return _underwriterReviewed; } set { _underwriterReviewed = value; } }
-        private Value<bool?> _underwritingDelegated;
+        private DirtyValue<bool?> _underwritingDelegated;
         public bool? UnderwritingDelegated { get { return _underwritingDelegated; } set { _underwritingDelegated = value; } }
-        private Value<bool?> _watchListFlag;
+        private DirtyValue<bool?> _watchListFlag;
         public bool? WatchListFlag { get { return _watchListFlag; } set { _watchListFlag = value; } }
-        private Value<string> _watchListReason;
+        private DirtyValue<string> _watchListReason;
         public string WatchListReason { get { return _watchListReason; } set { _watchListReason = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/TQL.cs
+++ b/src/EncompassRest/Loans/TQL.cs
@@ -118,12 +118,12 @@ namespace EncompassRest.Loans
         public string StonegateFloodBaselineReportRequired { get { return _stonegateFloodBaselineReportRequired; } set { _stonegateFloodBaselineReportRequired = value; } }
         private Value<string> _stonegateFraudBaselineReportRequired;
         public string StonegateFraudBaselineReportRequired { get { return _stonegateFraudBaselineReportRequired; } set { _stonegateFraudBaselineReportRequired = value; } }
-        private Value<List<TQLComplianceAlert>> _tQLComplianceAlerts;
-        public List<TQLComplianceAlert> TQLComplianceAlerts { get { return _tQLComplianceAlerts; } set { _tQLComplianceAlerts = value; } }
-        private Value<List<TQLDocument>> _tQLDocuments;
-        public List<TQLDocument> TQLDocuments { get { return _tQLDocuments; } set { _tQLDocuments = value; } }
-        private Value<List<TQLFraudAlert>> _tQLFraudAlerts;
-        public List<TQLFraudAlert> TQLFraudAlerts { get { return _tQLFraudAlerts; } set { _tQLFraudAlerts = value; } }
+        private DirtyList<TQLComplianceAlert> _tQLComplianceAlerts;
+        public IList<TQLComplianceAlert> TQLComplianceAlerts { get { var v = _tQLComplianceAlerts; return v ?? Interlocked.CompareExchange(ref _tQLComplianceAlerts, (v = new DirtyList<TQLComplianceAlert>()), null) ?? v; } set { _tQLComplianceAlerts = new DirtyList<TQLComplianceAlert>(value); } }
+        private DirtyList<TQLDocument> _tQLDocuments;
+        public IList<TQLDocument> TQLDocuments { get { var v = _tQLDocuments; return v ?? Interlocked.CompareExchange(ref _tQLDocuments, (v = new DirtyList<TQLDocument>()), null) ?? v; } set { _tQLDocuments = new DirtyList<TQLDocument>(value); } }
+        private DirtyList<TQLFraudAlert> _tQLFraudAlerts;
+        public IList<TQLFraudAlert> TQLFraudAlerts { get { var v = _tQLFraudAlerts; return v ?? Interlocked.CompareExchange(ref _tQLFraudAlerts, (v = new DirtyList<TQLFraudAlert>()), null) ?? v; } set { _tQLFraudAlerts = new DirtyList<TQLFraudAlert>(value); } }
         private Value<int?> _tQLFraudAlertsTotal;
         public int? TQLFraudAlertsTotal { get { return _tQLFraudAlertsTotal; } set { _tQLFraudAlertsTotal = value; } }
         private Value<int?> _tQLFraudAlertsTotalHigh;
@@ -208,9 +208,6 @@ namespace EncompassRest.Loans
                     || _stonegateComplianceBaselineReportRequired.Dirty
                     || _stonegateFloodBaselineReportRequired.Dirty
                     || _stonegateFraudBaselineReportRequired.Dirty
-                    || _tQLComplianceAlerts.Dirty
-                    || _tQLDocuments.Dirty
-                    || _tQLFraudAlerts.Dirty
                     || _tQLFraudAlertsTotal.Dirty
                     || _tQLFraudAlertsTotalHigh.Dirty
                     || _tQLFraudAlertsTotalHighUnaddressed.Dirty
@@ -221,7 +218,10 @@ namespace EncompassRest.Loans
                     || _wellsFargo4506TBaselineReportRequired.Dirty
                     || _wellsFargoComplianceBaselineReportRequired.Dirty
                     || _wellsFargoFloodBaselineReportRequired.Dirty
-                    || _wellsFargoFraudBaselineReportRequired.Dirty;
+                    || _wellsFargoFraudBaselineReportRequired.Dirty
+                    || _tQLComplianceAlerts?.Dirty == true
+                    || _tQLDocuments?.Dirty == true
+                    || _tQLFraudAlerts?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -283,9 +283,6 @@ namespace EncompassRest.Loans
                 _stonegateComplianceBaselineReportRequired.Dirty = value;
                 _stonegateFloodBaselineReportRequired.Dirty = value;
                 _stonegateFraudBaselineReportRequired.Dirty = value;
-                _tQLComplianceAlerts.Dirty = value;
-                _tQLDocuments.Dirty = value;
-                _tQLFraudAlerts.Dirty = value;
                 _tQLFraudAlertsTotal.Dirty = value;
                 _tQLFraudAlertsTotalHigh.Dirty = value;
                 _tQLFraudAlertsTotalHighUnaddressed.Dirty = value;
@@ -297,6 +294,9 @@ namespace EncompassRest.Loans
                 _wellsFargoComplianceBaselineReportRequired.Dirty = value;
                 _wellsFargoFloodBaselineReportRequired.Dirty = value;
                 _wellsFargoFraudBaselineReportRequired.Dirty = value;
+                if (_tQLComplianceAlerts != null) _tQLComplianceAlerts.Dirty = value;
+                if (_tQLDocuments != null) _tQLDocuments.Dirty = value;
+                if (_tQLFraudAlerts != null) _tQLFraudAlerts.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/TQL.cs
+++ b/src/EncompassRest/Loans/TQL.cs
@@ -8,115 +8,115 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TQL : IDirty
     {
-        private Value<string> _citibank4506TBaselineReportRequired;
+        private DirtyValue<string> _citibank4506TBaselineReportRequired;
         public string Citibank4506TBaselineReportRequired { get { return _citibank4506TBaselineReportRequired; } set { _citibank4506TBaselineReportRequired = value; } }
-        private Value<string> _citibankCCVPBaselineReportRequired;
+        private DirtyValue<string> _citibankCCVPBaselineReportRequired;
         public string CitibankCCVPBaselineReportRequired { get { return _citibankCCVPBaselineReportRequired; } set { _citibankCCVPBaselineReportRequired = value; } }
-        private Value<string> _citibankComplianceBaselineReportRequired;
+        private DirtyValue<string> _citibankComplianceBaselineReportRequired;
         public string CitibankComplianceBaselineReportRequired { get { return _citibankComplianceBaselineReportRequired; } set { _citibankComplianceBaselineReportRequired = value; } }
-        private Value<string> _citibankFloodBaselineReportRequired;
+        private DirtyValue<string> _citibankFloodBaselineReportRequired;
         public string CitibankFloodBaselineReportRequired { get { return _citibankFloodBaselineReportRequired; } set { _citibankFloodBaselineReportRequired = value; } }
-        private Value<string> _citibankFraudBaselineReportRequired;
+        private DirtyValue<string> _citibankFraudBaselineReportRequired;
         public string CitibankFraudBaselineReportRequired { get { return _citibankFraudBaselineReportRequired; } set { _citibankFraudBaselineReportRequired = value; } }
-        private Value<string> _currentInvestorPublishingStatus;
+        private DirtyValue<string> _currentInvestorPublishingStatus;
         public string CurrentInvestorPublishingStatus { get { return _currentInvestorPublishingStatus; } set { _currentInvestorPublishingStatus = value; } }
-        private Value<int?> _driveAppVerifyScore;
+        private DirtyValue<int?> _driveAppVerifyScore;
         public int? DriveAppVerifyScore { get { return _driveAppVerifyScore; } set { _driveAppVerifyScore = value; } }
-        private Value<int?> _driveIDVerifyScore;
+        private DirtyValue<int?> _driveIDVerifyScore;
         public int? DriveIDVerifyScore { get { return _driveIDVerifyScore; } set { _driveIDVerifyScore = value; } }
-        private Value<int?> _drivePropertyVerifyScore;
+        private DirtyValue<int?> _drivePropertyVerifyScore;
         public int? DrivePropertyVerifyScore { get { return _drivePropertyVerifyScore; } set { _drivePropertyVerifyScore = value; } }
-        private Value<int?> _driveScore;
+        private DirtyValue<int?> _driveScore;
         public int? DriveScore { get { return _driveScore; } set { _driveScore = value; } }
-        private Value<string> _driveStatus;
+        private DirtyValue<string> _driveStatus;
         public string DriveStatus { get { return _driveStatus; } set { _driveStatus = value; } }
-        private Value<string> _homeward4506TBaselineReportRequired;
+        private DirtyValue<string> _homeward4506TBaselineReportRequired;
         public string Homeward4506TBaselineReportRequired { get { return _homeward4506TBaselineReportRequired; } set { _homeward4506TBaselineReportRequired = value; } }
-        private Value<string> _homewardComplianceBaselineReportRequired;
+        private DirtyValue<string> _homewardComplianceBaselineReportRequired;
         public string HomewardComplianceBaselineReportRequired { get { return _homewardComplianceBaselineReportRequired; } set { _homewardComplianceBaselineReportRequired = value; } }
-        private Value<string> _homewardFloodBaselineReportRequired;
+        private DirtyValue<string> _homewardFloodBaselineReportRequired;
         public string HomewardFloodBaselineReportRequired { get { return _homewardFloodBaselineReportRequired; } set { _homewardFloodBaselineReportRequired = value; } }
-        private Value<string> _homewardFraudBaselineReportRequired;
+        private DirtyValue<string> _homewardFraudBaselineReportRequired;
         public string HomewardFraudBaselineReportRequired { get { return _homewardFraudBaselineReportRequired; } set { _homewardFraudBaselineReportRequired = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _lastCCVPCompletedDate;
+        private DirtyValue<DateTime?> _lastCCVPCompletedDate;
         public DateTime? LastCCVPCompletedDate { get { return _lastCCVPCompletedDate; } set { _lastCCVPCompletedDate = value; } }
-        private Value<string> _lastCCVPConfidenceScore;
+        private DirtyValue<string> _lastCCVPConfidenceScore;
         public string LastCCVPConfidenceScore { get { return _lastCCVPConfidenceScore; } set { _lastCCVPConfidenceScore = value; } }
-        private Value<string> _lastCCVPEstimatedValue;
+        private DirtyValue<string> _lastCCVPEstimatedValue;
         public string LastCCVPEstimatedValue { get { return _lastCCVPEstimatedValue; } set { _lastCCVPEstimatedValue = value; } }
-        private Value<string> _lastCCVPForecastDeviationScore;
+        private DirtyValue<string> _lastCCVPForecastDeviationScore;
         public string LastCCVPForecastDeviationScore { get { return _lastCCVPForecastDeviationScore; } set { _lastCCVPForecastDeviationScore = value; } }
-        private Value<string> _lastCCVPReportHistoryProResult;
+        private DirtyValue<string> _lastCCVPReportHistoryProResult;
         public string LastCCVPReportHistoryProResult { get { return _lastCCVPReportHistoryProResult; } set { _lastCCVPReportHistoryProResult = value; } }
-        private Value<string> _lastCCVPReportID;
+        private DirtyValue<string> _lastCCVPReportID;
         public string LastCCVPReportID { get { return _lastCCVPReportID; } set { _lastCCVPReportID = value; } }
-        private Value<string> _lastCCVPReportOrdered;
+        private DirtyValue<string> _lastCCVPReportOrdered;
         public string LastCCVPReportOrdered { get { return _lastCCVPReportOrdered; } set { _lastCCVPReportOrdered = value; } }
-        private Value<string> _lastCCVPReportPassResult;
+        private DirtyValue<string> _lastCCVPReportPassResult;
         public string LastCCVPReportPassResult { get { return _lastCCVPReportPassResult; } set { _lastCCVPReportPassResult = value; } }
-        private Value<string> _lastCCVPResultsReportReturned;
+        private DirtyValue<string> _lastCCVPResultsReportReturned;
         public string LastCCVPResultsReportReturned { get { return _lastCCVPResultsReportReturned; } set { _lastCCVPResultsReportReturned = value; } }
-        private Value<DateTime?> _lastComplianceCompletedDate;
+        private DirtyValue<DateTime?> _lastComplianceCompletedDate;
         public DateTime? LastComplianceCompletedDate { get { return _lastComplianceCompletedDate; } set { _lastComplianceCompletedDate = value; } }
-        private Value<int?> _lastComplianceNumberOfAlertMessages;
+        private DirtyValue<int?> _lastComplianceNumberOfAlertMessages;
         public int? LastComplianceNumberOfAlertMessages { get { return _lastComplianceNumberOfAlertMessages; } set { _lastComplianceNumberOfAlertMessages = value; } }
-        private Value<int?> _lastComplianceNumberOfErrorMessages;
+        private DirtyValue<int?> _lastComplianceNumberOfErrorMessages;
         public int? LastComplianceNumberOfErrorMessages { get { return _lastComplianceNumberOfErrorMessages; } set { _lastComplianceNumberOfErrorMessages = value; } }
-        private Value<int?> _lastComplianceNumberOfFailMessages;
+        private DirtyValue<int?> _lastComplianceNumberOfFailMessages;
         public int? LastComplianceNumberOfFailMessages { get { return _lastComplianceNumberOfFailMessages; } set { _lastComplianceNumberOfFailMessages = value; } }
-        private Value<int?> _lastComplianceNumberOfPassMessages;
+        private DirtyValue<int?> _lastComplianceNumberOfPassMessages;
         public int? LastComplianceNumberOfPassMessages { get { return _lastComplianceNumberOfPassMessages; } set { _lastComplianceNumberOfPassMessages = value; } }
-        private Value<int?> _lastComplianceNumberOfWarningMessages;
+        private DirtyValue<int?> _lastComplianceNumberOfWarningMessages;
         public int? LastComplianceNumberOfWarningMessages { get { return _lastComplianceNumberOfWarningMessages; } set { _lastComplianceNumberOfWarningMessages = value; } }
-        private Value<string> _lastComplianceOrderType;
+        private DirtyValue<string> _lastComplianceOrderType;
         public string LastComplianceOrderType { get { return _lastComplianceOrderType; } set { _lastComplianceOrderType = value; } }
-        private Value<string> _lastComplianceProductNameReportOrdered;
+        private DirtyValue<string> _lastComplianceProductNameReportOrdered;
         public string LastComplianceProductNameReportOrdered { get { return _lastComplianceProductNameReportOrdered; } set { _lastComplianceProductNameReportOrdered = value; } }
-        private Value<string> _lastComplianceReportID;
+        private DirtyValue<string> _lastComplianceReportID;
         public string LastComplianceReportID { get { return _lastComplianceReportID; } set { _lastComplianceReportID = value; } }
-        private Value<int?> _lastFraudOrderAlerts;
+        private DirtyValue<int?> _lastFraudOrderAlerts;
         public int? LastFraudOrderAlerts { get { return _lastFraudOrderAlerts; } set { _lastFraudOrderAlerts = value; } }
-        private Value<DateTime?> _lastFraudOrderCompletedDate;
+        private DirtyValue<DateTime?> _lastFraudOrderCompletedDate;
         public DateTime? LastFraudOrderCompletedDate { get { return _lastFraudOrderCompletedDate; } set { _lastFraudOrderCompletedDate = value; } }
-        private Value<string> _lastFraudOrderProduct;
+        private DirtyValue<string> _lastFraudOrderProduct;
         public string LastFraudOrderProduct { get { return _lastFraudOrderProduct; } set { _lastFraudOrderProduct = value; } }
-        private Value<string> _lastFraudReportID;
+        private DirtyValue<string> _lastFraudReportID;
         public string LastFraudReportID { get { return _lastFraudReportID; } set { _lastFraudReportID = value; } }
-        private Value<string> _lastInvestorPublishingInvestor;
+        private DirtyValue<string> _lastInvestorPublishingInvestor;
         public string LastInvestorPublishingInvestor { get { return _lastInvestorPublishingInvestor; } set { _lastInvestorPublishingInvestor = value; } }
-        private Value<DateTime?> _lastInvestorPublishingStatusChangeDate;
+        private DirtyValue<DateTime?> _lastInvestorPublishingStatusChangeDate;
         public DateTime? LastInvestorPublishingStatusChangeDate { get { return _lastInvestorPublishingStatusChangeDate; } set { _lastInvestorPublishingStatusChangeDate = value; } }
-        private Value<string> _lastInvestorPublishingUserWhoChangeStatus;
+        private DirtyValue<string> _lastInvestorPublishingUserWhoChangeStatus;
         public string LastInvestorPublishingUserWhoChangeStatus { get { return _lastInvestorPublishingUserWhoChangeStatus; } set { _lastInvestorPublishingUserWhoChangeStatus = value; } }
-        private Value<string> _lastUserIDWhoOrderedCCVP;
+        private DirtyValue<string> _lastUserIDWhoOrderedCCVP;
         public string LastUserIDWhoOrderedCCVP { get { return _lastUserIDWhoOrderedCCVP; } set { _lastUserIDWhoOrderedCCVP = value; } }
-        private Value<string> _lastUserIDWhoOrderedCompliance;
+        private DirtyValue<string> _lastUserIDWhoOrderedCompliance;
         public string LastUserIDWhoOrderedCompliance { get { return _lastUserIDWhoOrderedCompliance; } set { _lastUserIDWhoOrderedCompliance = value; } }
-        private Value<string> _lastUserIDWhoOrderedFraudOrder;
+        private DirtyValue<string> _lastUserIDWhoOrderedFraudOrder;
         public string LastUserIDWhoOrderedFraudOrder { get { return _lastUserIDWhoOrderedFraudOrder; } set { _lastUserIDWhoOrderedFraudOrder = value; } }
-        private Value<bool?> _mIVendorsArchAutoOrderIndicator;
+        private DirtyValue<bool?> _mIVendorsArchAutoOrderIndicator;
         public bool? MIVendorsArchAutoOrderIndicator { get { return _mIVendorsArchAutoOrderIndicator; } set { _mIVendorsArchAutoOrderIndicator = value; } }
-        private Value<bool?> _mIVendorsMgicAutoOrderIndicator;
+        private DirtyValue<bool?> _mIVendorsMgicAutoOrderIndicator;
         public bool? MIVendorsMgicAutoOrderIndicator { get { return _mIVendorsMgicAutoOrderIndicator; } set { _mIVendorsMgicAutoOrderIndicator = value; } }
-        private Value<bool?> _mIVendorsRadianAutoOrderIndicator;
+        private DirtyValue<bool?> _mIVendorsRadianAutoOrderIndicator;
         public bool? MIVendorsRadianAutoOrderIndicator { get { return _mIVendorsRadianAutoOrderIndicator; } set { _mIVendorsRadianAutoOrderIndicator = value; } }
-        private Value<string> _pHH4506TBaselineReportRequired;
+        private DirtyValue<string> _pHH4506TBaselineReportRequired;
         public string PHH4506TBaselineReportRequired { get { return _pHH4506TBaselineReportRequired; } set { _pHH4506TBaselineReportRequired = value; } }
-        private Value<string> _pHHComplianceBaselineReportRequired;
+        private DirtyValue<string> _pHHComplianceBaselineReportRequired;
         public string PHHComplianceBaselineReportRequired { get { return _pHHComplianceBaselineReportRequired; } set { _pHHComplianceBaselineReportRequired = value; } }
-        private Value<string> _pHHFloodBaselineReportRequired;
+        private DirtyValue<string> _pHHFloodBaselineReportRequired;
         public string PHHFloodBaselineReportRequired { get { return _pHHFloodBaselineReportRequired; } set { _pHHFloodBaselineReportRequired = value; } }
-        private Value<string> _pHHFraudBaselineReportRequired;
+        private DirtyValue<string> _pHHFraudBaselineReportRequired;
         public string PHHFraudBaselineReportRequired { get { return _pHHFraudBaselineReportRequired; } set { _pHHFraudBaselineReportRequired = value; } }
-        private Value<string> _stonegate4506TBaselineReport;
+        private DirtyValue<string> _stonegate4506TBaselineReport;
         public string Stonegate4506TBaselineReport { get { return _stonegate4506TBaselineReport; } set { _stonegate4506TBaselineReport = value; } }
-        private Value<string> _stonegateComplianceBaselineReportRequired;
+        private DirtyValue<string> _stonegateComplianceBaselineReportRequired;
         public string StonegateComplianceBaselineReportRequired { get { return _stonegateComplianceBaselineReportRequired; } set { _stonegateComplianceBaselineReportRequired = value; } }
-        private Value<string> _stonegateFloodBaselineReportRequired;
+        private DirtyValue<string> _stonegateFloodBaselineReportRequired;
         public string StonegateFloodBaselineReportRequired { get { return _stonegateFloodBaselineReportRequired; } set { _stonegateFloodBaselineReportRequired = value; } }
-        private Value<string> _stonegateFraudBaselineReportRequired;
+        private DirtyValue<string> _stonegateFraudBaselineReportRequired;
         public string StonegateFraudBaselineReportRequired { get { return _stonegateFraudBaselineReportRequired; } set { _stonegateFraudBaselineReportRequired = value; } }
         private DirtyList<TQLComplianceAlert> _tQLComplianceAlerts;
         public IList<TQLComplianceAlert> TQLComplianceAlerts { get { var v = _tQLComplianceAlerts; return v ?? Interlocked.CompareExchange(ref _tQLComplianceAlerts, (v = new DirtyList<TQLComplianceAlert>()), null) ?? v; } set { _tQLComplianceAlerts = new DirtyList<TQLComplianceAlert>(value); } }
@@ -124,27 +124,27 @@ namespace EncompassRest.Loans
         public IList<TQLDocument> TQLDocuments { get { var v = _tQLDocuments; return v ?? Interlocked.CompareExchange(ref _tQLDocuments, (v = new DirtyList<TQLDocument>()), null) ?? v; } set { _tQLDocuments = new DirtyList<TQLDocument>(value); } }
         private DirtyList<TQLFraudAlert> _tQLFraudAlerts;
         public IList<TQLFraudAlert> TQLFraudAlerts { get { var v = _tQLFraudAlerts; return v ?? Interlocked.CompareExchange(ref _tQLFraudAlerts, (v = new DirtyList<TQLFraudAlert>()), null) ?? v; } set { _tQLFraudAlerts = new DirtyList<TQLFraudAlert>(value); } }
-        private Value<int?> _tQLFraudAlertsTotal;
+        private DirtyValue<int?> _tQLFraudAlertsTotal;
         public int? TQLFraudAlertsTotal { get { return _tQLFraudAlertsTotal; } set { _tQLFraudAlertsTotal = value; } }
-        private Value<int?> _tQLFraudAlertsTotalHigh;
+        private DirtyValue<int?> _tQLFraudAlertsTotalHigh;
         public int? TQLFraudAlertsTotalHigh { get { return _tQLFraudAlertsTotalHigh; } set { _tQLFraudAlertsTotalHigh = value; } }
-        private Value<int?> _tQLFraudAlertsTotalHighUnaddressed;
+        private DirtyValue<int?> _tQLFraudAlertsTotalHighUnaddressed;
         public int? TQLFraudAlertsTotalHighUnaddressed { get { return _tQLFraudAlertsTotalHighUnaddressed; } set { _tQLFraudAlertsTotalHighUnaddressed = value; } }
-        private Value<int?> _tQLFraudAlertsTotalLow;
+        private DirtyValue<int?> _tQLFraudAlertsTotalLow;
         public int? TQLFraudAlertsTotalLow { get { return _tQLFraudAlertsTotalLow; } set { _tQLFraudAlertsTotalLow = value; } }
-        private Value<int?> _tQLFraudAlertsTotalLowUnaddressed;
+        private DirtyValue<int?> _tQLFraudAlertsTotalLowUnaddressed;
         public int? TQLFraudAlertsTotalLowUnaddressed { get { return _tQLFraudAlertsTotalLowUnaddressed; } set { _tQLFraudAlertsTotalLowUnaddressed = value; } }
-        private Value<int?> _tQLFraudAlertsTotalMedium;
+        private DirtyValue<int?> _tQLFraudAlertsTotalMedium;
         public int? TQLFraudAlertsTotalMedium { get { return _tQLFraudAlertsTotalMedium; } set { _tQLFraudAlertsTotalMedium = value; } }
-        private Value<int?> _tQLFraudAlertsTotalMediumUnaddressed;
+        private DirtyValue<int?> _tQLFraudAlertsTotalMediumUnaddressed;
         public int? TQLFraudAlertsTotalMediumUnaddressed { get { return _tQLFraudAlertsTotalMediumUnaddressed; } set { _tQLFraudAlertsTotalMediumUnaddressed = value; } }
-        private Value<string> _wellsFargo4506TBaselineReportRequired;
+        private DirtyValue<string> _wellsFargo4506TBaselineReportRequired;
         public string WellsFargo4506TBaselineReportRequired { get { return _wellsFargo4506TBaselineReportRequired; } set { _wellsFargo4506TBaselineReportRequired = value; } }
-        private Value<string> _wellsFargoComplianceBaselineReportRequired;
+        private DirtyValue<string> _wellsFargoComplianceBaselineReportRequired;
         public string WellsFargoComplianceBaselineReportRequired { get { return _wellsFargoComplianceBaselineReportRequired; } set { _wellsFargoComplianceBaselineReportRequired = value; } }
-        private Value<string> _wellsFargoFloodBaselineReportRequired;
+        private DirtyValue<string> _wellsFargoFloodBaselineReportRequired;
         public string WellsFargoFloodBaselineReportRequired { get { return _wellsFargoFloodBaselineReportRequired; } set { _wellsFargoFloodBaselineReportRequired = value; } }
-        private Value<string> _wellsFargoFraudBaselineReportRequired;
+        private DirtyValue<string> _wellsFargoFraudBaselineReportRequired;
         public string WellsFargoFraudBaselineReportRequired { get { return _wellsFargoFraudBaselineReportRequired; } set { _wellsFargoFraudBaselineReportRequired = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/TQLComplianceAlert.cs
+++ b/src/EncompassRest/Loans/TQLComplianceAlert.cs
@@ -8,15 +8,15 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TQLComplianceAlert : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lastComplianceOrderAlertCategories;
+        private DirtyValue<string> _lastComplianceOrderAlertCategories;
         public string LastComplianceOrderAlertCategories { get { return _lastComplianceOrderAlertCategories; } set { _lastComplianceOrderAlertCategories = value; } }
-        private Value<string> _lastComplianceOrderAlertMessage;
+        private DirtyValue<string> _lastComplianceOrderAlertMessage;
         public string LastComplianceOrderAlertMessage { get { return _lastComplianceOrderAlertMessage; } set { _lastComplianceOrderAlertMessage = value; } }
-        private Value<string> _lastComplianceOrderDescriptionOfAlerts;
+        private DirtyValue<string> _lastComplianceOrderDescriptionOfAlerts;
         public string LastComplianceOrderDescriptionOfAlerts { get { return _lastComplianceOrderDescriptionOfAlerts; } set { _lastComplianceOrderDescriptionOfAlerts = value; } }
-        private Value<int?> _tQLComplianceAlertIndex;
+        private DirtyValue<int?> _tQLComplianceAlertIndex;
         public int? TQLComplianceAlertIndex { get { return _tQLComplianceAlertIndex; } set { _tQLComplianceAlertIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/TQLDocument.cs
+++ b/src/EncompassRest/Loans/TQLDocument.cs
@@ -8,9 +8,9 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TQLDocument : IDirty
     {
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<DateTime?> _tQLDocumentDeliveredDate;
+        private DirtyValue<DateTime?> _tQLDocumentDeliveredDate;
         public DateTime? TQLDocumentDeliveredDate { get { return _tQLDocumentDeliveredDate; } set { _tQLDocumentDeliveredDate = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/TQLFraudAlert.cs
+++ b/src/EncompassRest/Loans/TQLFraudAlert.cs
@@ -8,25 +8,25 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TQLFraudAlert : IDirty
     {
-        private Value<string> _driveFraudAlertCode;
+        private DirtyValue<string> _driveFraudAlertCode;
         public string DriveFraudAlertCode { get { return _driveFraudAlertCode; } set { _driveFraudAlertCode = value; } }
-        private Value<string> _driveFraudAlertStatus;
+        private DirtyValue<string> _driveFraudAlertStatus;
         public string DriveFraudAlertStatus { get { return _driveFraudAlertStatus; } set { _driveFraudAlertStatus = value; } }
-        private Value<string> _fraudGuardFraudAlertCode;
+        private DirtyValue<string> _fraudGuardFraudAlertCode;
         public string FraudGuardFraudAlertCode { get { return _fraudGuardFraudAlertCode; } set { _fraudGuardFraudAlertCode = value; } }
-        private Value<string> _fraudGuardFraudAlertStatus;
+        private DirtyValue<string> _fraudGuardFraudAlertStatus;
         public string FraudGuardFraudAlertStatus { get { return _fraudGuardFraudAlertStatus; } set { _fraudGuardFraudAlertStatus = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _lastFraudOrderAlertCategories;
+        private DirtyValue<string> _lastFraudOrderAlertCategories;
         public string LastFraudOrderAlertCategories { get { return _lastFraudOrderAlertCategories; } set { _lastFraudOrderAlertCategories = value; } }
-        private Value<string> _lastFraudOrderAlertID;
+        private DirtyValue<string> _lastFraudOrderAlertID;
         public string LastFraudOrderAlertID { get { return _lastFraudOrderAlertID; } set { _lastFraudOrderAlertID = value; } }
-        private Value<string> _lastFraudOrderAlertLevel;
+        private DirtyValue<string> _lastFraudOrderAlertLevel;
         public string LastFraudOrderAlertLevel { get { return _lastFraudOrderAlertLevel; } set { _lastFraudOrderAlertLevel = value; } }
-        private Value<string> _lastFraudOrderDescriptionOfAlerts;
+        private DirtyValue<string> _lastFraudOrderDescriptionOfAlerts;
         public string LastFraudOrderDescriptionOfAlerts { get { return _lastFraudOrderDescriptionOfAlerts; } set { _lastFraudOrderDescriptionOfAlerts = value; } }
-        private Value<int?> _tQLFraudAlertIndex;
+        private DirtyValue<int?> _tQLFraudAlertIndex;
         public int? TQLFraudAlertIndex { get { return _tQLFraudAlertIndex; } set { _tQLFraudAlertIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/TQLFraudAlert.cs
+++ b/src/EncompassRest/Loans/TQLFraudAlert.cs
@@ -8,6 +8,14 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TQLFraudAlert : IDirty
     {
+        private Value<string> _driveFraudAlertCode;
+        public string DriveFraudAlertCode { get { return _driveFraudAlertCode; } set { _driveFraudAlertCode = value; } }
+        private Value<string> _driveFraudAlertStatus;
+        public string DriveFraudAlertStatus { get { return _driveFraudAlertStatus; } set { _driveFraudAlertStatus = value; } }
+        private Value<string> _fraudGuardFraudAlertCode;
+        public string FraudGuardFraudAlertCode { get { return _fraudGuardFraudAlertCode; } set { _fraudGuardFraudAlertCode = value; } }
+        private Value<string> _fraudGuardFraudAlertStatus;
+        public string FraudGuardFraudAlertStatus { get { return _fraudGuardFraudAlertStatus; } set { _fraudGuardFraudAlertStatus = value; } }
         private Value<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
         private Value<string> _lastFraudOrderAlertCategories;
@@ -27,7 +35,11 @@ namespace EncompassRest.Loans
             get
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
-                var dirty = _id.Dirty
+                var dirty = _driveFraudAlertCode.Dirty
+                    || _driveFraudAlertStatus.Dirty
+                    || _fraudGuardFraudAlertCode.Dirty
+                    || _fraudGuardFraudAlertStatus.Dirty
+                    || _id.Dirty
                     || _lastFraudOrderAlertCategories.Dirty
                     || _lastFraudOrderAlertID.Dirty
                     || _lastFraudOrderAlertLevel.Dirty
@@ -39,6 +51,10 @@ namespace EncompassRest.Loans
             set
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
+                _driveFraudAlertCode.Dirty = value;
+                _driveFraudAlertStatus.Dirty = value;
+                _fraudGuardFraudAlertCode.Dirty = value;
+                _fraudGuardFraudAlertStatus.Dirty = value;
                 _id.Dirty = value;
                 _lastFraudOrderAlertCategories.Dirty = value;
                 _lastFraudOrderAlertID.Dirty = value;

--- a/src/EncompassRest/Loans/TQLReportInformation.cs
+++ b/src/EncompassRest/Loans/TQLReportInformation.cs
@@ -8,57 +8,57 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TQLReportInformation : IDirty
     {
-        private Value<string> _altId;
+        private DirtyValue<string> _altId;
         public string AltId { get { return _altId; } set { _altId = value; } }
-        private Value<string> _borrowerID1;
+        private DirtyValue<string> _borrowerID1;
         public string BorrowerID1 { get { return _borrowerID1; } set { _borrowerID1 = value; } }
-        private Value<string> _borrowerID2;
+        private DirtyValue<string> _borrowerID2;
         public string BorrowerID2 { get { return _borrowerID2; } set { _borrowerID2 = value; } }
-        private Value<string> _borrowerID3;
+        private DirtyValue<string> _borrowerID3;
         public string BorrowerID3 { get { return _borrowerID3; } set { _borrowerID3 = value; } }
-        private Value<string> _borrowerID4;
+        private DirtyValue<string> _borrowerID4;
         public string BorrowerID4 { get { return _borrowerID4; } set { _borrowerID4 = value; } }
-        private Value<DateTime?> _completedDate;
+        private DirtyValue<DateTime?> _completedDate;
         public DateTime? CompletedDate { get { return _completedDate; } set { _completedDate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _investor;
+        private DirtyValue<string> _investor;
         public string Investor { get { return _investor; } set { _investor = value; } }
-        private Value<DateTime?> _orderDate;
+        private DirtyValue<DateTime?> _orderDate;
         public DateTime? OrderDate { get { return _orderDate; } set { _orderDate = value; } }
-        private Value<string> _orderNumber;
+        private DirtyValue<string> _orderNumber;
         public string OrderNumber { get { return _orderNumber; } set { _orderNumber = value; } }
-        private Value<string> _orderStatus;
+        private DirtyValue<string> _orderStatus;
         public string OrderStatus { get { return _orderStatus; } set { _orderStatus = value; } }
-        private Value<decimal?> _percentVariance1;
+        private DirtyValue<decimal?> _percentVariance1;
         public decimal? PercentVariance1 { get { return _percentVariance1; } set { _percentVariance1 = value; } }
-        private Value<decimal?> _percentVariance2;
+        private DirtyValue<decimal?> _percentVariance2;
         public decimal? PercentVariance2 { get { return _percentVariance2; } set { _percentVariance2 = value; } }
-        private Value<decimal?> _percentVariance3;
+        private DirtyValue<decimal?> _percentVariance3;
         public decimal? PercentVariance3 { get { return _percentVariance3; } set { _percentVariance3 = value; } }
-        private Value<decimal?> _percentVariance4;
+        private DirtyValue<decimal?> _percentVariance4;
         public decimal? PercentVariance4 { get { return _percentVariance4; } set { _percentVariance4 = value; } }
-        private Value<string> _productsOrdered;
+        private DirtyValue<string> _productsOrdered;
         public string ProductsOrdered { get { return _productsOrdered; } set { _productsOrdered = value; } }
-        private Value<string> _reportYear1;
+        private DirtyValue<string> _reportYear1;
         public string ReportYear1 { get { return _reportYear1; } set { _reportYear1 = value; } }
-        private Value<string> _reportYear2;
+        private DirtyValue<string> _reportYear2;
         public string ReportYear2 { get { return _reportYear2; } set { _reportYear2 = value; } }
-        private Value<string> _reportYear3;
+        private DirtyValue<string> _reportYear3;
         public string ReportYear3 { get { return _reportYear3; } set { _reportYear3 = value; } }
-        private Value<string> _reportYear4;
+        private DirtyValue<string> _reportYear4;
         public string ReportYear4 { get { return _reportYear4; } set { _reportYear4 = value; } }
-        private Value<decimal?> _totalIncome1;
+        private DirtyValue<decimal?> _totalIncome1;
         public decimal? TotalIncome1 { get { return _totalIncome1; } set { _totalIncome1 = value; } }
-        private Value<decimal?> _totalIncome2;
+        private DirtyValue<decimal?> _totalIncome2;
         public decimal? TotalIncome2 { get { return _totalIncome2; } set { _totalIncome2 = value; } }
-        private Value<decimal?> _totalIncome3;
+        private DirtyValue<decimal?> _totalIncome3;
         public decimal? TotalIncome3 { get { return _totalIncome3; } set { _totalIncome3 = value; } }
-        private Value<decimal?> _totalIncome4;
+        private DirtyValue<decimal?> _totalIncome4;
         public decimal? TotalIncome4 { get { return _totalIncome4; } set { _totalIncome4 = value; } }
-        private Value<string> _transcriptType;
+        private DirtyValue<string> _transcriptType;
         public string TranscriptType { get { return _transcriptType; } set { _transcriptType = value; } }
-        private Value<string> _userID;
+        private DirtyValue<string> _userID;
         public string UserID { get { return _userID; } set { _userID = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Tax4506.cs
+++ b/src/EncompassRest/Loans/Tax4506.cs
@@ -8,125 +8,125 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Tax4506 : IDirty
     {
-        private Value<bool?> _accountTranscript;
+        private DirtyValue<bool?> _accountTranscript;
         public bool? AccountTranscript { get { return _accountTranscript; } set { _accountTranscript = value; } }
-        private Value<string> _address;
+        private DirtyValue<string> _address;
         public string Address { get { return _address; } set { _address = value; } }
-        private Value<string> _city;
+        private DirtyValue<string> _city;
         public string City { get { return _city; } set { _city = value; } }
-        private Value<decimal?> _costForEachPeriod;
+        private DirtyValue<decimal?> _costForEachPeriod;
         public decimal? CostForEachPeriod { get { return _costForEachPeriod; } set { _costForEachPeriod = value; } }
-        private Value<string> _currentFirst;
+        private DirtyValue<string> _currentFirst;
         public string CurrentFirst { get { return _currentFirst; } set { _currentFirst = value; } }
-        private Value<string> _currentLast;
+        private DirtyValue<string> _currentLast;
         public string CurrentLast { get { return _currentLast; } set { _currentLast = value; } }
-        private Value<string> _first;
+        private DirtyValue<string> _first;
         public string First { get { return _first; } set { _first = value; } }
-        private Value<bool?> _formsSeriesTranscript;
+        private DirtyValue<bool?> _formsSeriesTranscript;
         public bool? FormsSeriesTranscript { get { return _formsSeriesTranscript; } set { _formsSeriesTranscript = value; } }
-        private Value<string> _historyId;
+        private DirtyValue<string> _historyId;
         public string HistoryId { get { return _historyId; } set { _historyId = value; } }
-        private Value<bool?> _historyIndicator;
+        private DirtyValue<bool?> _historyIndicator;
         public bool? HistoryIndicator { get { return _historyIndicator; } set { _historyIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _ifTaxRecordNotFound;
+        private DirtyValue<bool?> _ifTaxRecordNotFound;
         public bool? IfTaxRecordNotFound { get { return _ifTaxRecordNotFound; } set { _ifTaxRecordNotFound = value; } }
-        private Value<string> _last;
+        private DirtyValue<string> _last;
         public string Last { get { return _last; } set { _last = value; } }
-        private Value<DateTime?> _lastUpdatedDate;
+        private DirtyValue<DateTime?> _lastUpdatedDate;
         public DateTime? LastUpdatedDate { get { return _lastUpdatedDate; } set { _lastUpdatedDate = value; } }
-        private Value<int?> _lastUpdatedHistory;
+        private DirtyValue<int?> _lastUpdatedHistory;
         public int? LastUpdatedHistory { get { return _lastUpdatedHistory; } set { _lastUpdatedHistory = value; } }
-        private Value<string> _lastUpdatedTime;
+        private DirtyValue<string> _lastUpdatedTime;
         public string LastUpdatedTime { get { return _lastUpdatedTime; } set { _lastUpdatedTime = value; } }
-        private Value<bool?> _notifiedIrsIdentityTheftIndicator;
+        private DirtyValue<bool?> _notifiedIrsIdentityTheftIndicator;
         public bool? NotifiedIrsIdentityTheftIndicator { get { return _notifiedIrsIdentityTheftIndicator; } set { _notifiedIrsIdentityTheftIndicator = value; } }
-        private Value<int?> _numberOfPeriods;
+        private DirtyValue<int?> _numberOfPeriods;
         public int? NumberOfPeriods { get { return _numberOfPeriods; } set { _numberOfPeriods = value; } }
-        private Value<string> _person;
+        private DirtyValue<string> _person;
         public string Person { get { return _person; } set { _person = value; } }
-        private Value<bool?> _recordOfAccount;
+        private DirtyValue<bool?> _recordOfAccount;
         public bool? RecordOfAccount { get { return _recordOfAccount; } set { _recordOfAccount = value; } }
-        private Value<string> _requestorPhoneNumber;
+        private DirtyValue<string> _requestorPhoneNumber;
         public string RequestorPhoneNumber { get { return _requestorPhoneNumber; } set { _requestorPhoneNumber = value; } }
-        private Value<string> _requestorTitle;
+        private DirtyValue<string> _requestorTitle;
         public string RequestorTitle { get { return _requestorTitle; } set { _requestorTitle = value; } }
-        private Value<DateTime?> _requestYear1;
+        private DirtyValue<DateTime?> _requestYear1;
         public DateTime? RequestYear1 { get { return _requestYear1; } set { _requestYear1 = value; } }
-        private Value<DateTime?> _requestYear2;
+        private DirtyValue<DateTime?> _requestYear2;
         public DateTime? RequestYear2 { get { return _requestYear2; } set { _requestYear2 = value; } }
-        private Value<DateTime?> _requestYear3;
+        private DirtyValue<DateTime?> _requestYear3;
         public DateTime? RequestYear3 { get { return _requestYear3; } set { _requestYear3 = value; } }
-        private Value<DateTime?> _requestYear4;
+        private DirtyValue<DateTime?> _requestYear4;
         public DateTime? RequestYear4 { get { return _requestYear4; } set { _requestYear4 = value; } }
-        private Value<DateTime?> _requestYear5;
+        private DirtyValue<DateTime?> _requestYear5;
         public DateTime? RequestYear5 { get { return _requestYear5; } set { _requestYear5 = value; } }
-        private Value<DateTime?> _requestYear6;
+        private DirtyValue<DateTime?> _requestYear6;
         public DateTime? RequestYear6 { get { return _requestYear6; } set { _requestYear6 = value; } }
-        private Value<DateTime?> _requestYear7;
+        private DirtyValue<DateTime?> _requestYear7;
         public DateTime? RequestYear7 { get { return _requestYear7; } set { _requestYear7 = value; } }
-        private Value<DateTime?> _requestYear8;
+        private DirtyValue<DateTime?> _requestYear8;
         public DateTime? RequestYear8 { get { return _requestYear8; } set { _requestYear8 = value; } }
-        private Value<string> _returnAddress;
+        private DirtyValue<string> _returnAddress;
         public string ReturnAddress { get { return _returnAddress; } set { _returnAddress = value; } }
-        private Value<string> _returnCity;
+        private DirtyValue<string> _returnCity;
         public string ReturnCity { get { return _returnCity; } set { _returnCity = value; } }
-        private Value<string> _returnState;
+        private DirtyValue<string> _returnState;
         public string ReturnState { get { return _returnState; } set { _returnState = value; } }
-        private Value<bool?> _returnTranscript;
+        private DirtyValue<bool?> _returnTranscript;
         public bool? ReturnTranscript { get { return _returnTranscript; } set { _returnTranscript = value; } }
-        private Value<string> _returnZip;
+        private DirtyValue<string> _returnZip;
         public string ReturnZip { get { return _returnZip; } set { _returnZip = value; } }
-        private Value<string> _selectedRecordNumber;
+        private DirtyValue<string> _selectedRecordNumber;
         public string SelectedRecordNumber { get { return _selectedRecordNumber; } set { _selectedRecordNumber = value; } }
-        private Value<string> _sendAddress;
+        private DirtyValue<string> _sendAddress;
         public string SendAddress { get { return _sendAddress; } set { _sendAddress = value; } }
-        private Value<string> _sendCity;
+        private DirtyValue<string> _sendCity;
         public string SendCity { get { return _sendCity; } set { _sendCity = value; } }
-        private Value<string> _sendFirst;
+        private DirtyValue<string> _sendFirst;
         public string SendFirst { get { return _sendFirst; } set { _sendFirst = value; } }
-        private Value<string> _sendLast;
+        private DirtyValue<string> _sendLast;
         public string SendLast { get { return _sendLast; } set { _sendLast = value; } }
-        private Value<string> _sendPhone;
+        private DirtyValue<string> _sendPhone;
         public string SendPhone { get { return _sendPhone; } set { _sendPhone = value; } }
-        private Value<string> _sendState;
+        private DirtyValue<string> _sendState;
         public string SendState { get { return _sendState; } set { _sendState = value; } }
-        private Value<string> _sendZip;
+        private DirtyValue<string> _sendZip;
         public string SendZip { get { return _sendZip; } set { _sendZip = value; } }
-        private Value<bool?> _signatoryAttestation;
+        private DirtyValue<bool?> _signatoryAttestation;
         public bool? SignatoryAttestation { get { return _signatoryAttestation; } set { _signatoryAttestation = value; } }
-        private Value<bool?> _signatoryAttestationT;
+        private DirtyValue<bool?> _signatoryAttestationT;
         public bool? SignatoryAttestationT { get { return _signatoryAttestationT; } set { _signatoryAttestationT = value; } }
-        private Value<string> _spouseFirst;
+        private DirtyValue<string> _spouseFirst;
         public string SpouseFirst { get { return _spouseFirst; } set { _spouseFirst = value; } }
-        private Value<string> _spouseLast;
+        private DirtyValue<string> _spouseLast;
         public string SpouseLast { get { return _spouseLast; } set { _spouseLast = value; } }
-        private Value<string> _spouseSSN;
+        private DirtyValue<string> _spouseSSN;
         public string SpouseSSN { get { return _spouseSSN; } set { _spouseSSN = value; } }
-        private Value<bool?> _spouseUseEIN;
+        private DirtyValue<bool?> _spouseUseEIN;
         public bool? SpouseUseEIN { get { return _spouseUseEIN; } set { _spouseUseEIN = value; } }
-        private Value<string> _sSN;
+        private DirtyValue<string> _sSN;
         public string SSN { get { return _sSN; } set { _sSN = value; } }
-        private Value<string> _state;
+        private DirtyValue<string> _state;
         public string State { get { return _state; } set { _state = value; } }
-        private Value<int?> _tax4506Index;
+        private DirtyValue<int?> _tax4506Index;
         public int? Tax4506Index { get { return _tax4506Index; } set { _tax4506Index = value; } }
-        private Value<bool?> _tax4506TIndicator;
+        private DirtyValue<bool?> _tax4506TIndicator;
         public bool? Tax4506TIndicator { get { return _tax4506TIndicator; } set { _tax4506TIndicator = value; } }
-        private Value<string> _taxFormNumber;
+        private DirtyValue<string> _taxFormNumber;
         public string TaxFormNumber { get { return _taxFormNumber; } set { _taxFormNumber = value; } }
-        private Value<bool?> _theseCopiesMustBeCertified;
+        private DirtyValue<bool?> _theseCopiesMustBeCertified;
         public bool? TheseCopiesMustBeCertified { get { return _theseCopiesMustBeCertified; } set { _theseCopiesMustBeCertified = value; } }
-        private Value<decimal?> _totalCost;
+        private DirtyValue<decimal?> _totalCost;
         public decimal? TotalCost { get { return _totalCost; } set { _totalCost = value; } }
-        private Value<bool?> _useEIN;
+        private DirtyValue<bool?> _useEIN;
         public bool? UseEIN { get { return _useEIN; } set { _useEIN = value; } }
-        private Value<bool?> _useWellsFargoRules;
+        private DirtyValue<bool?> _useWellsFargoRules;
         public bool? UseWellsFargoRules { get { return _useWellsFargoRules; } set { _useWellsFargoRules = value; } }
-        private Value<bool?> _verificationOfNonfiling;
+        private DirtyValue<bool?> _verificationOfNonfiling;
         public bool? VerificationOfNonfiling { get { return _verificationOfNonfiling; } set { _verificationOfNonfiling = value; } }
-        private Value<string> _zip;
+        private DirtyValue<string> _zip;
         public string Zip { get { return _zip; } set { _zip = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/TrustAccount.cs
+++ b/src/EncompassRest/Loans/TrustAccount.cs
@@ -8,13 +8,13 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TrustAccount : IDirty
     {
-        private Value<decimal?> _balance;
+        private DirtyValue<decimal?> _balance;
         public decimal? Balance { get { return _balance; } set { _balance = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _total1;
+        private DirtyValue<decimal?> _total1;
         public decimal? Total1 { get { return _total1; } set { _total1 = value; } }
-        private Value<decimal?> _total2;
+        private DirtyValue<decimal?> _total2;
         public decimal? Total2 { get { return _total2; } set { _total2 = value; } }
         private DirtyList<TrustAccountItem> _trustAccountItems;
         public IList<TrustAccountItem> TrustAccountItems { get { var v = _trustAccountItems; return v ?? Interlocked.CompareExchange(ref _trustAccountItems, (v = new DirtyList<TrustAccountItem>()), null) ?? v; } set { _trustAccountItems = new DirtyList<TrustAccountItem>(value); } }

--- a/src/EncompassRest/Loans/TrustAccount.cs
+++ b/src/EncompassRest/Loans/TrustAccount.cs
@@ -16,8 +16,8 @@ namespace EncompassRest.Loans
         public decimal? Total1 { get { return _total1; } set { _total1 = value; } }
         private Value<decimal?> _total2;
         public decimal? Total2 { get { return _total2; } set { _total2 = value; } }
-        private Value<List<TrustAccountItem>> _trustAccountItems;
-        public List<TrustAccountItem> TrustAccountItems { get { return _trustAccountItems; } set { _trustAccountItems = value; } }
+        private DirtyList<TrustAccountItem> _trustAccountItems;
+        public IList<TrustAccountItem> TrustAccountItems { get { var v = _trustAccountItems; return v ?? Interlocked.CompareExchange(ref _trustAccountItems, (v = new DirtyList<TrustAccountItem>()), null) ?? v; } set { _trustAccountItems = new DirtyList<TrustAccountItem>(value); } }
         private int _gettingDirty;
         private int _settingDirty; 
         internal bool Dirty
@@ -29,7 +29,7 @@ namespace EncompassRest.Loans
                     || _id.Dirty
                     || _total1.Dirty
                     || _total2.Dirty
-                    || _trustAccountItems.Dirty;
+                    || _trustAccountItems?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -40,7 +40,7 @@ namespace EncompassRest.Loans
                 _id.Dirty = value;
                 _total1.Dirty = value;
                 _total2.Dirty = value;
-                _trustAccountItems.Dirty = value;
+                if (_trustAccountItems != null) _trustAccountItems.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/TrustAccountItem.cs
+++ b/src/EncompassRest/Loans/TrustAccountItem.cs
@@ -8,23 +8,23 @@ namespace EncompassRest.Loans
 {
     public sealed partial class TrustAccountItem : IDirty
     {
-        private Value<DateTime?> _date;
+        private DirtyValue<DateTime?> _date;
         public DateTime? Date { get { return _date; } set { _date = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _notes;
+        private DirtyValue<string> _notes;
         public string Notes { get { return _notes; } set { _notes = value; } }
-        private Value<decimal?> _paymentAmount;
+        private DirtyValue<decimal?> _paymentAmount;
         public decimal? PaymentAmount { get { return _paymentAmount; } set { _paymentAmount = value; } }
-        private Value<string> _paymentCheckNo;
+        private DirtyValue<string> _paymentCheckNo;
         public string PaymentCheckNo { get { return _paymentCheckNo; } set { _paymentCheckNo = value; } }
-        private Value<decimal?> _receiptAmount;
+        private DirtyValue<decimal?> _receiptAmount;
         public decimal? ReceiptAmount { get { return _receiptAmount; } set { _receiptAmount = value; } }
-        private Value<string> _receiptCheckNo;
+        private DirtyValue<string> _receiptCheckNo;
         public string ReceiptCheckNo { get { return _receiptCheckNo; } set { _receiptCheckNo = value; } }
-        private Value<int?> _trustAccountItemIndex;
+        private DirtyValue<int?> _trustAccountItemIndex;
         public int? TrustAccountItemIndex { get { return _trustAccountItemIndex; } set { _trustAccountItemIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Tsum.cs
+++ b/src/EncompassRest/Loans/Tsum.cs
@@ -8,137 +8,137 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Tsum : IDirty
     {
-        private Value<decimal?> _aboveOrBelowRatePercent;
+        private DirtyValue<decimal?> _aboveOrBelowRatePercent;
         public decimal? AboveOrBelowRatePercent { get { return _aboveOrBelowRatePercent; } set { _aboveOrBelowRatePercent = value; } }
-        private Value<string> _adjustorCoverage;
+        private DirtyValue<string> _adjustorCoverage;
         public string AdjustorCoverage { get { return _adjustorCoverage; } set { _adjustorCoverage = value; } }
-        private Value<string> _ausRecommendation;
+        private DirtyValue<string> _ausRecommendation;
         public string AusRecommendation { get { return _ausRecommendation; } set { _ausRecommendation = value; } }
-        private Value<int?> _bedroomsUnit1;
+        private DirtyValue<int?> _bedroomsUnit1;
         public int? BedroomsUnit1 { get { return _bedroomsUnit1; } set { _bedroomsUnit1 = value; } }
-        private Value<int?> _bedroomsUnit2;
+        private DirtyValue<int?> _bedroomsUnit2;
         public int? BedroomsUnit2 { get { return _bedroomsUnit2; } set { _bedroomsUnit2 = value; } }
-        private Value<int?> _bedroomsUnit3;
+        private DirtyValue<int?> _bedroomsUnit3;
         public int? BedroomsUnit3 { get { return _bedroomsUnit3; } set { _bedroomsUnit3 = value; } }
-        private Value<int?> _bedroomsUnit4;
+        private DirtyValue<int?> _bedroomsUnit4;
         public int? BedroomsUnit4 { get { return _bedroomsUnit4; } set { _bedroomsUnit4 = value; } }
-        private Value<string> _certificateNumber;
+        private DirtyValue<string> _certificateNumber;
         public string CertificateNumber { get { return _certificateNumber; } set { _certificateNumber = value; } }
-        private Value<string> _commitmentNumber;
+        private DirtyValue<string> _commitmentNumber;
         public string CommitmentNumber { get { return _commitmentNumber; } set { _commitmentNumber = value; } }
-        private Value<bool?> _communityLendingAfordableHousingInitiative;
+        private DirtyValue<bool?> _communityLendingAfordableHousingInitiative;
         public bool? CommunityLendingAfordableHousingInitiative { get { return _communityLendingAfordableHousingInitiative; } set { _communityLendingAfordableHousingInitiative = value; } }
-        private Value<string> _contactTitle;
+        private DirtyValue<string> _contactTitle;
         public string ContactTitle { get { return _contactTitle; } set { _contactTitle = value; } }
-        private Value<string> _contractNumber;
+        private DirtyValue<string> _contractNumber;
         public string ContractNumber { get { return _contractNumber; } set { _contractNumber = value; } }
-        private Value<string> _cpmProjectId;
+        private DirtyValue<string> _cpmProjectId;
         public string CpmProjectId { get { return _cpmProjectId; } set { _cpmProjectId = value; } }
-        private Value<string> _duCaseIdLpAusKey;
+        private DirtyValue<string> _duCaseIdLpAusKey;
         public string DuCaseIdLpAusKey { get { return _duCaseIdLpAusKey; } set { _duCaseIdLpAusKey = value; } }
-        private Value<string> _formNumber;
+        private DirtyValue<string> _formNumber;
         public string FormNumber { get { return _formNumber; } set { _formNumber = value; } }
-        private Value<int?> _grossRentUnit1;
+        private DirtyValue<int?> _grossRentUnit1;
         public int? GrossRentUnit1 { get { return _grossRentUnit1; } set { _grossRentUnit1 = value; } }
-        private Value<int?> _grossRentUnit2;
+        private DirtyValue<int?> _grossRentUnit2;
         public int? GrossRentUnit2 { get { return _grossRentUnit2; } set { _grossRentUnit2 = value; } }
-        private Value<int?> _grossRentUnit3;
+        private DirtyValue<int?> _grossRentUnit3;
         public int? GrossRentUnit3 { get { return _grossRentUnit3; } set { _grossRentUnit3 = value; } }
-        private Value<int?> _grossRentUnit4;
+        private DirtyValue<int?> _grossRentUnit4;
         public int? GrossRentUnit4 { get { return _grossRentUnit4; } set { _grossRentUnit4 = value; } }
-        private Value<string> _homeBuyersOwnershipEducationCertificateInFile;
+        private DirtyValue<string> _homeBuyersOwnershipEducationCertificateInFile;
         public string HomeBuyersOwnershipEducationCertificateInFile { get { return _homeBuyersOwnershipEducationCertificateInFile; } set { _homeBuyersOwnershipEducationCertificateInFile = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _insurerCode;
+        private DirtyValue<string> _insurerCode;
         public string InsurerCode { get { return _insurerCode; } set { _insurerCode = value; } }
-        private Value<decimal?> _interestedPartyContributions;
+        private DirtyValue<decimal?> _interestedPartyContributions;
         public decimal? InterestedPartyContributions { get { return _interestedPartyContributions; } set { _interestedPartyContributions = value; } }
-        private Value<string> _investorLoanNumber;
+        private DirtyValue<string> _investorLoanNumber;
         public string InvestorLoanNumber { get { return _investorLoanNumber; } set { _investorLoanNumber = value; } }
-        private Value<string> _levelOfPropertyReviewType;
+        private DirtyValue<string> _levelOfPropertyReviewType;
         public string LevelOfPropertyReviewType { get { return _levelOfPropertyReviewType; } set { _levelOfPropertyReviewType = value; } }
-        private Value<string> _lpDocClass;
+        private DirtyValue<string> _lpDocClass;
         public string LpDocClass { get { return _lpDocClass; } set { _lpDocClass = value; } }
-        private Value<string> _mortgageOriginator;
+        private DirtyValue<string> _mortgageOriginator;
         public string MortgageOriginator { get { return _mortgageOriginator; } set { _mortgageOriginator = value; } }
-        private Value<DateTime?> _noteDate;
+        private DirtyValue<DateTime?> _noteDate;
         public DateTime? NoteDate { get { return _noteDate; } set { _noteDate = value; } }
-        private Value<string> _noteRateType;
+        private DirtyValue<string> _noteRateType;
         public string NoteRateType { get { return _noteRateType; } set { _noteRateType = value; } }
-        private Value<int?> _numberOfBorrowers;
+        private DirtyValue<int?> _numberOfBorrowers;
         public int? NumberOfBorrowers { get { return _numberOfBorrowers; } set { _numberOfBorrowers = value; } }
-        private Value<int?> _numberOfMonthsReserves;
+        private DirtyValue<int?> _numberOfMonthsReserves;
         public int? NumberOfMonthsReserves { get { return _numberOfMonthsReserves; } set { _numberOfMonthsReserves = value; } }
-        private Value<decimal?> _originalAmountOfFirstMortgage;
+        private DirtyValue<decimal?> _originalAmountOfFirstMortgage;
         public decimal? OriginalAmountOfFirstMortgage { get { return _originalAmountOfFirstMortgage; } set { _originalAmountOfFirstMortgage = value; } }
-        private Value<string> _otherTypeDescription;
+        private DirtyValue<string> _otherTypeDescription;
         public string OtherTypeDescription { get { return _otherTypeDescription; } set { _otherTypeDescription = value; } }
-        private Value<string> _percentageofCoverage;
+        private DirtyValue<string> _percentageofCoverage;
         public string PercentageofCoverage { get { return _percentageofCoverage; } set { _percentageofCoverage = value; } }
-        private Value<string> _projectName;
+        private DirtyValue<string> _projectName;
         public string ProjectName { get { return _projectName; } set { _projectName = value; } }
-        private Value<string> _propertyFormType;
+        private DirtyValue<string> _propertyFormType;
         public string PropertyFormType { get { return _propertyFormType; } set { _propertyFormType = value; } }
-        private Value<string> _propertyType;
+        private DirtyValue<string> _propertyType;
         public string PropertyType { get { return _propertyType; } set { _propertyType = value; } }
-        private Value<decimal?> _required;
+        private DirtyValue<decimal?> _required;
         public decimal? Required { get { return _required; } set { _required = value; } }
-        private Value<string> _riskAssessmentType;
+        private DirtyValue<string> _riskAssessmentType;
         public string RiskAssessmentType { get { return _riskAssessmentType; } set { _riskAssessmentType = value; } }
-        private Value<string> _sellerAddress;
+        private DirtyValue<string> _sellerAddress;
         public string SellerAddress { get { return _sellerAddress; } set { _sellerAddress = value; } }
-        private Value<string> _sellerCity;
+        private DirtyValue<string> _sellerCity;
         public string SellerCity { get { return _sellerCity; } set { _sellerCity = value; } }
-        private Value<string> _sellerContactName;
+        private DirtyValue<string> _sellerContactName;
         public string SellerContactName { get { return _sellerContactName; } set { _sellerContactName = value; } }
-        private Value<string> _sellerName;
+        private DirtyValue<string> _sellerName;
         public string SellerName { get { return _sellerName; } set { _sellerName = value; } }
-        private Value<string> _sellerNumber;
+        private DirtyValue<string> _sellerNumber;
         public string SellerNumber { get { return _sellerNumber; } set { _sellerNumber = value; } }
-        private Value<string> _sellerPhone;
+        private DirtyValue<string> _sellerPhone;
         public string SellerPhone { get { return _sellerPhone; } set { _sellerPhone = value; } }
-        private Value<string> _sellerPostalCode;
+        private DirtyValue<string> _sellerPostalCode;
         public string SellerPostalCode { get { return _sellerPostalCode; } set { _sellerPostalCode = value; } }
-        private Value<string> _sellerState;
+        private DirtyValue<string> _sellerState;
         public string SellerState { get { return _sellerState; } set { _sellerState = value; } }
-        private Value<string> _specialFeatureCode1;
+        private DirtyValue<string> _specialFeatureCode1;
         public string SpecialFeatureCode1 { get { return _specialFeatureCode1; } set { _specialFeatureCode1 = value; } }
-        private Value<string> _specialFeatureCode2;
+        private DirtyValue<string> _specialFeatureCode2;
         public string SpecialFeatureCode2 { get { return _specialFeatureCode2; } set { _specialFeatureCode2 = value; } }
-        private Value<string> _specialFeatureCode3;
+        private DirtyValue<string> _specialFeatureCode3;
         public string SpecialFeatureCode3 { get { return _specialFeatureCode3; } set { _specialFeatureCode3 = value; } }
-        private Value<string> _specialFeatureCode4;
+        private DirtyValue<string> _specialFeatureCode4;
         public string SpecialFeatureCode4 { get { return _specialFeatureCode4; } set { _specialFeatureCode4 = value; } }
-        private Value<string> _specialFeatureCode5;
+        private DirtyValue<string> _specialFeatureCode5;
         public string SpecialFeatureCode5 { get { return _specialFeatureCode5; } set { _specialFeatureCode5 = value; } }
-        private Value<string> _specialFeatureCode6;
+        private DirtyValue<string> _specialFeatureCode6;
         public string SpecialFeatureCode6 { get { return _specialFeatureCode6; } set { _specialFeatureCode6 = value; } }
-        private Value<string> _thirdPartyName1;
+        private DirtyValue<string> _thirdPartyName1;
         public string ThirdPartyName1 { get { return _thirdPartyName1; } set { _thirdPartyName1 = value; } }
-        private Value<string> _thirdPartyName2;
+        private DirtyValue<string> _thirdPartyName2;
         public string ThirdPartyName2 { get { return _thirdPartyName2; } set { _thirdPartyName2 = value; } }
-        private Value<string> _typeOfCommitment;
+        private DirtyValue<string> _typeOfCommitment;
         public string TypeOfCommitment { get { return _typeOfCommitment; } set { _typeOfCommitment = value; } }
-        private Value<string> _underwritingComment1;
+        private DirtyValue<string> _underwritingComment1;
         public string UnderwritingComment1 { get { return _underwritingComment1; } set { _underwritingComment1 = value; } }
-        private Value<string> _underwritingComment2;
+        private DirtyValue<string> _underwritingComment2;
         public string UnderwritingComment2 { get { return _underwritingComment2; } set { _underwritingComment2 = value; } }
-        private Value<string> _underwritingComment3;
+        private DirtyValue<string> _underwritingComment3;
         public string UnderwritingComment3 { get { return _underwritingComment3; } set { _underwritingComment3 = value; } }
-        private Value<string> _underwritingComment4;
+        private DirtyValue<string> _underwritingComment4;
         public string UnderwritingComment4 { get { return _underwritingComment4; } set { _underwritingComment4 = value; } }
-        private Value<string> _underwritingComment5;
+        private DirtyValue<string> _underwritingComment5;
         public string UnderwritingComment5 { get { return _underwritingComment5; } set { _underwritingComment5 = value; } }
-        private Value<string> _underwritingComment6;
+        private DirtyValue<string> _underwritingComment6;
         public string UnderwritingComment6 { get { return _underwritingComment6; } set { _underwritingComment6 = value; } }
-        private Value<string> _underwritingComment7;
+        private DirtyValue<string> _underwritingComment7;
         public string UnderwritingComment7 { get { return _underwritingComment7; } set { _underwritingComment7 = value; } }
-        private Value<string> _underwritingComment8;
+        private DirtyValue<string> _underwritingComment8;
         public string UnderwritingComment8 { get { return _underwritingComment8; } set { _underwritingComment8 = value; } }
-        private Value<decimal?> _unpaidBalance;
+        private DirtyValue<decimal?> _unpaidBalance;
         public decimal? UnpaidBalance { get { return _unpaidBalance; } set { _unpaidBalance = value; } }
-        private Value<decimal?> _verified;
+        private DirtyValue<decimal?> _verified;
         public decimal? Verified { get { return _verified; } set { _verified = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/UCDDetail.cs
+++ b/src/EncompassRest/Loans/UCDDetail.cs
@@ -8,29 +8,29 @@ namespace EncompassRest.Loans
 {
     public sealed partial class UCDDetail : IDirty
     {
-        private Value<string> _feeAccountType;
+        private DirtyValue<string> _feeAccountType;
         public string FeeAccountType { get { return _feeAccountType; } set { _feeAccountType = value; } }
-        private Value<decimal?> _feeAmount;
+        private DirtyValue<decimal?> _feeAmount;
         public decimal? FeeAmount { get { return _feeAmount; } set { _feeAmount = value; } }
-        private Value<DateTime?> _feeDateFrom;
+        private DirtyValue<DateTime?> _feeDateFrom;
         public DateTime? FeeDateFrom { get { return _feeDateFrom; } set { _feeDateFrom = value; } }
-        private Value<DateTime?> _feeDateTo;
+        private DirtyValue<DateTime?> _feeDateTo;
         public DateTime? FeeDateTo { get { return _feeDateTo; } set { _feeDateTo = value; } }
-        private Value<string> _feeDesc;
+        private DirtyValue<string> _feeDesc;
         public string FeeDesc { get { return _feeDesc; } set { _feeDesc = value; } }
-        private Value<int?> _feeIndex;
+        private DirtyValue<int?> _feeIndex;
         public int? FeeIndex { get { return _feeIndex; } set { _feeIndex = value; } }
-        private Value<string> _feePaidBy;
+        private DirtyValue<string> _feePaidBy;
         public string FeePaidBy { get { return _feePaidBy; } set { _feePaidBy = value; } }
-        private Value<string> _feePaidTo;
+        private DirtyValue<string> _feePaidTo;
         public string FeePaidTo { get { return _feePaidTo; } set { _feePaidTo = value; } }
-        private Value<bool?> _feePOC;
+        private DirtyValue<bool?> _feePOC;
         public bool? FeePOC { get { return _feePOC; } set { _feePOC = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<int?> _lineNumber;
+        private DirtyValue<int?> _lineNumber;
         public int? LineNumber { get { return _lineNumber; } set { _lineNumber = value; } }
-        private Value<string> _section;
+        private DirtyValue<string> _section;
         public string Section { get { return _section; } set { _section = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Uldd.cs
+++ b/src/EncompassRest/Loans/Uldd.cs
@@ -8,603 +8,603 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Uldd : IDirty
     {
-        private Value<string> _aCHABARoutingAndTransitIdentifier;
+        private DirtyValue<string> _aCHABARoutingAndTransitIdentifier;
         public string ACHABARoutingAndTransitIdentifier { get { return _aCHABARoutingAndTransitIdentifier; } set { _aCHABARoutingAndTransitIdentifier = value; } }
-        private Value<string> _aCHABARoutingAndTransitNumber;
+        private DirtyValue<string> _aCHABARoutingAndTransitNumber;
         public string ACHABARoutingAndTransitNumber { get { return _aCHABARoutingAndTransitNumber; } set { _aCHABARoutingAndTransitNumber = value; } }
-        private Value<string> _aCHBankAccountDescription;
+        private DirtyValue<string> _aCHBankAccountDescription;
         public string ACHBankAccountDescription { get { return _aCHBankAccountDescription; } set { _aCHBankAccountDescription = value; } }
-        private Value<string> _aCHBankAccountIdentifier;
+        private DirtyValue<string> _aCHBankAccountIdentifier;
         public string ACHBankAccountIdentifier { get { return _aCHBankAccountIdentifier; } set { _aCHBankAccountIdentifier = value; } }
-        private Value<string> _aCHBankAccountPurposeTransitIdentifier;
+        private DirtyValue<string> _aCHBankAccountPurposeTransitIdentifier;
         public string ACHBankAccountPurposeTransitIdentifier { get { return _aCHBankAccountPurposeTransitIdentifier; } set { _aCHBankAccountPurposeTransitIdentifier = value; } }
-        private Value<string> _aCHBankAccountPurposeType;
+        private DirtyValue<string> _aCHBankAccountPurposeType;
         public string ACHBankAccountPurposeType { get { return _aCHBankAccountPurposeType; } set { _aCHBankAccountPurposeType = value; } }
-        private Value<string> _aCHInstitutionTelegraphicAbbreviationName;
+        private DirtyValue<string> _aCHInstitutionTelegraphicAbbreviationName;
         public string ACHInstitutionTelegraphicAbbreviationName { get { return _aCHInstitutionTelegraphicAbbreviationName; } set { _aCHInstitutionTelegraphicAbbreviationName = value; } }
-        private Value<string> _aCHReceiverSubaccountName;
+        private DirtyValue<string> _aCHReceiverSubaccountName;
         public string ACHReceiverSubaccountName { get { return _aCHReceiverSubaccountName; } set { _aCHReceiverSubaccountName = value; } }
-        private Value<bool?> _additionalPrincipalAmountIndicator;
+        private DirtyValue<bool?> _additionalPrincipalAmountIndicator;
         public bool? AdditionalPrincipalAmountIndicator { get { return _additionalPrincipalAmountIndicator; } set { _additionalPrincipalAmountIndicator = value; } }
-        private Value<decimal?> _aggregateLoanCurtailmentAmount;
+        private DirtyValue<decimal?> _aggregateLoanCurtailmentAmount;
         public decimal? AggregateLoanCurtailmentAmount { get { return _aggregateLoanCurtailmentAmount; } set { _aggregateLoanCurtailmentAmount = value; } }
-        private Value<string> _appraisalIdentifier;
+        private DirtyValue<string> _appraisalIdentifier;
         public string AppraisalIdentifier { get { return _appraisalIdentifier; } set { _appraisalIdentifier = value; } }
-        private Value<string> _attachmentType;
+        private DirtyValue<string> _attachmentType;
         public string AttachmentType { get { return _attachmentType; } set { _attachmentType = value; } }
-        private Value<string> _aVMModelNameType;
+        private DirtyValue<string> _aVMModelNameType;
         public string AVMModelNameType { get { return _aVMModelNameType; } set { _aVMModelNameType = value; } }
-        private Value<bool?> _balloonResetIndicator;
+        private DirtyValue<bool?> _balloonResetIndicator;
         public bool? BalloonResetIndicator { get { return _balloonResetIndicator; } set { _balloonResetIndicator = value; } }
-        private Value<decimal?> _baseGuarantyFeePercent;
+        private DirtyValue<decimal?> _baseGuarantyFeePercent;
         public decimal? BaseGuarantyFeePercent { get { return _baseGuarantyFeePercent; } set { _baseGuarantyFeePercent = value; } }
-        private Value<string> _bondFinancePool;
+        private DirtyValue<string> _bondFinancePool;
         public string BondFinancePool { get { return _bondFinancePool; } set { _bondFinancePool = value; } }
-        private Value<string> _bondFinanceProgramName;
+        private DirtyValue<string> _bondFinanceProgramName;
         public string BondFinanceProgramName { get { return _bondFinanceProgramName; } set { _bondFinanceProgramName = value; } }
-        private Value<string> _bondFinanceProgramType;
+        private DirtyValue<string> _bondFinanceProgramType;
         public string BondFinanceProgramType { get { return _bondFinanceProgramType; } set { _bondFinanceProgramType = value; } }
-        private Value<bool?> _borrowerMailToAddressSameasPropertyIndicator;
+        private DirtyValue<bool?> _borrowerMailToAddressSameasPropertyIndicator;
         public bool? BorrowerMailToAddressSameasPropertyIndicator { get { return _borrowerMailToAddressSameasPropertyIndicator; } set { _borrowerMailToAddressSameasPropertyIndicator = value; } }
-        private Value<string> _borrowerType;
+        private DirtyValue<string> _borrowerType;
         public string BorrowerType { get { return _borrowerType; } set { _borrowerType = value; } }
-        private Value<bool?> _capitalizedLoanIndicator;
+        private DirtyValue<bool?> _capitalizedLoanIndicator;
         public bool? CapitalizedLoanIndicator { get { return _capitalizedLoanIndicator; } set { _capitalizedLoanIndicator = value; } }
-        private Value<string> _certificateIdentifier;
+        private DirtyValue<string> _certificateIdentifier;
         public string CertificateIdentifier { get { return _certificateIdentifier; } set { _certificateIdentifier = value; } }
-        private Value<DateTime?> _certificateMaturityDate;
+        private DirtyValue<DateTime?> _certificateMaturityDate;
         public DateTime? CertificateMaturityDate { get { return _certificateMaturityDate; } set { _certificateMaturityDate = value; } }
-        private Value<decimal?> _certificatePrincipalBalanceAmount;
+        private DirtyValue<decimal?> _certificatePrincipalBalanceAmount;
         public decimal? CertificatePrincipalBalanceAmount { get { return _certificatePrincipalBalanceAmount; } set { _certificatePrincipalBalanceAmount = value; } }
-        private Value<string> _certificateType;
+        private DirtyValue<string> _certificateType;
         public string CertificateType { get { return _certificateType; } set { _certificateType = value; } }
-        private Value<decimal?> _closingCost2ContributionAmount;
+        private DirtyValue<decimal?> _closingCost2ContributionAmount;
         public decimal? ClosingCost2ContributionAmount { get { return _closingCost2ContributionAmount; } set { _closingCost2ContributionAmount = value; } }
-        private Value<string> _closingCost2FundsType;
+        private DirtyValue<string> _closingCost2FundsType;
         public string ClosingCost2FundsType { get { return _closingCost2FundsType; } set { _closingCost2FundsType = value; } }
-        private Value<string> _closingCost2FundsTypeOtherDescription;
+        private DirtyValue<string> _closingCost2FundsTypeOtherDescription;
         public string ClosingCost2FundsTypeOtherDescription { get { return _closingCost2FundsTypeOtherDescription; } set { _closingCost2FundsTypeOtherDescription = value; } }
-        private Value<string> _closingCost2SourceType;
+        private DirtyValue<string> _closingCost2SourceType;
         public string ClosingCost2SourceType { get { return _closingCost2SourceType; } set { _closingCost2SourceType = value; } }
-        private Value<string> _closingCost2SourceTypeOtherDescription;
+        private DirtyValue<string> _closingCost2SourceTypeOtherDescription;
         public string ClosingCost2SourceTypeOtherDescription { get { return _closingCost2SourceTypeOtherDescription; } set { _closingCost2SourceTypeOtherDescription = value; } }
-        private Value<decimal?> _closingCost3ContributionAmount;
+        private DirtyValue<decimal?> _closingCost3ContributionAmount;
         public decimal? ClosingCost3ContributionAmount { get { return _closingCost3ContributionAmount; } set { _closingCost3ContributionAmount = value; } }
-        private Value<string> _closingCost3FundsType;
+        private DirtyValue<string> _closingCost3FundsType;
         public string ClosingCost3FundsType { get { return _closingCost3FundsType; } set { _closingCost3FundsType = value; } }
-        private Value<string> _closingCost3FundsTypeOtherDescription;
+        private DirtyValue<string> _closingCost3FundsTypeOtherDescription;
         public string ClosingCost3FundsTypeOtherDescription { get { return _closingCost3FundsTypeOtherDescription; } set { _closingCost3FundsTypeOtherDescription = value; } }
-        private Value<string> _closingCost3SourceType;
+        private DirtyValue<string> _closingCost3SourceType;
         public string ClosingCost3SourceType { get { return _closingCost3SourceType; } set { _closingCost3SourceType = value; } }
-        private Value<string> _closingCost3SourceTypeOtherDescription;
+        private DirtyValue<string> _closingCost3SourceTypeOtherDescription;
         public string ClosingCost3SourceTypeOtherDescription { get { return _closingCost3SourceTypeOtherDescription; } set { _closingCost3SourceTypeOtherDescription = value; } }
-        private Value<decimal?> _closingCost4ContributionAmount;
+        private DirtyValue<decimal?> _closingCost4ContributionAmount;
         public decimal? ClosingCost4ContributionAmount { get { return _closingCost4ContributionAmount; } set { _closingCost4ContributionAmount = value; } }
-        private Value<string> _closingCost4FundsType;
+        private DirtyValue<string> _closingCost4FundsType;
         public string ClosingCost4FundsType { get { return _closingCost4FundsType; } set { _closingCost4FundsType = value; } }
-        private Value<string> _closingCost4FundsTypeOtherDescription;
+        private DirtyValue<string> _closingCost4FundsTypeOtherDescription;
         public string ClosingCost4FundsTypeOtherDescription { get { return _closingCost4FundsTypeOtherDescription; } set { _closingCost4FundsTypeOtherDescription = value; } }
-        private Value<string> _closingCost4SourceType;
+        private DirtyValue<string> _closingCost4SourceType;
         public string ClosingCost4SourceType { get { return _closingCost4SourceType; } set { _closingCost4SourceType = value; } }
-        private Value<string> _closingCost4SourceTypeOtherDescription;
+        private DirtyValue<string> _closingCost4SourceTypeOtherDescription;
         public string ClosingCost4SourceTypeOtherDescription { get { return _closingCost4SourceTypeOtherDescription; } set { _closingCost4SourceTypeOtherDescription = value; } }
-        private Value<decimal?> _closingCostContributionAmount;
+        private DirtyValue<decimal?> _closingCostContributionAmount;
         public decimal? ClosingCostContributionAmount { get { return _closingCostContributionAmount; } set { _closingCostContributionAmount = value; } }
-        private Value<string> _closingCostFundsType;
+        private DirtyValue<string> _closingCostFundsType;
         public string ClosingCostFundsType { get { return _closingCostFundsType; } set { _closingCostFundsType = value; } }
-        private Value<string> _closingCostFundsTypeOtherDescription;
+        private DirtyValue<string> _closingCostFundsTypeOtherDescription;
         public string ClosingCostFundsTypeOtherDescription { get { return _closingCostFundsTypeOtherDescription; } set { _closingCostFundsTypeOtherDescription = value; } }
-        private Value<string> _closingCostSourceType;
+        private DirtyValue<string> _closingCostSourceType;
         public string ClosingCostSourceType { get { return _closingCostSourceType; } set { _closingCostSourceType = value; } }
-        private Value<string> _closingCostSourceTypeOtherDescription;
+        private DirtyValue<string> _closingCostSourceTypeOtherDescription;
         public string ClosingCostSourceTypeOtherDescription { get { return _closingCostSourceTypeOtherDescription; } set { _closingCostSourceTypeOtherDescription = value; } }
-        private Value<string> _coBorrowerCountryCode;
+        private DirtyValue<string> _coBorrowerCountryCode;
         public string CoBorrowerCountryCode { get { return _coBorrowerCountryCode; } set { _coBorrowerCountryCode = value; } }
-        private Value<bool?> _coBorrowerMailToAddressSameasPropertyIndicator;
+        private DirtyValue<bool?> _coBorrowerMailToAddressSameasPropertyIndicator;
         public bool? CoBorrowerMailToAddressSameasPropertyIndicator { get { return _coBorrowerMailToAddressSameasPropertyIndicator; } set { _coBorrowerMailToAddressSameasPropertyIndicator = value; } }
-        private Value<string> _coBorrowerType;
+        private DirtyValue<string> _coBorrowerType;
         public string CoBorrowerType { get { return _coBorrowerType; } set { _coBorrowerType = value; } }
-        private Value<string> _condominiumProjectStatusType;
+        private DirtyValue<string> _condominiumProjectStatusType;
         public string CondominiumProjectStatusType { get { return _condominiumProjectStatusType; } set { _condominiumProjectStatusType = value; } }
-        private Value<string> _constructionMethodType;
+        private DirtyValue<string> _constructionMethodType;
         public string ConstructionMethodType { get { return _constructionMethodType; } set { _constructionMethodType = value; } }
-        private Value<string> _constructionMethodTypeOtherDescription;
+        private DirtyValue<string> _constructionMethodTypeOtherDescription;
         public string ConstructionMethodTypeOtherDescription { get { return _constructionMethodTypeOtherDescription; } set { _constructionMethodTypeOtherDescription = value; } }
-        private Value<string> _constructionToPermanentClosingFeatureType;
+        private DirtyValue<string> _constructionToPermanentClosingFeatureType;
         public string ConstructionToPermanentClosingFeatureType { get { return _constructionToPermanentClosingFeatureType; } set { _constructionToPermanentClosingFeatureType = value; } }
-        private Value<string> _constructionToPermanentClosingType;
+        private DirtyValue<string> _constructionToPermanentClosingType;
         public string ConstructionToPermanentClosingType { get { return _constructionToPermanentClosingType; } set { _constructionToPermanentClosingType = value; } }
-        private Value<string> _convertibleStatusType;
+        private DirtyValue<string> _convertibleStatusType;
         public string ConvertibleStatusType { get { return _convertibleStatusType; } set { _convertibleStatusType = value; } }
-        private Value<string> _counselingFormatType;
+        private DirtyValue<string> _counselingFormatType;
         public string CounselingFormatType { get { return _counselingFormatType; } set { _counselingFormatType = value; } }
-        private Value<string> _counselingFormatTypeOtherDescription;
+        private DirtyValue<string> _counselingFormatTypeOtherDescription;
         public string CounselingFormatTypeOtherDescription { get { return _counselingFormatTypeOtherDescription; } set { _counselingFormatTypeOtherDescription = value; } }
-        private Value<string> _counselTypeOther;
+        private DirtyValue<string> _counselTypeOther;
         public string CounselTypeOther { get { return _counselTypeOther; } set { _counselTypeOther = value; } }
-        private Value<string> _countryCode;
+        private DirtyValue<string> _countryCode;
         public string CountryCode { get { return _countryCode; } set { _countryCode = value; } }
-        private Value<string> _creditScoreImpairmentType;
+        private DirtyValue<string> _creditScoreImpairmentType;
         public string CreditScoreImpairmentType { get { return _creditScoreImpairmentType; } set { _creditScoreImpairmentType = value; } }
-        private Value<decimal?> _currentAccruedInterestAmount;
+        private DirtyValue<decimal?> _currentAccruedInterestAmount;
         public decimal? CurrentAccruedInterestAmount { get { return _currentAccruedInterestAmount; } set { _currentAccruedInterestAmount = value; } }
-        private Value<int?> _delinquentPaymentsOverPastTwelveMonthsCount;
+        private DirtyValue<int?> _delinquentPaymentsOverPastTwelveMonthsCount;
         public int? DelinquentPaymentsOverPastTwelveMonthsCount { get { return _delinquentPaymentsOverPastTwelveMonthsCount; } set { _delinquentPaymentsOverPastTwelveMonthsCount = value; } }
-        private Value<string> _documentCustodianID;
+        private DirtyValue<string> _documentCustodianID;
         public string DocumentCustodianID { get { return _documentCustodianID; } set { _documentCustodianID = value; } }
-        private Value<string> _documentRequiredIndicator;
+        private DirtyValue<string> _documentRequiredIndicator;
         public string DocumentRequiredIndicator { get { return _documentRequiredIndicator; } set { _documentRequiredIndicator = value; } }
-        private Value<string> _documentSubmissionIndicator;
+        private DirtyValue<string> _documentSubmissionIndicator;
         public string DocumentSubmissionIndicator { get { return _documentSubmissionIndicator; } set { _documentSubmissionIndicator = value; } }
-        private Value<string> _downPaymentFundsType;
+        private DirtyValue<string> _downPaymentFundsType;
         public string DownPaymentFundsType { get { return _downPaymentFundsType; } set { _downPaymentFundsType = value; } }
-        private Value<string> _downPaymentOtherTypeDescription;
+        private DirtyValue<string> _downPaymentOtherTypeDescription;
         public string DownPaymentOtherTypeDescription { get { return _downPaymentOtherTypeDescription; } set { _downPaymentOtherTypeDescription = value; } }
-        private Value<string> _downPaymentSourceType;
+        private DirtyValue<string> _downPaymentSourceType;
         public string DownPaymentSourceType { get { return _downPaymentSourceType; } set { _downPaymentSourceType = value; } }
-        private Value<string> _downPaymentSourceTypeOtherDescription;
+        private DirtyValue<string> _downPaymentSourceTypeOtherDescription;
         public string DownPaymentSourceTypeOtherDescription { get { return _downPaymentSourceTypeOtherDescription; } set { _downPaymentSourceTypeOtherDescription = value; } }
-        private Value<string> _fannieARMIndexType;
+        private DirtyValue<string> _fannieARMIndexType;
         public string FannieARMIndexType { get { return _fannieARMIndexType; } set { _fannieARMIndexType = value; } }
-        private Value<string> _fannieAutoUWDec;
+        private DirtyValue<string> _fannieAutoUWDec;
         public string FannieAutoUWDec { get { return _fannieAutoUWDec; } set { _fannieAutoUWDec = value; } }
-        private Value<int?> _fannieBLTV;
+        private DirtyValue<int?> _fannieBLTV;
         public int? FannieBLTV { get { return _fannieBLTV; } set { _fannieBLTV = value; } }
-        private Value<string> _fannieBorrowerFirstName;
+        private DirtyValue<string> _fannieBorrowerFirstName;
         public string FannieBorrowerFirstName { get { return _fannieBorrowerFirstName; } set { _fannieBorrowerFirstName = value; } }
-        private Value<string> _fannieBorrowerMiddleName;
+        private DirtyValue<string> _fannieBorrowerMiddleName;
         public string FannieBorrowerMiddleName { get { return _fannieBorrowerMiddleName; } set { _fannieBorrowerMiddleName = value; } }
-        private Value<string> _fannieBuydownContributer;
+        private DirtyValue<string> _fannieBuydownContributer;
         public string FannieBuydownContributer { get { return _fannieBuydownContributer; } set { _fannieBuydownContributer = value; } }
-        private Value<int?> _fannieCLTV;
+        private DirtyValue<int?> _fannieCLTV;
         public int? FannieCLTV { get { return _fannieCLTV; } set { _fannieCLTV = value; } }
-        private Value<string> _fannieCoBorrowerFirstName;
+        private DirtyValue<string> _fannieCoBorrowerFirstName;
         public string FannieCoBorrowerFirstName { get { return _fannieCoBorrowerFirstName; } set { _fannieCoBorrowerFirstName = value; } }
-        private Value<string> _fannieCoBorrowerMiddleName;
+        private DirtyValue<string> _fannieCoBorrowerMiddleName;
         public string FannieCoBorrowerMiddleName { get { return _fannieCoBorrowerMiddleName; } set { _fannieCoBorrowerMiddleName = value; } }
-        private Value<string> _fannieCreditScoreProviderName;
+        private DirtyValue<string> _fannieCreditScoreProviderName;
         public string FannieCreditScoreProviderName { get { return _fannieCreditScoreProviderName; } set { _fannieCreditScoreProviderName = value; } }
-        private Value<string> _fannieFloodSpecialFeatureCode;
+        private DirtyValue<string> _fannieFloodSpecialFeatureCode;
         public string FannieFloodSpecialFeatureCode { get { return _fannieFloodSpecialFeatureCode; } set { _fannieFloodSpecialFeatureCode = value; } }
-        private Value<int?> _fannieHCLTV;
+        private DirtyValue<int?> _fannieHCLTV;
         public int? FannieHCLTV { get { return _fannieHCLTV; } set { _fannieHCLTV = value; } }
-        private Value<int?> _fannieInvestorOwnershipPercent;
+        private DirtyValue<int?> _fannieInvestorOwnershipPercent;
         public int? FannieInvestorOwnershipPercent { get { return _fannieInvestorOwnershipPercent; } set { _fannieInvestorOwnershipPercent = value; } }
-        private Value<string> _fannieLegalEntityType;
+        private DirtyValue<string> _fannieLegalEntityType;
         public string FannieLegalEntityType { get { return _fannieLegalEntityType; } set { _fannieLegalEntityType = value; } }
-        private Value<string> _fannieLegalEntityTypeOther;
+        private DirtyValue<string> _fannieLegalEntityTypeOther;
         public string FannieLegalEntityTypeOther { get { return _fannieLegalEntityTypeOther; } set { _fannieLegalEntityTypeOther = value; } }
-        private Value<decimal?> _fannieLenderPaidMIInterestRateAdjustmentPercent;
+        private DirtyValue<decimal?> _fannieLenderPaidMIInterestRateAdjustmentPercent;
         public decimal? FannieLenderPaidMIInterestRateAdjustmentPercent { get { return _fannieLenderPaidMIInterestRateAdjustmentPercent; } set { _fannieLenderPaidMIInterestRateAdjustmentPercent = value; } }
-        private Value<string> _fannieLoanProgramIdentifier;
+        private DirtyValue<string> _fannieLoanProgramIdentifier;
         public string FannieLoanProgramIdentifier { get { return _fannieLoanProgramIdentifier; } set { _fannieLoanProgramIdentifier = value; } }
-        private Value<int?> _fannieLTV;
+        private DirtyValue<int?> _fannieLTV;
         public int? FannieLTV { get { return _fannieLTV; } set { _fannieLTV = value; } }
-        private Value<string> _fannieMICompanyNameTypeOther;
+        private DirtyValue<string> _fannieMICompanyNameTypeOther;
         public string FannieMICompanyNameTypeOther { get { return _fannieMICompanyNameTypeOther; } set { _fannieMICompanyNameTypeOther = value; } }
-        private Value<int?> _fannieMICoveragePercent;
+        private DirtyValue<int?> _fannieMICoveragePercent;
         public int? FannieMICoveragePercent { get { return _fannieMICoveragePercent; } set { _fannieMICoveragePercent = value; } }
-        private Value<int?> _fanniePoolOwnershipPercent;
+        private DirtyValue<int?> _fanniePoolOwnershipPercent;
         public int? FanniePoolOwnershipPercent { get { return _fanniePoolOwnershipPercent; } set { _fanniePoolOwnershipPercent = value; } }
-        private Value<string> _fannieProjectClassificationType;
+        private DirtyValue<string> _fannieProjectClassificationType;
         public string FannieProjectClassificationType { get { return _fannieProjectClassificationType; } set { _fannieProjectClassificationType = value; } }
-        private Value<string> _fanniePropertyFormType;
+        private DirtyValue<string> _fanniePropertyFormType;
         public string FanniePropertyFormType { get { return _fanniePropertyFormType; } set { _fanniePropertyFormType = value; } }
-        private Value<decimal?> _fannieRateSpread;
+        private DirtyValue<decimal?> _fannieRateSpread;
         public decimal? FannieRateSpread { get { return _fannieRateSpread; } set { _fannieRateSpread = value; } }
-        private Value<string> _fannieRefinanceType;
+        private DirtyValue<string> _fannieRefinanceType;
         public string FannieRefinanceType { get { return _fannieRefinanceType; } set { _fannieRefinanceType = value; } }
-        private Value<string> _fannieRelatedInvestorLoanID;
+        private DirtyValue<string> _fannieRelatedInvestorLoanID;
         public string FannieRelatedInvestorLoanID { get { return _fannieRelatedInvestorLoanID; } set { _fannieRelatedInvestorLoanID = value; } }
-        private Value<string> _fannieRelatedLoanAmortizationType;
+        private DirtyValue<string> _fannieRelatedLoanAmortizationType;
         public string FannieRelatedLoanAmortizationType { get { return _fannieRelatedLoanAmortizationType; } set { _fannieRelatedLoanAmortizationType = value; } }
-        private Value<string> _fannieRelatedLoanLienPosition;
+        private DirtyValue<string> _fannieRelatedLoanLienPosition;
         public string FannieRelatedLoanLienPosition { get { return _fannieRelatedLoanLienPosition; } set { _fannieRelatedLoanLienPosition = value; } }
-        private Value<string> _fannieRelatedLoanType;
+        private DirtyValue<string> _fannieRelatedLoanType;
         public string FannieRelatedLoanType { get { return _fannieRelatedLoanType; } set { _fannieRelatedLoanType = value; } }
-        private Value<string> _fannieSectionOfAct;
+        private DirtyValue<string> _fannieSectionOfAct;
         public string FannieSectionOfAct { get { return _fannieSectionOfAct; } set { _fannieSectionOfAct = value; } }
-        private Value<int?> _fannieTLTV;
+        private DirtyValue<int?> _fannieTLTV;
         public int? FannieTLTV { get { return _fannieTLTV; } set { _fannieTLTV = value; } }
-        private Value<string> _fannieTrustName;
+        private DirtyValue<string> _fannieTrustName;
         public string FannieTrustName { get { return _fannieTrustName; } set { _fannieTrustName = value; } }
-        private Value<string> _fannnieMortgageType;
+        private DirtyValue<string> _fannnieMortgageType;
         public string FannnieMortgageType { get { return _fannnieMortgageType; } set { _fannnieMortgageType = value; } }
-        private Value<int?> _financedUnitCount;
+        private DirtyValue<int?> _financedUnitCount;
         public int? FinancedUnitCount { get { return _financedUnitCount; } set { _financedUnitCount = value; } }
-        private Value<DateTime?> _firstRateChangePaymentEffectiveDate;
+        private DirtyValue<DateTime?> _firstRateChangePaymentEffectiveDate;
         public DateTime? FirstRateChangePaymentEffectiveDate { get { return _firstRateChangePaymentEffectiveDate; } set { _firstRateChangePaymentEffectiveDate = value; } }
-        private Value<string> _fNMHomeImprovementProductType;
+        private DirtyValue<string> _fNMHomeImprovementProductType;
         public string FNMHomeImprovementProductType { get { return _fNMHomeImprovementProductType; } set { _fNMHomeImprovementProductType = value; } }
-        private Value<string> _freddieARMIndexType;
+        private DirtyValue<string> _freddieARMIndexType;
         public string FreddieARMIndexType { get { return _freddieARMIndexType; } set { _freddieARMIndexType = value; } }
-        private Value<string> _freddieAutoUWDec;
+        private DirtyValue<string> _freddieAutoUWDec;
         public string FreddieAutoUWDec { get { return _freddieAutoUWDec; } set { _freddieAutoUWDec = value; } }
-        private Value<string> _freddieAVMModelNameTypeExpl;
+        private DirtyValue<string> _freddieAVMModelNameTypeExpl;
         public string FreddieAVMModelNameTypeExpl { get { return _freddieAVMModelNameTypeExpl; } set { _freddieAVMModelNameTypeExpl = value; } }
-        private Value<string> _freddieBorrowerAlienStatus;
+        private DirtyValue<string> _freddieBorrowerAlienStatus;
         public string FreddieBorrowerAlienStatus { get { return _freddieBorrowerAlienStatus; } set { _freddieBorrowerAlienStatus = value; } }
-        private Value<string> _freddieCoBorrowerAlienStatus;
+        private DirtyValue<string> _freddieCoBorrowerAlienStatus;
         public string FreddieCoBorrowerAlienStatus { get { return _freddieCoBorrowerAlienStatus; } set { _freddieCoBorrowerAlienStatus = value; } }
-        private Value<string> _freddieCreditScoreProviderName;
+        private DirtyValue<string> _freddieCreditScoreProviderName;
         public string FreddieCreditScoreProviderName { get { return _freddieCreditScoreProviderName; } set { _freddieCreditScoreProviderName = value; } }
-        private Value<string> _freddieDownPaymentType;
+        private DirtyValue<string> _freddieDownPaymentType;
         public string FreddieDownPaymentType { get { return _freddieDownPaymentType; } set { _freddieDownPaymentType = value; } }
-        private Value<string> _freddieDownPmt2SourceType;
+        private DirtyValue<string> _freddieDownPmt2SourceType;
         public string FreddieDownPmt2SourceType { get { return _freddieDownPmt2SourceType; } set { _freddieDownPmt2SourceType = value; } }
-        private Value<string> _freddieDownPmt2SourceTypeExpl;
+        private DirtyValue<string> _freddieDownPmt2SourceTypeExpl;
         public string FreddieDownPmt2SourceTypeExpl { get { return _freddieDownPmt2SourceTypeExpl; } set { _freddieDownPmt2SourceTypeExpl = value; } }
-        private Value<string> _freddieDownPmt2Type;
+        private DirtyValue<string> _freddieDownPmt2Type;
         public string FreddieDownPmt2Type { get { return _freddieDownPmt2Type; } set { _freddieDownPmt2Type = value; } }
-        private Value<string> _freddieDownPmt2TypeExpl;
+        private DirtyValue<string> _freddieDownPmt2TypeExpl;
         public string FreddieDownPmt2TypeExpl { get { return _freddieDownPmt2TypeExpl; } set { _freddieDownPmt2TypeExpl = value; } }
-        private Value<decimal?> _freddieDownPmt3Amt;
+        private DirtyValue<decimal?> _freddieDownPmt3Amt;
         public decimal? FreddieDownPmt3Amt { get { return _freddieDownPmt3Amt; } set { _freddieDownPmt3Amt = value; } }
-        private Value<string> _freddieDownPmt3SourceType;
+        private DirtyValue<string> _freddieDownPmt3SourceType;
         public string FreddieDownPmt3SourceType { get { return _freddieDownPmt3SourceType; } set { _freddieDownPmt3SourceType = value; } }
-        private Value<string> _freddieDownPmt3SourceTypeExpl;
+        private DirtyValue<string> _freddieDownPmt3SourceTypeExpl;
         public string FreddieDownPmt3SourceTypeExpl { get { return _freddieDownPmt3SourceTypeExpl; } set { _freddieDownPmt3SourceTypeExpl = value; } }
-        private Value<string> _freddieDownPmt3Type;
+        private DirtyValue<string> _freddieDownPmt3Type;
         public string FreddieDownPmt3Type { get { return _freddieDownPmt3Type; } set { _freddieDownPmt3Type = value; } }
-        private Value<string> _freddieDownPmt3TypeExpl;
+        private DirtyValue<string> _freddieDownPmt3TypeExpl;
         public string FreddieDownPmt3TypeExpl { get { return _freddieDownPmt3TypeExpl; } set { _freddieDownPmt3TypeExpl = value; } }
-        private Value<decimal?> _freddieDownPmt4Amt;
+        private DirtyValue<decimal?> _freddieDownPmt4Amt;
         public decimal? FreddieDownPmt4Amt { get { return _freddieDownPmt4Amt; } set { _freddieDownPmt4Amt = value; } }
-        private Value<string> _freddieDownPmt4SourceType;
+        private DirtyValue<string> _freddieDownPmt4SourceType;
         public string FreddieDownPmt4SourceType { get { return _freddieDownPmt4SourceType; } set { _freddieDownPmt4SourceType = value; } }
-        private Value<string> _freddieDownPmt4SourceTypeExpl;
+        private DirtyValue<string> _freddieDownPmt4SourceTypeExpl;
         public string FreddieDownPmt4SourceTypeExpl { get { return _freddieDownPmt4SourceTypeExpl; } set { _freddieDownPmt4SourceTypeExpl = value; } }
-        private Value<string> _freddieDownPmt4Type;
+        private DirtyValue<string> _freddieDownPmt4Type;
         public string FreddieDownPmt4Type { get { return _freddieDownPmt4Type; } set { _freddieDownPmt4Type = value; } }
-        private Value<string> _freddieDownPmt4TypeExpl;
+        private DirtyValue<string> _freddieDownPmt4TypeExpl;
         public string FreddieDownPmt4TypeExpl { get { return _freddieDownPmt4TypeExpl; } set { _freddieDownPmt4TypeExpl = value; } }
-        private Value<string> _freddieExplanationOfDownPayment;
+        private DirtyValue<string> _freddieExplanationOfDownPayment;
         public string FreddieExplanationOfDownPayment { get { return _freddieExplanationOfDownPayment; } set { _freddieExplanationOfDownPayment = value; } }
-        private Value<string> _freddieInvestorCollateralProgramIdentifier;
+        private DirtyValue<string> _freddieInvestorCollateralProgramIdentifier;
         public string FreddieInvestorCollateralProgramIdentifier { get { return _freddieInvestorCollateralProgramIdentifier; } set { _freddieInvestorCollateralProgramIdentifier = value; } }
-        private Value<string> _freddieInvestorFeatureIdentifier;
+        private DirtyValue<string> _freddieInvestorFeatureIdentifier;
         public string FreddieInvestorFeatureIdentifier { get { return _freddieInvestorFeatureIdentifier; } set { _freddieInvestorFeatureIdentifier = value; } }
-        private Value<string> _freddieLegalEntityType;
+        private DirtyValue<string> _freddieLegalEntityType;
         public string FreddieLegalEntityType { get { return _freddieLegalEntityType; } set { _freddieLegalEntityType = value; } }
-        private Value<string> _freddieLegalEntityTypeOther;
+        private DirtyValue<string> _freddieLegalEntityTypeOther;
         public string FreddieLegalEntityTypeOther { get { return _freddieLegalEntityTypeOther; } set { _freddieLegalEntityTypeOther = value; } }
-        private Value<string> _freddieLoanProgramIdentifier;
+        private DirtyValue<string> _freddieLoanProgramIdentifier;
         public string FreddieLoanProgramIdentifier { get { return _freddieLoanProgramIdentifier; } set { _freddieLoanProgramIdentifier = value; } }
-        private Value<string> _freddieLoanTypePublicAndIndianHousingIndicator;
+        private DirtyValue<string> _freddieLoanTypePublicAndIndianHousingIndicator;
         public string FreddieLoanTypePublicAndIndianHousingIndicator { get { return _freddieLoanTypePublicAndIndianHousingIndicator; } set { _freddieLoanTypePublicAndIndianHousingIndicator = value; } }
-        private Value<string> _freddieMICompanyNameTypeOther;
+        private DirtyValue<string> _freddieMICompanyNameTypeOther;
         public string FreddieMICompanyNameTypeOther { get { return _freddieMICompanyNameTypeOther; } set { _freddieMICompanyNameTypeOther = value; } }
-        private Value<string> _freddieMortgageType;
+        private DirtyValue<string> _freddieMortgageType;
         public string FreddieMortgageType { get { return _freddieMortgageType; } set { _freddieMortgageType = value; } }
-        private Value<string> _freddieProjectClassificationType;
+        private DirtyValue<string> _freddieProjectClassificationType;
         public string FreddieProjectClassificationType { get { return _freddieProjectClassificationType; } set { _freddieProjectClassificationType = value; } }
-        private Value<string> _freddiePropertyFormType;
+        private DirtyValue<string> _freddiePropertyFormType;
         public string FreddiePropertyFormType { get { return _freddiePropertyFormType; } set { _freddiePropertyFormType = value; } }
-        private Value<string> _freddieRefinanceCashOutDeterminationType;
+        private DirtyValue<string> _freddieRefinanceCashOutDeterminationType;
         public string FreddieRefinanceCashOutDeterminationType { get { return _freddieRefinanceCashOutDeterminationType; } set { _freddieRefinanceCashOutDeterminationType = value; } }
-        private Value<string> _freddieRefinanceType;
+        private DirtyValue<string> _freddieRefinanceType;
         public string FreddieRefinanceType { get { return _freddieRefinanceType; } set { _freddieRefinanceType = value; } }
-        private Value<bool?> _freddieRelatedClosedEndSecondIndicator;
+        private DirtyValue<bool?> _freddieRelatedClosedEndSecondIndicator;
         public bool? FreddieRelatedClosedEndSecondIndicator { get { return _freddieRelatedClosedEndSecondIndicator; } set { _freddieRelatedClosedEndSecondIndicator = value; } }
-        private Value<string> _freddieRelatedInvestorLoanID;
+        private DirtyValue<string> _freddieRelatedInvestorLoanID;
         public string FreddieRelatedInvestorLoanID { get { return _freddieRelatedInvestorLoanID; } set { _freddieRelatedInvestorLoanID = value; } }
-        private Value<string> _freddieRelatedLoanInvestorType;
+        private DirtyValue<string> _freddieRelatedLoanInvestorType;
         public string FreddieRelatedLoanInvestorType { get { return _freddieRelatedLoanInvestorType; } set { _freddieRelatedLoanInvestorType = value; } }
-        private Value<string> _freddieRelatedLoanLienPosition;
+        private DirtyValue<string> _freddieRelatedLoanLienPosition;
         public string FreddieRelatedLoanLienPosition { get { return _freddieRelatedLoanLienPosition; } set { _freddieRelatedLoanLienPosition = value; } }
-        private Value<string> _freddieRelatedLoanType;
+        private DirtyValue<string> _freddieRelatedLoanType;
         public string FreddieRelatedLoanType { get { return _freddieRelatedLoanType; } set { _freddieRelatedLoanType = value; } }
-        private Value<string> _freddieSectionOfAct;
+        private DirtyValue<string> _freddieSectionOfAct;
         public string FreddieSectionOfAct { get { return _freddieSectionOfAct; } set { _freddieSectionOfAct = value; } }
-        private Value<string> _freddieUnderwritingTypeOther;
+        private DirtyValue<string> _freddieUnderwritingTypeOther;
         public string FreddieUnderwritingTypeOther { get { return _freddieUnderwritingTypeOther; } set { _freddieUnderwritingTypeOther = value; } }
-        private Value<string> _ginnieConstructionMethodType;
+        private DirtyValue<string> _ginnieConstructionMethodType;
         public string GinnieConstructionMethodType { get { return _ginnieConstructionMethodType; } set { _ginnieConstructionMethodType = value; } }
-        private Value<decimal?> _ginnieGovernmentAnnualPremiumAmount;
+        private DirtyValue<decimal?> _ginnieGovernmentAnnualPremiumAmount;
         public decimal? GinnieGovernmentAnnualPremiumAmount { get { return _ginnieGovernmentAnnualPremiumAmount; } set { _ginnieGovernmentAnnualPremiumAmount = value; } }
-        private Value<string> _ginnieMortgageType;
+        private DirtyValue<string> _ginnieMortgageType;
         public string GinnieMortgageType { get { return _ginnieMortgageType; } set { _ginnieMortgageType = value; } }
-        private Value<string> _ginnieOtherConstructionMethodType;
+        private DirtyValue<string> _ginnieOtherConstructionMethodType;
         public string GinnieOtherConstructionMethodType { get { return _ginnieOtherConstructionMethodType; } set { _ginnieOtherConstructionMethodType = value; } }
-        private Value<decimal?> _governmentAnnualPremiumPercent;
+        private DirtyValue<decimal?> _governmentAnnualPremiumPercent;
         public decimal? GovernmentAnnualPremiumPercent { get { return _governmentAnnualPremiumPercent; } set { _governmentAnnualPremiumPercent = value; } }
-        private Value<string> _governmentRefinanceType;
+        private DirtyValue<string> _governmentRefinanceType;
         public string GovernmentRefinanceType { get { return _governmentRefinanceType; } set { _governmentRefinanceType = value; } }
-        private Value<decimal?> _governmentUpfrontPremiumAmount;
+        private DirtyValue<decimal?> _governmentUpfrontPremiumAmount;
         public decimal? GovernmentUpfrontPremiumAmount { get { return _governmentUpfrontPremiumAmount; } set { _governmentUpfrontPremiumAmount = value; } }
-        private Value<decimal?> _governmentUpfrontPremiumPercent;
+        private DirtyValue<decimal?> _governmentUpfrontPremiumPercent;
         public decimal? GovernmentUpfrontPremiumPercent { get { return _governmentUpfrontPremiumPercent; } set { _governmentUpfrontPremiumPercent = value; } }
-        private Value<string> _gSEProjectType;
+        private DirtyValue<string> _gSEProjectType;
         public string GSEProjectType { get { return _gSEProjectType; } set { _gSEProjectType = value; } }
-        private Value<bool?> _guaranteeFeeAddOnIndicator;
+        private DirtyValue<bool?> _guaranteeFeeAddOnIndicator;
         public bool? GuaranteeFeeAddOnIndicator { get { return _guaranteeFeeAddOnIndicator; } set { _guaranteeFeeAddOnIndicator = value; } }
-        private Value<decimal?> _guarantyFeeAfterAlternatePaymentMethodPercent;
+        private DirtyValue<decimal?> _guarantyFeeAfterAlternatePaymentMethodPercent;
         public decimal? GuarantyFeeAfterAlternatePaymentMethodPercent { get { return _guarantyFeeAfterAlternatePaymentMethodPercent; } set { _guarantyFeeAfterAlternatePaymentMethodPercent = value; } }
-        private Value<decimal?> _guarantyFeePercent;
+        private DirtyValue<decimal?> _guarantyFeePercent;
         public decimal? GuarantyFeePercent { get { return _guarantyFeePercent; } set { _guarantyFeePercent = value; } }
-        private Value<decimal?> _guarantyPercent;
+        private DirtyValue<decimal?> _guarantyPercent;
         public decimal? GuarantyPercent { get { return _guarantyPercent; } set { _guarantyPercent = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _indexType;
+        private DirtyValue<string> _indexType;
         public string IndexType { get { return _indexType; } set { _indexType = value; } }
-        private Value<int?> _initialFixedPeriodEffectiveMonthsCount;
+        private DirtyValue<int?> _initialFixedPeriodEffectiveMonthsCount;
         public int? InitialFixedPeriodEffectiveMonthsCount { get { return _initialFixedPeriodEffectiveMonthsCount; } set { _initialFixedPeriodEffectiveMonthsCount = value; } }
-        private Value<string> _interestAccrualType;
+        private DirtyValue<string> _interestAccrualType;
         public string InterestAccrualType { get { return _interestAccrualType; } set { _interestAccrualType = value; } }
-        private Value<int?> _interestAndPaymentAdjustmentIndexLeadDaysCount;
+        private DirtyValue<int?> _interestAndPaymentAdjustmentIndexLeadDaysCount;
         public int? InterestAndPaymentAdjustmentIndexLeadDaysCount { get { return _interestAndPaymentAdjustmentIndexLeadDaysCount; } set { _interestAndPaymentAdjustmentIndexLeadDaysCount = value; } }
-        private Value<string> _interestCalculationBasisType;
+        private DirtyValue<string> _interestCalculationBasisType;
         public string InterestCalculationBasisType { get { return _interestCalculationBasisType; } set { _interestCalculationBasisType = value; } }
-        private Value<int?> _interestCalculationEffectiveMonthsCount;
+        private DirtyValue<int?> _interestCalculationEffectiveMonthsCount;
         public int? InterestCalculationEffectiveMonthsCount { get { return _interestCalculationEffectiveMonthsCount; } set { _interestCalculationEffectiveMonthsCount = value; } }
-        private Value<string> _interestCalculationType;
+        private DirtyValue<string> _interestCalculationType;
         public string InterestCalculationType { get { return _interestCalculationType; } set { _interestCalculationType = value; } }
-        private Value<string> _investorCollateralProgramIdentifier;
+        private DirtyValue<string> _investorCollateralProgramIdentifier;
         public string InvestorCollateralProgramIdentifier { get { return _investorCollateralProgramIdentifier; } set { _investorCollateralProgramIdentifier = value; } }
-        private Value<string> _investorCommitmentIdentifier;
+        private DirtyValue<string> _investorCommitmentIdentifier;
         public string InvestorCommitmentIdentifier { get { return _investorCommitmentIdentifier; } set { _investorCommitmentIdentifier = value; } }
-        private Value<string> _investorFeatureIdentifier;
+        private DirtyValue<string> _investorFeatureIdentifier;
         public string InvestorFeatureIdentifier { get { return _investorFeatureIdentifier; } set { _investorFeatureIdentifier = value; } }
-        private Value<string> _investorFeatureIdPool;
+        private DirtyValue<string> _investorFeatureIdPool;
         public string InvestorFeatureIdPool { get { return _investorFeatureIdPool; } set { _investorFeatureIdPool = value; } }
-        private Value<decimal?> _investorOwnershipPercent;
+        private DirtyValue<decimal?> _investorOwnershipPercent;
         public decimal? InvestorOwnershipPercent { get { return _investorOwnershipPercent; } set { _investorOwnershipPercent = value; } }
-        private Value<string> _investorProductPlanIdentifier;
+        private DirtyValue<string> _investorProductPlanIdentifier;
         public string InvestorProductPlanIdentifier { get { return _investorProductPlanIdentifier; } set { _investorProductPlanIdentifier = value; } }
-        private Value<int?> _investorRemittanceDay;
+        private DirtyValue<int?> _investorRemittanceDay;
         public int? InvestorRemittanceDay { get { return _investorRemittanceDay; } set { _investorRemittanceDay = value; } }
-        private Value<string> _investorRemittanceType;
+        private DirtyValue<string> _investorRemittanceType;
         public string InvestorRemittanceType { get { return _investorRemittanceType; } set { _investorRemittanceType = value; } }
-        private Value<string> _issuerIdentifier;
+        private DirtyValue<string> _issuerIdentifier;
         public string IssuerIdentifier { get { return _issuerIdentifier; } set { _issuerIdentifier = value; } }
-        private Value<DateTime?> _lastPaidInstallmentDueDate;
+        private DirtyValue<DateTime?> _lastPaidInstallmentDueDate;
         public DateTime? LastPaidInstallmentDueDate { get { return _lastPaidInstallmentDueDate; } set { _lastPaidInstallmentDueDate = value; } }
-        private Value<DateTime?> _lastPaymentReceivedDate;
+        private DirtyValue<DateTime?> _lastPaymentReceivedDate;
         public DateTime? LastPaymentReceivedDate { get { return _lastPaymentReceivedDate; } set { _lastPaymentReceivedDate = value; } }
-        private Value<DateTime?> _latestConversionEffectiveDate;
+        private DirtyValue<DateTime?> _latestConversionEffectiveDate;
         public DateTime? LatestConversionEffectiveDate { get { return _latestConversionEffectiveDate; } set { _latestConversionEffectiveDate = value; } }
-        private Value<decimal?> _lenderPaidMIInterestRateAdjustmentPercent;
+        private DirtyValue<decimal?> _lenderPaidMIInterestRateAdjustmentPercent;
         public decimal? LenderPaidMIInterestRateAdjustmentPercent { get { return _lenderPaidMIInterestRateAdjustmentPercent; } set { _lenderPaidMIInterestRateAdjustmentPercent = value; } }
-        private Value<DateTime?> _lendersDeliveryDate;
+        private DirtyValue<DateTime?> _lendersDeliveryDate;
         public DateTime? LendersDeliveryDate { get { return _lendersDeliveryDate; } set { _lendersDeliveryDate = value; } }
-        private Value<decimal?> _loanAcquisitionScheduledUPBAmount;
+        private DirtyValue<decimal?> _loanAcquisitionScheduledUPBAmount;
         public decimal? LoanAcquisitionScheduledUPBAmount { get { return _loanAcquisitionScheduledUPBAmount; } set { _loanAcquisitionScheduledUPBAmount = value; } }
-        private Value<int?> _loanAmortizationMaximumTermMonthsCount;
+        private DirtyValue<int?> _loanAmortizationMaximumTermMonthsCount;
         public int? LoanAmortizationMaximumTermMonthsCount { get { return _loanAmortizationMaximumTermMonthsCount; } set { _loanAmortizationMaximumTermMonthsCount = value; } }
-        private Value<int?> _loanBuyupBuydownBasisPointNumber;
+        private DirtyValue<int?> _loanBuyupBuydownBasisPointNumber;
         public int? LoanBuyupBuydownBasisPointNumber { get { return _loanBuyupBuydownBasisPointNumber; } set { _loanBuyupBuydownBasisPointNumber = value; } }
-        private Value<string> _loanBuyupBuydownType;
+        private DirtyValue<string> _loanBuyupBuydownType;
         public string LoanBuyupBuydownType { get { return _loanBuyupBuydownType; } set { _loanBuyupBuydownType = value; } }
-        private Value<string> _loanDefaultLossPartyType;
+        private DirtyValue<string> _loanDefaultLossPartyType;
         public string LoanDefaultLossPartyType { get { return _loanDefaultLossPartyType; } set { _loanDefaultLossPartyType = value; } }
-        private Value<bool?> _loanDeliveredThroughServicingReleasedProcessIndicator;
+        private DirtyValue<bool?> _loanDeliveredThroughServicingReleasedProcessIndicator;
         public bool? LoanDeliveredThroughServicingReleasedProcessIndicator { get { return _loanDeliveredThroughServicingReleasedProcessIndicator; } set { _loanDeliveredThroughServicingReleasedProcessIndicator = value; } }
-        private Value<string> _loanIdentifierValueType;
+        private DirtyValue<string> _loanIdentifierValueType;
         public string LoanIdentifierValueType { get { return _loanIdentifierValueType; } set { _loanIdentifierValueType = value; } }
-        private Value<DateTime?> _loanInterestAccrualStartDate;
+        private DirtyValue<DateTime?> _loanInterestAccrualStartDate;
         public DateTime? LoanInterestAccrualStartDate { get { return _loanInterestAccrualStartDate; } set { _loanInterestAccrualStartDate = value; } }
-        private Value<bool?> _loanLevelCreditScoreSelectionMethodSellerSpecificIndicator;
+        private DirtyValue<bool?> _loanLevelCreditScoreSelectionMethodSellerSpecificIndicator;
         public bool? LoanLevelCreditScoreSelectionMethodSellerSpecificIndicator { get { return _loanLevelCreditScoreSelectionMethodSellerSpecificIndicator; } set { _loanLevelCreditScoreSelectionMethodSellerSpecificIndicator = value; } }
-        private Value<string> _loanLevelCreditScoreSelectionMethodType;
+        private DirtyValue<string> _loanLevelCreditScoreSelectionMethodType;
         public string LoanLevelCreditScoreSelectionMethodType { get { return _loanLevelCreditScoreSelectionMethodType; } set { _loanLevelCreditScoreSelectionMethodType = value; } }
-        private Value<int?> _loanLevelCreditScoreValue;
+        private DirtyValue<int?> _loanLevelCreditScoreValue;
         public int? LoanLevelCreditScoreValue { get { return _loanLevelCreditScoreValue; } set { _loanLevelCreditScoreValue = value; } }
-        private Value<DateTime?> _loanModificationEffectiveDate;
+        private DirtyValue<DateTime?> _loanModificationEffectiveDate;
         public DateTime? LoanModificationEffectiveDate { get { return _loanModificationEffectiveDate; } set { _loanModificationEffectiveDate = value; } }
-        private Value<DateTime?> _loanStateDate;
+        private DirtyValue<DateTime?> _loanStateDate;
         public DateTime? LoanStateDate { get { return _loanStateDate; } set { _loanStateDate = value; } }
-        private Value<string> _manufacturedHomeWidthType;
+        private DirtyValue<string> _manufacturedHomeWidthType;
         public string ManufacturedHomeWidthType { get { return _manufacturedHomeWidthType; } set { _manufacturedHomeWidthType = value; } }
-        private Value<bool?> _mBSWeightedMarginIndicator;
+        private DirtyValue<bool?> _mBSWeightedMarginIndicator;
         public bool? MBSWeightedMarginIndicator { get { return _mBSWeightedMarginIndicator; } set { _mBSWeightedMarginIndicator = value; } }
-        private Value<string> _mERSOriginalMortgageeOfRecordIndicator;
+        private DirtyValue<string> _mERSOriginalMortgageeOfRecordIndicator;
         public string MERSOriginalMortgageeOfRecordIndicator { get { return _mERSOriginalMortgageeOfRecordIndicator; } set { _mERSOriginalMortgageeOfRecordIndicator = value; } }
-        private Value<string> _mICompanyNameType;
+        private DirtyValue<string> _mICompanyNameType;
         public string MICompanyNameType { get { return _mICompanyNameType; } set { _mICompanyNameType = value; } }
-        private Value<string> _mIPremiumSourceType;
+        private DirtyValue<string> _mIPremiumSourceType;
         public string MIPremiumSourceType { get { return _mIPremiumSourceType; } set { _mIPremiumSourceType = value; } }
-        private Value<DateTime?> _monetaryEventAppliedDate;
+        private DirtyValue<DateTime?> _monetaryEventAppliedDate;
         public DateTime? MonetaryEventAppliedDate { get { return _monetaryEventAppliedDate; } set { _monetaryEventAppliedDate = value; } }
-        private Value<decimal?> _monetaryEventGrossPrincipalAmount;
+        private DirtyValue<decimal?> _monetaryEventGrossPrincipalAmount;
         public decimal? MonetaryEventGrossPrincipalAmount { get { return _monetaryEventGrossPrincipalAmount; } set { _monetaryEventGrossPrincipalAmount = value; } }
-        private Value<string> _monetaryEventType;
+        private DirtyValue<string> _monetaryEventType;
         public string MonetaryEventType { get { return _monetaryEventType; } set { _monetaryEventType = value; } }
-        private Value<bool?> _mortgageBackedSecurityIndicator;
+        private DirtyValue<bool?> _mortgageBackedSecurityIndicator;
         public bool? MortgageBackedSecurityIndicator { get { return _mortgageBackedSecurityIndicator; } set { _mortgageBackedSecurityIndicator = value; } }
-        private Value<bool?> _mortgageModificationIndicator;
+        private DirtyValue<bool?> _mortgageModificationIndicator;
         public bool? MortgageModificationIndicator { get { return _mortgageModificationIndicator; } set { _mortgageModificationIndicator = value; } }
-        private Value<string> _mortgageOriginator;
+        private DirtyValue<string> _mortgageOriginator;
         public string MortgageOriginator { get { return _mortgageOriginator; } set { _mortgageOriginator = value; } }
-        private Value<string> _mortgageProgramType;
+        private DirtyValue<string> _mortgageProgramType;
         public string MortgageProgramType { get { return _mortgageProgramType; } set { _mortgageProgramType = value; } }
-        private Value<bool?> _multipleConcurrentlyClosingLienOnSubjectPropertyIndicator;
+        private DirtyValue<bool?> _multipleConcurrentlyClosingLienOnSubjectPropertyIndicator;
         public bool? MultipleConcurrentlyClosingLienOnSubjectPropertyIndicator { get { return _multipleConcurrentlyClosingLienOnSubjectPropertyIndicator; } set { _multipleConcurrentlyClosingLienOnSubjectPropertyIndicator = value; } }
-        private Value<DateTime?> _nextRateAdjustmentEffectiveDate;
+        private DirtyValue<DateTime?> _nextRateAdjustmentEffectiveDate;
         public DateTime? NextRateAdjustmentEffectiveDate { get { return _nextRateAdjustmentEffectiveDate; } set { _nextRateAdjustmentEffectiveDate = value; } }
-        private Value<string> _notePayToName;
+        private DirtyValue<string> _notePayToName;
         public string NotePayToName { get { return _notePayToName; } set { _notePayToName = value; } }
-        private Value<int?> _numberOfUnitsSold;
+        private DirtyValue<int?> _numberOfUnitsSold;
         public int? NumberOfUnitsSold { get { return _numberOfUnitsSold; } set { _numberOfUnitsSold = value; } }
-        private Value<string> _otherDownPaymentFundsType;
+        private DirtyValue<string> _otherDownPaymentFundsType;
         public string OtherDownPaymentFundsType { get { return _otherDownPaymentFundsType; } set { _otherDownPaymentFundsType = value; } }
-        private Value<decimal?> _otherFundsCollectedAtClosingAmount;
+        private DirtyValue<decimal?> _otherFundsCollectedAtClosingAmount;
         public decimal? OtherFundsCollectedAtClosingAmount { get { return _otherFundsCollectedAtClosingAmount; } set { _otherFundsCollectedAtClosingAmount = value; } }
-        private Value<string> _otherFundsCollectedAtClosingType;
+        private DirtyValue<string> _otherFundsCollectedAtClosingType;
         public string OtherFundsCollectedAtClosingType { get { return _otherFundsCollectedAtClosingType; } set { _otherFundsCollectedAtClosingType = value; } }
-        private Value<string> _payeeID;
+        private DirtyValue<string> _payeeID;
         public string PayeeID { get { return _payeeID; } set { _payeeID = value; } }
-        private Value<int?> _paymentBillingStatementLeadDaysCount;
+        private DirtyValue<int?> _paymentBillingStatementLeadDaysCount;
         public int? PaymentBillingStatementLeadDaysCount { get { return _paymentBillingStatementLeadDaysCount; } set { _paymentBillingStatementLeadDaysCount = value; } }
-        private Value<decimal?> _perChangeMaximumDecreaseRatePercent;
+        private DirtyValue<decimal?> _perChangeMaximumDecreaseRatePercent;
         public decimal? PerChangeMaximumDecreaseRatePercent { get { return _perChangeMaximumDecreaseRatePercent; } set { _perChangeMaximumDecreaseRatePercent = value; } }
-        private Value<decimal?> _perChangeMaximumIncreaseRatePercent;
+        private DirtyValue<decimal?> _perChangeMaximumIncreaseRatePercent;
         public decimal? PerChangeMaximumIncreaseRatePercent { get { return _perChangeMaximumIncreaseRatePercent; } set { _perChangeMaximumIncreaseRatePercent = value; } }
-        private Value<decimal?> _perChangePrincipalAndInterestPaymentAdjustmentPercent;
+        private DirtyValue<decimal?> _perChangePrincipalAndInterestPaymentAdjustmentPercent;
         public decimal? PerChangePrincipalAndInterestPaymentAdjustmentPercent { get { return _perChangePrincipalAndInterestPaymentAdjustmentPercent; } set { _perChangePrincipalAndInterestPaymentAdjustmentPercent = value; } }
-        private Value<DateTime?> _perChangeRateAdjustmentEffectiveDate;
+        private DirtyValue<DateTime?> _perChangeRateAdjustmentEffectiveDate;
         public DateTime? PerChangeRateAdjustmentEffectiveDate { get { return _perChangeRateAdjustmentEffectiveDate; } set { _perChangeRateAdjustmentEffectiveDate = value; } }
-        private Value<int?> _perChangeRateAdjustmentFrequencyMonthsCount;
+        private DirtyValue<int?> _perChangeRateAdjustmentFrequencyMonthsCount;
         public int? PerChangeRateAdjustmentFrequencyMonthsCount { get { return _perChangeRateAdjustmentFrequencyMonthsCount; } set { _perChangeRateAdjustmentFrequencyMonthsCount = value; } }
-        private Value<string> _poolAccrualRateStructureType;
+        private DirtyValue<string> _poolAccrualRateStructureType;
         public string PoolAccrualRateStructureType { get { return _poolAccrualRateStructureType; } set { _poolAccrualRateStructureType = value; } }
-        private Value<string> _poolAmortizationType;
+        private DirtyValue<string> _poolAmortizationType;
         public string PoolAmortizationType { get { return _poolAmortizationType; } set { _poolAmortizationType = value; } }
-        private Value<bool?> _poolAssumabilityIndicator;
+        private DirtyValue<bool?> _poolAssumabilityIndicator;
         public bool? PoolAssumabilityIndicator { get { return _poolAssumabilityIndicator; } set { _poolAssumabilityIndicator = value; } }
-        private Value<bool?> _poolBalloonIndicator;
+        private DirtyValue<bool?> _poolBalloonIndicator;
         public bool? PoolBalloonIndicator { get { return _poolBalloonIndicator; } set { _poolBalloonIndicator = value; } }
-        private Value<DateTime?> _poolCertificatePaymentDate;
+        private DirtyValue<DateTime?> _poolCertificatePaymentDate;
         public DateTime? PoolCertificatePaymentDate { get { return _poolCertificatePaymentDate; } set { _poolCertificatePaymentDate = value; } }
-        private Value<string> _poolClassType;
+        private DirtyValue<string> _poolClassType;
         public string PoolClassType { get { return _poolClassType; } set { _poolClassType = value; } }
-        private Value<string> _poolConcurrentTransferIndicator;
+        private DirtyValue<string> _poolConcurrentTransferIndicator;
         public string PoolConcurrentTransferIndicator { get { return _poolConcurrentTransferIndicator; } set { _poolConcurrentTransferIndicator = value; } }
-        private Value<int?> _poolCurrentLoanCount;
+        private DirtyValue<int?> _poolCurrentLoanCount;
         public int? PoolCurrentLoanCount { get { return _poolCurrentLoanCount; } set { _poolCurrentLoanCount = value; } }
-        private Value<decimal?> _poolCurrentPrincipalBalanceAmount;
+        private DirtyValue<decimal?> _poolCurrentPrincipalBalanceAmount;
         public decimal? PoolCurrentPrincipalBalanceAmount { get { return _poolCurrentPrincipalBalanceAmount; } set { _poolCurrentPrincipalBalanceAmount = value; } }
-        private Value<string> _poolDocumentCustodianID;
+        private DirtyValue<string> _poolDocumentCustodianID;
         public string PoolDocumentCustodianID { get { return _poolDocumentCustodianID; } set { _poolDocumentCustodianID = value; } }
-        private Value<decimal?> _poolFixedServicingFeePercent;
+        private DirtyValue<decimal?> _poolFixedServicingFeePercent;
         public decimal? PoolFixedServicingFeePercent { get { return _poolFixedServicingFeePercent; } set { _poolFixedServicingFeePercent = value; } }
-        private Value<string> _poolIdentifier;
+        private DirtyValue<string> _poolIdentifier;
         public string PoolIdentifier { get { return _poolIdentifier; } set { _poolIdentifier = value; } }
-        private Value<string> _poolingMethodType;
+        private DirtyValue<string> _poolingMethodType;
         public string PoolingMethodType { get { return _poolingMethodType; } set { _poolingMethodType = value; } }
-        private Value<DateTime?> _poolInterestAdjustmentEffectiveDate;
+        private DirtyValue<DateTime?> _poolInterestAdjustmentEffectiveDate;
         public DateTime? PoolInterestAdjustmentEffectiveDate { get { return _poolInterestAdjustmentEffectiveDate; } set { _poolInterestAdjustmentEffectiveDate = value; } }
-        private Value<int?> _poolInterestAdjustmentIndexLeadDaysCount;
+        private DirtyValue<int?> _poolInterestAdjustmentIndexLeadDaysCount;
         public int? PoolInterestAdjustmentIndexLeadDaysCount { get { return _poolInterestAdjustmentIndexLeadDaysCount; } set { _poolInterestAdjustmentIndexLeadDaysCount = value; } }
-        private Value<int?> _poolInterestAndPaymentAdjustmentIndexLeadDaysCount;
+        private DirtyValue<int?> _poolInterestAndPaymentAdjustmentIndexLeadDaysCount;
         public int? PoolInterestAndPaymentAdjustmentIndexLeadDaysCount { get { return _poolInterestAndPaymentAdjustmentIndexLeadDaysCount; } set { _poolInterestAndPaymentAdjustmentIndexLeadDaysCount = value; } }
-        private Value<bool?> _poolInterestOnlyIndicator;
+        private DirtyValue<bool?> _poolInterestOnlyIndicator;
         public bool? PoolInterestOnlyIndicator { get { return _poolInterestOnlyIndicator; } set { _poolInterestOnlyIndicator = value; } }
-        private Value<decimal?> _poolInterestRateRoundingPercent;
+        private DirtyValue<decimal?> _poolInterestRateRoundingPercent;
         public decimal? PoolInterestRateRoundingPercent { get { return _poolInterestRateRoundingPercent; } set { _poolInterestRateRoundingPercent = value; } }
-        private Value<string> _poolInterestRateRoundingType;
+        private DirtyValue<string> _poolInterestRateRoundingType;
         public string PoolInterestRateRoundingType { get { return _poolInterestRateRoundingType; } set { _poolInterestRateRoundingType = value; } }
-        private Value<string> _poolInvestorProductPlanIdentifier;
+        private DirtyValue<string> _poolInvestorProductPlanIdentifier;
         public string PoolInvestorProductPlanIdentifier { get { return _poolInvestorProductPlanIdentifier; } set { _poolInvestorProductPlanIdentifier = value; } }
-        private Value<DateTime?> _poolIssueDate;
+        private DirtyValue<DateTime?> _poolIssueDate;
         public DateTime? PoolIssueDate { get { return _poolIssueDate; } set { _poolIssueDate = value; } }
-        private Value<string> _poolIssuerTransferee;
+        private DirtyValue<string> _poolIssuerTransferee;
         public string PoolIssuerTransferee { get { return _poolIssuerTransferee; } set { _poolIssuerTransferee = value; } }
-        private Value<decimal?> _poolMarginRatePercent;
+        private DirtyValue<decimal?> _poolMarginRatePercent;
         public decimal? PoolMarginRatePercent { get { return _poolMarginRatePercent; } set { _poolMarginRatePercent = value; } }
-        private Value<DateTime?> _poolMaturityDate;
+        private DirtyValue<DateTime?> _poolMaturityDate;
         public DateTime? PoolMaturityDate { get { return _poolMaturityDate; } set { _poolMaturityDate = value; } }
-        private Value<int?> _poolMaturityPeriodCount;
+        private DirtyValue<int?> _poolMaturityPeriodCount;
         public int? PoolMaturityPeriodCount { get { return _poolMaturityPeriodCount; } set { _poolMaturityPeriodCount = value; } }
-        private Value<decimal?> _poolMaximumAccrualRatePercent;
+        private DirtyValue<decimal?> _poolMaximumAccrualRatePercent;
         public decimal? PoolMaximumAccrualRatePercent { get { return _poolMaximumAccrualRatePercent; } set { _poolMaximumAccrualRatePercent = value; } }
-        private Value<decimal?> _poolMinimumAccrualRatePercent;
+        private DirtyValue<decimal?> _poolMinimumAccrualRatePercent;
         public decimal? PoolMinimumAccrualRatePercent { get { return _poolMinimumAccrualRatePercent; } set { _poolMinimumAccrualRatePercent = value; } }
-        private Value<string> _poolMortgageType;
+        private DirtyValue<string> _poolMortgageType;
         public string PoolMortgageType { get { return _poolMortgageType; } set { _poolMortgageType = value; } }
-        private Value<int?> _poolScheduledRemittancePaymentDay;
+        private DirtyValue<int?> _poolScheduledRemittancePaymentDay;
         public int? PoolScheduledRemittancePaymentDay { get { return _poolScheduledRemittancePaymentDay; } set { _poolScheduledRemittancePaymentDay = value; } }
-        private Value<decimal?> _poolSecurityIssueDateInterestRatePercent;
+        private DirtyValue<decimal?> _poolSecurityIssueDateInterestRatePercent;
         public decimal? PoolSecurityIssueDateInterestRatePercent { get { return _poolSecurityIssueDateInterestRatePercent; } set { _poolSecurityIssueDateInterestRatePercent = value; } }
-        private Value<string> _poolSellerID;
+        private DirtyValue<string> _poolSellerID;
         public string PoolSellerID { get { return _poolSellerID; } set { _poolSellerID = value; } }
-        private Value<string> _poolServicerID;
+        private DirtyValue<string> _poolServicerID;
         public string PoolServicerID { get { return _poolServicerID; } set { _poolServicerID = value; } }
-        private Value<string> _poolStructureType;
+        private DirtyValue<string> _poolStructureType;
         public string PoolStructureType { get { return _poolStructureType; } set { _poolStructureType = value; } }
-        private Value<string> _poolSuffixIdentifier;
+        private DirtyValue<string> _poolSuffixIdentifier;
         public string PoolSuffixIdentifier { get { return _poolSuffixIdentifier; } set { _poolSuffixIdentifier = value; } }
-        private Value<DateTime?> _priceLockDatetime;
+        private DirtyValue<DateTime?> _priceLockDatetime;
         public DateTime? PriceLockDatetime { get { return _priceLockDatetime; } set { _priceLockDatetime = value; } }
-        private Value<string> _primaryMIAbsenceReasonType;
+        private DirtyValue<string> _primaryMIAbsenceReasonType;
         public string PrimaryMIAbsenceReasonType { get { return _primaryMIAbsenceReasonType; } set { _primaryMIAbsenceReasonType = value; } }
-        private Value<string> _primaryMIAbsenceReasonTypeOtherDescription;
+        private DirtyValue<string> _primaryMIAbsenceReasonTypeOtherDescription;
         public string PrimaryMIAbsenceReasonTypeOtherDescription { get { return _primaryMIAbsenceReasonTypeOtherDescription; } set { _primaryMIAbsenceReasonTypeOtherDescription = value; } }
-        private Value<string> _projectAttachmentType;
+        private DirtyValue<string> _projectAttachmentType;
         public string ProjectAttachmentType { get { return _projectAttachmentType; } set { _projectAttachmentType = value; } }
-        private Value<string> _projectDesignType;
+        private DirtyValue<string> _projectDesignType;
         public string ProjectDesignType { get { return _projectDesignType; } set { _projectDesignType = value; } }
-        private Value<int?> _projectUnitCount;
+        private DirtyValue<int?> _projectUnitCount;
         public int? ProjectUnitCount { get { return _projectUnitCount; } set { _projectUnitCount = value; } }
-        private Value<DateTime?> _propertyValuationEffectiveDate;
+        private DirtyValue<DateTime?> _propertyValuationEffectiveDate;
         public DateTime? PropertyValuationEffectiveDate { get { return _propertyValuationEffectiveDate; } set { _propertyValuationEffectiveDate = value; } }
-        private Value<string> _propertyValuationMethodType;
+        private DirtyValue<string> _propertyValuationMethodType;
         public string PropertyValuationMethodType { get { return _propertyValuationMethodType; } set { _propertyValuationMethodType = value; } }
-        private Value<decimal?> _refinanceCashOutAmount;
+        private DirtyValue<decimal?> _refinanceCashOutAmount;
         public decimal? RefinanceCashOutAmount { get { return _refinanceCashOutAmount; } set { _refinanceCashOutAmount = value; } }
-        private Value<string> _refinanceCashOutDeterminationType;
+        private DirtyValue<string> _refinanceCashOutDeterminationType;
         public string RefinanceCashOutDeterminationType { get { return _refinanceCashOutDeterminationType; } set { _refinanceCashOutDeterminationType = value; } }
-        private Value<bool?> _relatedLoanBalloonIndicator;
+        private DirtyValue<bool?> _relatedLoanBalloonIndicator;
         public bool? RelatedLoanBalloonIndicator { get { return _relatedLoanBalloonIndicator; } set { _relatedLoanBalloonIndicator = value; } }
-        private Value<bool?> _relatedLoanHELOCIndicator;
+        private DirtyValue<bool?> _relatedLoanHELOCIndicator;
         public bool? RelatedLoanHELOCIndicator { get { return _relatedLoanHELOCIndicator; } set { _relatedLoanHELOCIndicator = value; } }
-        private Value<bool?> _relatedLoanIndicator;
+        private DirtyValue<bool?> _relatedLoanIndicator;
         public bool? RelatedLoanIndicator { get { return _relatedLoanIndicator; } set { _relatedLoanIndicator = value; } }
-        private Value<string> _relatedLoanInvestorType;
+        private DirtyValue<string> _relatedLoanInvestorType;
         public string RelatedLoanInvestorType { get { return _relatedLoanInvestorType; } set { _relatedLoanInvestorType = value; } }
-        private Value<int?> _relatedLoanMaturityPeriodCount;
+        private DirtyValue<int?> _relatedLoanMaturityPeriodCount;
         public int? RelatedLoanMaturityPeriodCount { get { return _relatedLoanMaturityPeriodCount; } set { _relatedLoanMaturityPeriodCount = value; } }
-        private Value<DateTime?> _relatedLoanNoteDate;
+        private DirtyValue<DateTime?> _relatedLoanNoteDate;
         public DateTime? RelatedLoanNoteDate { get { return _relatedLoanNoteDate; } set { _relatedLoanNoteDate = value; } }
-        private Value<DateTime?> _relatedLoanScheduledFirstPaymentDate;
+        private DirtyValue<DateTime?> _relatedLoanScheduledFirstPaymentDate;
         public DateTime? RelatedLoanScheduledFirstPaymentDate { get { return _relatedLoanScheduledFirstPaymentDate; } set { _relatedLoanScheduledFirstPaymentDate = value; } }
-        private Value<DateTime?> _relatedLoanStateDateAtClosing;
+        private DirtyValue<DateTime?> _relatedLoanStateDateAtClosing;
         public DateTime? RelatedLoanStateDateAtClosing { get { return _relatedLoanStateDateAtClosing; } set { _relatedLoanStateDateAtClosing = value; } }
-        private Value<decimal?> _relatedLoanUnpaidPrincipalBalanceAmount;
+        private DirtyValue<decimal?> _relatedLoanUnpaidPrincipalBalanceAmount;
         public decimal? RelatedLoanUnpaidPrincipalBalanceAmount { get { return _relatedLoanUnpaidPrincipalBalanceAmount; } set { _relatedLoanUnpaidPrincipalBalanceAmount = value; } }
-        private Value<bool?> _relocationLoanIndicator;
+        private DirtyValue<bool?> _relocationLoanIndicator;
         public bool? RelocationLoanIndicator { get { return _relocationLoanIndicator; } set { _relocationLoanIndicator = value; } }
-        private Value<string> _rEOMarketingPartyType;
+        private DirtyValue<string> _rEOMarketingPartyType;
         public string REOMarketingPartyType { get { return _rEOMarketingPartyType; } set { _rEOMarketingPartyType = value; } }
-        private Value<bool?> _secondLienIsDeliveredIndicator;
+        private DirtyValue<bool?> _secondLienIsDeliveredIndicator;
         public bool? SecondLienIsDeliveredIndicator { get { return _secondLienIsDeliveredIndicator; } set { _secondLienIsDeliveredIndicator = value; } }
-        private Value<decimal?> _securityOriginalSubscriptionAmount;
+        private DirtyValue<decimal?> _securityOriginalSubscriptionAmount;
         public decimal? SecurityOriginalSubscriptionAmount { get { return _securityOriginalSubscriptionAmount; } set { _securityOriginalSubscriptionAmount = value; } }
-        private Value<DateTime?> _securityTradeBookEntryDate;
+        private DirtyValue<DateTime?> _securityTradeBookEntryDate;
         public DateTime? SecurityTradeBookEntryDate { get { return _securityTradeBookEntryDate; } set { _securityTradeBookEntryDate = value; } }
-        private Value<string> _sellerID;
+        private DirtyValue<string> _sellerID;
         public string SellerID { get { return _sellerID; } set { _sellerID = value; } }
-        private Value<string> _sellerLoanIdentifier;
+        private DirtyValue<string> _sellerLoanIdentifier;
         public string SellerLoanIdentifier { get { return _sellerLoanIdentifier; } set { _sellerLoanIdentifier = value; } }
-        private Value<string> _servicerID;
+        private DirtyValue<string> _servicerID;
         public string ServicerID { get { return _servicerID; } set { _servicerID = value; } }
-        private Value<string> _servicerLoanIdentifier;
+        private DirtyValue<string> _servicerLoanIdentifier;
         public string ServicerLoanIdentifier { get { return _servicerLoanIdentifier; } set { _servicerLoanIdentifier = value; } }
-        private Value<bool?> _sharedEquityIndicator;
+        private DirtyValue<bool?> _sharedEquityIndicator;
         public bool? SharedEquityIndicator { get { return _sharedEquityIndicator; } set { _sharedEquityIndicator = value; } }
-        private Value<bool?> _siteBuiltIndicator;
+        private DirtyValue<bool?> _siteBuiltIndicator;
         public bool? SiteBuiltIndicator { get { return _siteBuiltIndicator; } set { _siteBuiltIndicator = value; } }
-        private Value<bool?> _specialFloodHazardAreaIndicator;
+        private DirtyValue<bool?> _specialFloodHazardAreaIndicator;
         public bool? SpecialFloodHazardAreaIndicator { get { return _specialFloodHazardAreaIndicator; } set { _specialFloodHazardAreaIndicator = value; } }
-        private Value<decimal?> _subsequentPerChangeMaximumDecreaseRatePercent;
+        private DirtyValue<decimal?> _subsequentPerChangeMaximumDecreaseRatePercent;
         public decimal? SubsequentPerChangeMaximumDecreaseRatePercent { get { return _subsequentPerChangeMaximumDecreaseRatePercent; } set { _subsequentPerChangeMaximumDecreaseRatePercent = value; } }
-        private Value<decimal?> _subsequentPerChangeMaximumIncreaseRatePercent;
+        private DirtyValue<decimal?> _subsequentPerChangeMaximumIncreaseRatePercent;
         public decimal? SubsequentPerChangeMaximumIncreaseRatePercent { get { return _subsequentPerChangeMaximumIncreaseRatePercent; } set { _subsequentPerChangeMaximumIncreaseRatePercent = value; } }
-        private Value<DateTime?> _subsequentPerChangeRateAdjustmentEffectiveDate;
+        private DirtyValue<DateTime?> _subsequentPerChangeRateAdjustmentEffectiveDate;
         public DateTime? SubsequentPerChangeRateAdjustmentEffectiveDate { get { return _subsequentPerChangeRateAdjustmentEffectiveDate; } set { _subsequentPerChangeRateAdjustmentEffectiveDate = value; } }
-        private Value<int?> _subsequentPerChangeRateAdjustmentFrequencyMonthsCount;
+        private DirtyValue<int?> _subsequentPerChangeRateAdjustmentFrequencyMonthsCount;
         public int? SubsequentPerChangeRateAdjustmentFrequencyMonthsCount { get { return _subsequentPerChangeRateAdjustmentFrequencyMonthsCount; } set { _subsequentPerChangeRateAdjustmentFrequencyMonthsCount = value; } }
-        private Value<bool?> _temporaryBuydownIndicator;
+        private DirtyValue<bool?> _temporaryBuydownIndicator;
         public bool? TemporaryBuydownIndicator { get { return _temporaryBuydownIndicator; } set { _temporaryBuydownIndicator = value; } }
-        private Value<int?> _totalMortgagedPropertiesCount;
+        private DirtyValue<int?> _totalMortgagedPropertiesCount;
         public int? TotalMortgagedPropertiesCount { get { return _totalMortgagedPropertiesCount; } set { _totalMortgagedPropertiesCount = value; } }
-        private Value<decimal?> _unit1SubjectPropertyGrossRentalIncome;
+        private DirtyValue<decimal?> _unit1SubjectPropertyGrossRentalIncome;
         public decimal? Unit1SubjectPropertyGrossRentalIncome { get { return _unit1SubjectPropertyGrossRentalIncome; } set { _unit1SubjectPropertyGrossRentalIncome = value; } }
-        private Value<int?> _unit1TotalBedrooms;
+        private DirtyValue<int?> _unit1TotalBedrooms;
         public int? Unit1TotalBedrooms { get { return _unit1TotalBedrooms; } set { _unit1TotalBedrooms = value; } }
-        private Value<decimal?> _unit2SubjectPropertyGrossRentalIncome;
+        private DirtyValue<decimal?> _unit2SubjectPropertyGrossRentalIncome;
         public decimal? Unit2SubjectPropertyGrossRentalIncome { get { return _unit2SubjectPropertyGrossRentalIncome; } set { _unit2SubjectPropertyGrossRentalIncome = value; } }
-        private Value<int?> _unit2TotalBedrooms;
+        private DirtyValue<int?> _unit2TotalBedrooms;
         public int? Unit2TotalBedrooms { get { return _unit2TotalBedrooms; } set { _unit2TotalBedrooms = value; } }
-        private Value<decimal?> _unit3SubjectPropertyGrossRentalIncome;
+        private DirtyValue<decimal?> _unit3SubjectPropertyGrossRentalIncome;
         public decimal? Unit3SubjectPropertyGrossRentalIncome { get { return _unit3SubjectPropertyGrossRentalIncome; } set { _unit3SubjectPropertyGrossRentalIncome = value; } }
-        private Value<int?> _unit3TotalBedrooms;
+        private DirtyValue<int?> _unit3TotalBedrooms;
         public int? Unit3TotalBedrooms { get { return _unit3TotalBedrooms; } set { _unit3TotalBedrooms = value; } }
-        private Value<decimal?> _unit4SubjectPropertyGrossRentalIncome;
+        private DirtyValue<decimal?> _unit4SubjectPropertyGrossRentalIncome;
         public decimal? Unit4SubjectPropertyGrossRentalIncome { get { return _unit4SubjectPropertyGrossRentalIncome; } set { _unit4SubjectPropertyGrossRentalIncome = value; } }
-        private Value<int?> _unit4TotalBedrooms;
+        private DirtyValue<int?> _unit4TotalBedrooms;
         public int? Unit4TotalBedrooms { get { return _unit4TotalBedrooms; } set { _unit4TotalBedrooms = value; } }
-        private Value<decimal?> _uPBAmount;
+        private DirtyValue<decimal?> _uPBAmount;
         public decimal? UPBAmount { get { return _uPBAmount; } set { _uPBAmount = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/UnderwriterSummary.cs
+++ b/src/EncompassRest/Loans/UnderwriterSummary.cs
@@ -8,113 +8,113 @@ namespace EncompassRest.Loans
 {
     public sealed partial class UnderwriterSummary : IDirty
     {
-        private Value<string> _appraisal;
+        private DirtyValue<string> _appraisal;
         public string Appraisal { get { return _appraisal; } set { _appraisal = value; } }
-        private Value<DateTime?> _appraisalCompletedDate;
+        private DirtyValue<DateTime?> _appraisalCompletedDate;
         public DateTime? AppraisalCompletedDate { get { return _appraisalCompletedDate; } set { _appraisalCompletedDate = value; } }
-        private Value<DateTime?> _appraisalExpiredDate;
+        private DirtyValue<DateTime?> _appraisalExpiredDate;
         public DateTime? AppraisalExpiredDate { get { return _appraisalExpiredDate; } set { _appraisalExpiredDate = value; } }
-        private Value<DateTime?> _appraisalOrderedDate;
+        private DirtyValue<DateTime?> _appraisalOrderedDate;
         public DateTime? AppraisalOrderedDate { get { return _appraisalOrderedDate; } set { _appraisalOrderedDate = value; } }
-        private Value<string> _appraisalType;
+        private DirtyValue<string> _appraisalType;
         public string AppraisalType { get { return _appraisalType; } set { _appraisalType = value; } }
-        private Value<DateTime?> _approvalExpiredDate;
+        private DirtyValue<DateTime?> _approvalExpiredDate;
         public DateTime? ApprovalExpiredDate { get { return _approvalExpiredDate; } set { _approvalExpiredDate = value; } }
-        private Value<string> _approvedBy;
+        private DirtyValue<string> _approvedBy;
         public string ApprovedBy { get { return _approvedBy; } set { _approvedBy = value; } }
-        private Value<DateTime?> _approvedDate;
+        private DirtyValue<DateTime?> _approvedDate;
         public DateTime? ApprovedDate { get { return _approvedDate; } set { _approvedDate = value; } }
-        private Value<string> _ausNumber;
+        private DirtyValue<string> _ausNumber;
         public string AusNumber { get { return _ausNumber; } set { _ausNumber = value; } }
-        private Value<DateTime?> _ausRunDate;
+        private DirtyValue<DateTime?> _ausRunDate;
         public DateTime? AusRunDate { get { return _ausRunDate; } set { _ausRunDate = value; } }
-        private Value<string> _ausSource;
+        private DirtyValue<string> _ausSource;
         public string AusSource { get { return _ausSource; } set { _ausSource = value; } }
-        private Value<bool?> _benefitRequiredIndicator;
+        private DirtyValue<bool?> _benefitRequiredIndicator;
         public bool? BenefitRequiredIndicator { get { return _benefitRequiredIndicator; } set { _benefitRequiredIndicator = value; } }
-        private Value<DateTime?> _clearToCloseDate;
+        private DirtyValue<DateTime?> _clearToCloseDate;
         public DateTime? ClearToCloseDate { get { return _clearToCloseDate; } set { _clearToCloseDate = value; } }
-        private Value<string> _concerns;
+        private DirtyValue<string> _concerns;
         public string Concerns { get { return _concerns; } set { _concerns = value; } }
-        private Value<string> _conditions;
+        private DirtyValue<string> _conditions;
         public string Conditions { get { return _conditions; } set { _conditions = value; } }
-        private Value<string> _credit;
+        private DirtyValue<string> _credit;
         public string Credit { get { return _credit; } set { _credit = value; } }
-        private Value<DateTime?> _creditApprovalDate;
+        private DirtyValue<DateTime?> _creditApprovalDate;
         public DateTime? CreditApprovalDate { get { return _creditApprovalDate; } set { _creditApprovalDate = value; } }
-        private Value<string> _deniedBy;
+        private DirtyValue<string> _deniedBy;
         public string DeniedBy { get { return _deniedBy; } set { _deniedBy = value; } }
-        private Value<DateTime?> _deniedDate;
+        private DirtyValue<DateTime?> _deniedDate;
         public DateTime? DeniedDate { get { return _deniedDate; } set { _deniedDate = value; } }
-        private Value<DateTime?> _differentApprovalExpiredDate;
+        private DirtyValue<DateTime?> _differentApprovalExpiredDate;
         public DateTime? DifferentApprovalExpiredDate { get { return _differentApprovalExpiredDate; } set { _differentApprovalExpiredDate = value; } }
-        private Value<string> _differentApprovedBy;
+        private DirtyValue<string> _differentApprovedBy;
         public string DifferentApprovedBy { get { return _differentApprovedBy; } set { _differentApprovedBy = value; } }
-        private Value<DateTime?> _differentApprovedDate;
+        private DirtyValue<DateTime?> _differentApprovedDate;
         public DateTime? DifferentApprovedDate { get { return _differentApprovedDate; } set { _differentApprovedDate = value; } }
-        private Value<string> _exceptions;
+        private DirtyValue<string> _exceptions;
         public string Exceptions { get { return _exceptions; } set { _exceptions = value; } }
-        private Value<string> _exceptionSignOffBy;
+        private DirtyValue<string> _exceptionSignOffBy;
         public string ExceptionSignOffBy { get { return _exceptionSignOffBy; } set { _exceptionSignOffBy = value; } }
-        private Value<DateTime?> _exceptionSignOffDate;
+        private DirtyValue<DateTime?> _exceptionSignOffDate;
         public DateTime? ExceptionSignOffDate { get { return _exceptionSignOffDate; } set { _exceptionSignOffDate = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isAgencyManually;
+        private DirtyValue<bool?> _isAgencyManually;
         public bool? IsAgencyManually { get { return _isAgencyManually; } set { _isAgencyManually = value; } }
-        private Value<bool?> _isAgencyWaiver;
+        private DirtyValue<bool?> _isAgencyWaiver;
         public bool? IsAgencyWaiver { get { return _isAgencyWaiver; } set { _isAgencyWaiver = value; } }
-        private Value<bool?> _isAgencyWithAgreement;
+        private DirtyValue<bool?> _isAgencyWithAgreement;
         public bool? IsAgencyWithAgreement { get { return _isAgencyWithAgreement; } set { _isAgencyWithAgreement = value; } }
-        private Value<decimal?> _maxRate;
+        private DirtyValue<decimal?> _maxRate;
         public decimal? MaxRate { get { return _maxRate; } set { _maxRate = value; } }
-        private Value<DateTime?> _miOrderedDate;
+        private DirtyValue<DateTime?> _miOrderedDate;
         public DateTime? MiOrderedDate { get { return _miOrderedDate; } set { _miOrderedDate = value; } }
-        private Value<DateTime?> _miReceivedDate;
+        private DirtyValue<DateTime?> _miReceivedDate;
         public DateTime? MiReceivedDate { get { return _miReceivedDate; } set { _miReceivedDate = value; } }
-        private Value<decimal?> _modifiedLoanAmount;
+        private DirtyValue<decimal?> _modifiedLoanAmount;
         public decimal? ModifiedLoanAmount { get { return _modifiedLoanAmount; } set { _modifiedLoanAmount = value; } }
-        private Value<decimal?> _modifiedLoanRate;
+        private DirtyValue<decimal?> _modifiedLoanRate;
         public decimal? ModifiedLoanRate { get { return _modifiedLoanRate; } set { _modifiedLoanRate = value; } }
-        private Value<int?> _modifiedLoanTerm;
+        private DirtyValue<int?> _modifiedLoanTerm;
         public int? ModifiedLoanTerm { get { return _modifiedLoanTerm; } set { _modifiedLoanTerm = value; } }
-        private Value<decimal?> _modifiedLtv;
+        private DirtyValue<decimal?> _modifiedLtv;
         public decimal? ModifiedLtv { get { return _modifiedLtv; } set { _modifiedLtv = value; } }
-        private Value<decimal?> _modifiedMonthlyPayment;
+        private DirtyValue<decimal?> _modifiedMonthlyPayment;
         public decimal? ModifiedMonthlyPayment { get { return _modifiedMonthlyPayment; } set { _modifiedMonthlyPayment = value; } }
-        private Value<string> _originalAppraiser;
+        private DirtyValue<string> _originalAppraiser;
         public string OriginalAppraiser { get { return _originalAppraiser; } set { _originalAppraiser = value; } }
-        private Value<decimal?> _originalAppraisersValue;
+        private DirtyValue<decimal?> _originalAppraisersValue;
         public decimal? OriginalAppraisersValue { get { return _originalAppraisersValue; } set { _originalAppraisersValue = value; } }
-        private Value<DateTime?> _resubmittedDate;
+        private DirtyValue<DateTime?> _resubmittedDate;
         public DateTime? ResubmittedDate { get { return _resubmittedDate; } set { _resubmittedDate = value; } }
-        private Value<string> _reviewAppraiser;
+        private DirtyValue<string> _reviewAppraiser;
         public string ReviewAppraiser { get { return _reviewAppraiser; } set { _reviewAppraiser = value; } }
-        private Value<DateTime?> _reviewCompletedDate;
+        private DirtyValue<DateTime?> _reviewCompletedDate;
         public DateTime? ReviewCompletedDate { get { return _reviewCompletedDate; } set { _reviewCompletedDate = value; } }
-        private Value<DateTime?> _reviewRequestedDate;
+        private DirtyValue<DateTime?> _reviewRequestedDate;
         public DateTime? ReviewRequestedDate { get { return _reviewRequestedDate; } set { _reviewRequestedDate = value; } }
-        private Value<string> _reviewType;
+        private DirtyValue<string> _reviewType;
         public string ReviewType { get { return _reviewType; } set { _reviewType = value; } }
-        private Value<decimal?> _reviewValue;
+        private DirtyValue<decimal?> _reviewValue;
         public decimal? ReviewValue { get { return _reviewValue; } set { _reviewValue = value; } }
-        private Value<DateTime?> _sentToDate;
+        private DirtyValue<DateTime?> _sentToDate;
         public DateTime? SentToDate { get { return _sentToDate; } set { _sentToDate = value; } }
-        private Value<string> _signOffBy;
+        private DirtyValue<string> _signOffBy;
         public string SignOffBy { get { return _signOffBy; } set { _signOffBy = value; } }
-        private Value<DateTime?> _signOffDate;
+        private DirtyValue<DateTime?> _signOffDate;
         public DateTime? SignOffDate { get { return _signOffDate; } set { _signOffDate = value; } }
-        private Value<string> _strengths;
+        private DirtyValue<string> _strengths;
         public string Strengths { get { return _strengths; } set { _strengths = value; } }
-        private Value<DateTime?> _submittedDate;
+        private DirtyValue<DateTime?> _submittedDate;
         public DateTime? SubmittedDate { get { return _submittedDate; } set { _submittedDate = value; } }
-        private Value<string> _supervisoryAppraiserLicenseNumber;
+        private DirtyValue<string> _supervisoryAppraiserLicenseNumber;
         public string SupervisoryAppraiserLicenseNumber { get { return _supervisoryAppraiserLicenseNumber; } set { _supervisoryAppraiserLicenseNumber = value; } }
-        private Value<string> _suspendedBy;
+        private DirtyValue<string> _suspendedBy;
         public string SuspendedBy { get { return _suspendedBy; } set { _suspendedBy = value; } }
-        private Value<DateTime?> _suspendedDate;
+        private DirtyValue<DateTime?> _suspendedDate;
         public DateTime? SuspendedDate { get { return _suspendedDate; } set { _suspendedDate = value; } }
-        private Value<string> _suspendedReasons;
+        private DirtyValue<string> _suspendedReasons;
         public string SuspendedReasons { get { return _suspendedReasons; } set { _suspendedReasons = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/UnderwritingConditionLog.cs
+++ b/src/EncompassRest/Loans/UnderwritingConditionLog.cs
@@ -8,117 +8,117 @@ namespace EncompassRest.Loans
 {
     public sealed partial class UnderwritingConditionLog : IDirty
     {
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<bool?> _allowToClearIndicator;
+        private DirtyValue<bool?> _allowToClearIndicator;
         public bool? AllowToClearIndicator { get { return _allowToClearIndicator; } set { _allowToClearIndicator = value; } }
-        private Value<string> _category;
+        private DirtyValue<string> _category;
         public string Category { get { return _category; } set { _category = value; } }
-        private Value<bool?> _cleared;
+        private DirtyValue<bool?> _cleared;
         public bool? Cleared { get { return _cleared; } set { _cleared = value; } }
-        private Value<string> _clearedBy;
+        private DirtyValue<string> _clearedBy;
         public string ClearedBy { get { return _clearedBy; } set { _clearedBy = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<DateTime?> _dateAddedUtc;
+        private DirtyValue<DateTime?> _dateAddedUtc;
         public DateTime? DateAddedUtc { get { return _dateAddedUtc; } set { _dateAddedUtc = value; } }
-        private Value<DateTime?> _dateClearedUtc;
+        private DirtyValue<DateTime?> _dateClearedUtc;
         public DateTime? DateClearedUtc { get { return _dateClearedUtc; } set { _dateClearedUtc = value; } }
-        private Value<DateTime?> _dateExpected;
+        private DirtyValue<DateTime?> _dateExpected;
         public DateTime? DateExpected { get { return _dateExpected; } set { _dateExpected = value; } }
-        private Value<DateTime?> _dateExpiredUtc;
+        private DirtyValue<DateTime?> _dateExpiredUtc;
         public DateTime? DateExpiredUtc { get { return _dateExpiredUtc; } set { _dateExpiredUtc = value; } }
-        private Value<DateTime?> _dateFulfilledUtc;
+        private DirtyValue<DateTime?> _dateFulfilledUtc;
         public DateTime? DateFulfilledUtc { get { return _dateFulfilledUtc; } set { _dateFulfilledUtc = value; } }
-        private Value<DateTime?> _dateReceived;
+        private DirtyValue<DateTime?> _dateReceived;
         public DateTime? DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateReceivedUtc;
+        private DirtyValue<DateTime?> _dateReceivedUtc;
         public DateTime? DateReceivedUtc { get { return _dateReceivedUtc; } set { _dateReceivedUtc = value; } }
-        private Value<DateTime?> _dateRejectedUtc;
+        private DirtyValue<DateTime?> _dateRejectedUtc;
         public DateTime? DateRejectedUtc { get { return _dateRejectedUtc; } set { _dateRejectedUtc = value; } }
-        private Value<DateTime?> _dateRequestedUtc;
+        private DirtyValue<DateTime?> _dateRequestedUtc;
         public DateTime? DateRequestedUtc { get { return _dateRequestedUtc; } set { _dateRequestedUtc = value; } }
-        private Value<DateTime?> _dateRerequestedUtc;
+        private DirtyValue<DateTime?> _dateRerequestedUtc;
         public DateTime? DateRerequestedUtc { get { return _dateRerequestedUtc; } set { _dateRerequestedUtc = value; } }
-        private Value<DateTime?> _dateReviewedUtc;
+        private DirtyValue<DateTime?> _dateReviewedUtc;
         public DateTime? DateReviewedUtc { get { return _dateReviewedUtc; } set { _dateReviewedUtc = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<DateTime?> _dateWaivedUtc;
+        private DirtyValue<DateTime?> _dateWaivedUtc;
         public DateTime? DateWaivedUtc { get { return _dateWaivedUtc; } set { _dateWaivedUtc = value; } }
-        private Value<string> _description;
+        private DirtyValue<string> _description;
         public string Description { get { return _description; } set { _description = value; } }
-        private Value<string> _details;
+        private DirtyValue<string> _details;
         public string Details { get { return _details; } set { _details = value; } }
-        private Value<bool?> _expected;
+        private DirtyValue<bool?> _expected;
         public bool? Expected { get { return _expected; } set { _expected = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<int?> _forRoleId;
+        private DirtyValue<int?> _forRoleId;
         public int? ForRoleId { get { return _forRoleId; } set { _forRoleId = value; } }
-        private Value<bool?> _fulfilled;
+        private DirtyValue<bool?> _fulfilled;
         public bool? Fulfilled { get { return _fulfilled; } set { _fulfilled = value; } }
-        private Value<string> _fulfilledBy;
+        private DirtyValue<string> _fulfilledBy;
         public string FulfilledBy { get { return _fulfilledBy; } set { _fulfilledBy = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isExternalIndicator;
+        private DirtyValue<bool?> _isExternalIndicator;
         public bool? IsExternalIndicator { get { return _isExternalIndicator; } set { _isExternalIndicator = value; } }
-        private Value<bool?> _isInternalIndicator;
+        private DirtyValue<bool?> _isInternalIndicator;
         public bool? IsInternalIndicator { get { return _isInternalIndicator; } set { _isInternalIndicator = value; } }
-        private Value<bool?> _isPastDue;
+        private DirtyValue<bool?> _isPastDue;
         public bool? IsPastDue { get { return _isPastDue; } set { _isPastDue = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<string> _pairId;
+        private DirtyValue<string> _pairId;
         public string PairId { get { return _pairId; } set { _pairId = value; } }
-        private Value<string> _priorTo;
+        private DirtyValue<string> _priorTo;
         public string PriorTo { get { return _priorTo; } set { _priorTo = value; } }
-        private Value<bool?> _received;
+        private DirtyValue<bool?> _received;
         public bool? Received { get { return _received; } set { _received = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<bool?> _rejected;
+        private DirtyValue<bool?> _rejected;
         public bool? Rejected { get { return _rejected; } set { _rejected = value; } }
-        private Value<string> _rejectedBy;
+        private DirtyValue<string> _rejectedBy;
         public string RejectedBy { get { return _rejectedBy; } set { _rejectedBy = value; } }
-        private Value<bool?> _requested;
+        private DirtyValue<bool?> _requested;
         public bool? Requested { get { return _requested; } set { _requested = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<bool?> _rerequested;
+        private DirtyValue<bool?> _rerequested;
         public bool? Rerequested { get { return _rerequested; } set { _rerequested = value; } }
-        private Value<string> _rerequestedBy;
+        private DirtyValue<string> _rerequestedBy;
         public string RerequestedBy { get { return _rerequestedBy; } set { _rerequestedBy = value; } }
-        private Value<bool?> _reviewed;
+        private DirtyValue<bool?> _reviewed;
         public bool? Reviewed { get { return _reviewed; } set { _reviewed = value; } }
-        private Value<string> _reviewedBy;
+        private DirtyValue<string> _reviewedBy;
         public string ReviewedBy { get { return _reviewedBy; } set { _reviewedBy = value; } }
-        private Value<string> _source;
+        private DirtyValue<string> _source;
         public string Source { get { return _source; } set { _source = value; } }
-        private Value<string> _status;
+        private DirtyValue<string> _status;
         public string Status { get { return _status; } set { _status = value; } }
-        private Value<string> _statusDescription;
+        private DirtyValue<string> _statusDescription;
         public string StatusDescription { get { return _statusDescription; } set { _statusDescription = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<bool?> _waived;
+        private DirtyValue<bool?> _waived;
         public bool? Waived { get { return _waived; } set { _waived = value; } }
-        private Value<string> _waivedBy;
+        private DirtyValue<string> _waivedBy;
         public string WaivedBy { get { return _waivedBy; } set { _waivedBy = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/UnderwritingConditionLog.cs
+++ b/src/EncompassRest/Loans/UnderwritingConditionLog.cs
@@ -10,8 +10,8 @@ namespace EncompassRest.Loans
     {
         private Value<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<bool?> _allowToClearIndicator;
@@ -22,8 +22,8 @@ namespace EncompassRest.Loans
         public bool? Cleared { get { return _cleared; } set { _cleared = value; } }
         private Value<string> _clearedBy;
         public string ClearedBy { get { return _clearedBy; } set { _clearedBy = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
@@ -128,13 +128,11 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _gettingDirty, 1, 0) != 0) return false;
                 var dirty = _addedBy.Dirty
-                    || _alerts.Dirty
                     || _alertsXml.Dirty
                     || _allowToClearIndicator.Dirty
                     || _category.Dirty
                     || _cleared.Dirty
                     || _clearedBy.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _dateAddedUtc.Dirty
@@ -182,7 +180,9 @@ namespace EncompassRest.Loans
                     || _systemId.Dirty
                     || _title.Dirty
                     || _waived.Dirty
-                    || _waivedBy.Dirty;
+                    || _waivedBy.Dirty
+                    || _alerts?.Dirty == true
+                    || _commentList?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -190,13 +190,11 @@ namespace EncompassRest.Loans
             {
                 if (Interlocked.CompareExchange(ref _settingDirty, 1, 0) != 0) return;
                 _addedBy.Dirty = value;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _allowToClearIndicator.Dirty = value;
                 _category.Dirty = value;
                 _cleared.Dirty = value;
                 _clearedBy.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _dateAddedUtc.Dirty = value;
@@ -245,6 +243,8 @@ namespace EncompassRest.Loans
                 _title.Dirty = value;
                 _waived.Dirty = value;
                 _waivedBy.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/Usda.cs
+++ b/src/EncompassRest/Loans/Usda.cs
@@ -8,283 +8,283 @@ namespace EncompassRest.Loans
 {
     public sealed partial class Usda : IDirty
     {
-        private Value<decimal?> _additionalIncomeFromPrimaryEmployment;
+        private DirtyValue<decimal?> _additionalIncomeFromPrimaryEmployment;
         public decimal? AdditionalIncomeFromPrimaryEmployment { get { return _additionalIncomeFromPrimaryEmployment; } set { _additionalIncomeFromPrimaryEmployment = value; } }
-        private Value<decimal?> _additionalMemberBaseIncome;
+        private DirtyValue<decimal?> _additionalMemberBaseIncome;
         public decimal? AdditionalMemberBaseIncome { get { return _additionalMemberBaseIncome; } set { _additionalMemberBaseIncome = value; } }
-        private Value<decimal?> _adjustedAnnualIncome;
+        private DirtyValue<decimal?> _adjustedAnnualIncome;
         public decimal? AdjustedAnnualIncome { get { return _adjustedAnnualIncome; } set { _adjustedAnnualIncome = value; } }
-        private Value<string> _adjustedIncomeCalculationDescription1;
+        private DirtyValue<string> _adjustedIncomeCalculationDescription1;
         public string AdjustedIncomeCalculationDescription1 { get { return _adjustedIncomeCalculationDescription1; } set { _adjustedIncomeCalculationDescription1 = value; } }
-        private Value<string> _adjustedIncomeCalculationDescription2;
+        private DirtyValue<string> _adjustedIncomeCalculationDescription2;
         public string AdjustedIncomeCalculationDescription2 { get { return _adjustedIncomeCalculationDescription2; } set { _adjustedIncomeCalculationDescription2 = value; } }
-        private Value<string> _adjustedIncomeCalculationDescription3;
+        private DirtyValue<string> _adjustedIncomeCalculationDescription3;
         public string AdjustedIncomeCalculationDescription3 { get { return _adjustedIncomeCalculationDescription3; } set { _adjustedIncomeCalculationDescription3 = value; } }
-        private Value<decimal?> _advanceAmountToDate;
+        private DirtyValue<decimal?> _advanceAmountToDate;
         public decimal? AdvanceAmountToDate { get { return _advanceAmountToDate; } set { _advanceAmountToDate = value; } }
-        private Value<decimal?> _amountLoanlineCredit;
+        private DirtyValue<decimal?> _amountLoanlineCredit;
         public decimal? AmountLoanlineCredit { get { return _amountLoanlineCredit; } set { _amountLoanlineCredit = value; } }
-        private Value<decimal?> _annualChildCareExpenses;
+        private DirtyValue<decimal?> _annualChildCareExpenses;
         public decimal? AnnualChildCareExpenses { get { return _annualChildCareExpenses; } set { _annualChildCareExpenses = value; } }
-        private Value<decimal?> _annualIncome;
+        private DirtyValue<decimal?> _annualIncome;
         public decimal? AnnualIncome { get { return _annualIncome; } set { _annualIncome = value; } }
-        private Value<string> _annualIncomeCalculationDescription1;
+        private DirtyValue<string> _annualIncomeCalculationDescription1;
         public string AnnualIncomeCalculationDescription1 { get { return _annualIncomeCalculationDescription1; } set { _annualIncomeCalculationDescription1 = value; } }
-        private Value<string> _annualIncomeCalculationDescription2;
+        private DirtyValue<string> _annualIncomeCalculationDescription2;
         public string AnnualIncomeCalculationDescription2 { get { return _annualIncomeCalculationDescription2; } set { _annualIncomeCalculationDescription2 = value; } }
-        private Value<string> _annualIncomeCalculationDescription3;
+        private DirtyValue<string> _annualIncomeCalculationDescription3;
         public string AnnualIncomeCalculationDescription3 { get { return _annualIncomeCalculationDescription3; } set { _annualIncomeCalculationDescription3 = value; } }
-        private Value<string> _annualIncomeCalculationDescription4;
+        private DirtyValue<string> _annualIncomeCalculationDescription4;
         public string AnnualIncomeCalculationDescription4 { get { return _annualIncomeCalculationDescription4; } set { _annualIncomeCalculationDescription4 = value; } }
-        private Value<string> _annualIncomeCalculationDescription5;
+        private DirtyValue<string> _annualIncomeCalculationDescription5;
         public string AnnualIncomeCalculationDescription5 { get { return _annualIncomeCalculationDescription5; } set { _annualIncomeCalculationDescription5 = value; } }
-        private Value<DateTime?> _annualReviewDate;
+        private DirtyValue<DateTime?> _annualReviewDate;
         public DateTime? AnnualReviewDate { get { return _annualReviewDate; } set { _annualReviewDate = value; } }
-        private Value<string> _applicationNumber;
+        private DirtyValue<string> _applicationNumber;
         public string ApplicationNumber { get { return _applicationNumber; } set { _applicationNumber = value; } }
-        private Value<string> _approvedLenderTaxId;
+        private DirtyValue<string> _approvedLenderTaxId;
         public string ApprovedLenderTaxId { get { return _approvedLenderTaxId; } set { _approvedLenderTaxId = value; } }
-        private Value<decimal?> _assetIncome;
+        private DirtyValue<decimal?> _assetIncome;
         public decimal? AssetIncome { get { return _assetIncome; } set { _assetIncome = value; } }
-        private Value<decimal?> _balanceOwedOnLoan;
+        private DirtyValue<decimal?> _balanceOwedOnLoan;
         public decimal? BalanceOwedOnLoan { get { return _balanceOwedOnLoan; } set { _balanceOwedOnLoan = value; } }
-        private Value<decimal?> _borrowerBaseIncome;
+        private DirtyValue<decimal?> _borrowerBaseIncome;
         public decimal? BorrowerBaseIncome { get { return _borrowerBaseIncome; } set { _borrowerBaseIncome = value; } }
-        private Value<decimal?> _borrowerTotalStableIncome;
+        private DirtyValue<decimal?> _borrowerTotalStableIncome;
         public decimal? BorrowerTotalStableIncome { get { return _borrowerTotalStableIncome; } set { _borrowerTotalStableIncome = value; } }
-        private Value<string> _borrowerTypeCode;
+        private DirtyValue<string> _borrowerTypeCode;
         public string BorrowerTypeCode { get { return _borrowerTypeCode; } set { _borrowerTypeCode = value; } }
-        private Value<decimal?> _buydownInterestAssistanceRate;
+        private DirtyValue<decimal?> _buydownInterestAssistanceRate;
         public decimal? BuydownInterestAssistanceRate { get { return _buydownInterestAssistanceRate; } set { _buydownInterestAssistanceRate = value; } }
-        private Value<string> _caseNumberBorrowerId;
+        private DirtyValue<string> _caseNumberBorrowerId;
         public string CaseNumberBorrowerId { get { return _caseNumberBorrowerId; } set { _caseNumberBorrowerId = value; } }
-        private Value<string> _caseNumberCo;
+        private DirtyValue<string> _caseNumberCo;
         public string CaseNumberCo { get { return _caseNumberCo; } set { _caseNumberCo = value; } }
-        private Value<string> _caseNumberSt;
+        private DirtyValue<string> _caseNumberSt;
         public string CaseNumberSt { get { return _caseNumberSt; } set { _caseNumberSt = value; } }
-        private Value<DateTime?> _certificationEffectiveDate;
+        private DirtyValue<DateTime?> _certificationEffectiveDate;
         public DateTime? CertificationEffectiveDate { get { return _certificationEffectiveDate; } set { _certificationEffectiveDate = value; } }
-        private Value<DateTime?> _certificationExpirationDate;
+        private DirtyValue<DateTime?> _certificationExpirationDate;
         public DateTime? CertificationExpirationDate { get { return _certificationExpirationDate; } set { _certificationExpirationDate = value; } }
-        private Value<bool?> _certifiedLoanIndicator;
+        private DirtyValue<bool?> _certifiedLoanIndicator;
         public bool? CertifiedLoanIndicator { get { return _certifiedLoanIndicator; } set { _certifiedLoanIndicator = value; } }
-        private Value<string> _childCareProviderAddress;
+        private DirtyValue<string> _childCareProviderAddress;
         public string ChildCareProviderAddress { get { return _childCareProviderAddress; } set { _childCareProviderAddress = value; } }
-        private Value<string> _childCareProviderCity;
+        private DirtyValue<string> _childCareProviderCity;
         public string ChildCareProviderCity { get { return _childCareProviderCity; } set { _childCareProviderCity = value; } }
-        private Value<string> _childCareProviderPhone;
+        private DirtyValue<string> _childCareProviderPhone;
         public string ChildCareProviderPhone { get { return _childCareProviderPhone; } set { _childCareProviderPhone = value; } }
-        private Value<string> _childCareProviderProviderName;
+        private DirtyValue<string> _childCareProviderProviderName;
         public string ChildCareProviderProviderName { get { return _childCareProviderProviderName; } set { _childCareProviderProviderName = value; } }
-        private Value<string> _childCareProviderState;
+        private DirtyValue<string> _childCareProviderState;
         public string ChildCareProviderState { get { return _childCareProviderState; } set { _childCareProviderState = value; } }
-        private Value<string> _childCareProviderZip;
+        private DirtyValue<string> _childCareProviderZip;
         public string ChildCareProviderZip { get { return _childCareProviderZip; } set { _childCareProviderZip = value; } }
-        private Value<decimal?> _childCostPerMonth;
+        private DirtyValue<decimal?> _childCostPerMonth;
         public decimal? ChildCostPerMonth { get { return _childCostPerMonth; } set { _childCostPerMonth = value; } }
-        private Value<decimal?> _childCostPerWeek;
+        private DirtyValue<decimal?> _childCostPerWeek;
         public decimal? ChildCostPerWeek { get { return _childCostPerWeek; } set { _childCostPerWeek = value; } }
-        private Value<decimal?> _coborrowerBaseIncome;
+        private DirtyValue<decimal?> _coborrowerBaseIncome;
         public decimal? CoborrowerBaseIncome { get { return _coborrowerBaseIncome; } set { _coborrowerBaseIncome = value; } }
-        private Value<decimal?> _coborrowerStableBaseIncome;
+        private DirtyValue<decimal?> _coborrowerStableBaseIncome;
         public decimal? CoborrowerStableBaseIncome { get { return _coborrowerStableBaseIncome; } set { _coborrowerStableBaseIncome = value; } }
-        private Value<string> _coborrowerStableBaseIncomeDesc;
+        private DirtyValue<string> _coborrowerStableBaseIncomeDesc;
         public string CoborrowerStableBaseIncomeDesc { get { return _coborrowerStableBaseIncomeDesc; } set { _coborrowerStableBaseIncomeDesc = value; } }
-        private Value<decimal?> _coborrowerStableOtherIncome;
+        private DirtyValue<decimal?> _coborrowerStableOtherIncome;
         public decimal? CoborrowerStableOtherIncome { get { return _coborrowerStableOtherIncome; } set { _coborrowerStableOtherIncome = value; } }
-        private Value<string> _coborrowerStableOtherIncomeDesc;
+        private DirtyValue<string> _coborrowerStableOtherIncomeDesc;
         public string CoborrowerStableOtherIncomeDesc { get { return _coborrowerStableOtherIncomeDesc; } set { _coborrowerStableOtherIncomeDesc = value; } }
-        private Value<decimal?> _coBorrowerTotalStableIncome;
+        private DirtyValue<decimal?> _coBorrowerTotalStableIncome;
         public decimal? CoBorrowerTotalStableIncome { get { return _coBorrowerTotalStableIncome; } set { _coBorrowerTotalStableIncome = value; } }
-        private Value<DateTime?> _dateConfirmedObligationProcessed;
+        private DirtyValue<DateTime?> _dateConfirmedObligationProcessed;
         public DateTime? DateConfirmedObligationProcessed { get { return _dateConfirmedObligationProcessed; } set { _dateConfirmedObligationProcessed = value; } }
-        private Value<DateTime?> _dateLoanNoteGuaranteeIssued;
+        private DirtyValue<DateTime?> _dateLoanNoteGuaranteeIssued;
         public DateTime? DateLoanNoteGuaranteeIssued { get { return _dateLoanNoteGuaranteeIssued; } set { _dateLoanNoteGuaranteeIssued = value; } }
-        private Value<DateTime?> _dateLoanNoteGuaranteeRequestReceived;
+        private DirtyValue<DateTime?> _dateLoanNoteGuaranteeRequestReceived;
         public DateTime? DateLoanNoteGuaranteeRequestReceived { get { return _dateLoanNoteGuaranteeRequestReceived; } set { _dateLoanNoteGuaranteeRequestReceived = value; } }
-        private Value<DateTime?> _dateObligationInGls;
+        private DirtyValue<DateTime?> _dateObligationInGls;
         public DateTime? DateObligationInGls { get { return _dateObligationInGls; } set { _dateObligationInGls = value; } }
-        private Value<DateTime?> _dateVerifiedInUnifi;
+        private DirtyValue<DateTime?> _dateVerifiedInUnifi;
         public DateTime? DateVerifiedInUnifi { get { return _dateVerifiedInUnifi; } set { _dateVerifiedInUnifi = value; } }
-        private Value<decimal?> _dependentDeduction;
+        private DirtyValue<decimal?> _dependentDeduction;
         public decimal? DependentDeduction { get { return _dependentDeduction; } set { _dependentDeduction = value; } }
-        private Value<decimal?> _disabilityDeduction;
+        private DirtyValue<decimal?> _disabilityDeduction;
         public decimal? DisabilityDeduction { get { return _disabilityDeduction; } set { _disabilityDeduction = value; } }
-        private Value<decimal?> _elderlyHouseholdDeduction;
+        private DirtyValue<decimal?> _elderlyHouseholdDeduction;
         public decimal? ElderlyHouseholdDeduction { get { return _elderlyHouseholdDeduction; } set { _elderlyHouseholdDeduction = value; } }
-        private Value<decimal?> _feeRate;
+        private DirtyValue<decimal?> _feeRate;
         public decimal? FeeRate { get { return _feeRate; } set { _feeRate = value; } }
-        private Value<string> _financedLoanClosingCostDescription;
+        private DirtyValue<string> _financedLoanClosingCostDescription;
         public string FinancedLoanClosingCostDescription { get { return _financedLoanClosingCostDescription; } set { _financedLoanClosingCostDescription = value; } }
-        private Value<decimal?> _guaranteeFeeCollected;
+        private DirtyValue<decimal?> _guaranteeFeeCollected;
         public decimal? GuaranteeFeeCollected { get { return _guaranteeFeeCollected; } set { _guaranteeFeeCollected = value; } }
-        private Value<decimal?> _guaranteeFeeOnCommitment;
+        private DirtyValue<decimal?> _guaranteeFeeOnCommitment;
         public decimal? GuaranteeFeeOnCommitment { get { return _guaranteeFeeOnCommitment; } set { _guaranteeFeeOnCommitment = value; } }
-        private Value<string> _guaranteeFeePurposeCodeType;
+        private DirtyValue<string> _guaranteeFeePurposeCodeType;
         public string GuaranteeFeePurposeCodeType { get { return _guaranteeFeePurposeCodeType; } set { _guaranteeFeePurposeCodeType = value; } }
-        private Value<DateTime?> _guaranteePeriodBeginsDate;
+        private DirtyValue<DateTime?> _guaranteePeriodBeginsDate;
         public DateTime? GuaranteePeriodBeginsDate { get { return _guaranteePeriodBeginsDate; } set { _guaranteePeriodBeginsDate = value; } }
-        private Value<DateTime?> _guaranteePeriodEndsDate;
+        private DirtyValue<DateTime?> _guaranteePeriodEndsDate;
         public DateTime? GuaranteePeriodEndsDate { get { return _guaranteePeriodEndsDate; } set { _guaranteePeriodEndsDate = value; } }
-        private Value<string> _guaranteeType;
+        private DirtyValue<string> _guaranteeType;
         public string GuaranteeType { get { return _guaranteeType; } set { _guaranteeType = value; } }
-        private Value<int?> _householdSize;
+        private DirtyValue<int?> _householdSize;
         public int? HouseholdSize { get { return _householdSize; } set { _householdSize = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _interestAssistanceCodeType;
+        private DirtyValue<string> _interestAssistanceCodeType;
         public string InterestAssistanceCodeType { get { return _interestAssistanceCodeType; } set { _interestAssistanceCodeType = value; } }
-        private Value<bool?> _interestRateBasedonFannieIndicator;
+        private DirtyValue<bool?> _interestRateBasedonFannieIndicator;
         public bool? InterestRateBasedonFannieIndicator { get { return _interestRateBasedonFannieIndicator; } set { _interestRateBasedonFannieIndicator = value; } }
-        private Value<string> _interestRateCodeType;
+        private DirtyValue<string> _interestRateCodeType;
         public string InterestRateCodeType { get { return _interestRateCodeType; } set { _interestRateCodeType = value; } }
-        private Value<bool?> _interestRateFloatToLoanClosingIndicator;
+        private DirtyValue<bool?> _interestRateFloatToLoanClosingIndicator;
         public bool? InterestRateFloatToLoanClosingIndicator { get { return _interestRateFloatToLoanClosingIndicator; } set { _interestRateFloatToLoanClosingIndicator = value; } }
-        private Value<bool?> _lackAdequateHeatIndicator;
+        private DirtyValue<bool?> _lackAdequateHeatIndicator;
         public bool? LackAdequateHeatIndicator { get { return _lackAdequateHeatIndicator; } set { _lackAdequateHeatIndicator = value; } }
-        private Value<string> _lenderAuthorizedRepCompany;
+        private DirtyValue<string> _lenderAuthorizedRepCompany;
         public string LenderAuthorizedRepCompany { get { return _lenderAuthorizedRepCompany; } set { _lenderAuthorizedRepCompany = value; } }
-        private Value<string> _lenderAuthorizedRepName;
+        private DirtyValue<string> _lenderAuthorizedRepName;
         public string LenderAuthorizedRepName { get { return _lenderAuthorizedRepName; } set { _lenderAuthorizedRepName = value; } }
-        private Value<string> _lenderAuthorizedRepTitle;
+        private DirtyValue<string> _lenderAuthorizedRepTitle;
         public string LenderAuthorizedRepTitle { get { return _lenderAuthorizedRepTitle; } set { _lenderAuthorizedRepTitle = value; } }
-        private Value<string> _lenderIdNo;
+        private DirtyValue<string> _lenderIdNo;
         public string LenderIdNo { get { return _lenderIdNo; } set { _lenderIdNo = value; } }
-        private Value<decimal?> _lenderNoteRateOnGuaranteedPortion;
+        private DirtyValue<decimal?> _lenderNoteRateOnGuaranteedPortion;
         public decimal? LenderNoteRateOnGuaranteedPortion { get { return _lenderNoteRateOnGuaranteedPortion; } set { _lenderNoteRateOnGuaranteedPortion = value; } }
-        private Value<decimal?> _lenderNoteRateOnNonGuaranteedPortion;
+        private DirtyValue<decimal?> _lenderNoteRateOnNonGuaranteedPortion;
         public decimal? LenderNoteRateOnNonGuaranteedPortion { get { return _lenderNoteRateOnNonGuaranteedPortion; } set { _lenderNoteRateOnNonGuaranteedPortion = value; } }
-        private Value<string> _lenderStatusCodeType;
+        private DirtyValue<string> _lenderStatusCodeType;
         public string LenderStatusCodeType { get { return _lenderStatusCodeType; } set { _lenderStatusCodeType = value; } }
-        private Value<string> _lenderTypeCode;
+        private DirtyValue<string> _lenderTypeCode;
         public string LenderTypeCode { get { return _lenderTypeCode; } set { _lenderTypeCode = value; } }
-        private Value<string> _loanType;
+        private DirtyValue<string> _loanType;
         public string LoanType { get { return _loanType; } set { _loanType = value; } }
-        private Value<bool?> _lockCompletePlumbingIndicator;
+        private DirtyValue<bool?> _lockCompletePlumbingIndicator;
         public bool? LockCompletePlumbingIndicator { get { return _lockCompletePlumbingIndicator; } set { _lockCompletePlumbingIndicator = value; } }
-        private Value<decimal?> _medicalExpenses;
+        private DirtyValue<decimal?> _medicalExpenses;
         public decimal? MedicalExpenses { get { return _medicalExpenses; } set { _medicalExpenses = value; } }
-        private Value<decimal?> _moderateIncomeLimit;
+        private DirtyValue<decimal?> _moderateIncomeLimit;
         public decimal? ModerateIncomeLimit { get { return _moderateIncomeLimit; } set { _moderateIncomeLimit = value; } }
-        private Value<decimal?> _monthlyRepaymentIncome;
+        private DirtyValue<decimal?> _monthlyRepaymentIncome;
         public decimal? MonthlyRepaymentIncome { get { return _monthlyRepaymentIncome; } set { _monthlyRepaymentIncome = value; } }
-        private Value<int?> _numberofDependents;
+        private DirtyValue<int?> _numberofDependents;
         public int? NumberofDependents { get { return _numberofDependents; } set { _numberofDependents = value; } }
-        private Value<int?> _numberofPeopleInHousehold;
+        private DirtyValue<int?> _numberofPeopleInHousehold;
         public int? NumberofPeopleInHousehold { get { return _numberofPeopleInHousehold; } set { _numberofPeopleInHousehold = value; } }
-        private Value<bool?> _obligationMatchesCommitmentLenderRequestIndicator;
+        private DirtyValue<bool?> _obligationMatchesCommitmentLenderRequestIndicator;
         public bool? ObligationMatchesCommitmentLenderRequestIndicator { get { return _obligationMatchesCommitmentLenderRequestIndicator; } set { _obligationMatchesCommitmentLenderRequestIndicator = value; } }
-        private Value<string> _officialWhoConfirmedGlsUpdated;
+        private DirtyValue<string> _officialWhoConfirmedGlsUpdated;
         public string OfficialWhoConfirmedGlsUpdated { get { return _officialWhoConfirmedGlsUpdated; } set { _officialWhoConfirmedGlsUpdated = value; } }
-        private Value<decimal?> _otherIncome;
+        private DirtyValue<decimal?> _otherIncome;
         public decimal? OtherIncome { get { return _otherIncome; } set { _otherIncome = value; } }
-        private Value<decimal?> _otherStableDependableMonthlyIncome;
+        private DirtyValue<decimal?> _otherStableDependableMonthlyIncome;
         public decimal? OtherStableDependableMonthlyIncome { get { return _otherStableDependableMonthlyIncome; } set { _otherStableDependableMonthlyIncome = value; } }
-        private Value<bool?> _overcrowdedIndicator;
+        private DirtyValue<bool?> _overcrowdedIndicator;
         public bool? OvercrowdedIndicator { get { return _overcrowdedIndicator; } set { _overcrowdedIndicator = value; } }
-        private Value<decimal?> _percentofLoanGuaranteed;
+        private DirtyValue<decimal?> _percentofLoanGuaranteed;
         public decimal? PercentofLoanGuaranteed { get { return _percentofLoanGuaranteed; } set { _percentofLoanGuaranteed = value; } }
-        private Value<string> _periodOperatingLineCreditYearsType;
+        private DirtyValue<string> _periodOperatingLineCreditYearsType;
         public string PeriodOperatingLineCreditYearsType { get { return _periodOperatingLineCreditYearsType; } set { _periodOperatingLineCreditYearsType = value; } }
-        private Value<bool?> _physicallyDeterioratedIndicator;
+        private DirtyValue<bool?> _physicallyDeterioratedIndicator;
         public bool? PhysicallyDeterioratedIndicator { get { return _physicallyDeterioratedIndicator; } set { _physicallyDeterioratedIndicator = value; } }
-        private Value<string> _preparedByName;
+        private DirtyValue<string> _preparedByName;
         public string PreparedByName { get { return _preparedByName; } set { _preparedByName = value; } }
-        private Value<string> _preparedByTitle;
+        private DirtyValue<string> _preparedByTitle;
         public string PreparedByTitle { get { return _preparedByTitle; } set { _preparedByTitle = value; } }
-        private Value<string> _presentLandloardAddress;
+        private DirtyValue<string> _presentLandloardAddress;
         public string PresentLandloardAddress { get { return _presentLandloardAddress; } set { _presentLandloardAddress = value; } }
-        private Value<string> _presentLandloardCity;
+        private DirtyValue<string> _presentLandloardCity;
         public string PresentLandloardCity { get { return _presentLandloardCity; } set { _presentLandloardCity = value; } }
-        private Value<string> _presentLandloardName;
+        private DirtyValue<string> _presentLandloardName;
         public string PresentLandloardName { get { return _presentLandloardName; } set { _presentLandloardName = value; } }
-        private Value<string> _presentLandloardPhone;
+        private DirtyValue<string> _presentLandloardPhone;
         public string PresentLandloardPhone { get { return _presentLandloardPhone; } set { _presentLandloardPhone = value; } }
-        private Value<string> _presentLandloardState;
+        private DirtyValue<string> _presentLandloardState;
         public string PresentLandloardState { get { return _presentLandloardState; } set { _presentLandloardState = value; } }
-        private Value<string> _presentLandloardZip;
+        private DirtyValue<string> _presentLandloardZip;
         public string PresentLandloardZip { get { return _presentLandloardZip; } set { _presentLandloardZip = value; } }
-        private Value<string> _previousLandloardAddress;
+        private DirtyValue<string> _previousLandloardAddress;
         public string PreviousLandloardAddress { get { return _previousLandloardAddress; } set { _previousLandloardAddress = value; } }
-        private Value<string> _previousLandloardCity;
+        private DirtyValue<string> _previousLandloardCity;
         public string PreviousLandloardCity { get { return _previousLandloardCity; } set { _previousLandloardCity = value; } }
-        private Value<string> _previousLandloardName;
+        private DirtyValue<string> _previousLandloardName;
         public string PreviousLandloardName { get { return _previousLandloardName; } set { _previousLandloardName = value; } }
-        private Value<string> _previousLandloardPhone;
+        private DirtyValue<string> _previousLandloardPhone;
         public string PreviousLandloardPhone { get { return _previousLandloardPhone; } set { _previousLandloardPhone = value; } }
-        private Value<string> _previousLandloardState;
+        private DirtyValue<string> _previousLandloardState;
         public string PreviousLandloardState { get { return _previousLandloardState; } set { _previousLandloardState = value; } }
-        private Value<string> _previousLandloardZip;
+        private DirtyValue<string> _previousLandloardZip;
         public string PreviousLandloardZip { get { return _previousLandloardZip; } set { _previousLandloardZip = value; } }
-        private Value<decimal?> _purchaseOrRefinancedAmount;
+        private DirtyValue<decimal?> _purchaseOrRefinancedAmount;
         public decimal? PurchaseOrRefinancedAmount { get { return _purchaseOrRefinancedAmount; } set { _purchaseOrRefinancedAmount = value; } }
-        private Value<string> _purchaseOrRefinanceDescription;
+        private DirtyValue<string> _purchaseOrRefinanceDescription;
         public string PurchaseOrRefinanceDescription { get { return _purchaseOrRefinanceDescription; } set { _purchaseOrRefinanceDescription = value; } }
-        private Value<string> _rdsfhRefinancedLoanIndicatorType;
+        private DirtyValue<string> _rdsfhRefinancedLoanIndicatorType;
         public string RdsfhRefinancedLoanIndicatorType { get { return _rdsfhRefinancedLoanIndicatorType; } set { _rdsfhRefinancedLoanIndicatorType = value; } }
-        private Value<bool?> _refinanceLoanIndicator;
+        private DirtyValue<bool?> _refinanceLoanIndicator;
         public bool? RefinanceLoanIndicator { get { return _refinanceLoanIndicator; } set { _refinanceLoanIndicator = value; } }
-        private Value<decimal?> _repairOtherAmount;
+        private DirtyValue<decimal?> _repairOtherAmount;
         public decimal? RepairOtherAmount { get { return _repairOtherAmount; } set { _repairOtherAmount = value; } }
-        private Value<string> _repairOtherDescription;
+        private DirtyValue<string> _repairOtherDescription;
         public string RepairOtherDescription { get { return _repairOtherDescription; } set { _repairOtherDescription = value; } }
-        private Value<decimal?> _reservationAmountRequested;
+        private DirtyValue<decimal?> _reservationAmountRequested;
         public decimal? ReservationAmountRequested { get { return _reservationAmountRequested; } set { _reservationAmountRequested = value; } }
-        private Value<string> _reserved;
+        private DirtyValue<string> _reserved;
         public string Reserved { get { return _reserved; } set { _reserved = value; } }
-        private Value<string> _servicingOfficeName;
+        private DirtyValue<string> _servicingOfficeName;
         public string ServicingOfficeName { get { return _servicingOfficeName; } set { _servicingOfficeName = value; } }
-        private Value<bool?> _sfhglpIndicator;
+        private DirtyValue<bool?> _sfhglpIndicator;
         public bool? SfhglpIndicator { get { return _sfhglpIndicator; } set { _sfhglpIndicator = value; } }
-        private Value<string> _sourceOfFundsType;
+        private DirtyValue<string> _sourceOfFundsType;
         public string SourceOfFundsType { get { return _sourceOfFundsType; } set { _sourceOfFundsType = value; } }
-        private Value<decimal?> _stableDependableMonthlyIncome;
+        private DirtyValue<decimal?> _stableDependableMonthlyIncome;
         public decimal? StableDependableMonthlyIncome { get { return _stableDependableMonthlyIncome; } set { _stableDependableMonthlyIncome = value; } }
-        private Value<string> _stableOtherIncomeDesc;
+        private DirtyValue<string> _stableOtherIncomeDesc;
         public string StableOtherIncomeDesc { get { return _stableOtherIncomeDesc; } set { _stableOtherIncomeDesc = value; } }
-        private Value<string> _submittingLenderAddress;
+        private DirtyValue<string> _submittingLenderAddress;
         public string SubmittingLenderAddress { get { return _submittingLenderAddress; } set { _submittingLenderAddress = value; } }
-        private Value<string> _submittingLenderCity;
+        private DirtyValue<string> _submittingLenderCity;
         public string SubmittingLenderCity { get { return _submittingLenderCity; } set { _submittingLenderCity = value; } }
-        private Value<string> _submittingLenderContactFax;
+        private DirtyValue<string> _submittingLenderContactFax;
         public string SubmittingLenderContactFax { get { return _submittingLenderContactFax; } set { _submittingLenderContactFax = value; } }
-        private Value<string> _submittingLenderContactName;
+        private DirtyValue<string> _submittingLenderContactName;
         public string SubmittingLenderContactName { get { return _submittingLenderContactName; } set { _submittingLenderContactName = value; } }
-        private Value<string> _submittingLenderContactPhone;
+        private DirtyValue<string> _submittingLenderContactPhone;
         public string SubmittingLenderContactPhone { get { return _submittingLenderContactPhone; } set { _submittingLenderContactPhone = value; } }
-        private Value<string> _submittingLenderName;
+        private DirtyValue<string> _submittingLenderName;
         public string SubmittingLenderName { get { return _submittingLenderName; } set { _submittingLenderName = value; } }
-        private Value<string> _submittingLenderState;
+        private DirtyValue<string> _submittingLenderState;
         public string SubmittingLenderState { get { return _submittingLenderState; } set { _submittingLenderState = value; } }
-        private Value<string> _submittingLenderTaxId;
+        private DirtyValue<string> _submittingLenderTaxId;
         public string SubmittingLenderTaxId { get { return _submittingLenderTaxId; } set { _submittingLenderTaxId = value; } }
-        private Value<string> _submittingLenderZip;
+        private DirtyValue<string> _submittingLenderZip;
         public string SubmittingLenderZip { get { return _submittingLenderZip; } set { _submittingLenderZip = value; } }
-        private Value<int?> _termOfBuydown;
+        private DirtyValue<int?> _termOfBuydown;
         public int? TermOfBuydown { get { return _termOfBuydown; } set { _termOfBuydown = value; } }
-        private Value<string> _thirdPartyOriginator;
+        private DirtyValue<string> _thirdPartyOriginator;
         public string ThirdPartyOriginator { get { return _thirdPartyOriginator; } set { _thirdPartyOriginator = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<decimal?> _totalBorrowerStableBaseIncome;
+        private DirtyValue<decimal?> _totalBorrowerStableBaseIncome;
         public decimal? TotalBorrowerStableBaseIncome { get { return _totalBorrowerStableBaseIncome; } set { _totalBorrowerStableBaseIncome = value; } }
-        private Value<decimal?> _totalBorrowerStableOtherIncome;
+        private DirtyValue<decimal?> _totalBorrowerStableOtherIncome;
         public decimal? TotalBorrowerStableOtherIncome { get { return _totalBorrowerStableOtherIncome; } set { _totalBorrowerStableOtherIncome = value; } }
-        private Value<decimal?> _totalHouseholdDeduction;
+        private DirtyValue<decimal?> _totalHouseholdDeduction;
         public decimal? TotalHouseholdDeduction { get { return _totalHouseholdDeduction; } set { _totalHouseholdDeduction = value; } }
-        private Value<decimal?> _totalRequestAmount;
+        private DirtyValue<decimal?> _totalRequestAmount;
         public decimal? TotalRequestAmount { get { return _totalRequestAmount; } set { _totalRequestAmount = value; } }
-        private Value<string> _tpoTaxId;
+        private DirtyValue<string> _tpoTaxId;
         public string TpoTaxId { get { return _tpoTaxId; } set { _tpoTaxId = value; } }
-        private Value<string> _underwritingDecisionBy;
+        private DirtyValue<string> _underwritingDecisionBy;
         public string UnderwritingDecisionBy { get { return _underwritingDecisionBy; } set { _underwritingDecisionBy = value; } }
-        private Value<DateTime?> _underwritingDecisionDate;
+        private DirtyValue<DateTime?> _underwritingDecisionDate;
         public DateTime? UnderwritingDecisionDate { get { return _underwritingDecisionDate; } set { _underwritingDecisionDate = value; } }
-        private Value<string> _underwritingDecisionType;
+        private DirtyValue<string> _underwritingDecisionType;
         public string UnderwritingDecisionType { get { return _underwritingDecisionType; } set { _underwritingDecisionType = value; } }
         private DirtyList<UsdaHouseholdIncome> _usdaHouseholdIncomes;
         public IList<UsdaHouseholdIncome> UsdaHouseholdIncomes { get { var v = _usdaHouseholdIncomes; return v ?? Interlocked.CompareExchange(ref _usdaHouseholdIncomes, (v = new DirtyList<UsdaHouseholdIncome>()), null) ?? v; } set { _usdaHouseholdIncomes = new DirtyList<UsdaHouseholdIncome>(value); } }
-        private Value<string> _verificationCode;
+        private DirtyValue<string> _verificationCode;
         public string VerificationCode { get { return _verificationCode; } set { _verificationCode = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/Usda.cs
+++ b/src/EncompassRest/Loans/Usda.cs
@@ -282,8 +282,8 @@ namespace EncompassRest.Loans
         public DateTime? UnderwritingDecisionDate { get { return _underwritingDecisionDate; } set { _underwritingDecisionDate = value; } }
         private Value<string> _underwritingDecisionType;
         public string UnderwritingDecisionType { get { return _underwritingDecisionType; } set { _underwritingDecisionType = value; } }
-        private Value<List<UsdaHouseholdIncome>> _usdaHouseholdIncomes;
-        public List<UsdaHouseholdIncome> UsdaHouseholdIncomes { get { return _usdaHouseholdIncomes; } set { _usdaHouseholdIncomes = value; } }
+        private DirtyList<UsdaHouseholdIncome> _usdaHouseholdIncomes;
+        public IList<UsdaHouseholdIncome> UsdaHouseholdIncomes { get { var v = _usdaHouseholdIncomes; return v ?? Interlocked.CompareExchange(ref _usdaHouseholdIncomes, (v = new DirtyList<UsdaHouseholdIncome>()), null) ?? v; } set { _usdaHouseholdIncomes = new DirtyList<UsdaHouseholdIncome>(value); } }
         private Value<string> _verificationCode;
         public string VerificationCode { get { return _verificationCode; } set { _verificationCode = value; } }
         private int _gettingDirty;
@@ -430,8 +430,8 @@ namespace EncompassRest.Loans
                     || _underwritingDecisionBy.Dirty
                     || _underwritingDecisionDate.Dirty
                     || _underwritingDecisionType.Dirty
-                    || _usdaHouseholdIncomes.Dirty
-                    || _verificationCode.Dirty;
+                    || _verificationCode.Dirty
+                    || _usdaHouseholdIncomes?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -575,8 +575,8 @@ namespace EncompassRest.Loans
                 _underwritingDecisionBy.Dirty = value;
                 _underwritingDecisionDate.Dirty = value;
                 _underwritingDecisionType.Dirty = value;
-                _usdaHouseholdIncomes.Dirty = value;
                 _verificationCode.Dirty = value;
+                if (_usdaHouseholdIncomes != null) _usdaHouseholdIncomes.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/UsdaHouseholdIncome.cs
+++ b/src/EncompassRest/Loans/UsdaHouseholdIncome.cs
@@ -8,29 +8,29 @@ namespace EncompassRest.Loans
 {
     public sealed partial class UsdaHouseholdIncome : IDirty
     {
-        private Value<int?> _age;
+        private DirtyValue<int?> _age;
         public int? Age { get { return _age; } set { _age = value; } }
-        private Value<string> _analysisDocumenting;
+        private DirtyValue<string> _analysisDocumenting;
         public string AnalysisDocumenting { get { return _analysisDocumenting; } set { _analysisDocumenting = value; } }
-        private Value<decimal?> _annualNonWageIncome;
+        private DirtyValue<decimal?> _annualNonWageIncome;
         public decimal? AnnualNonWageIncome { get { return _annualNonWageIncome; } set { _annualNonWageIncome = value; } }
-        private Value<decimal?> _annualWageIncome;
+        private DirtyValue<decimal?> _annualWageIncome;
         public decimal? AnnualWageIncome { get { return _annualWageIncome; } set { _annualWageIncome = value; } }
-        private Value<bool?> _disabledIndicator;
+        private DirtyValue<bool?> _disabledIndicator;
         public bool? DisabledIndicator { get { return _disabledIndicator; } set { _disabledIndicator = value; } }
-        private Value<bool?> _fullTimeStudentIndicator;
+        private DirtyValue<bool?> _fullTimeStudentIndicator;
         public bool? FullTimeStudentIndicator { get { return _fullTimeStudentIndicator; } set { _fullTimeStudentIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<string> _name;
+        private DirtyValue<string> _name;
         public string Name { get { return _name; } set { _name = value; } }
-        private Value<string> _recordOwnerType;
+        private DirtyValue<string> _recordOwnerType;
         public string RecordOwnerType { get { return _recordOwnerType; } set { _recordOwnerType = value; } }
-        private Value<string> _sourceofNonWageIncomeDescription;
+        private DirtyValue<string> _sourceofNonWageIncomeDescription;
         public string SourceofNonWageIncomeDescription { get { return _sourceofNonWageIncomeDescription; } set { _sourceofNonWageIncomeDescription = value; } }
-        private Value<string> _sourceofWageIncomeEmployerName;
+        private DirtyValue<string> _sourceofWageIncomeEmployerName;
         public string SourceofWageIncomeEmployerName { get { return _sourceofWageIncomeEmployerName; } set { _sourceofWageIncomeEmployerName = value; } }
-        private Value<int?> _usdaHouseholdIncomeIndex;
+        private DirtyValue<int?> _usdaHouseholdIncomeIndex;
         public int? UsdaHouseholdIncomeIndex { get { return _usdaHouseholdIncomeIndex; } set { _usdaHouseholdIncomeIndex = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/VaLoanData.cs
+++ b/src/EncompassRest/Loans/VaLoanData.cs
@@ -210,8 +210,8 @@ namespace EncompassRest.Loans
         public string MCRVNumber { get { return _mCRVNumber; } set { _mCRVNumber = value; } }
         private Value<string> _militaryBranchOfService;
         public string MilitaryBranchOfService { get { return _militaryBranchOfService; } set { _militaryBranchOfService = value; } }
-        private Value<List<MilitaryService>> _militaryServices;
-        public List<MilitaryService> MilitaryServices { get { return _militaryServices; } set { _militaryServices = value; } }
+        private DirtyList<MilitaryService> _militaryServices;
+        public IList<MilitaryService> MilitaryServices { get { var v = _militaryServices; return v ?? Interlocked.CompareExchange(ref _militaryServices, (v = new DirtyList<MilitaryService>()), null) ?? v; } set { _militaryServices = new DirtyList<MilitaryService>(value); } }
         private Value<string> _mineralRightsReserved;
         public string MineralRightsReserved { get { return _mineralRightsReserved; } set { _mineralRightsReserved = value; } }
         private Value<string> _nameOfOccupant;
@@ -298,8 +298,8 @@ namespace EncompassRest.Loans
         public decimal? PreliminaryTotal { get { return _preliminaryTotal; } set { _preliminaryTotal = value; } }
         private Value<bool?> _previousVALoanIndicator;
         public bool? PreviousVALoanIndicator { get { return _previousVALoanIndicator; } set { _previousVALoanIndicator = value; } }
-        private Value<List<PreviousVaLoan>> _previousVaLoans;
-        public List<PreviousVaLoan> PreviousVaLoans { get { return _previousVaLoans; } set { _previousVaLoans = value; } }
+        private DirtyList<PreviousVaLoan> _previousVaLoans;
+        public IList<PreviousVaLoan> PreviousVaLoans { get { var v = _previousVaLoans; return v ?? Interlocked.CompareExchange(ref _previousVaLoans, (v = new DirtyList<PreviousVaLoan>()), null) ?? v; } set { _previousVaLoans = new DirtyList<PreviousVaLoan>(value); } }
         private Value<bool?> _priorApprovalProcedure;
         public bool? PriorApprovalProcedure { get { return _priorApprovalProcedure; } set { _priorApprovalProcedure = value; } }
         private Value<string> _priorLoanType;
@@ -612,7 +612,6 @@ namespace EncompassRest.Loans
                     || _manufacturedHome.Dirty
                     || _mCRVNumber.Dirty
                     || _militaryBranchOfService.Dirty
-                    || _militaryServices.Dirty
                     || _mineralRightsReserved.Dirty
                     || _nameOfOccupant.Dirty
                     || _nameOfOwner.Dirty
@@ -656,7 +655,6 @@ namespace EncompassRest.Loans
                     || _preliminaryFundingFeeAmount.Dirty
                     || _preliminaryTotal.Dirty
                     || _previousVALoanIndicator.Dirty
-                    || _previousVaLoans.Dirty
                     || _priorApprovalProcedure.Dirty
                     || _priorLoanType.Dirty
                     || _propertyDesignation.Dirty
@@ -758,7 +756,9 @@ namespace EncompassRest.Loans
                     || _warrantorPostalCode.Dirty
                     || _warrantorState.Dirty
                     || _warrantyProgramExpirationDate.Dirty
-                    || _wWCarpetIndicator.Dirty;
+                    || _wWCarpetIndicator.Dirty
+                    || _militaryServices?.Dirty == true
+                    || _previousVaLoans?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -866,7 +866,6 @@ namespace EncompassRest.Loans
                 _manufacturedHome.Dirty = value;
                 _mCRVNumber.Dirty = value;
                 _militaryBranchOfService.Dirty = value;
-                _militaryServices.Dirty = value;
                 _mineralRightsReserved.Dirty = value;
                 _nameOfOccupant.Dirty = value;
                 _nameOfOwner.Dirty = value;
@@ -910,7 +909,6 @@ namespace EncompassRest.Loans
                 _preliminaryFundingFeeAmount.Dirty = value;
                 _preliminaryTotal.Dirty = value;
                 _previousVALoanIndicator.Dirty = value;
-                _previousVaLoans.Dirty = value;
                 _priorApprovalProcedure.Dirty = value;
                 _priorLoanType.Dirty = value;
                 _propertyDesignation.Dirty = value;
@@ -1013,6 +1011,8 @@ namespace EncompassRest.Loans
                 _warrantorState.Dirty = value;
                 _warrantyProgramExpirationDate.Dirty = value;
                 _wWCarpetIndicator.Dirty = value;
+                if (_militaryServices != null) _militaryServices.Dirty = value;
+                if (_previousVaLoans != null) _previousVaLoans.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Loans/VaLoanData.cs
+++ b/src/EncompassRest/Loans/VaLoanData.cs
@@ -8,501 +8,501 @@ namespace EncompassRest.Loans
 {
     public sealed partial class VaLoanData : IDirty
     {
-        private Value<decimal?> _acres;
+        private DirtyValue<decimal?> _acres;
         public decimal? Acres { get { return _acres; } set { _acres = value; } }
-        private Value<string> _additionalSecurityDescription;
+        private DirtyValue<string> _additionalSecurityDescription;
         public string AdditionalSecurityDescription { get { return _additionalSecurityDescription; } set { _additionalSecurityDescription = value; } }
-        private Value<string> _administratorAddress;
+        private DirtyValue<string> _administratorAddress;
         public string AdministratorAddress { get { return _administratorAddress; } set { _administratorAddress = value; } }
-        private Value<string> _administratorCity;
+        private DirtyValue<string> _administratorCity;
         public string AdministratorCity { get { return _administratorCity; } set { _administratorCity = value; } }
-        private Value<string> _administratorContact;
+        private DirtyValue<string> _administratorContact;
         public string AdministratorContact { get { return _administratorContact; } set { _administratorContact = value; } }
-        private Value<string> _administratorName;
+        private DirtyValue<string> _administratorName;
         public string AdministratorName { get { return _administratorName; } set { _administratorName = value; } }
-        private Value<string> _administratorPostalCode;
+        private DirtyValue<string> _administratorPostalCode;
         public string AdministratorPostalCode { get { return _administratorPostalCode; } set { _administratorPostalCode = value; } }
-        private Value<string> _administratorState;
+        private DirtyValue<string> _administratorState;
         public string AdministratorState { get { return _administratorState; } set { _administratorState = value; } }
-        private Value<int?> _ageOfProperty;
+        private DirtyValue<int?> _ageOfProperty;
         public int? AgeOfProperty { get { return _ageOfProperty; } set { _ageOfProperty = value; } }
-        private Value<decimal?> _amountSpentOnEnergyImprovements;
+        private DirtyValue<decimal?> _amountSpentOnEnergyImprovements;
         public decimal? AmountSpentOnEnergyImprovements { get { return _amountSpentOnEnergyImprovements; } set { _amountSpentOnEnergyImprovements = value; } }
-        private Value<string> _amountTypeWithheld;
+        private DirtyValue<string> _amountTypeWithheld;
         public string AmountTypeWithheld { get { return _amountTypeWithheld; } set { _amountTypeWithheld = value; } }
-        private Value<decimal?> _amountWithheld;
+        private DirtyValue<decimal?> _amountWithheld;
         public decimal? AmountWithheld { get { return _amountWithheld; } set { _amountWithheld = value; } }
-        private Value<decimal?> _annualGroundRent;
+        private DirtyValue<decimal?> _annualGroundRent;
         public decimal? AnnualGroundRent { get { return _annualGroundRent; } set { _annualGroundRent = value; } }
-        private Value<decimal?> _annualMaintenanceAssessment;
+        private DirtyValue<decimal?> _annualMaintenanceAssessment;
         public decimal? AnnualMaintenanceAssessment { get { return _annualMaintenanceAssessment; } set { _annualMaintenanceAssessment = value; } }
-        private Value<decimal?> _annualRealEstateTaxes;
+        private DirtyValue<decimal?> _annualRealEstateTaxes;
         public decimal? AnnualRealEstateTaxes { get { return _annualRealEstateTaxes; } set { _annualRealEstateTaxes = value; } }
-        private Value<decimal?> _annualSpecialAssessment;
+        private DirtyValue<decimal?> _annualSpecialAssessment;
         public decimal? AnnualSpecialAssessment { get { return _annualSpecialAssessment; } set { _annualSpecialAssessment = value; } }
-        private Value<string> _applicantAddressCity;
+        private DirtyValue<string> _applicantAddressCity;
         public string ApplicantAddressCity { get { return _applicantAddressCity; } set { _applicantAddressCity = value; } }
-        private Value<string> _applicantAddressPostalCode;
+        private DirtyValue<string> _applicantAddressPostalCode;
         public string ApplicantAddressPostalCode { get { return _applicantAddressPostalCode; } set { _applicantAddressPostalCode = value; } }
-        private Value<string> _applicantAddressState;
+        private DirtyValue<string> _applicantAddressState;
         public string ApplicantAddressState { get { return _applicantAddressState; } set { _applicantAddressState = value; } }
-        private Value<string> _applicantAddressStreetLine1;
+        private DirtyValue<string> _applicantAddressStreetLine1;
         public string ApplicantAddressStreetLine1 { get { return _applicantAddressStreetLine1; } set { _applicantAddressStreetLine1 = value; } }
-        private Value<DateTime?> _applicantBirthDate;
+        private DirtyValue<DateTime?> _applicantBirthDate;
         public DateTime? ApplicantBirthDate { get { return _applicantBirthDate; } set { _applicantBirthDate = value; } }
-        private Value<string> _applicantEmailAddressText;
+        private DirtyValue<string> _applicantEmailAddressText;
         public string ApplicantEmailAddressText { get { return _applicantEmailAddressText; } set { _applicantEmailAddressText = value; } }
-        private Value<string> _applicantFirstNameWithMiddleName;
+        private DirtyValue<string> _applicantFirstNameWithMiddleName;
         public string ApplicantFirstNameWithMiddleName { get { return _applicantFirstNameWithMiddleName; } set { _applicantFirstNameWithMiddleName = value; } }
-        private Value<string> _applicantHmdaGenderType;
+        private DirtyValue<string> _applicantHmdaGenderType;
         public string ApplicantHmdaGenderType { get { return _applicantHmdaGenderType; } set { _applicantHmdaGenderType = value; } }
-        private Value<string> _applicantHomePhoneNumber;
+        private DirtyValue<string> _applicantHomePhoneNumber;
         public string ApplicantHomePhoneNumber { get { return _applicantHomePhoneNumber; } set { _applicantHomePhoneNumber = value; } }
-        private Value<string> _applicantLastNameWithSuffix;
+        private DirtyValue<string> _applicantLastNameWithSuffix;
         public string ApplicantLastNameWithSuffix { get { return _applicantLastNameWithSuffix; } set { _applicantLastNameWithSuffix = value; } }
-        private Value<string> _applicantTaxIdentificationIdentifier;
+        private DirtyValue<string> _applicantTaxIdentificationIdentifier;
         public string ApplicantTaxIdentificationIdentifier { get { return _applicantTaxIdentificationIdentifier; } set { _applicantTaxIdentificationIdentifier = value; } }
-        private Value<string> _appraisalType;
+        private DirtyValue<string> _appraisalType;
         public string AppraisalType { get { return _appraisalType; } set { _appraisalType = value; } }
-        private Value<bool?> _automaticProcedure;
+        private DirtyValue<bool?> _automaticProcedure;
         public bool? AutomaticProcedure { get { return _automaticProcedure; } set { _automaticProcedure = value; } }
-        private Value<bool?> _availableForInspectionAMIndicator;
+        private DirtyValue<bool?> _availableForInspectionAMIndicator;
         public bool? AvailableForInspectionAMIndicator { get { return _availableForInspectionAMIndicator; } set { _availableForInspectionAMIndicator = value; } }
-        private Value<string> _availableForInspectionDateAndTime;
+        private DirtyValue<string> _availableForInspectionDateAndTime;
         public string AvailableForInspectionDateAndTime { get { return _availableForInspectionDateAndTime; } set { _availableForInspectionDateAndTime = value; } }
-        private Value<decimal?> _borrowerPaidDiscountPointsTotalAmount;
+        private DirtyValue<decimal?> _borrowerPaidDiscountPointsTotalAmount;
         public decimal? BorrowerPaidDiscountPointsTotalAmount { get { return _borrowerPaidDiscountPointsTotalAmount; } set { _borrowerPaidDiscountPointsTotalAmount = value; } }
-        private Value<string> _buildingType;
+        private DirtyValue<string> _buildingType;
         public string BuildingType { get { return _buildingType; } set { _buildingType = value; } }
-        private Value<bool?> _buyerPurchasingLotSeparately;
+        private DirtyValue<bool?> _buyerPurchasingLotSeparately;
         public bool? BuyerPurchasingLotSeparately { get { return _buyerPurchasingLotSeparately; } set { _buyerPurchasingLotSeparately = value; } }
-        private Value<decimal?> _cashPaymentFromVeteran;
+        private DirtyValue<decimal?> _cashPaymentFromVeteran;
         public decimal? CashPaymentFromVeteran { get { return _cashPaymentFromVeteran; } set { _cashPaymentFromVeteran = value; } }
-        private Value<string> _claimDisabilityBenefits;
+        private DirtyValue<string> _claimDisabilityBenefits;
         public string ClaimDisabilityBenefits { get { return _claimDisabilityBenefits; } set { _claimDisabilityBenefits = value; } }
-        private Value<bool?> _clothesWasherIndicator;
+        private DirtyValue<bool?> _clothesWasherIndicator;
         public bool? ClothesWasherIndicator { get { return _clothesWasherIndicator; } set { _clothesWasherIndicator = value; } }
-        private Value<DateTime?> _constructionCompletedDate;
+        private DirtyValue<DateTime?> _constructionCompletedDate;
         public DateTime? ConstructionCompletedDate { get { return _constructionCompletedDate; } set { _constructionCompletedDate = value; } }
-        private Value<string> _constructionPlan;
+        private DirtyValue<string> _constructionPlan;
         public string ConstructionPlan { get { return _constructionPlan; } set { _constructionPlan = value; } }
-        private Value<bool?> _constructionWarrantyIncluded;
+        private DirtyValue<bool?> _constructionWarrantyIncluded;
         public bool? ConstructionWarrantyIncluded { get { return _constructionWarrantyIncluded; } set { _constructionWarrantyIncluded = value; } }
-        private Value<string> _contractNoApprovedByVA;
+        private DirtyValue<string> _contractNoApprovedByVA;
         public string ContractNoApprovedByVA { get { return _contractNoApprovedByVA; } set { _contractNoApprovedByVA = value; } }
-        private Value<int?> _creditScore;
+        private DirtyValue<int?> _creditScore;
         public int? CreditScore { get { return _creditScore; } set { _creditScore = value; } }
-        private Value<bool?> _currentlyOnMilitaryDuty;
+        private DirtyValue<bool?> _currentlyOnMilitaryDuty;
         public bool? CurrentlyOnMilitaryDuty { get { return _currentlyOnMilitaryDuty; } set { _currentlyOnMilitaryDuty = value; } }
-        private Value<DateTime?> _dateAquiredLand;
+        private DirtyValue<DateTime?> _dateAquiredLand;
         public DateTime? DateAquiredLand { get { return _dateAquiredLand; } set { _dateAquiredLand = value; } }
-        private Value<DateTime?> _dateOfAssignment;
+        private DirtyValue<DateTime?> _dateOfAssignment;
         public DateTime? DateOfAssignment { get { return _dateOfAssignment; } set { _dateOfAssignment = value; } }
-        private Value<DateTime?> _dateSAR;
+        private DirtyValue<DateTime?> _dateSAR;
         public DateTime? DateSAR { get { return _dateSAR; } set { _dateSAR = value; } }
-        private Value<decimal?> _disabilityAmountCollected;
+        private DirtyValue<decimal?> _disabilityAmountCollected;
         public decimal? DisabilityAmountCollected { get { return _disabilityAmountCollected; } set { _disabilityAmountCollected = value; } }
-        private Value<decimal?> _discountPercentage;
+        private DirtyValue<decimal?> _discountPercentage;
         public decimal? DiscountPercentage { get { return _discountPercentage; } set { _discountPercentage = value; } }
-        private Value<decimal?> _discountPoint;
+        private DirtyValue<decimal?> _discountPoint;
         public decimal? DiscountPoint { get { return _discountPoint; } set { _discountPoint = value; } }
-        private Value<bool?> _dishwasherIndicator;
+        private DirtyValue<bool?> _dishwasherIndicator;
         public bool? DishwasherIndicator { get { return _dishwasherIndicator; } set { _dishwasherIndicator = value; } }
-        private Value<bool?> _dryerIndicator;
+        private DirtyValue<bool?> _dryerIndicator;
         public bool? DryerIndicator { get { return _dryerIndicator; } set { _dryerIndicator = value; } }
-        private Value<string> _emailToBeNotifiedWhenUploaded;
+        private DirtyValue<string> _emailToBeNotifiedWhenUploaded;
         public string EmailToBeNotifiedWhenUploaded { get { return _emailToBeNotifiedWhenUploaded; } set { _emailToBeNotifiedWhenUploaded = value; } }
-        private Value<bool?> _energyImprovementsAdditionOfFeature;
+        private DirtyValue<bool?> _energyImprovementsAdditionOfFeature;
         public bool? EnergyImprovementsAdditionOfFeature { get { return _energyImprovementsAdditionOfFeature; } set { _energyImprovementsAdditionOfFeature = value; } }
-        private Value<string> _entitlementCode;
+        private DirtyValue<string> _entitlementCode;
         public string EntitlementCode { get { return _entitlementCode; } set { _entitlementCode = value; } }
-        private Value<string> _equipmentOtherDescription;
+        private DirtyValue<string> _equipmentOtherDescription;
         public string EquipmentOtherDescription { get { return _equipmentOtherDescription; } set { _equipmentOtherDescription = value; } }
-        private Value<bool?> _excludeTaxesInsuranceIndicator;
+        private DirtyValue<bool?> _excludeTaxesInsuranceIndicator;
         public bool? ExcludeTaxesInsuranceIndicator { get { return _excludeTaxesInsuranceIndicator; } set { _excludeTaxesInsuranceIndicator = value; } }
-        private Value<decimal?> _finalDiscountAmount;
+        private DirtyValue<decimal?> _finalDiscountAmount;
         public decimal? FinalDiscountAmount { get { return _finalDiscountAmount; } set { _finalDiscountAmount = value; } }
-        private Value<decimal?> _finalFundingFeeAmount;
+        private DirtyValue<decimal?> _finalFundingFeeAmount;
         public decimal? FinalFundingFeeAmount { get { return _finalFundingFeeAmount; } set { _finalFundingFeeAmount = value; } }
-        private Value<bool?> _firstChattelLoanType;
+        private DirtyValue<bool?> _firstChattelLoanType;
         public bool? FirstChattelLoanType { get { return _firstChattelLoanType; } set { _firstChattelLoanType = value; } }
-        private Value<bool?> _firstTimeUse;
+        private DirtyValue<bool?> _firstTimeUse;
         public bool? FirstTimeUse { get { return _firstTimeUse; } set { _firstTimeUse = value; } }
-        private Value<bool?> _fundingFeeExempt;
+        private DirtyValue<bool?> _fundingFeeExempt;
         public bool? FundingFeeExempt { get { return _fundingFeeExempt; } set { _fundingFeeExempt = value; } }
-        private Value<bool?> _garbageDisposalIndicator;
+        private DirtyValue<bool?> _garbageDisposalIndicator;
         public bool? GarbageDisposalIndicator { get { return _garbageDisposalIndicator; } set { _garbageDisposalIndicator = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<decimal?> _initialTotal;
+        private DirtyValue<decimal?> _initialTotal;
         public decimal? InitialTotal { get { return _initialTotal; } set { _initialTotal = value; } }
-        private Value<string> _inspectionWillBeMadeBy;
+        private DirtyValue<string> _inspectionWillBeMadeBy;
         public string InspectionWillBeMadeBy { get { return _inspectionWillBeMadeBy; } set { _inspectionWillBeMadeBy = value; } }
-        private Value<bool?> _insulation;
+        private DirtyValue<bool?> _insulation;
         public bool? Insulation { get { return _insulation; } set { _insulation = value; } }
-        private Value<string> _insuranceType;
+        private DirtyValue<string> _insuranceType;
         public string InsuranceType { get { return _insuranceType; } set { _insuranceType = value; } }
-        private Value<int?> _irregularLotSizeInSquareFeet;
+        private DirtyValue<int?> _irregularLotSizeInSquareFeet;
         public int? IrregularLotSizeInSquareFeet { get { return _irregularLotSizeInSquareFeet; } set { _irregularLotSizeInSquareFeet = value; } }
-        private Value<bool?> _isDelinquent30Days;
+        private DirtyValue<bool?> _isDelinquent30Days;
         public bool? IsDelinquent30Days { get { return _isDelinquent30Days; } set { _isDelinquent30Days = value; } }
-        private Value<string> _keysAtAddress;
+        private DirtyValue<string> _keysAtAddress;
         public string KeysAtAddress { get { return _keysAtAddress; } set { _keysAtAddress = value; } }
-        private Value<decimal?> _landPurchasePrice;
+        private DirtyValue<decimal?> _landPurchasePrice;
         public decimal? LandPurchasePrice { get { return _landPurchasePrice; } set { _landPurchasePrice = value; } }
-        private Value<string> _leaseholdType;
+        private DirtyValue<string> _leaseholdType;
         public string LeaseholdType { get { return _leaseholdType; } set { _leaseholdType = value; } }
-        private Value<string> _lenderSAR;
+        private DirtyValue<string> _lenderSAR;
         public string LenderSAR { get { return _lenderSAR; } set { _lenderSAR = value; } }
-        private Value<string> _loanAnalysisRemarks1;
+        private DirtyValue<string> _loanAnalysisRemarks1;
         public string LoanAnalysisRemarks1 { get { return _loanAnalysisRemarks1; } set { _loanAnalysisRemarks1 = value; } }
-        private Value<string> _loanAnalysisRemarks2;
+        private DirtyValue<string> _loanAnalysisRemarks2;
         public string LoanAnalysisRemarks2 { get { return _loanAnalysisRemarks2; } set { _loanAnalysisRemarks2 = value; } }
-        private Value<string> _loanAnalysisRemarks3;
+        private DirtyValue<string> _loanAnalysisRemarks3;
         public string LoanAnalysisRemarks3 { get { return _loanAnalysisRemarks3; } set { _loanAnalysisRemarks3 = value; } }
-        private Value<string> _loanAnalysisRemarks4;
+        private DirtyValue<string> _loanAnalysisRemarks4;
         public string LoanAnalysisRemarks4 { get { return _loanAnalysisRemarks4; } set { _loanAnalysisRemarks4 = value; } }
-        private Value<string> _loanAnalysisRemarks5;
+        private DirtyValue<string> _loanAnalysisRemarks5;
         public string LoanAnalysisRemarks5 { get { return _loanAnalysisRemarks5; } set { _loanAnalysisRemarks5 = value; } }
-        private Value<string> _loanAnalysisRemarks6;
+        private DirtyValue<string> _loanAnalysisRemarks6;
         public string LoanAnalysisRemarks6 { get { return _loanAnalysisRemarks6; } set { _loanAnalysisRemarks6 = value; } }
-        private Value<string> _loanAnalysisRemarks7;
+        private DirtyValue<string> _loanAnalysisRemarks7;
         public string LoanAnalysisRemarks7 { get { return _loanAnalysisRemarks7; } set { _loanAnalysisRemarks7 = value; } }
-        private Value<string> _loanAnalysisRemarks8;
+        private DirtyValue<string> _loanAnalysisRemarks8;
         public string LoanAnalysisRemarks8 { get { return _loanAnalysisRemarks8; } set { _loanAnalysisRemarks8 = value; } }
-        private Value<string> _loanAnalysisRemarks9;
+        private DirtyValue<string> _loanAnalysisRemarks9;
         public string LoanAnalysisRemarks9 { get { return _loanAnalysisRemarks9; } set { _loanAnalysisRemarks9 = value; } }
-        private Value<string> _loanCode;
+        private DirtyValue<string> _loanCode;
         public string LoanCode { get { return _loanCode; } set { _loanCode = value; } }
-        private Value<string> _loanProcedure;
+        private DirtyValue<string> _loanProcedure;
         public string LoanProcedure { get { return _loanProcedure; } set { _loanProcedure = value; } }
-        private Value<bool?> _loanProcessedUnderAU;
+        private DirtyValue<bool?> _loanProcessedUnderAU;
         public bool? LoanProcessedUnderAU { get { return _loanProcessedUnderAU; } set { _loanProcessedUnderAU = value; } }
-        private Value<string> _loanSummaryRemarks1;
+        private DirtyValue<string> _loanSummaryRemarks1;
         public string LoanSummaryRemarks1 { get { return _loanSummaryRemarks1; } set { _loanSummaryRemarks1 = value; } }
-        private Value<string> _loanSummaryRemarks2;
+        private DirtyValue<string> _loanSummaryRemarks2;
         public string LoanSummaryRemarks2 { get { return _loanSummaryRemarks2; } set { _loanSummaryRemarks2 = value; } }
-        private Value<string> _loanSummaryRemarks3;
+        private DirtyValue<string> _loanSummaryRemarks3;
         public string LoanSummaryRemarks3 { get { return _loanSummaryRemarks3; } set { _loanSummaryRemarks3 = value; } }
-        private Value<string> _loanSummaryRemarks4;
+        private DirtyValue<string> _loanSummaryRemarks4;
         public string LoanSummaryRemarks4 { get { return _loanSummaryRemarks4; } set { _loanSummaryRemarks4 = value; } }
-        private Value<string> _loanSummaryRemarks5;
+        private DirtyValue<string> _loanSummaryRemarks5;
         public string LoanSummaryRemarks5 { get { return _loanSummaryRemarks5; } set { _loanSummaryRemarks5 = value; } }
-        private Value<string> _loanSummaryRemarks6;
+        private DirtyValue<string> _loanSummaryRemarks6;
         public string LoanSummaryRemarks6 { get { return _loanSummaryRemarks6; } set { _loanSummaryRemarks6 = value; } }
-        private Value<string> _loanSummaryRemarks7;
+        private DirtyValue<string> _loanSummaryRemarks7;
         public string LoanSummaryRemarks7 { get { return _loanSummaryRemarks7; } set { _loanSummaryRemarks7 = value; } }
-        private Value<string> _loanSummaryRemarks8;
+        private DirtyValue<string> _loanSummaryRemarks8;
         public string LoanSummaryRemarks8 { get { return _loanSummaryRemarks8; } set { _loanSummaryRemarks8 = value; } }
-        private Value<string> _lotDimensions;
+        private DirtyValue<string> _lotDimensions;
         public string LotDimensions { get { return _lotDimensions; } set { _lotDimensions = value; } }
-        private Value<string> _mailingAddress;
+        private DirtyValue<string> _mailingAddress;
         public string MailingAddress { get { return _mailingAddress; } set { _mailingAddress = value; } }
-        private Value<string> _mailingCity;
+        private DirtyValue<string> _mailingCity;
         public string MailingCity { get { return _mailingCity; } set { _mailingCity = value; } }
-        private Value<string> _mailingPostalCode;
+        private DirtyValue<string> _mailingPostalCode;
         public string MailingPostalCode { get { return _mailingPostalCode; } set { _mailingPostalCode = value; } }
-        private Value<string> _mailingState;
+        private DirtyValue<string> _mailingState;
         public string MailingState { get { return _mailingState; } set { _mailingState = value; } }
-        private Value<string> _manufacturedHome;
+        private DirtyValue<string> _manufacturedHome;
         public string ManufacturedHome { get { return _manufacturedHome; } set { _manufacturedHome = value; } }
-        private Value<string> _mCRVNumber;
+        private DirtyValue<string> _mCRVNumber;
         public string MCRVNumber { get { return _mCRVNumber; } set { _mCRVNumber = value; } }
-        private Value<string> _militaryBranchOfService;
+        private DirtyValue<string> _militaryBranchOfService;
         public string MilitaryBranchOfService { get { return _militaryBranchOfService; } set { _militaryBranchOfService = value; } }
         private DirtyList<MilitaryService> _militaryServices;
         public IList<MilitaryService> MilitaryServices { get { var v = _militaryServices; return v ?? Interlocked.CompareExchange(ref _militaryServices, (v = new DirtyList<MilitaryService>()), null) ?? v; } set { _militaryServices = new DirtyList<MilitaryService>(value); } }
-        private Value<string> _mineralRightsReserved;
+        private DirtyValue<string> _mineralRightsReserved;
         public string MineralRightsReserved { get { return _mineralRightsReserved; } set { _mineralRightsReserved = value; } }
-        private Value<string> _nameOfOccupant;
+        private DirtyValue<string> _nameOfOccupant;
         public string NameOfOccupant { get { return _nameOfOccupant; } set { _nameOfOccupant = value; } }
-        private Value<string> _nameOfOwner;
+        private DirtyValue<string> _nameOfOwner;
         public string NameOfOwner { get { return _nameOfOwner; } set { _nameOfOwner = value; } }
-        private Value<string> _nameOfWarrantyProgram;
+        private DirtyValue<string> _nameOfWarrantyProgram;
         public string NameOfWarrantyProgram { get { return _nameOfWarrantyProgram; } set { _nameOfWarrantyProgram = value; } }
-        private Value<decimal?> _negativeRents;
+        private DirtyValue<decimal?> _negativeRents;
         public decimal? NegativeRents { get { return _negativeRents; } set { _negativeRents = value; } }
-        private Value<bool?> _noEnergyImprovements;
+        private DirtyValue<bool?> _noEnergyImprovements;
         public bool? NoEnergyImprovements { get { return _noEnergyImprovements; } set { _noEnergyImprovements = value; } }
-        private Value<string> _nonrealtyDescription;
+        private DirtyValue<string> _nonrealtyDescription;
         public string NonrealtyDescription { get { return _nonrealtyDescription; } set { _nonrealtyDescription = value; } }
-        private Value<string> _numberOfBuildings;
+        private DirtyValue<string> _numberOfBuildings;
         public string NumberOfBuildings { get { return _numberOfBuildings; } set { _numberOfBuildings = value; } }
-        private Value<string> _occupantTelephone;
+        private DirtyValue<string> _occupantTelephone;
         public string OccupantTelephone { get { return _occupantTelephone; } set { _occupantTelephone = value; } }
-        private Value<bool?> _onMilitaryDutyFollowingSeparation;
+        private DirtyValue<bool?> _onMilitaryDutyFollowingSeparation;
         public bool? OnMilitaryDutyFollowingSeparation { get { return _onMilitaryDutyFollowingSeparation; } set { _onMilitaryDutyFollowingSeparation = value; } }
-        private Value<decimal?> _originalInterestRate;
+        private DirtyValue<decimal?> _originalInterestRate;
         public decimal? OriginalInterestRate { get { return _originalInterestRate; } set { _originalInterestRate = value; } }
-        private Value<decimal?> _originalLoanAmount;
+        private DirtyValue<decimal?> _originalLoanAmount;
         public decimal? OriginalLoanAmount { get { return _originalLoanAmount; } set { _originalLoanAmount = value; } }
-        private Value<int?> _originalTerm;
+        private DirtyValue<int?> _originalTerm;
         public int? OriginalTerm { get { return _originalTerm; } set { _originalTerm = value; } }
-        private Value<bool?> _originalValueEstimateChanged;
+        private DirtyValue<bool?> _originalValueEstimateChanged;
         public bool? OriginalValueEstimateChanged { get { return _originalValueEstimateChanged; } set { _originalValueEstimateChanged = value; } }
-        private Value<decimal?> _originationFeeAmount;
+        private DirtyValue<decimal?> _originationFeeAmount;
         public decimal? OriginationFeeAmount { get { return _originationFeeAmount; } set { _originationFeeAmount = value; } }
-        private Value<decimal?> _otherClosingCosts;
+        private DirtyValue<decimal?> _otherClosingCosts;
         public decimal? OtherClosingCosts { get { return _otherClosingCosts; } set { _otherClosingCosts = value; } }
-        private Value<string> _otherDescriptionEstateProperty;
+        private DirtyValue<string> _otherDescriptionEstateProperty;
         public string OtherDescriptionEstateProperty { get { return _otherDescriptionEstateProperty; } set { _otherDescriptionEstateProperty = value; } }
-        private Value<string> _otherDescriptionLoanType;
+        private DirtyValue<string> _otherDescriptionLoanType;
         public string OtherDescriptionLoanType { get { return _otherDescriptionLoanType; } set { _otherDescriptionLoanType = value; } }
-        private Value<bool?> _otherEstateProperty;
+        private DirtyValue<bool?> _otherEstateProperty;
         public bool? OtherEstateProperty { get { return _otherEstateProperty; } set { _otherEstateProperty = value; } }
-        private Value<bool?> _otherImprovements;
+        private DirtyValue<bool?> _otherImprovements;
         public bool? OtherImprovements { get { return _otherImprovements; } set { _otherImprovements = value; } }
-        private Value<bool?> _otherLoanType;
+        private DirtyValue<bool?> _otherLoanType;
         public bool? OtherLoanType { get { return _otherLoanType; } set { _otherLoanType = value; } }
-        private Value<string> _paidInFullVALoanNumber;
+        private DirtyValue<string> _paidInFullVALoanNumber;
         public string PaidInFullVALoanNumber { get { return _paidInFullVALoanNumber; } set { _paidInFullVALoanNumber = value; } }
-        private Value<bool?> _payoffIndicator1;
+        private DirtyValue<bool?> _payoffIndicator1;
         public bool? PayoffIndicator1 { get { return _payoffIndicator1; } set { _payoffIndicator1 = value; } }
-        private Value<bool?> _payoffIndicator2;
+        private DirtyValue<bool?> _payoffIndicator2;
         public bool? PayoffIndicator2 { get { return _payoffIndicator2; } set { _payoffIndicator2 = value; } }
-        private Value<bool?> _payoffIndicator3;
+        private DirtyValue<bool?> _payoffIndicator3;
         public bool? PayoffIndicator3 { get { return _payoffIndicator3; } set { _payoffIndicator3 = value; } }
-        private Value<bool?> _payoffIndicator4;
+        private DirtyValue<bool?> _payoffIndicator4;
         public bool? PayoffIndicator4 { get { return _payoffIndicator4; } set { _payoffIndicator4 = value; } }
-        private Value<bool?> _payoffIndicator5;
+        private DirtyValue<bool?> _payoffIndicator5;
         public bool? PayoffIndicator5 { get { return _payoffIndicator5; } set { _payoffIndicator5 = value; } }
-        private Value<bool?> _payoffIndicator6;
+        private DirtyValue<bool?> _payoffIndicator6;
         public bool? PayoffIndicator6 { get { return _payoffIndicator6; } set { _payoffIndicator6 = value; } }
-        private Value<bool?> _payoffIndicator7;
+        private DirtyValue<bool?> _payoffIndicator7;
         public bool? PayoffIndicator7 { get { return _payoffIndicator7; } set { _payoffIndicator7 = value; } }
-        private Value<bool?> _payoffIndicator8;
+        private DirtyValue<bool?> _payoffIndicator8;
         public bool? PayoffIndicator8 { get { return _payoffIndicator8; } set { _payoffIndicator8 = value; } }
-        private Value<bool?> _payoffIndicator9;
+        private DirtyValue<bool?> _payoffIndicator9;
         public bool? PayoffIndicator9 { get { return _payoffIndicator9; } set { _payoffIndicator9 = value; } }
-        private Value<decimal?> _pestReportFee;
+        private DirtyValue<decimal?> _pestReportFee;
         public decimal? PestReportFee { get { return _pestReportFee; } set { _pestReportFee = value; } }
-        private Value<string> _plansSubmitted;
+        private DirtyValue<string> _plansSubmitted;
         public string PlansSubmitted { get { return _plansSubmitted; } set { _plansSubmitted = value; } }
-        private Value<string> _pOCAddress;
+        private DirtyValue<string> _pOCAddress;
         public string POCAddress { get { return _pOCAddress; } set { _pOCAddress = value; } }
-        private Value<string> _pOCCity;
+        private DirtyValue<string> _pOCCity;
         public string POCCity { get { return _pOCCity; } set { _pOCCity = value; } }
-        private Value<string> _pOCName;
+        private DirtyValue<string> _pOCName;
         public string POCName { get { return _pOCName; } set { _pOCName = value; } }
-        private Value<string> _pOCPhone;
+        private DirtyValue<string> _pOCPhone;
         public string POCPhone { get { return _pOCPhone; } set { _pOCPhone = value; } }
-        private Value<string> _pOCState;
+        private DirtyValue<string> _pOCState;
         public string POCState { get { return _pOCState; } set { _pOCState = value; } }
-        private Value<string> _pOCZipCode;
+        private DirtyValue<string> _pOCZipCode;
         public string POCZipCode { get { return _pOCZipCode; } set { _pOCZipCode = value; } }
-        private Value<decimal?> _preliminaryDiscountAmount;
+        private DirtyValue<decimal?> _preliminaryDiscountAmount;
         public decimal? PreliminaryDiscountAmount { get { return _preliminaryDiscountAmount; } set { _preliminaryDiscountAmount = value; } }
-        private Value<decimal?> _preliminaryFundingFeeAmount;
+        private DirtyValue<decimal?> _preliminaryFundingFeeAmount;
         public decimal? PreliminaryFundingFeeAmount { get { return _preliminaryFundingFeeAmount; } set { _preliminaryFundingFeeAmount = value; } }
-        private Value<decimal?> _preliminaryTotal;
+        private DirtyValue<decimal?> _preliminaryTotal;
         public decimal? PreliminaryTotal { get { return _preliminaryTotal; } set { _preliminaryTotal = value; } }
-        private Value<bool?> _previousVALoanIndicator;
+        private DirtyValue<bool?> _previousVALoanIndicator;
         public bool? PreviousVALoanIndicator { get { return _previousVALoanIndicator; } set { _previousVALoanIndicator = value; } }
         private DirtyList<PreviousVaLoan> _previousVaLoans;
         public IList<PreviousVaLoan> PreviousVaLoans { get { var v = _previousVaLoans; return v ?? Interlocked.CompareExchange(ref _previousVaLoans, (v = new DirtyList<PreviousVaLoan>()), null) ?? v; } set { _previousVaLoans = new DirtyList<PreviousVaLoan>(value); } }
-        private Value<bool?> _priorApprovalProcedure;
+        private DirtyValue<bool?> _priorApprovalProcedure;
         public bool? PriorApprovalProcedure { get { return _priorApprovalProcedure; } set { _priorApprovalProcedure = value; } }
-        private Value<string> _priorLoanType;
+        private DirtyValue<string> _priorLoanType;
         public string PriorLoanType { get { return _priorLoanType; } set { _priorLoanType = value; } }
-        private Value<string> _propertyDesignation;
+        private DirtyValue<string> _propertyDesignation;
         public string PropertyDesignation { get { return _propertyDesignation; } set { _propertyDesignation = value; } }
-        private Value<int?> _propertyGrossLivingArea;
+        private DirtyValue<int?> _propertyGrossLivingArea;
         public int? PropertyGrossLivingArea { get { return _propertyGrossLivingArea; } set { _propertyGrossLivingArea = value; } }
-        private Value<string> _propertyLegalDescription1;
+        private DirtyValue<string> _propertyLegalDescription1;
         public string PropertyLegalDescription1 { get { return _propertyLegalDescription1; } set { _propertyLegalDescription1 = value; } }
-        private Value<string> _propertyLegalDescription2;
+        private DirtyValue<string> _propertyLegalDescription2;
         public string PropertyLegalDescription2 { get { return _propertyLegalDescription2; } set { _propertyLegalDescription2 = value; } }
-        private Value<string> _propertyLegalDescription3;
+        private DirtyValue<string> _propertyLegalDescription3;
         public string PropertyLegalDescription3 { get { return _propertyLegalDescription3; } set { _propertyLegalDescription3 = value; } }
-        private Value<string> _propertyLegalDescription4;
+        private DirtyValue<string> _propertyLegalDescription4;
         public string PropertyLegalDescription4 { get { return _propertyLegalDescription4; } set { _propertyLegalDescription4 = value; } }
-        private Value<string> _propertyOccupancyType;
+        private DirtyValue<string> _propertyOccupancyType;
         public string PropertyOccupancyType { get { return _propertyOccupancyType; } set { _propertyOccupancyType = value; } }
-        private Value<bool?> _proposedSaleContractAttached;
+        private DirtyValue<bool?> _proposedSaleContractAttached;
         public bool? ProposedSaleContractAttached { get { return _proposedSaleContractAttached; } set { _proposedSaleContractAttached = value; } }
-        private Value<string> _purposeOfLoan;
+        private DirtyValue<string> _purposeOfLoan;
         public string PurposeOfLoan { get { return _purposeOfLoan; } set { _purposeOfLoan = value; } }
-        private Value<bool?> _rangeOvenIndicator;
+        private DirtyValue<bool?> _rangeOvenIndicator;
         public bool? RangeOvenIndicator { get { return _rangeOvenIndicator; } set { _rangeOvenIndicator = value; } }
-        private Value<bool?> _reasonableValueCompleted;
+        private DirtyValue<bool?> _reasonableValueCompleted;
         public bool? ReasonableValueCompleted { get { return _reasonableValueCompleted; } set { _reasonableValueCompleted = value; } }
-        private Value<bool?> _refrigeratorIndicator;
+        private DirtyValue<bool?> _refrigeratorIndicator;
         public bool? RefrigeratorIndicator { get { return _refrigeratorIndicator; } set { _refrigeratorIndicator = value; } }
-        private Value<string> _rent;
+        private DirtyValue<string> _rent;
         public string Rent { get { return _rent; } set { _rent = value; } }
-        private Value<bool?> _replacementOfSystem;
+        private DirtyValue<bool?> _replacementOfSystem;
         public bool? ReplacementOfSystem { get { return _replacementOfSystem; } set { _replacementOfSystem = value; } }
-        private Value<string> _riskClasification;
+        private DirtyValue<string> _riskClasification;
         public string RiskClasification { get { return _riskClasification; } set { _riskClasification = value; } }
-        private Value<string> _serviceNumber;
+        private DirtyValue<string> _serviceNumber;
         public string ServiceNumber { get { return _serviceNumber; } set { _serviceNumber = value; } }
-        private Value<bool?> _solarHeatingOrCooling;
+        private DirtyValue<bool?> _solarHeatingOrCooling;
         public bool? SolarHeatingOrCooling { get { return _solarHeatingOrCooling; } set { _solarHeatingOrCooling = value; } }
-        private Value<string> _specialAssessmentComments1;
+        private DirtyValue<string> _specialAssessmentComments1;
         public string SpecialAssessmentComments1 { get { return _specialAssessmentComments1; } set { _specialAssessmentComments1 = value; } }
-        private Value<string> _specialAssessmentComments2;
+        private DirtyValue<string> _specialAssessmentComments2;
         public string SpecialAssessmentComments2 { get { return _specialAssessmentComments2; } set { _specialAssessmentComments2 = value; } }
-        private Value<string> _specialAssessmentComments3;
+        private DirtyValue<string> _specialAssessmentComments3;
         public string SpecialAssessmentComments3 { get { return _specialAssessmentComments3; } set { _specialAssessmentComments3 = value; } }
-        private Value<string> _streetAccess;
+        private DirtyValue<string> _streetAccess;
         public string StreetAccess { get { return _streetAccess; } set { _streetAccess = value; } }
-        private Value<string> _streetMaintenance;
+        private DirtyValue<string> _streetMaintenance;
         public string StreetMaintenance { get { return _streetMaintenance; } set { _streetMaintenance = value; } }
-        private Value<string> _systemUsed;
+        private DirtyValue<string> _systemUsed;
         public string SystemUsed { get { return _systemUsed; } set { _systemUsed = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<string> _titleLimitations1;
+        private DirtyValue<string> _titleLimitations1;
         public string TitleLimitations1 { get { return _titleLimitations1; } set { _titleLimitations1 = value; } }
-        private Value<string> _titleLimitations2;
+        private DirtyValue<string> _titleLimitations2;
         public string TitleLimitations2 { get { return _titleLimitations2; } set { _titleLimitations2 = value; } }
-        private Value<string> _titleLimitations3;
+        private DirtyValue<string> _titleLimitations3;
         public string TitleLimitations3 { get { return _titleLimitations3; } set { _titleLimitations3 = value; } }
-        private Value<decimal?> _totalBaths;
+        private DirtyValue<decimal?> _totalBaths;
         public decimal? TotalBaths { get { return _totalBaths; } set { _totalBaths = value; } }
-        private Value<int?> _totalBedrooms;
+        private DirtyValue<int?> _totalBedrooms;
         public int? TotalBedrooms { get { return _totalBedrooms; } set { _totalBedrooms = value; } }
-        private Value<decimal?> _totalDebtMonthlyPayment;
+        private DirtyValue<decimal?> _totalDebtMonthlyPayment;
         public decimal? TotalDebtMonthlyPayment { get { return _totalDebtMonthlyPayment; } set { _totalDebtMonthlyPayment = value; } }
-        private Value<decimal?> _totalDiscountPointCharged;
+        private DirtyValue<decimal?> _totalDiscountPointCharged;
         public decimal? TotalDiscountPointCharged { get { return _totalDiscountPointCharged; } set { _totalDiscountPointCharged = value; } }
-        private Value<decimal?> _totalDiscountPointsCharged;
+        private DirtyValue<decimal?> _totalDiscountPointsCharged;
         public decimal? TotalDiscountPointsCharged { get { return _totalDiscountPointsCharged; } set { _totalDiscountPointsCharged = value; } }
-        private Value<decimal?> _totalForMaxLoanAmount;
+        private DirtyValue<decimal?> _totalForMaxLoanAmount;
         public decimal? TotalForMaxLoanAmount { get { return _totalForMaxLoanAmount; } set { _totalForMaxLoanAmount = value; } }
-        private Value<decimal?> _totalMonthlyPayment;
+        private DirtyValue<decimal?> _totalMonthlyPayment;
         public decimal? TotalMonthlyPayment { get { return _totalMonthlyPayment; } set { _totalMonthlyPayment = value; } }
-        private Value<decimal?> _totalProposedMonthlyPayment;
+        private DirtyValue<decimal?> _totalProposedMonthlyPayment;
         public decimal? TotalProposedMonthlyPayment { get { return _totalProposedMonthlyPayment; } set { _totalProposedMonthlyPayment = value; } }
-        private Value<int?> _totalRooms;
+        private DirtyValue<int?> _totalRooms;
         public int? TotalRooms { get { return _totalRooms; } set { _totalRooms = value; } }
-        private Value<decimal?> _totalUnpaidSpecialAssessments;
+        private DirtyValue<decimal?> _totalUnpaidSpecialAssessments;
         public decimal? TotalUnpaidSpecialAssessments { get { return _totalUnpaidSpecialAssessments; } set { _totalUnpaidSpecialAssessments = value; } }
-        private Value<string> _typeOfHybridARM;
+        private DirtyValue<string> _typeOfHybridARM;
         public string TypeOfHybridARM { get { return _typeOfHybridARM; } set { _typeOfHybridARM = value; } }
-        private Value<string> _typeOfMortgage;
+        private DirtyValue<string> _typeOfMortgage;
         public string TypeOfMortgage { get { return _typeOfMortgage; } set { _typeOfMortgage = value; } }
-        private Value<string> _typeOfOwnsership;
+        private DirtyValue<string> _typeOfOwnsership;
         public string TypeOfOwnsership { get { return _typeOfOwnsership; } set { _typeOfOwnsership = value; } }
-        private Value<string> _typeOfStructure;
+        private DirtyValue<string> _typeOfStructure;
         public string TypeOfStructure { get { return _typeOfStructure; } set { _typeOfStructure = value; } }
-        private Value<string> _typeOfVeteran;
+        private DirtyValue<string> _typeOfVeteran;
         public string TypeOfVeteran { get { return _typeOfVeteran; } set { _typeOfVeteran = value; } }
-        private Value<bool?> _unsecuredLoanType;
+        private DirtyValue<bool?> _unsecuredLoanType;
         public bool? UnsecuredLoanType { get { return _unsecuredLoanType; } set { _unsecuredLoanType = value; } }
-        private Value<string> _utilitiesElectricDescription;
+        private DirtyValue<string> _utilitiesElectricDescription;
         public string UtilitiesElectricDescription { get { return _utilitiesElectricDescription; } set { _utilitiesElectricDescription = value; } }
-        private Value<string> _utilitiesGasDescription;
+        private DirtyValue<string> _utilitiesGasDescription;
         public string UtilitiesGasDescription { get { return _utilitiesGasDescription; } set { _utilitiesGasDescription = value; } }
-        private Value<string> _utilitiesSewerDescription;
+        private DirtyValue<string> _utilitiesSewerDescription;
         public string UtilitiesSewerDescription { get { return _utilitiesSewerDescription; } set { _utilitiesSewerDescription = value; } }
-        private Value<string> _utilitiesWaterDescription;
+        private DirtyValue<string> _utilitiesWaterDescription;
         public string UtilitiesWaterDescription { get { return _utilitiesWaterDescription; } set { _utilitiesWaterDescription = value; } }
-        private Value<DateTime?> _vAAppraisalSentDate;
+        private DirtyValue<DateTime?> _vAAppraisalSentDate;
         public DateTime? VAAppraisalSentDate { get { return _vAAppraisalSentDate; } set { _vAAppraisalSentDate = value; } }
-        private Value<string> _vABenefitRelatedIndebtedness;
+        private DirtyValue<string> _vABenefitRelatedIndebtedness;
         public string VABenefitRelatedIndebtedness { get { return _vABenefitRelatedIndebtedness; } set { _vABenefitRelatedIndebtedness = value; } }
-        private Value<string> _vABuilderDescription;
+        private DirtyValue<string> _vABuilderDescription;
         public string VABuilderDescription { get { return _vABuilderDescription; } set { _vABuilderDescription = value; } }
-        private Value<string> _vABuilderIDNo;
+        private DirtyValue<string> _vABuilderIDNo;
         public string VABuilderIDNo { get { return _vABuilderIDNo; } set { _vABuilderIDNo = value; } }
-        private Value<string> _vAClaimFolderNumber;
+        private DirtyValue<string> _vAClaimFolderNumber;
         public string VAClaimFolderNumber { get { return _vAClaimFolderNumber; } set { _vAClaimFolderNumber = value; } }
-        private Value<string> _vAClaimNumber;
+        private DirtyValue<string> _vAClaimNumber;
         public string VAClaimNumber { get { return _vAClaimNumber; } set { _vAClaimNumber = value; } }
-        private Value<DateTime?> _vADateNOVAppraisalMailedToBorrower;
+        private DirtyValue<DateTime?> _vADateNOVAppraisalMailedToBorrower;
         public DateTime? VADateNOVAppraisalMailedToBorrower { get { return _vADateNOVAppraisalMailedToBorrower; } set { _vADateNOVAppraisalMailedToBorrower = value; } }
-        private Value<bool?> _vAIsDelinquent30Days;
+        private DirtyValue<bool?> _vAIsDelinquent30Days;
         public bool? VAIsDelinquent30Days { get { return _vAIsDelinquent30Days; } set { _vAIsDelinquent30Days = value; } }
-        private Value<bool?> _vALatePaymentIn6Months;
+        private DirtyValue<bool?> _vALatePaymentIn6Months;
         public bool? VALatePaymentIn6Months { get { return _vALatePaymentIn6Months; } set { _vALatePaymentIn6Months = value; } }
-        private Value<string> _vaLoanSummaryApplicantType;
+        private DirtyValue<string> _vaLoanSummaryApplicantType;
         public string VaLoanSummaryApplicantType { get { return _vaLoanSummaryApplicantType; } set { _vaLoanSummaryApplicantType = value; } }
-        private Value<DateTime?> _vANOVDateReceived;
+        private DirtyValue<DateTime?> _vANOVDateReceived;
         public DateTime? VANOVDateReceived { get { return _vANOVDateReceived; } set { _vANOVDateReceived = value; } }
-        private Value<DateTime?> _vANOVDateReviewed;
+        private DirtyValue<DateTime?> _vANOVDateReviewed;
         public DateTime? VANOVDateReviewed { get { return _vANOVDateReviewed; } set { _vANOVDateReviewed = value; } }
-        private Value<DateTime?> _vANOVIssuedDate;
+        private DirtyValue<DateTime?> _vANOVIssuedDate;
         public DateTime? VANOVIssuedDate { get { return _vANOVIssuedDate; } set { _vANOVIssuedDate = value; } }
-        private Value<string> _vAOriginalAmortizationType;
+        private DirtyValue<string> _vAOriginalAmortizationType;
         public string VAOriginalAmortizationType { get { return _vAOriginalAmortizationType; } set { _vAOriginalAmortizationType = value; } }
-        private Value<decimal?> _vAOriginalMonthlyPayment;
+        private DirtyValue<decimal?> _vAOriginalMonthlyPayment;
         public decimal? VAOriginalMonthlyPayment { get { return _vAOriginalMonthlyPayment; } set { _vAOriginalMonthlyPayment = value; } }
-        private Value<string> _vAQualification2ndTierEntitlement;
+        private DirtyValue<string> _vAQualification2ndTierEntitlement;
         public string VAQualification2ndTierEntitlement { get { return _vAQualification2ndTierEntitlement; } set { _vAQualification2ndTierEntitlement = value; } }
-        private Value<string> _vAQualificationCountryRegion;
+        private DirtyValue<string> _vAQualificationCountryRegion;
         public string VAQualificationCountryRegion { get { return _vAQualificationCountryRegion; } set { _vAQualificationCountryRegion = value; } }
-        private Value<decimal?> _vAQualificationCountyLimits;
+        private DirtyValue<decimal?> _vAQualificationCountyLimits;
         public decimal? VAQualificationCountyLimits { get { return _vAQualificationCountyLimits; } set { _vAQualificationCountyLimits = value; } }
-        private Value<int?> _vARecoupmentClosingCosts;
+        private DirtyValue<int?> _vARecoupmentClosingCosts;
         public int? VARecoupmentClosingCosts { get { return _vARecoupmentClosingCosts; } set { _vARecoupmentClosingCosts = value; } }
-        private Value<bool?> _vARecoupmentExcludePrepaids;
+        private DirtyValue<bool?> _vARecoupmentExcludePrepaids;
         public bool? VARecoupmentExcludePrepaids { get { return _vARecoupmentExcludePrepaids; } set { _vARecoupmentExcludePrepaids = value; } }
-        private Value<decimal?> _vARecoupmentMonthlyDecreaseInPayment;
+        private DirtyValue<decimal?> _vARecoupmentMonthlyDecreaseInPayment;
         public decimal? VARecoupmentMonthlyDecreaseInPayment { get { return _vARecoupmentMonthlyDecreaseInPayment; } set { _vARecoupmentMonthlyDecreaseInPayment = value; } }
-        private Value<int?> _vARecoupmentMonths;
+        private DirtyValue<int?> _vARecoupmentMonths;
         public int? VARecoupmentMonths { get { return _vARecoupmentMonths; } set { _vARecoupmentMonths = value; } }
-        private Value<decimal?> _vARecoupmentTotalClosingCosts;
+        private DirtyValue<decimal?> _vARecoupmentTotalClosingCosts;
         public decimal? VARecoupmentTotalClosingCosts { get { return _vARecoupmentTotalClosingCosts; } set { _vARecoupmentTotalClosingCosts = value; } }
-        private Value<int?> _vARecoupmentYears;
+        private DirtyValue<int?> _vARecoupmentYears;
         public int? VARecoupmentYears { get { return _vARecoupmentYears; } set { _vARecoupmentYears = value; } }
-        private Value<DateTime?> _vATrackingCertOfCommitmentIssued;
+        private DirtyValue<DateTime?> _vATrackingCertOfCommitmentIssued;
         public DateTime? VATrackingCertOfCommitmentIssued { get { return _vATrackingCertOfCommitmentIssued; } set { _vATrackingCertOfCommitmentIssued = value; } }
-        private Value<DateTime?> _vATrackingCOEIssueDate;
+        private DirtyValue<DateTime?> _vATrackingCOEIssueDate;
         public DateTime? VATrackingCOEIssueDate { get { return _vATrackingCOEIssueDate; } set { _vATrackingCOEIssueDate = value; } }
-        private Value<string> _vATrackingCOEIssueHistory;
+        private DirtyValue<string> _vATrackingCOEIssueHistory;
         public string VATrackingCOEIssueHistory { get { return _vATrackingCOEIssueHistory; } set { _vATrackingCOEIssueHistory = value; } }
-        private Value<DateTime?> _vATrackingFinalApprovalCommitmentDate;
+        private DirtyValue<DateTime?> _vATrackingFinalApprovalCommitmentDate;
         public DateTime? VATrackingFinalApprovalCommitmentDate { get { return _vATrackingFinalApprovalCommitmentDate; } set { _vATrackingFinalApprovalCommitmentDate = value; } }
-        private Value<bool?> _vATrackingGSAExclusionaryListChecked;
+        private DirtyValue<bool?> _vATrackingGSAExclusionaryListChecked;
         public bool? VATrackingGSAExclusionaryListChecked { get { return _vATrackingGSAExclusionaryListChecked; } set { _vATrackingGSAExclusionaryListChecked = value; } }
-        private Value<bool?> _vATrackingInuranceFloodPolicy;
+        private DirtyValue<bool?> _vATrackingInuranceFloodPolicy;
         public bool? VATrackingInuranceFloodPolicy { get { return _vATrackingInuranceFloodPolicy; } set { _vATrackingInuranceFloodPolicy = value; } }
-        private Value<bool?> _vATrackingInuranceHazardPolicy;
+        private DirtyValue<bool?> _vATrackingInuranceHazardPolicy;
         public bool? VATrackingInuranceHazardPolicy { get { return _vATrackingInuranceHazardPolicy; } set { _vATrackingInuranceHazardPolicy = value; } }
-        private Value<bool?> _vATrackingInuranceWindOrHailPolicy;
+        private DirtyValue<bool?> _vATrackingInuranceWindOrHailPolicy;
         public bool? VATrackingInuranceWindOrHailPolicy { get { return _vATrackingInuranceWindOrHailPolicy; } set { _vATrackingInuranceWindOrHailPolicy = value; } }
-        private Value<bool?> _vATrackingInuranceWoodDestroyingPolicy;
+        private DirtyValue<bool?> _vATrackingInuranceWoodDestroyingPolicy;
         public bool? VATrackingInuranceWoodDestroyingPolicy { get { return _vATrackingInuranceWoodDestroyingPolicy; } set { _vATrackingInuranceWoodDestroyingPolicy = value; } }
-        private Value<bool?> _vATrackingIsSARLAPPCertified;
+        private DirtyValue<bool?> _vATrackingIsSARLAPPCertified;
         public bool? VATrackingIsSARLAPPCertified { get { return _vATrackingIsSARLAPPCertified; } set { _vATrackingIsSARLAPPCertified = value; } }
-        private Value<DateTime?> _vATrackingLoanGuaranteeCertReceipt;
+        private DirtyValue<DateTime?> _vATrackingLoanGuaranteeCertReceipt;
         public DateTime? VATrackingLoanGuaranteeCertReceipt { get { return _vATrackingLoanGuaranteeCertReceipt; } set { _vATrackingLoanGuaranteeCertReceipt = value; } }
-        private Value<DateTime?> _vATrackingMasterCommitmentLockExpired;
+        private DirtyValue<DateTime?> _vATrackingMasterCommitmentLockExpired;
         public DateTime? VATrackingMasterCommitmentLockExpired { get { return _vATrackingMasterCommitmentLockExpired; } set { _vATrackingMasterCommitmentLockExpired = value; } }
-        private Value<DateTime?> _vATrackingOrderedDate;
+        private DirtyValue<DateTime?> _vATrackingOrderedDate;
         public DateTime? VATrackingOrderedDate { get { return _vATrackingOrderedDate; } set { _vATrackingOrderedDate = value; } }
-        private Value<DateTime?> _vATrackingPaidDate;
+        private DirtyValue<DateTime?> _vATrackingPaidDate;
         public DateTime? VATrackingPaidDate { get { return _vATrackingPaidDate; } set { _vATrackingPaidDate = value; } }
-        private Value<DateTime?> _vATrackingPurchaseContractDate;
+        private DirtyValue<DateTime?> _vATrackingPurchaseContractDate;
         public DateTime? VATrackingPurchaseContractDate { get { return _vATrackingPurchaseContractDate; } set { _vATrackingPurchaseContractDate = value; } }
-        private Value<bool?> _vATrackingReceiptReceived;
+        private DirtyValue<bool?> _vATrackingReceiptReceived;
         public bool? VATrackingReceiptReceived { get { return _vATrackingReceiptReceived; } set { _vATrackingReceiptReceived = value; } }
-        private Value<string> _vATrackingSARID;
+        private DirtyValue<string> _vATrackingSARID;
         public string VATrackingSARID { get { return _vATrackingSARID; } set { _vATrackingSARID = value; } }
-        private Value<string> _vATrackingSARName;
+        private DirtyValue<string> _vATrackingSARName;
         public string VATrackingSARName { get { return _vATrackingSARName; } set { _vATrackingSARName = value; } }
-        private Value<bool?> _ventFanIndicator;
+        private DirtyValue<bool?> _ventFanIndicator;
         public bool? VentFanIndicator { get { return _ventFanIndicator; } set { _ventFanIndicator = value; } }
-        private Value<bool?> _veteranDischargedIndicator;
+        private DirtyValue<bool?> _veteranDischargedIndicator;
         public bool? VeteranDischargedIndicator { get { return _veteranDischargedIndicator; } set { _veteranDischargedIndicator = value; } }
-        private Value<string> _veteranServiceType;
+        private DirtyValue<string> _veteranServiceType;
         public string VeteranServiceType { get { return _veteranServiceType; } set { _veteranServiceType = value; } }
-        private Value<string> _warrantorAddress;
+        private DirtyValue<string> _warrantorAddress;
         public string WarrantorAddress { get { return _warrantorAddress; } set { _warrantorAddress = value; } }
-        private Value<string> _warrantorCity;
+        private DirtyValue<string> _warrantorCity;
         public string WarrantorCity { get { return _warrantorCity; } set { _warrantorCity = value; } }
-        private Value<string> _warrantorName;
+        private DirtyValue<string> _warrantorName;
         public string WarrantorName { get { return _warrantorName; } set { _warrantorName = value; } }
-        private Value<string> _warrantorPhone;
+        private DirtyValue<string> _warrantorPhone;
         public string WarrantorPhone { get { return _warrantorPhone; } set { _warrantorPhone = value; } }
-        private Value<string> _warrantorPostalCode;
+        private DirtyValue<string> _warrantorPostalCode;
         public string WarrantorPostalCode { get { return _warrantorPostalCode; } set { _warrantorPostalCode = value; } }
-        private Value<string> _warrantorState;
+        private DirtyValue<string> _warrantorState;
         public string WarrantorState { get { return _warrantorState; } set { _warrantorState = value; } }
-        private Value<DateTime?> _warrantyProgramExpirationDate;
+        private DirtyValue<DateTime?> _warrantyProgramExpirationDate;
         public DateTime? WarrantyProgramExpirationDate { get { return _warrantyProgramExpirationDate; } set { _warrantyProgramExpirationDate = value; } }
-        private Value<bool?> _wWCarpetIndicator;
+        private DirtyValue<bool?> _wWCarpetIndicator;
         public bool? WWCarpetIndicator { get { return _wWCarpetIndicator; } set { _wWCarpetIndicator = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/VerificationLog.cs
+++ b/src/EncompassRest/Loans/VerificationLog.cs
@@ -8,145 +8,145 @@ namespace EncompassRest.Loans
 {
     public sealed partial class VerificationLog : IDirty
     {
-        private Value<string> _accessedBy;
+        private DirtyValue<string> _accessedBy;
         public string AccessedBy { get { return _accessedBy; } set { _accessedBy = value; } }
-        private Value<DateTime?> _accessedDateUtc;
+        private DirtyValue<DateTime?> _accessedDateUtc;
         public DateTime? AccessedDateUtc { get { return _accessedDateUtc; } set { _accessedDateUtc = value; } }
-        private Value<string> _addedBy;
+        private DirtyValue<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
         private DirtyList<LogAlert> _alerts;
         public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
-        private Value<string> _alertsXml;
+        private DirtyValue<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
-        private Value<string> _allowedRoleDelimitedList;
+        private DirtyValue<string> _allowedRoleDelimitedList;
         public string AllowedRoleDelimitedList { get { return _allowedRoleDelimitedList; } set { _allowedRoleDelimitedList = value; } }
         private DirtyList<EntityReference> _allowedRoles;
         public IList<EntityReference> AllowedRoles { get { var v = _allowedRoles; return v ?? Interlocked.CompareExchange(ref _allowedRoles, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _allowedRoles = new DirtyList<EntityReference>(value); } }
-        private Value<string> _allowedRolesXml;
+        private DirtyValue<string> _allowedRolesXml;
         public string AllowedRolesXml { get { return _allowedRolesXml; } set { _allowedRolesXml = value; } }
-        private Value<DateTime?> _archiveDateUtc;
+        private DirtyValue<DateTime?> _archiveDateUtc;
         public DateTime? ArchiveDateUtc { get { return _archiveDateUtc; } set { _archiveDateUtc = value; } }
-        private Value<string> _archivedBy;
+        private DirtyValue<string> _archivedBy;
         public string ArchivedBy { get { return _archivedBy; } set { _archivedBy = value; } }
-        private Value<bool?> _closingDocumentIndicator;
+        private DirtyValue<bool?> _closingDocumentIndicator;
         public bool? ClosingDocumentIndicator { get { return _closingDocumentIndicator; } set { _closingDocumentIndicator = value; } }
         private DirtyList<LogComment> _commentList;
         public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
-        private Value<string> _commentListXml;
+        private DirtyValue<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
-        private Value<string> _comments;
+        private DirtyValue<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
-        private Value<string> _company;
+        private DirtyValue<string> _company;
         public string Company { get { return _company; } set { _company = value; } }
         private DirtyList<EntityReference> _conditions;
         public IList<EntityReference> Conditions { get { var v = _conditions; return v ?? Interlocked.CompareExchange(ref _conditions, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _conditions = new DirtyList<EntityReference>(value); } }
-        private Value<string> _conditionsXml;
+        private DirtyValue<string> _conditionsXml;
         public string ConditionsXml { get { return _conditionsXml; } set { _conditionsXml = value; } }
-        private Value<DateTime?> _dateAddedUtc;
+        private DirtyValue<DateTime?> _dateAddedUtc;
         public DateTime? DateAddedUtc { get { return _dateAddedUtc; } set { _dateAddedUtc = value; } }
-        private Value<DateTime?> _dateExpected;
+        private DirtyValue<DateTime?> _dateExpected;
         public DateTime? DateExpected { get { return _dateExpected; } set { _dateExpected = value; } }
-        private Value<DateTime?> _dateExpires;
+        private DirtyValue<DateTime?> _dateExpires;
         public DateTime? DateExpires { get { return _dateExpires; } set { _dateExpires = value; } }
-        private Value<DateTime?> _dateReceived;
+        private DirtyValue<DateTime?> _dateReceived;
         public DateTime? DateReceived { get { return _dateReceived; } set { _dateReceived = value; } }
-        private Value<DateTime?> _dateRequested;
+        private DirtyValue<DateTime?> _dateRequested;
         public DateTime? DateRequested { get { return _dateRequested; } set { _dateRequested = value; } }
-        private Value<DateTime?> _dateRerequested;
+        private DirtyValue<DateTime?> _dateRerequested;
         public DateTime? DateRerequested { get { return _dateRerequested; } set { _dateRerequested = value; } }
-        private Value<DateTime?> _dateUtc;
+        private DirtyValue<DateTime?> _dateUtc;
         public DateTime? DateUtc { get { return _dateUtc; } set { _dateUtc = value; } }
-        private Value<int?> _daysDue;
+        private DirtyValue<int?> _daysDue;
         public int? DaysDue { get { return _daysDue; } set { _daysDue = value; } }
-        private Value<int?> _daysTillExpire;
+        private DirtyValue<int?> _daysTillExpire;
         public int? DaysTillExpire { get { return _daysTillExpire; } set { _daysTillExpire = value; } }
-        private Value<string> _documentDateTimeType;
+        private DirtyValue<string> _documentDateTimeType;
         public string DocumentDateTimeType { get { return _documentDateTimeType; } set { _documentDateTimeType = value; } }
-        private Value<bool?> _eDisclosureIndicator;
+        private DirtyValue<bool?> _eDisclosureIndicator;
         public bool? EDisclosureIndicator { get { return _eDisclosureIndicator; } set { _eDisclosureIndicator = value; } }
-        private Value<string> _ePassSignature;
+        private DirtyValue<string> _ePassSignature;
         public string EPassSignature { get { return _ePassSignature; } set { _ePassSignature = value; } }
-        private Value<bool?> _expected;
+        private DirtyValue<bool?> _expected;
         public bool? Expected { get { return _expected; } set { _expected = value; } }
-        private Value<bool?> _expires;
+        private DirtyValue<bool?> _expires;
         public bool? Expires { get { return _expires; } set { _expires = value; } }
-        private Value<bool?> _fileAttachmentsMigrated;
+        private DirtyValue<bool?> _fileAttachmentsMigrated;
         public bool? FileAttachmentsMigrated { get { return _fileAttachmentsMigrated; } set { _fileAttachmentsMigrated = value; } }
-        private Value<string> _fileAttachmentsXml;
+        private DirtyValue<string> _fileAttachmentsXml;
         public string FileAttachmentsXml { get { return _fileAttachmentsXml; } set { _fileAttachmentsXml = value; } }
-        private Value<string> _guid;
+        private DirtyValue<string> _guid;
         public string Guid { get { return _guid; } set { _guid = value; } }
-        private Value<string> _id;
+        private DirtyValue<string> _id;
         public string Id { get { return _id; } set { _id = value; } }
-        private Value<bool?> _isEPassIndicator;
+        private DirtyValue<bool?> _isEPassIndicator;
         public bool? IsEPassIndicator { get { return _isEPassIndicator; } set { _isEPassIndicator = value; } }
-        private Value<bool?> _isExpired;
+        private DirtyValue<bool?> _isExpired;
         public bool? IsExpired { get { return _isExpired; } set { _isExpired = value; } }
-        private Value<bool?> _isExternalIndicator;
+        private DirtyValue<bool?> _isExternalIndicator;
         public bool? IsExternalIndicator { get { return _isExternalIndicator; } set { _isExternalIndicator = value; } }
-        private Value<bool?> _isPastDue;
+        private DirtyValue<bool?> _isPastDue;
         public bool? IsPastDue { get { return _isPastDue; } set { _isPastDue = value; } }
-        private Value<bool?> _isSystemSpecificIndicator;
+        private DirtyValue<bool?> _isSystemSpecificIndicator;
         public bool? IsSystemSpecificIndicator { get { return _isSystemSpecificIndicator; } set { _isSystemSpecificIndicator = value; } }
-        private Value<bool?> _isThirdPartyDocIndicator;
+        private DirtyValue<bool?> _isThirdPartyDocIndicator;
         public bool? IsThirdPartyDocIndicator { get { return _isThirdPartyDocIndicator; } set { _isThirdPartyDocIndicator = value; } }
-        private Value<bool?> _isTPOWebcenterPortalIndicator;
+        private DirtyValue<bool?> _isTPOWebcenterPortalIndicator;
         public bool? IsTPOWebcenterPortalIndicator { get { return _isTPOWebcenterPortalIndicator; } set { _isTPOWebcenterPortalIndicator = value; } }
-        private Value<bool?> _isWebCenterIndicator;
+        private DirtyValue<bool?> _isWebCenterIndicator;
         public bool? IsWebCenterIndicator { get { return _isWebCenterIndicator; } set { _isWebCenterIndicator = value; } }
-        private Value<string> _logId;
+        private DirtyValue<string> _logId;
         public string LogId { get { return _logId; } set { _logId = value; } }
-        private Value<int?> _logRecordIndex;
+        private DirtyValue<int?> _logRecordIndex;
         public int? LogRecordIndex { get { return _logRecordIndex; } set { _logRecordIndex = value; } }
-        private Value<DateTime?> _orderDateUtc;
+        private DirtyValue<DateTime?> _orderDateUtc;
         public DateTime? OrderDateUtc { get { return _orderDateUtc; } set { _orderDateUtc = value; } }
-        private Value<string> _pairId;
+        private DirtyValue<string> _pairId;
         public string PairId { get { return _pairId; } set { _pairId = value; } }
-        private Value<bool?> _preClosingDocumentIndicator;
+        private DirtyValue<bool?> _preClosingDocumentIndicator;
         public bool? PreClosingDocumentIndicator { get { return _preClosingDocumentIndicator; } set { _preClosingDocumentIndicator = value; } }
-        private Value<bool?> _received;
+        private DirtyValue<bool?> _received;
         public bool? Received { get { return _received; } set { _received = value; } }
-        private Value<DateTime?> _receiveDateUtc;
+        private DirtyValue<DateTime?> _receiveDateUtc;
         public DateTime? ReceiveDateUtc { get { return _receiveDateUtc; } set { _receiveDateUtc = value; } }
-        private Value<string> _receivedBy;
+        private DirtyValue<string> _receivedBy;
         public string ReceivedBy { get { return _receivedBy; } set { _receivedBy = value; } }
-        private Value<DateTime?> _reorderDateUtc;
+        private DirtyValue<DateTime?> _reorderDateUtc;
         public DateTime? ReorderDateUtc { get { return _reorderDateUtc; } set { _reorderDateUtc = value; } }
-        private Value<bool?> _requested;
+        private DirtyValue<bool?> _requested;
         public bool? Requested { get { return _requested; } set { _requested = value; } }
-        private Value<string> _requestedBy;
+        private DirtyValue<string> _requestedBy;
         public string RequestedBy { get { return _requestedBy; } set { _requestedBy = value; } }
-        private Value<string> _requestedFrom;
+        private DirtyValue<string> _requestedFrom;
         public string RequestedFrom { get { return _requestedFrom; } set { _requestedFrom = value; } }
-        private Value<bool?> _rerequested;
+        private DirtyValue<bool?> _rerequested;
         public bool? Rerequested { get { return _rerequested; } set { _rerequested = value; } }
-        private Value<string> _rerequestedBy;
+        private DirtyValue<string> _rerequestedBy;
         public string RerequestedBy { get { return _rerequestedBy; } set { _rerequestedBy = value; } }
-        private Value<bool?> _reviewed;
+        private DirtyValue<bool?> _reviewed;
         public bool? Reviewed { get { return _reviewed; } set { _reviewed = value; } }
-        private Value<string> _reviewedBy;
+        private DirtyValue<string> _reviewedBy;
         public string ReviewedBy { get { return _reviewedBy; } set { _reviewedBy = value; } }
-        private Value<DateTime?> _reviewedDateUtc;
+        private DirtyValue<DateTime?> _reviewedDateUtc;
         public DateTime? ReviewedDateUtc { get { return _reviewedDateUtc; } set { _reviewedDateUtc = value; } }
-        private Value<bool?> _shippingReady;
+        private DirtyValue<bool?> _shippingReady;
         public bool? ShippingReady { get { return _shippingReady; } set { _shippingReady = value; } }
-        private Value<string> _shippingReadyBy;
+        private DirtyValue<string> _shippingReadyBy;
         public string ShippingReadyBy { get { return _shippingReadyBy; } set { _shippingReadyBy = value; } }
-        private Value<DateTime?> _shippingReadyDateUtc;
+        private DirtyValue<DateTime?> _shippingReadyDateUtc;
         public DateTime? ShippingReadyDateUtc { get { return _shippingReadyDateUtc; } set { _shippingReadyDateUtc = value; } }
-        private Value<string> _stage;
+        private DirtyValue<string> _stage;
         public string Stage { get { return _stage; } set { _stage = value; } }
-        private Value<string> _status;
+        private DirtyValue<string> _status;
         public string Status { get { return _status; } set { _status = value; } }
-        private Value<string> _systemId;
+        private DirtyValue<string> _systemId;
         public string SystemId { get { return _systemId; } set { _systemId = value; } }
-        private Value<string> _title;
+        private DirtyValue<string> _title;
         public string Title { get { return _title; } set { _title = value; } }
-        private Value<bool?> _underwritingReady;
+        private DirtyValue<bool?> _underwritingReady;
         public bool? UnderwritingReady { get { return _underwritingReady; } set { _underwritingReady = value; } }
-        private Value<string> _underwritingReadyBy;
+        private DirtyValue<string> _underwritingReadyBy;
         public string UnderwritingReadyBy { get { return _underwritingReadyBy; } set { _underwritingReadyBy = value; } }
-        private Value<DateTime?> _underwritingReadyDateUtc;
+        private DirtyValue<DateTime?> _underwritingReadyDateUtc;
         public DateTime? UnderwritingReadyDateUtc { get { return _underwritingReadyDateUtc; } set { _underwritingReadyDateUtc = value; } }
         private int _gettingDirty;
         private int _settingDirty; 

--- a/src/EncompassRest/Loans/VerificationLog.cs
+++ b/src/EncompassRest/Loans/VerificationLog.cs
@@ -14,14 +14,14 @@ namespace EncompassRest.Loans
         public DateTime? AccessedDateUtc { get { return _accessedDateUtc; } set { _accessedDateUtc = value; } }
         private Value<string> _addedBy;
         public string AddedBy { get { return _addedBy; } set { _addedBy = value; } }
-        private Value<List<LogAlert>> _alerts;
-        public List<LogAlert> Alerts { get { return _alerts; } set { _alerts = value; } }
+        private DirtyList<LogAlert> _alerts;
+        public IList<LogAlert> Alerts { get { var v = _alerts; return v ?? Interlocked.CompareExchange(ref _alerts, (v = new DirtyList<LogAlert>()), null) ?? v; } set { _alerts = new DirtyList<LogAlert>(value); } }
         private Value<string> _alertsXml;
         public string AlertsXml { get { return _alertsXml; } set { _alertsXml = value; } }
         private Value<string> _allowedRoleDelimitedList;
         public string AllowedRoleDelimitedList { get { return _allowedRoleDelimitedList; } set { _allowedRoleDelimitedList = value; } }
-        private Value<List<EntityReference>> _allowedRoles;
-        public List<EntityReference> AllowedRoles { get { return _allowedRoles; } set { _allowedRoles = value; } }
+        private DirtyList<EntityReference> _allowedRoles;
+        public IList<EntityReference> AllowedRoles { get { var v = _allowedRoles; return v ?? Interlocked.CompareExchange(ref _allowedRoles, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _allowedRoles = new DirtyList<EntityReference>(value); } }
         private Value<string> _allowedRolesXml;
         public string AllowedRolesXml { get { return _allowedRolesXml; } set { _allowedRolesXml = value; } }
         private Value<DateTime?> _archiveDateUtc;
@@ -30,16 +30,16 @@ namespace EncompassRest.Loans
         public string ArchivedBy { get { return _archivedBy; } set { _archivedBy = value; } }
         private Value<bool?> _closingDocumentIndicator;
         public bool? ClosingDocumentIndicator { get { return _closingDocumentIndicator; } set { _closingDocumentIndicator = value; } }
-        private Value<List<LogComment>> _commentList;
-        public List<LogComment> CommentList { get { return _commentList; } set { _commentList = value; } }
+        private DirtyList<LogComment> _commentList;
+        public IList<LogComment> CommentList { get { var v = _commentList; return v ?? Interlocked.CompareExchange(ref _commentList, (v = new DirtyList<LogComment>()), null) ?? v; } set { _commentList = new DirtyList<LogComment>(value); } }
         private Value<string> _commentListXml;
         public string CommentListXml { get { return _commentListXml; } set { _commentListXml = value; } }
         private Value<string> _comments;
         public string Comments { get { return _comments; } set { _comments = value; } }
         private Value<string> _company;
         public string Company { get { return _company; } set { _company = value; } }
-        private Value<List<EntityReference>> _conditions;
-        public List<EntityReference> Conditions { get { return _conditions; } set { _conditions = value; } }
+        private DirtyList<EntityReference> _conditions;
+        public IList<EntityReference> Conditions { get { var v = _conditions; return v ?? Interlocked.CompareExchange(ref _conditions, (v = new DirtyList<EntityReference>()), null) ?? v; } set { _conditions = new DirtyList<EntityReference>(value); } }
         private Value<string> _conditionsXml;
         public string ConditionsXml { get { return _conditionsXml; } set { _conditionsXml = value; } }
         private Value<DateTime?> _dateAddedUtc;
@@ -158,19 +158,15 @@ namespace EncompassRest.Loans
                 var dirty = _accessedBy.Dirty
                     || _accessedDateUtc.Dirty
                     || _addedBy.Dirty
-                    || _alerts.Dirty
                     || _alertsXml.Dirty
                     || _allowedRoleDelimitedList.Dirty
-                    || _allowedRoles.Dirty
                     || _allowedRolesXml.Dirty
                     || _archiveDateUtc.Dirty
                     || _archivedBy.Dirty
                     || _closingDocumentIndicator.Dirty
-                    || _commentList.Dirty
                     || _commentListXml.Dirty
                     || _comments.Dirty
                     || _company.Dirty
-                    || _conditions.Dirty
                     || _conditionsXml.Dirty
                     || _dateAddedUtc.Dirty
                     || _dateExpected.Dirty
@@ -224,7 +220,11 @@ namespace EncompassRest.Loans
                     || _title.Dirty
                     || _underwritingReady.Dirty
                     || _underwritingReadyBy.Dirty
-                    || _underwritingReadyDateUtc.Dirty;
+                    || _underwritingReadyDateUtc.Dirty
+                    || _alerts?.Dirty == true
+                    || _allowedRoles?.Dirty == true
+                    || _commentList?.Dirty == true
+                    || _conditions?.Dirty == true;
                 _gettingDirty = 0;
                 return dirty;
             }
@@ -234,19 +234,15 @@ namespace EncompassRest.Loans
                 _accessedBy.Dirty = value;
                 _accessedDateUtc.Dirty = value;
                 _addedBy.Dirty = value;
-                _alerts.Dirty = value;
                 _alertsXml.Dirty = value;
                 _allowedRoleDelimitedList.Dirty = value;
-                _allowedRoles.Dirty = value;
                 _allowedRolesXml.Dirty = value;
                 _archiveDateUtc.Dirty = value;
                 _archivedBy.Dirty = value;
                 _closingDocumentIndicator.Dirty = value;
-                _commentList.Dirty = value;
                 _commentListXml.Dirty = value;
                 _comments.Dirty = value;
                 _company.Dirty = value;
-                _conditions.Dirty = value;
                 _conditionsXml.Dirty = value;
                 _dateAddedUtc.Dirty = value;
                 _dateExpected.Dirty = value;
@@ -301,6 +297,10 @@ namespace EncompassRest.Loans
                 _underwritingReady.Dirty = value;
                 _underwritingReadyBy.Dirty = value;
                 _underwritingReadyDateUtc.Dirty = value;
+                if (_alerts != null) _alerts.Dirty = value;
+                if (_allowedRoles != null) _allowedRoles.Dirty = value;
+                if (_commentList != null) _commentList.Dirty = value;
+                if (_conditions != null) _conditions.Dirty = value;
                 _settingDirty = 0;
             }
         }

--- a/src/EncompassRest/Utilities/JsonHelper.cs
+++ b/src/EncompassRest/Utilities/JsonHelper.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using EncompassRest.Loans;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -140,18 +141,42 @@ namespace EncompassRest.Utilities
                     {
                         property.Converter = new EnumJsonConverter(enumOutputAttribute.EnumOutput);
                     }
-                    if (propertyInfo.PropertyType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)))
+                    var toAssignShouldSerializeMethod = true;
+                    if (member.DeclaringType == TypeData<CustomField>.Type)
                     {
-                        property.ShouldSerialize = o => o != null && ((IDirty)propertyInfo.GetValue(o))?.Dirty == true;
-                    }
-                    else
-                    {
-                        var propertyName = propertyInfo.Name;
-                        var backingFieldName = $"_{char.ToLower(propertyName[0])}{propertyName.Substring(1)}";
-                        var backingField = propertyInfo.DeclaringType.GetTypeInfo().DeclaredFields.FirstOrDefault(f => f.Name == backingFieldName && f.FieldType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)));
-                        if (backingField != null)
+                        if (propertyInfo.Name == "Id")
                         {
-                            property.ShouldSerialize = o => o != null && ((IDirty)backingField.GetValue(o))?.Dirty == true;
+                            property.ShouldSerialize = o => false;
+                            toAssignShouldSerializeMethod = false;
+                        }
+                        else if (propertyInfo.Name == "FieldName")
+                        {
+                            property.ShouldSerialize = o => true;
+                            toAssignShouldSerializeMethod = false;
+                        }
+                    }
+                    if (toAssignShouldSerializeMethod)
+                    {
+                        if (propertyInfo.Name == "Id")
+                        {
+                            property.ShouldSerialize = o => propertyInfo.GetValue(o) != null;
+                        }
+                        else
+                        {
+                            if (propertyInfo.PropertyType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)))
+                            {
+                                property.ShouldSerialize = o => o != null && ((IDirty)propertyInfo.GetValue(o))?.Dirty == true;
+                            }
+                            else
+                            {
+                                var propertyName = propertyInfo.Name;
+                                var backingFieldName = $"_{char.ToLower(propertyName[0])}{propertyName.Substring(1)}";
+                                var backingField = propertyInfo.DeclaringType.GetTypeInfo().DeclaredFields.FirstOrDefault(f => f.Name == backingFieldName && f.FieldType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)));
+                                if (backingField != null)
+                                {
+                                    property.ShouldSerialize = o => o != null && ((IDirty)backingField.GetValue(o))?.Dirty == true;
+                                }
+                            }
                         }
                     }
                 }

--- a/src/EncompassRest/Utilities/JsonHelper.cs
+++ b/src/EncompassRest/Utilities/JsonHelper.cs
@@ -157,25 +157,18 @@ namespace EncompassRest.Utilities
                     }
                     if (toAssignShouldSerializeMethod)
                     {
-                        if (propertyInfo.Name == "Id")
+                        var propertyName = propertyInfo.Name;
+                        if (propertyName == "Id")
                         {
                             property.ShouldSerialize = o => propertyInfo.GetValue(o) != null;
                         }
                         else
                         {
-                            if (propertyInfo.PropertyType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)))
+                            var backingFieldName = $"_{char.ToLower(propertyName[0])}{propertyName.Substring(1)}";
+                            var backingField = propertyInfo.DeclaringType.GetTypeInfo().DeclaredFields.FirstOrDefault(f => f.Name == backingFieldName && f.FieldType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)));
+                            if (backingField != null)
                             {
-                                property.ShouldSerialize = o => o != null && ((IDirty)propertyInfo.GetValue(o))?.Dirty == true;
-                            }
-                            else
-                            {
-                                var propertyName = propertyInfo.Name;
-                                var backingFieldName = $"_{char.ToLower(propertyName[0])}{propertyName.Substring(1)}";
-                                var backingField = propertyInfo.DeclaringType.GetTypeInfo().DeclaredFields.FirstOrDefault(f => f.Name == backingFieldName && f.FieldType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDirty)));
-                                if (backingField != null)
-                                {
-                                    property.ShouldSerialize = o => o != null && ((IDirty)backingField.GetValue(o))?.Dirty == true;
-                                }
+                                property.ShouldSerialize = o => o != null && ((IDirty)backingField.GetValue(o))?.Dirty == true;
                             }
                         }
                     }

--- a/src/EncompassRest/Utilities/TypeData.cs
+++ b/src/EncompassRest/Utilities/TypeData.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace EncompassRest.Utilities
 {
-    internal class TypeData
+    internal sealed class TypeData
     {
         private static ConcurrentDictionary<Type, TypeData> s_typeDatas = new ConcurrentDictionary<Type, TypeData>();
 
@@ -36,5 +36,14 @@ namespace EncompassRest.Utilities
         {
             Type = type;
         }
+    }
+
+    internal static class TypeData<T>
+    {
+        public static TypeData Data { get; } = TypeData.Get(typeof(T));
+
+        public static Type Type => Data.Type;
+
+        public static TypeInfo TypeInfo => Data.TypeInfo;
     }
 }

--- a/src/EncompassRest/Value.cs
+++ b/src/EncompassRest/Value.cs
@@ -1,4 +1,7 @@
-﻿namespace EncompassRest
+﻿using System.Linq;
+using EncompassRest.Utilities;
+
+namespace EncompassRest
 {
     /// <summary>
     /// Value wrapper to use for dirty checking.
@@ -10,14 +13,34 @@
 
         public static implicit operator Value<T>(T value) => new Value<T>(value);
 
-        private readonly T _value;
+        private static readonly bool s_tImplementsIDirty = TypeData<T>.Data.TypeInfo.ImplementedInterfaces.Any(implInterface => implInterface == TypeData<IDirty>.Type);
 
-        public bool Dirty { get; set; }
+        private readonly T _value;
+        private bool _dirty;
+
+        public bool Dirty
+        {
+            get
+            {
+                return s_tImplementsIDirty ? ((IDirty)_value).Dirty : _dirty;
+            }
+            set
+            {
+                if (s_tImplementsIDirty)
+                {
+                    ((IDirty)_value).Dirty = value;
+                }
+                else
+                {
+                    _dirty = value;
+                }
+            }
+        }
 
         public Value(T value)
         {
             _value = value;
-            Dirty = true;
+            _dirty = true;
         }
 
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;


### PR DESCRIPTION
Added support for dirty-checking collections. Had to change exposed type to `IList<T>` instead of `List<T>`.

Made entity and collection property getters new up references when null.

Added serialization logic to always serialize the `Id` property of objects except in the case of `CustomField`s which instead always serialize the `FieldName` property.

Fixes #26.