### PR TITLE
Changed TLS 1.2 handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EncompassRest
-Encompass API Client Library for .NET Framework 4.5+ and .NET Standard 1.3+.
+Encompass API Client Library for .NET Framework 4.5+ and .NET Standard 1.1+.
 
 ## Why does this exist?
 You may wonder why this library exists when Ellie Mae has provided their own [Encompass API .NET Language Bindings](https://github.com/EllieMae/developerconnect-dotnet-bindings).

--- a/src/EncompassRest.Tests/EncompassRest.Tests.csproj
+++ b/src/EncompassRest.Tests/EncompassRest.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net46;net45;netcoreapp2.0;netcoreapp1.1</TargetFrameworks>
     <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
     <RepositoryType>git</RepositoryType>
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\EncompassRest\EncompassRest.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/EncompassRest/EncompassRest.csproj
+++ b/src/EncompassRest/EncompassRest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.1;net46;net45</TargetFrameworks>
     <Version>0.3.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/EncompassRest/EncompassRest</PackageProjectUrl>
@@ -23,23 +23,28 @@
     <EmbeddedResource Include="LoanFields.zip" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <AssemblyTitle>EncompassRest .NET Standard 2.0</AssemblyTitle>
-    <DefineConstants>NETSTANDARD;NETSTANDARD2_0;HAVE_ICLONEABLE;HAVE_SSL_PROTOCOLS</DefineConstants>
+    <DefineConstants>NETSTANDARD;NETSTANDARD2_0;HAVE_ICLONEABLE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <AssemblyTitle>EncompassRest .NET Standard 1.3</AssemblyTitle>
-    <DefineConstants>NETSTANDARD;NETSTANDARD1_3;HAVE_SSL_PROTOCOLS</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.1'">
+    <AssemblyTitle>EncompassRest .NET Standard 1.1</AssemblyTitle>
+    <DefineConstants>NETSTANDARD;NETSTANDARD1_1</DefineConstants>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <AssemblyTitle>EncompassRest .NET 4.5</AssemblyTitle>
     <DefineConstants>NET45;HAVE_ICLONEABLE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
+    <AssemblyTitle>EncompassRest .NET 4.6</AssemblyTitle>
+    <DefineConstants>NET46;HAVE_ICLONEABLE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -15,7 +15,7 @@ namespace EncompassRest
 {
     public sealed class EncompassRestClient : IDisposable
     {
-#if !HAVE_SSL_PROTOCOLS
+#if NET45
         static EncompassRestClient()
         {
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
@@ -292,11 +292,7 @@ namespace EncompassRest
             private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1);
 
             public RetryHandler(EncompassRestClient client, bool retryOnUnauthorized)
-                : base(new HttpClientHandler()
-#if HAVE_SSL_PROTOCOLS
-                    { SslProtocols = System.Security.Authentication.SslProtocols.Tls12 }
-#endif
-                )
+                : base(new HttpClientHandler())
             {
                 _client = client;
                 _retryOnUnauthorized = retryOnUnauthorized;

--- a/src/EncompassRest/ModelPath.cs
+++ b/src/EncompassRest/ModelPath.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -217,7 +218,7 @@ namespace EncompassRest
             {
                 throw new ArgumentException("bad path");
             }
-            Segments = segments.AsReadOnly();
+            Segments = new ReadOnlyCollection<PathSegment>(segments);
 
             // Local functions
             void Increment(ref int value)
@@ -343,7 +344,7 @@ namespace EncompassRest
 
         private static string EscapeWithTick(string value, out bool escapeNeeded)
         {
-            escapeNeeded = char.IsDigit(value[0]) || !value.All(c => char.IsLetterOrDigit(c) || c == '_');
+            escapeNeeded = char.IsDigit(value[0]) || !value.Cast<char>().All(c => char.IsLetterOrDigit(c) || c == '_');
             return escapeNeeded ? value.Replace("'", "\\'").Replace("\\", "\\\\") : value;
         }
 


### PR DESCRIPTION
Changes target back to .NET Standard 1.1 from 1.3

Adds target of .NET Framework 4.6

Removed use of SslProtocols

Closes #141 