### PR TITLE
Obsoleted the EncompassRestClient.CreateFromUserCredentialsAsync method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `EncompassRestClient` class implements `IDisposable` so it is recommended to
 
 #### From User Credentials
 ```c#
-using (var client = await EncompassRestClient.CreateFromUserCredentialsAsync("apiClientId", "apiSecret", "encompassInstance", "encompassUserId", "encompassPassword"))
+using (var client = await EncompassRestClient.CreateFromUserCredentialsAsync("apiClientId", "apiClientSecret", "encompassInstanceId", "encompassUserId", "encompassPassword"))
 {
     // use client
 }
@@ -54,7 +54,7 @@ using (var client = await EncompassRestClient.CreateFromUserCredentialsAsync("ap
 
 #### From Authorization Code
 ```c#
-using (var client = await EncompassRestClient.CreateFromAuthorizationCodeAsync("apiClientId", "apiSecret", "redirectUri", "authorizationCode"))
+using (var client = await EncompassRestClient.CreateFromAuthorizationCodeAsync("apiClientId", "apiClientSecret", "redirectUri", "authorizationCode"))
 {
     // use client
 }
@@ -62,7 +62,16 @@ using (var client = await EncompassRestClient.CreateFromAuthorizationCodeAsync("
 
 #### From Access Token
 ```c#
-using (var client = EncompassRestClient.CreateFromAccessToken("apiClientId", "apiSecret", "accessToken"))
+using (var client = EncompassRestClient.CreateFromAccessToken("apiClientId", "apiClientSecret", "accessToken"))
+{
+    // use client
+}
+```
+
+#### Auto-retrieve new token when expired
+```c#
+using (var client = await EncompassRestClient.CreateAsync("apiClientId", "apiClientSecret", "encompassInstanceId",
+    (tokenCreator, ct) => tokenCreator.FromUserCredentialsAsync("encompassUserId", "encompassPassword", ct)))
 {
     // use client
 }

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -31,11 +31,12 @@ namespace EncompassRest
             return client;
         }
 
-        public static async Task<EncompassRestClient> CreateFromUserCredentialsAsync(string apiClientId, string apiClientSecret, string instanceId, string userId, string password, TokenExpirationHandling tokenExpirationHandling = default, CancellationToken cancellationToken = default)
+        public static Task<EncompassRestClient> CreateFromUserCredentialsAsync(string apiClientId, string apiClientSecret, string instanceId, string userId, string password, CancellationToken cancellationToken = default) =>
+            CreateFromUserCredentialsAsync(apiClientId, apiClientSecret, instanceId, userId, password, TokenExpirationHandling.Default, cancellationToken);
+
+        [Obsolete("To avoid storing user credentials this method has been made obsolete. Use the CreateAsync method instead.")]
+        public static async Task<EncompassRestClient> CreateFromUserCredentialsAsync(string apiClientId, string apiClientSecret, string instanceId, string userId, string password, TokenExpirationHandling tokenExpirationHandling, CancellationToken cancellationToken = default)
         {
-            Preconditions.NotNullOrEmpty(apiClientId, nameof(apiClientId));
-            Preconditions.NotNullOrEmpty(apiClientSecret, nameof(apiClientSecret));
-            Preconditions.NotNullOrEmpty(instanceId, nameof(instanceId));
             Preconditions.NotNullOrEmpty(userId, nameof(userId));
             Preconditions.NotNullOrEmpty(password, nameof(password));
 
@@ -43,6 +44,11 @@ namespace EncompassRest
             {
                 return await CreateAsync(apiClientId, apiClientSecret, instanceId, (tokenCreator, ct) => tokenCreator.FromUserCredentialsAsync(userId, password, ct), cancellationToken).ConfigureAwait(false);
             }
+
+            Preconditions.NotNullOrEmpty(apiClientId, nameof(apiClientId));
+            Preconditions.NotNullOrEmpty(apiClientSecret, nameof(apiClientSecret));
+            Preconditions.NotNullOrEmpty(instanceId, nameof(instanceId));
+
             var client = new EncompassRestClient(apiClientId, apiClientSecret, instanceId, null);
             var accessToken = await client.AccessToken.GetTokenFromUserCredentialsAsync(userId, password, nameof(CreateFromUserCredentialsAsync), cancellationToken).ConfigureAwait(false);
             client.AccessToken.Token = accessToken;


### PR DESCRIPTION
Obsoleted the EncompassRestClient.CreateFromUserCredentialsAsync method with a TokenExpirationHandling parameter.