### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -48,6 +48,9 @@ namespace EncompassRest.Tests
             Assert.IsNotNull(loanId);
             Assert.AreEqual(loanId, loan.EncompassId);
             var json = JsonConvert.SerializeObject(loan, serializerSettings);
+            var deserializedLoan = JsonConvert.DeserializeObject<Loan>(json, serializerSettings);
+            var newJson = JsonConvert.SerializeObject(loan, serializerSettings);
+            Assert.AreEqual(json, newJson);
             await Task.Delay(5000);
             Assert.IsTrue(await client.Loans.DeleteLoanAsync(loanId));
         }
@@ -62,6 +65,17 @@ namespace EncompassRest.Tests
             Assert.AreEqual(true, loan.ExtensionData["dog"]);
             loan = JsonConvert.DeserializeObject<Loan>(@"{""applicationTakenMethodType"":""Telephone""}");
             Assert.AreEqual(ApplicationTakenMethodType.Telephone, loan.ApplicationTakenMethodType.EnumValue.Value);
+
+            var value = new { Loan = loan, TestString = "TESTING" };
+            var serializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
+            var json = JsonConvert.SerializeObject(value, serializerSettings);
+            Assert.AreEqual(@"{
+  ""Loan"": {
+    ""applicationTakenMethodType"": ""Telephone""
+  },
+  ""TestString"": ""TESTING""
+}", json);
+            var newValue = JsonConvert.DeserializeAnonymousType(json, value);
         }
 
         [TestMethod]

--- a/src/EncompassRest/Contacts/Contact.cs
+++ b/src/EncompassRest/Contacts/Contact.cs
@@ -16,21 +16,24 @@ namespace EncompassRest.Contacts
 
         internal Contact(EncompassRestClient client, string contactId)
         {
-            Preconditions.NotNull(client, nameof(client));
-            Preconditions.NotNullOrEmpty(contactId, nameof(contactId));
-
-            Id = contactId;
-            Initialize(client);
+            Initialize(client, contactId);
         }
         
         internal Contact()
         {
         }
 
-        internal void Initialize(EncompassRestClient client)
+        public void Initialize(EncompassRestClient client, string contactId)
         {
-            Client = client;
-            Notes = new ContactNotes(client, Id, ApiPath);
+            Preconditions.NotNull(client, nameof(client));
+            Preconditions.NotNullOrEmpty(contactId, nameof(contactId));
+
+            if (!ReferenceEquals(Client, client))
+            {
+                Client = client;
+                Id = contactId;
+                Notes = new ContactNotes(client, Id, ApiPath);
+            }
         }
 
         private DirtyValue<string> _firstName;

--- a/src/EncompassRest/Contacts/Contacts.cs
+++ b/src/EncompassRest/Contacts/Contacts.cs
@@ -17,7 +17,7 @@ namespace EncompassRest.Contacts
             Preconditions.NotNullOrEmpty(contactId, nameof(contactId));
 
             var contact = await GetDirtyAsync<TContact>(contactId, null, nameof(GetContactAsync), contactId, cancellationToken).ConfigureAwait(false);
-            contact.Initialize(Client);
+            contact.Initialize(Client, contact.Id);
             return contact;
         }
 
@@ -36,7 +36,7 @@ namespace EncompassRest.Contacts
             Preconditions.NullOrEmpty(contact.Id, $"{nameof(contact)}.{nameof(contact.Id)}");
 
             var contactId = await PostPopulateDirtyAsync(null, contact, nameof(CreateContactAsync), populate, cancellationToken).ConfigureAwait(false);
-            contact.Initialize(Client);
+            contact.Initialize(Client, contactId);
             return contactId;
         }
 
@@ -56,7 +56,7 @@ namespace EncompassRest.Contacts
             Preconditions.NotNull(contact, nameof(contact));
             Preconditions.NotNullOrEmpty(contact.Id, $"{nameof(contact)}.{nameof(contact.Id)}");
 
-            contact.Initialize(Client);
+            contact.Initialize(Client, contact.Id);
             return PatchPopulateDirtyAsync(contact.Id, JsonStreamContent.Create(contact), nameof(UpdateContactAsync), contact.Id, contact, populate, cancellationToken);
         }
 

