### PR TITLE
Added ResponseMessageData - #138

### DIFF
--- a/src/EncompassRest/ApiObject.cs
+++ b/src/EncompassRest/ApiObject.cs
@@ -115,6 +115,8 @@ namespace EncompassRest
                         throw await EncompassRestException.CreateAsync(CreateErrorMessage(methodName, resourceId), response).ConfigureAwait(false);
                     }
 
+                    Client.AddResponseMessageData(await ResponseMessageData.CreateAsync(response).ConfigureAwait(false));
+
                     if (func != null)
                     {
                         return await func(response).ConfigureAwait(false);

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -10,6 +10,7 @@ using EncompassRest.Token;
 using EncompassRest.Utilities;
 using EncompassRest.Contacts;
 using EncompassRest.CustomDataObjects;
+using System.Collections.Concurrent;
 
 namespace EncompassRest
 {
@@ -91,8 +92,11 @@ namespace EncompassRest
         private Users.Users _users;
         private LoanFolders.LoanFolders _loanFolders;
         private Settings.Settings _settings;
+        private ConcurrentBag<ResponseMessageData> responseBag;
 
         #region Properties
+        public ConcurrentBag<ResponseMessageData> ResponseMessages => responseBag;
+
         public AccessToken AccessToken { get; }
 
         public TokenExpirationHandling TokenExpirationHandling => _tokenInitializer != null ? TokenExpirationHandling.RetrieveNewToken : TokenExpirationHandling.Default;
@@ -270,6 +274,16 @@ namespace EncompassRest
         {
             AccessToken.Dispose();
             _httpClient?.Dispose();
+        }
+
+        internal void AddResponseMessageData(ResponseMessageData newData)
+        {
+            if (responseBag == null)
+            {
+                responseBag = new ConcurrentBag<ResponseMessageData>();
+            }
+
+            responseBag.Add(newData);
         }
 
         private RetryHandler GetRetryHandler()

--- a/src/EncompassRest/ResponseMessageData.cs
+++ b/src/EncompassRest/ResponseMessageData.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using EncompassRest.Utilities;
+
+namespace EncompassRest
+{
+    public sealed class ResponseMessageData
+    {
+        internal static async Task<ResponseMessageData> CreateAsync(HttpResponseMessage response)
+        {
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var requestContent = GetRequestContent(response.RequestMessage.Content);
+            return new ResponseMessageData(response, responseContent, requestContent);
+        }
+
+        private static string GetRequestContent(HttpContent content)
+        {
+            switch (content)
+            {
+                case JsonStreamContent jsonStreamContent:
+                    return JsonHelper.ToJson(jsonStreamContent.Value, jsonStreamContent.Type);
+                case JsonStringContent jsonStringContent:
+                    return jsonStringContent.Json;
+                default:
+                    return null;
+            }
+        }
+
+        public HttpRequestMessage Request => Response.RequestMessage;
+
+        public string RequestContent { get; }
+
+        public HttpStatusCode StatusCode => Response.StatusCode;
+
+        public HttpResponseMessage Response { get; }
+
+        public string ResponseContent { get; }
+
+        public string Date => Response.Headers.TryGetValues("Date", out var values) ? values.FirstOrDefault() : null;
+
+        public string CorrelationId => Response.Headers.TryGetValues("X-Correlation-ID", out var values) ? values.FirstOrDefault() : null;
+
+        private ResponseMessageData(HttpResponseMessage response, string responseContent, string requestContent)            
+        {
+            Response = response;
+            ResponseContent = responseContent;
+            RequestContent = requestContent;
+        }
+    }
+}


### PR DESCRIPTION
Added ResponseMessageData to hold successful responses, updated EncompassRestClient to hold ResponseMessageData, updated APIObject to store ResponseMessageData in EncompassRestClient.  

I mimicked the design of EncompassRestException for the ResponseMessageData class, adding the Date header as a property, and remove the Exception aspect.

I updated ApiObject to store ResponseMessageData objects in the Client, again, mimicking how it deals with EncompassRestException.

I used my best judgement for updating the EncompassRestClient to have a ConcurrentBag for storing the ResponseMessageData.