### PR TITLE
Added method overloads without the populate parameter

### DIFF
--- a/src/EncompassRest/Loans/Attachments/LoanAttachments.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachments.cs
@@ -110,6 +110,10 @@ namespace EncompassRest.Loans.Attachments
             public string MediaUrl { get; set; }
         }
 
+        public Task UpdateAttachmentAsync(LoanAttachment attachment) => UpdateAttachmentAsync(attachment, false, CancellationToken.None);
+
+        public Task UpdateAttachmentAsync(LoanAttachment attachment, CancellationToken cancellationToken) => UpdateAttachmentAsync(attachment, false, cancellationToken);
+
         public Task UpdateAttachmentAsync(LoanAttachment attachment, bool populate) => UpdateAttachmentAsync(attachment, populate, CancellationToken.None);
 
         public Task UpdateAttachmentAsync(LoanAttachment attachment, bool populate, CancellationToken cancellationToken)

--- a/src/EncompassRest/Loans/Documents/LoanDocuments.cs
+++ b/src/EncompassRest/Loans/Documents/LoanDocuments.cs
@@ -119,6 +119,10 @@ namespace EncompassRest.Loans.Documents
             }
         }
 
+        public Task<string> CreateDocumentAsync(LoanDocument document) => CreateDocumentAsync(document, false, CancellationToken.None);
+
+        public Task<string> CreateDocumentAsync(LoanDocument document, CancellationToken cancellationToken) => CreateDocumentAsync(document, false, cancellationToken);
+
         public Task<string> CreateDocumentAsync(LoanDocument document, bool populate) => CreateDocumentAsync(document, populate, CancellationToken.None);
 
         public Task<string> CreateDocumentAsync(LoanDocument document, bool populate, CancellationToken cancellationToken)
@@ -165,6 +169,10 @@ namespace EncompassRest.Loans.Documents
                 return await func(response).ConfigureAwait(false);
             }
         }
+
+        public Task UpdateDocumentAsync(LoanDocument document) => UpdateDocumentAsync(document, false, CancellationToken.None);
+
+        public Task UpdateDocumentAsync(LoanDocument document, CancellationToken cancellationToken) => UpdateDocumentAsync(document, false, cancellationToken);
 
         public Task UpdateDocumentAsync(LoanDocument document, bool populate) => UpdateDocumentAsync(document, populate, CancellationToken.None);
 

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -139,6 +139,10 @@ namespace EncompassRest.Loans
             }
         }
 
+        public Task<string> CreateLoanAsync(Loan loan) => CreateLoanAsync(loan, false, CancellationToken.None);
+
+        public Task<string> CreateLoanAsync(Loan loan, CancellationToken cancellationToken) => CreateLoanAsync(loan, false, cancellationToken);
+
         public Task<string> CreateLoanAsync(Loan loan, bool populate) => CreateLoanAsync(loan, populate, CancellationToken.None);
 
         public Task<string> CreateLoanAsync(Loan loan, bool populate, CancellationToken cancellationToken)
@@ -189,6 +193,10 @@ namespace EncompassRest.Loans
                 return await func(response).ConfigureAwait(false);
             }
         }
+
+        public Task UpdateLoanAsync(Loan loan) => UpdateLoanAsync(loan, false, CancellationToken.None);
+
+        public Task UpdateLoanAsync(Loan loan, CancellationToken cancellationToken) => UpdateLoanAsync(loan, false, cancellationToken);
 
         public Task UpdateLoanAsync(Loan loan, bool populate) => UpdateLoanAsync(loan, populate, CancellationToken.None);
 


### PR DESCRIPTION
Added method overloads without the populate parameter to parallel with other methods that may add populate overloads later when supported by the Encompass API. I defaulted the methods to not populate.