--- a/src/EncompassRest/CustomDataObjects/CustomDataObjects.cs
+++ b/src/EncompassRest/CustomDataObjects/CustomDataObjects.cs
@@ -33,7 +33,7 @@ namespace EncompassRest.CustomDataObjects
         public Task CreateOrReplaceCustomDataObjectAsync(CustomDataObject cdo, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNull(cdo, nameof(cdo));
-            Preconditions.NotNullOrEmpty(cdo.Name, $"{cdo}.{cdo.Name}");
+            Preconditions.NotNullOrEmpty(cdo.Name, $"{nameof(cdo)}.{nameof(cdo.Name)}");
 
             return PutAsync(cdo.Name, null, JsonStreamContent.Create(cdo), nameof(CreateOrReplaceCustomDataObjectAsync), cdo.Name, cancellationToken);
         }
@@ -58,7 +58,7 @@ namespace EncompassRest.CustomDataObjects
         public Task AppendToCustomDataObjectAsync(CustomDataObject cdo, bool populate, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNull(cdo, nameof(cdo));
-            Preconditions.NotNullOrEmpty(cdo.Name, $"{cdo}.{cdo.Name}");
+            Preconditions.NotNullOrEmpty(cdo.Name, $"{nameof(cdo)}.{nameof(cdo.Name)}");
 
             return PatchPopulateDirtyAsync(cdo.Name, JsonStreamContent.Create(cdo), nameof(AppendToCustomDataObjectAsync), cdo.Name, cdo, populate, cancellationToken);
         }

--- a/src/EncompassRest/EncompassRest.csproj
+++ b/src/EncompassRest/EncompassRest.csproj
@@ -10,12 +10,14 @@
     <Summary>Encompass API Client Library for .NET</Summary>
     <RepositoryUrl>https://github.com/EncompassRest/EncompassRest</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Enums.NET" Version="2.3.0" />
