### PR TITLE
Adds support for auto-retry on server-side timeouts

### DIFF
--- a/src/EncompassRest.Tests/TestBaseClass.cs
+++ b/src/EncompassRest.Tests/TestBaseClass.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using EncompassRest.Token;
 using EncompassRest.Utilities;
 
 namespace EncompassRest.Tests
@@ -31,12 +30,12 @@ namespace EncompassRest.Tests
                             credentials = JsonHelper.FromJson<TestClientCredentials>(sr);
                         }
                     }
-                    client = await EncompassRestClient.CreateFromUserCredentialsAsync(credentials.ClientId, credentials.ClientSecret, credentials.InstanceId, credentials.UserId, credentials.Password, TokenExpirationHandling.RetrieveNewToken).ConfigureAwait(false);
+                    client = await EncompassRestClient.CreateAsync(credentials.Parameters, tc => tc.FromUserCredentialsAsync(credentials.InstanceId, credentials.UserId, credentials.Password)).ConfigureAwait(false);
                     Console.WriteLine("Using test client credentials file");
                 }
                 else
                 {
-                    client = new EncompassRestClient("ClientId", "ClientSecret");
+                    client = new EncompassRestClient(new ClientParameters("ApiClientId", "ApiClientSecret"));
                     var accessToken = client.AccessToken;
                     accessToken.Token = "Token";
                     var httpClient = client.HttpClient;
@@ -54,8 +53,7 @@ namespace EncompassRest.Tests
 
         private sealed class TestClientCredentials
         {
-            public string ClientId { get; set; }
-            public string ClientSecret { get; set; }
+            public ClientParameters Parameters { get; set; }
             public string InstanceId { get; set; }
             public string UserId { get; set; }
             public string Password { get; set; }

--- a/src/EncompassRest/ClientParameters.cs
+++ b/src/EncompassRest/ClientParameters.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using EncompassRest.Utilities;
+
+namespace EncompassRest
+{
+    public sealed class ClientParameters
+    {
+        private string _apiClientId;
+        private string _apiClientSecret;
+        private int _timeoutRetryCount;
+
+        public string ApiClientId
+        {
+            get => _apiClientId;
+            set
+            {
+                Preconditions.NotNullOrEmpty(value, nameof(ApiClientId));
+
+                _apiClientId = value;
+            }
+        }
+
+        public string ApiClientSecret
+        {
+            get => _apiClientSecret;
+            set
+            {
+                Preconditions.NotNullOrEmpty(value, nameof(ApiClientSecret));
+
+                _apiClientSecret = value;
+            }
+        }
+
+        public TimeSpan Timeout { get; set; }
+
+        public int TimeoutRetryCount
+        {
+            get => _timeoutRetryCount;
+            set
+            {
+                Preconditions.GreaterThanOrEquals(value, nameof(TimeoutRetryCount), 0);
+                Preconditions.LessThanOrEquals(value, nameof(TimeoutRetryCount), 3);
+
+                _timeoutRetryCount = value;
+            }
+        }
+
+        public ClientParameters(string apiClientId, string apiClientSecret)
+        {
+            ApiClientId = apiClientId;
+            ApiClientSecret = apiClientSecret;
+        }
+    }
+}

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EncompassRest.Loans.Attachments;
-using EncompassRest.Loans.Documents;
 using EncompassRest.Utilities;
 using EnumsNET;
 
@@ -16,24 +12,6 @@ namespace EncompassRest.Loans
         internal Loans(EncompassRestClient client)
             : base(client, "encompass/v1/loans")
         {
-        }
-
-        [Obsolete("Use GetLoanApis(loanId).Documents instead")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public LoanDocuments GetLoanDocuments(string loanId)
-        {
-            Preconditions.NotNullOrEmpty(loanId, nameof(loanId));
-
-            return new LoanDocuments(Client, loanId);
-        }
-
-        [Obsolete("Use GetLoanApis(loanId).Attachments instead")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public LoanAttachments GetLoanAttachments(string loanId)
-        {
-            Preconditions.NotNullOrEmpty(loanId, nameof(loanId));
-
-            return new LoanAttachments(Client, loanId);
         }
 
         public LoanApis GetLoanApis(string loanId)

--- a/src/EncompassRest/TimeoutRetryEventArgs.cs
+++ b/src/EncompassRest/TimeoutRetryEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Net.Http;
+
+namespace EncompassRest
+{
+    public sealed class TimeoutRetryEventArgs : EventArgs
+    {
+        public HttpRequestMessage Request { get; }
+
+        public HttpResponseMessage TimeoutResponse { get; }
+
+        public int RetryCount { get; }
+
+        internal TimeoutRetryEventArgs(HttpRequestMessage request, HttpResponseMessage timeoutResponse, int retryCount)
+        {
+            Request = request;
+            TimeoutResponse = timeoutResponse;
+            RetryCount = retryCount;
+        }
+    }
+}

--- a/src/EncompassRest/Token/AccessToken.cs
+++ b/src/EncompassRest/Token/AccessToken.cs
@@ -30,7 +30,10 @@ namespace EncompassRest.Token
                 var tokenClient = _tokenClient;
                 if (tokenClient == null)
                 {
-                    tokenClient = new HttpClient();
+                    tokenClient = new HttpClient(new EncompassRestClient.RetryHandler(Client, false))
+                    {
+                        Timeout = Client.Timeout
+                    };
                     tokenClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{WebUtility.UrlEncode(_apiClientId)}:{WebUtility.UrlEncode(_apiClientSecret)}")));
                     tokenClient = Interlocked.CompareExchange(ref _tokenClient, tokenClient, null) ?? tokenClient;
                 }
@@ -57,10 +60,10 @@ namespace EncompassRest.Token
 
         internal void Dispose() => _tokenClient?.Dispose();
 
-        internal Task<string> GetTokenFromUserCredentialsAsync(string userId, string password, string methodName, CancellationToken cancellationToken) => GetTokenAsync(new[]
+        internal Task<string> GetTokenFromUserCredentialsAsync(string instanceId, string userId, string password, string methodName, CancellationToken cancellationToken) => GetTokenAsync(new[]
             {
                 KeyValuePair.Create("grant_type", "password"),
-                KeyValuePair.Create("username", $"{userId}@encompass:{Client.InstanceId}"),
+                KeyValuePair.Create("username", $"{userId}@encompass:{instanceId}"),
                 KeyValuePair.Create("password", password)
             }, methodName, cancellationToken);
 

--- a/src/EncompassRest/TokenCreator.cs
+++ b/src/EncompassRest/TokenCreator.cs
@@ -7,13 +7,19 @@ namespace EncompassRest
     {
         private readonly EncompassRestClient _client;
 
-        internal TokenCreator(EncompassRestClient client)
+        /// <summary>
+        /// The request <see cref="CancellationToken"/> is automatically applied to uses of this class.
+        /// </summary>
+        public CancellationToken RequestCancellationToken { get; }
+
+        internal TokenCreator(EncompassRestClient client, CancellationToken requestCancellationToken)
         {
             _client = client;
+            RequestCancellationToken = requestCancellationToken;
         }
 
-        public Task<string> FromUserCredentialsAsync(string userId, string password, CancellationToken cancellationToken = default) => _client.AccessToken.GetTokenFromUserCredentialsAsync(userId, password, nameof(FromUserCredentialsAsync), cancellationToken);
+        public Task<string> FromUserCredentialsAsync(string instanceId, string userId, string password, CancellationToken cancellationToken = default) => _client.AccessToken.GetTokenFromUserCredentialsAsync(instanceId, userId, password, nameof(FromUserCredentialsAsync), CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, RequestCancellationToken).Token);
 
-        public Task<string> FromAuthorizationCodeAsync(string redirectUri, string authorizationCode, CancellationToken cancellationToken = default) => _client.AccessToken.GetTokenFromAuthorizationCodeAsync(redirectUri, authorizationCode, nameof(FromAuthorizationCodeAsync), cancellationToken);
+        public Task<string> FromAuthorizationCodeAsync(string redirectUri, string authorizationCode, CancellationToken cancellationToken = default) => _client.AccessToken.GetTokenFromAuthorizationCodeAsync(redirectUri, authorizationCode, nameof(FromAuthorizationCodeAsync), CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, RequestCancellationToken).Token);
     }
 }


### PR DESCRIPTION
Adds support for auto-retry on server-side timeouts.

Adds support for specifying a timeout upon client creation through the ClientParameters parameter.

Internalizes the RequestCancellationToken in TokenCreator so users don't need to remember to pass it on.

Removes some obsolete methods.

Includes some breaking changes.

Fixes #120 
Closes #117 