+    <PackageReference Include="Enums.NET" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
@@ -33,11 +35,5 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <AssemblyTitle>EncompassRest .NET 4.5</AssemblyTitle>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -15,39 +15,39 @@ namespace EncompassRest
 {
     public sealed class EncompassRestClient : IDisposable
     {
-        public static async Task<EncompassRestClient> CreateFromUserCredentialsAsync(string clientId, string clientSecret, string instanceId, string userId, string password, TokenExpirationHandling tokenExpirationHandling, CancellationToken cancellationToken = default)
+        public static async Task<EncompassRestClient> CreateFromUserCredentialsAsync(string apiClientId, string apiClientSecret, string instanceId, string userId, string password, TokenExpirationHandling tokenExpirationHandling, CancellationToken cancellationToken = default)
         {
-            Preconditions.NotNullOrEmpty(clientId, nameof(clientId));
-            Preconditions.NotNullOrEmpty(clientSecret, nameof(clientSecret));
+            Preconditions.NotNullOrEmpty(apiClientId, nameof(apiClientId));
+            Preconditions.NotNullOrEmpty(apiClientSecret, nameof(apiClientSecret));
             Preconditions.NotNullOrEmpty(instanceId, nameof(instanceId));
             Preconditions.NotNullOrEmpty(userId, nameof(userId));
             Preconditions.NotNullOrEmpty(password, nameof(password));
 
-            var client = tokenExpirationHandling == TokenExpirationHandling.RetrieveNewToken ? new EncompassRestClient(clientId, clientSecret, instanceId, userId, password, tokenExpirationHandling) : new EncompassRestClient(clientId, clientSecret);
+            var client = tokenExpirationHandling == TokenExpirationHandling.RetrieveNewToken ? new EncompassRestClient(apiClientId, apiClientSecret, instanceId, userId, password, tokenExpirationHandling) : new EncompassRestClient(apiClientId, apiClientSecret);
             await client.AccessToken.SetTokenWithUserCredentialsAsync(instanceId, userId, password, cancellationToken).ConfigureAwait(false);
             return client;
         }
 
-        public static async Task<EncompassRestClient> CreateFromAuthorizationCodeAsync(string clientId, string clientSecret, string redirectUri, string authorizationCode, CancellationToken cancellationToken = default)
+        public static async Task<EncompassRestClient> CreateFromAuthorizationCodeAsync(string apiClientId, string apiClientSecret, string redirectUri, string authorizationCode, CancellationToken cancellationToken = default)
         {
-            Preconditions.NotNullOrEmpty(clientId, nameof(clientId));
-            Preconditions.NotNullOrEmpty(clientSecret, nameof(clientSecret));
+            Preconditions.NotNullOrEmpty(apiClientId, nameof(apiClientId));
+            Preconditions.NotNullOrEmpty(apiClientSecret, nameof(apiClientSecret));
             Preconditions.NotNullOrEmpty(redirectUri, nameof(redirectUri));
             Preconditions.NotNullOrEmpty(authorizationCode, nameof(authorizationCode));
 
-            var client = new EncompassRestClient(clientId, clientSecret);
+            var client = new EncompassRestClient(apiClientId, apiClientSecret);
             await client.AccessToken.SetTokenWithAuthorizationCodeAsync(redirectUri, authorizationCode, cancellationToken).ConfigureAwait(false);
             return client;
         }
 
-        public static EncompassRestClient CreateFromAccessToken(string clientId, string clientSecret, string accessToken, string tokenType = "Bearer")
+        public static EncompassRestClient CreateFromAccessToken(string apiClientId, string apiClientSecret, string accessToken, string tokenType = "Bearer")
         {
-            Preconditions.NotNullOrEmpty(clientId, nameof(clientId));
-            Preconditions.NotNullOrEmpty(clientSecret, nameof(clientSecret));
+            Preconditions.NotNullOrEmpty(apiClientId, nameof(apiClientId));
+            Preconditions.NotNullOrEmpty(apiClientSecret, nameof(apiClientSecret));
             Preconditions.NotNullOrEmpty(accessToken, nameof(accessToken));
             Preconditions.NotNullOrEmpty(tokenType, nameof(tokenType));
 
-            var client = new EncompassRestClient(clientId, clientSecret);
+            var client = new EncompassRestClient(apiClientId, apiClientSecret);
             client.AccessToken.Token = accessToken;
             client.AccessToken.Type = tokenType;
             return client;
@@ -212,13 +212,13 @@ namespace EncompassRest
         }
         #endregion
 
-        internal EncompassRestClient(string clientId, string clientSecret)
+        internal EncompassRestClient(string apiClientId, string apiClientSecret)
         {
-            AccessToken = new AccessToken(clientId, clientSecret, this);
+            AccessToken = new AccessToken(apiClientId, apiClientSecret, this);
         }
 
-        private EncompassRestClient(string clientId, string clientSecret, string instanceId, string userId, string password, TokenExpirationHandling tokenExpirationHandling)
-            : this(clientId, clientSecret)
+        private EncompassRestClient(string apiClientId, string apiClientSecret, string instanceId, string userId, string password, TokenExpirationHandling tokenExpirationHandling)
+            : this(apiClientId, apiClientSecret)
         {
             _instanceId = instanceId;
             _userId = userId;

--- a/src/EncompassRest/Loans/LoanCustomizations.cs
+++ b/src/EncompassRest/Loans/LoanCustomizations.cs
@@ -32,11 +32,7 @@ namespace EncompassRest.Loans
         /// <param name="loanId"></param>
         public Loan(EncompassRestClient client, string loanId)
         {
-            Preconditions.NotNull(client, nameof(client));
-            Preconditions.NotNullOrEmpty(loanId, nameof(loanId));
-
-            EncompassId = loanId;
-            Initialize(client);
+            Initialize(client, loanId);
         }
 
         /// <summary>
@@ -47,13 +43,20 @@ namespace EncompassRest.Loans
         {
         }
 
-        internal void Initialize(EncompassRestClient client)
+        public void Initialize(EncompassRestClient client, string loanId)
         {
-            Client = client;
-            Documents = new LoanDocuments(client, EncompassId);
-            Attachments = new LoanAttachments(client, EncompassId);
-            CustomDataObjects = new LoanCustomDataObjects(client, EncompassId);
-            LoanApis = new LoanObjectBoundApis(client, this);
+            Preconditions.NotNull(client, nameof(client));
+            Preconditions.NotNullOrEmpty(loanId, nameof(loanId));
+
+            if (!ReferenceEquals(Client, client))
+            {
+                Client = client;
+                EncompassId = loanId;
+                Documents = new LoanDocuments(client, EncompassId);
+                Attachments = new LoanAttachments(client, EncompassId);
+                CustomDataObjects = new LoanCustomDataObjects(client, EncompassId);
+                LoanApis = new LoanObjectBoundApis(client, this);
+            }
         }
     }
 }

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -58,7 +58,7 @@ namespace EncompassRest.Loans
             }
 
             var loan = await GetDirtyAsync<Loan>(loanId, queryParameters.ToString(), nameof(GetLoanAsync), loanId, cancellationToken).ConfigureAwait(false);
-            loan.Initialize(Client);
+            loan.Initialize(Client, loan.EncompassId);
             return loan;
         }
 
@@ -98,7 +98,7 @@ namespace EncompassRest.Loans
             Preconditions.NullOrEmpty(loan.EncompassId, $"{nameof(loan)}.{nameof(loan.EncompassId)}");
 
             var loanId = await PostPopulateDirtyAsync(null, createLoanOptions?.ToQueryParameters()?.ToString(), loan, nameof(CreateLoanAsync), createLoanOptions?.Populate == true, cancellationToken).ConfigureAwait(false);
-            loan.Initialize(Client);
+            loan.Initialize(Client, loanId);
             return loanId;
         }
 
@@ -120,7 +120,7 @@ namespace EncompassRest.Loans
             Preconditions.NotNull(loan, nameof(loan));
             Preconditions.NotNullOrEmpty(loan.EncompassId, $"{nameof(loan)}.{nameof(loan.EncompassId)}");
 
-            loan.Initialize(Client);
+            loan.Initialize(Client, loan.EncompassId);
             return PatchPopulateDirtyAsync(loan.EncompassId, updateLoanOptions?.ToQueryParameters()?.ToString(), JsonStreamContent.Create(loan), nameof(UpdateLoanAsync), loan.EncompassId, loan, updateLoanOptions?.Populate == true, cancellationToken);
         }
 

--- a/src/EncompassRest/PublicallySerializableConverter.cs
+++ b/src/EncompassRest/PublicallySerializableConverter.cs
@@ -11,6 +11,7 @@ namespace EncompassRest
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var publicSerializer = JsonHelper.CreatePublicSerializer(serializer);
+            publicSerializer.CheckAdditionalContent = false;
             return publicSerializer.Deserialize(reader, objectType);
         }
 

--- a/src/EncompassRest/Token/AccessToken.cs
+++ b/src/EncompassRest/Token/AccessToken.cs
@@ -15,8 +15,8 @@ namespace EncompassRest.Token
     public sealed class AccessToken : ApiObject
     {
         private HttpClient _tokenClient;
-        private readonly string _clientId;
-        private readonly string _clientSecret;
+        private readonly string _apiClientId;
+        private readonly string _apiClientSecret;
 
         #region Properties
         public string Token { get; internal set; }
@@ -34,7 +34,7 @@ namespace EncompassRest.Token
                     {
                         BaseAddress = new Uri("https://api.elliemae.com/oauth2/v1/")
                     };
-                    tokenClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{WebUtility.UrlEncode(_clientId)}:{WebUtility.UrlEncode(_clientSecret)}")));
+                    tokenClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{WebUtility.UrlEncode(_apiClientId)}:{WebUtility.UrlEncode(_apiClientSecret)}")));
                     tokenClient = Interlocked.CompareExchange(ref _tokenClient, tokenClient, null) ?? tokenClient;
                 }
                 return tokenClient;
@@ -42,11 +42,11 @@ namespace EncompassRest.Token
         }
         #endregion
 
-        internal AccessToken(string clientId, string clientSecret, EncompassRestClient client)
+        internal AccessToken(string apiClientId, string apiClientSecret, EncompassRestClient client)
             : base(client, "token")
         {
-            _clientId = clientId;
-            _clientSecret = clientSecret;
+            _apiClientId = apiClientId;
+            _apiClientSecret = apiClientSecret;
         }
 
         #region Public Methods


### PR DESCRIPTION
Fixed Loan deserialization as property

Fixed use in .NET Standard 1.x libraries

Renamed clientId and clientSecret to apiClientId and apiClientSecret

Made Loan.Initialize and Contact.Initialize public

Closes #91 
Closes #92 
Closes #97