### PR TITLE
Added Constructor Overloads

### DIFF
--- a/src/EncompassRest.Tests/BorrowerPairsTests.cs
+++ b/src/EncompassRest.Tests/BorrowerPairsTests.cs
@@ -25,50 +25,62 @@ namespace EncompassRest.Tests
                 }
             };
             var loanId = await client.Loans.CreateLoanAsync(loan);
-            loan = new Loan(client, loanId);
-            Assert.AreEqual(0, loan.Applications.Count);
-            loan.LoanApis.ReflectToLoanObject = true;
-            var borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
-            Assert.IsTrue(loan.Applications.Count > 0);
-            Assert.AreEqual(borrowerPairs.Count, loan.Applications.Count);
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            var oldCount = loan.Applications.Count;
-            var application = new Application();
-            var applicationId = await loan.LoanApis.BorrowerPairs.CreateBorrowerPairAsync(application);
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(oldCount + 1, loan.Applications.Count);
-            Assert.AreSame(application, loan.Applications.First(a => a.ApplicationId == applicationId));
-            application.ApplicationSignedDate = DateTime.Now.AddDays(-5);
-            var newApplication = new Application { ApplicationId = applicationId, ApplicationSignedDate = DateTime.Now.AddDays(2), Borrower = new Borrower { FirstName = "Bob", LastName = "Smith" }, Coborrower = new Borrower { FirstName = "Jane", LastName = "Doe" } };
-            await loan.LoanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(newApplication.ApplicationSignedDate, loan.Applications.First(a => a.ApplicationId == applicationId).ApplicationSignedDate);
+            try
+            {
+                loan = new Loan(client, loanId);
+                Assert.AreEqual(0, loan.Applications.Count);
+                loan.LoanApis.ReflectToLoanObject = true;
+                var borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
+                Assert.IsTrue(loan.Applications.Count > 0);
+                Assert.AreEqual(borrowerPairs.Count, loan.Applications.Count);
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                var oldCount = loan.Applications.Count;
+                var application = new Application();
+                var applicationId = await loan.LoanApis.BorrowerPairs.CreateBorrowerPairAsync(application);
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(oldCount + 1, loan.Applications.Count);
+                Assert.AreSame(application, loan.Applications.First(a => a.ApplicationId == applicationId));
+                application.ApplicationSignedDate = DateTime.Now.AddDays(-5);
+                var newApplication = new Application { ApplicationId = applicationId, ApplicationSignedDate = DateTime.Now.AddDays(2), Borrower = new Borrower { FirstName = "Bob", LastName = "Smith" }, Coborrower = new Borrower { FirstName = "Jane", LastName = "Doe" } };
+                await loan.LoanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(newApplication.ApplicationSignedDate, loan.Applications.First(a => a.ApplicationId == applicationId).ApplicationSignedDate);
 
-            borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
-            Assert.AreEqual(2, borrowerPairs.Count);
-            await loan.LoanApis.BorrowerPairs.MoveBorrowerPairsAsync(new[] { new Application { Id = borrowerPairs[0].Id, ApplicationIndex = borrowerPairs[1].ApplicationIndex, Borrower = new Borrower { AltId = borrowerPairs[0].Borrower.AltId }, Coborrower = new Borrower { AltId = borrowerPairs[1].Coborrower.AltId } }, new Application { Id = borrowerPairs[1].Id, ApplicationIndex = borrowerPairs[0].ApplicationIndex, Borrower = new Borrower { AltId = borrowerPairs[0].Coborrower.AltId }, Coborrower = new Borrower { AltId = borrowerPairs[1].Borrower.AltId } } });
+                borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
+                Assert.AreEqual(2, borrowerPairs.Count);
+                await loan.LoanApis.BorrowerPairs.MoveBorrowerPairsAsync(new[] { new Application { Id = borrowerPairs[0].Id, ApplicationIndex = borrowerPairs[1].ApplicationIndex, Borrower = new Borrower { AltId = borrowerPairs[0].Borrower.AltId }, Coborrower = new Borrower { AltId = borrowerPairs[1].Coborrower.AltId } }, new Application { Id = borrowerPairs[1].Id, ApplicationIndex = borrowerPairs[0].ApplicationIndex, Borrower = new Borrower { AltId = borrowerPairs[0].Coborrower.AltId }, Coborrower = new Borrower { AltId = borrowerPairs[1].Borrower.AltId } } });
 
-            Assert.AreEqual(2, loan.Applications.Count);
-            var firstApplication = loan.Applications.First(app => app.ApplicationIndex == 0);
-            Assert.AreEqual("Brenda Smith", firstApplication.Borrower.FullName);
-            Assert.AreEqual("Bob Smith", firstApplication.Coborrower.FullName);
-            var secondApplication = loan.Applications.First(app => app.ApplicationIndex == 1);
-            Assert.AreEqual("John Doe", secondApplication.Borrower.FullName);
-            Assert.AreEqual("Jane Doe", secondApplication.Coborrower.FullName);
+                Assert.AreEqual(2, loan.Applications.Count);
+                var firstApplication = loan.Applications.First(app => app.ApplicationIndex == 0);
+                Assert.AreEqual("Brenda Smith", firstApplication.Borrower.FullName);
+                Assert.AreEqual("Bob Smith", firstApplication.Coborrower.FullName);
+                var secondApplication = loan.Applications.First(app => app.ApplicationIndex == 1);
+                Assert.AreEqual("John Doe", secondApplication.Borrower.FullName);
+                Assert.AreEqual("Jane Doe", secondApplication.Coborrower.FullName);
 
-            borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
-            Assert.AreEqual(2, borrowerPairs.Count);
-            Assert.AreEqual("Brenda Smith", borrowerPairs[0].Borrower.FullName);
-            Assert.AreEqual("Bob Smith", borrowerPairs[0].Coborrower.FullName);
-            Assert.AreEqual("John Doe", borrowerPairs[1].Borrower.FullName);
-            Assert.AreEqual("Jane Doe", borrowerPairs[1].Coborrower.FullName);
+                borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
+                Assert.AreEqual(2, borrowerPairs.Count);
+                Assert.AreEqual("Brenda Smith", borrowerPairs[0].Borrower.FullName);
+                Assert.AreEqual("Bob Smith", borrowerPairs[0].Coborrower.FullName);
+                Assert.AreEqual("John Doe", borrowerPairs[1].Borrower.FullName);
+                Assert.AreEqual("Jane Doe", borrowerPairs[1].Coborrower.FullName);
 
-            oldCount = loan.Applications.Count;
-            Assert.IsTrue(await loan.LoanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(oldCount - 1, loan.Applications.Count);
-            Assert.IsNull(loan.Applications.FirstOrDefault(a => a.ApplicationId == applicationId));
-            Assert.IsTrue(await client.Loans.DeleteLoanAsync(loanId));
+                oldCount = loan.Applications.Count;
+                Assert.IsTrue(await loan.LoanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(oldCount - 1, loan.Applications.Count);
+                Assert.IsNull(loan.Applications.FirstOrDefault(a => a.ApplicationId == applicationId));
+            }
+            finally
+            {
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
+            }
         }
 
         [TestMethod]
@@ -93,21 +105,33 @@ namespace EncompassRest.Tests
 
         private static async Task BorrowerPairsTest(EncompassRestClient client, Loan loan, string loanId, LoanApis loanApis)
         {
-            var borrowerPairs = await loanApis.BorrowerPairs.GetBorrowerPairsAsync();
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(0, loan.Applications.Count);
-            var application = new Application();
-            var applicationId = await loanApis.BorrowerPairs.CreateBorrowerPairAsync(application);
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(0, loan.Applications.Count);
-            var newApplication = new Application { ApplicationId = applicationId, ApplicationSignedDate = DateTime.Now.AddDays(2) };
-            await loanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(0, loan.Applications.Count);
-            Assert.IsTrue(await loanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
-            Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
-            Assert.AreEqual(0, loan.Applications.Count);
-            Assert.IsTrue(await client.Loans.DeleteLoanAsync(loanId));
+            try
+            {
+                var borrowerPairs = await loanApis.BorrowerPairs.GetBorrowerPairsAsync();
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(0, loan.Applications.Count);
+                var application = new Application();
+                var applicationId = await loanApis.BorrowerPairs.CreateBorrowerPairAsync(application);
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(0, loan.Applications.Count);
+                var newApplication = new Application { ApplicationId = applicationId, ApplicationSignedDate = DateTime.Now.AddDays(2) };
+                await loanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(0, loan.Applications.Count);
+                Assert.IsTrue(await loanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual(0, loan.Applications.Count);
+            }
+            finally
+            {
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
+            }
         }
     }
 }

--- a/src/EncompassRest.Tests/ContactGroupsTests.cs
+++ b/src/EncompassRest.Tests/ContactGroupsTests.cs
@@ -17,7 +17,7 @@ namespace EncompassRest.Tests
             foreach (var contactType in Enums.GetValues<ContactType>())
             {
                 var groupType = contactType == ContactType.Business ? ContactGroupType.Public : ContactGroupType.Private;
-                var groupAdded = new ContactGroup("ABC") { ContactType = contactType, GroupType = groupType, Description = "123" };
+                var groupAdded = new ContactGroup("ABC", contactType, groupType);
                 var groupId = await contactGroups.CreateGroupAsync(groupAdded, true);
                 try
                 {
@@ -36,15 +36,14 @@ namespace EncompassRest.Tests
                     Assert.AreEqual(groupAdded.ContactType.Value, retrievedGroup.ContactType.Value);
                     Assert.AreEqual(groupAdded.Name, retrievedGroup.Name);
                     Assert.AreEqual(groupAdded.GroupType.Value, retrievedGroup.GroupType.Value);
-                    Assert.AreEqual(groupAdded.Description, retrievedGroup.Description);
-                    groupAdded.Name = "DEF";
+
+                    groupAdded = new ContactGroup(groupId, "DEF", contactType, groupType);
                     await contactGroups.UpdateGroupAsync(groupAdded);
                     retrievedGroup = await contactGroups.GetGroupAsync(groupId);
                     Assert.IsNotNull(retrievedGroup);
                     Assert.AreEqual(groupAdded.ContactType.Value, retrievedGroup.ContactType.Value);
                     Assert.AreEqual(groupAdded.Name, retrievedGroup.Name);
                     Assert.AreEqual(groupAdded.GroupType.Value, retrievedGroup.GroupType.Value);
-                    Assert.AreEqual(groupAdded.Description, retrievedGroup.Description);
                 }
                 finally
                 {

--- a/src/EncompassRest.Tests/ContactNoteTests.cs
+++ b/src/EncompassRest.Tests/ContactNoteTests.cs
@@ -47,8 +47,8 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(note.Subject, retrievedNote.Subject);
                 Assert.AreEqual(note.Details, retrievedNote.Details);
 
-                Assert.IsTrue(await businessContact.Notes.DeleteNoteAsync(noteId).ConfigureAwait(false));
-                Assert.IsFalse(await businessContact.Notes.DeleteNoteAsync(noteId).ConfigureAwait(false));
+                Assert.IsTrue(await businessContact.Notes.DeleteNoteAsync(noteId));
+                Assert.IsFalse(await businessContact.Notes.DeleteNoteAsync(noteId));
             }
             finally
             {

--- a/src/EncompassRest.Tests/ContactsTests.cs
+++ b/src/EncompassRest.Tests/ContactsTests.cs
@@ -43,7 +43,7 @@ namespace EncompassRest.Tests
             if (client.AccessToken.Token != "Token")
             {
                 var borrowerContact = new BorrowerContact("Bob", "Bob@gmail.com");
-                var contactId = await client.BorrowerContacts.CreateContactAsync(borrowerContact).ConfigureAwait(false);
+                var contactId = await client.BorrowerContacts.CreateContactAsync(borrowerContact);
 
                 try
                 {
@@ -71,7 +71,7 @@ namespace EncompassRest.Tests
                 {
                     try
                     {
-                        await client.BorrowerContacts.DeleteContactAsync(contactId).ConfigureAwait(false);
+                        await client.BorrowerContacts.DeleteContactAsync(contactId);
                     }
                     catch
                     {
@@ -85,7 +85,7 @@ namespace EncompassRest.Tests
         {
             var client = await GetTestClientAsync();
             var businessContact = new BusinessContact("Bob", "Bob@gmail.com");
-            var contactId = await client.BusinessContacts.CreateContactAsync(businessContact).ConfigureAwait(false);
+            var contactId = await client.BusinessContacts.CreateContactAsync(businessContact);
 
             try
             {
@@ -113,7 +113,7 @@ namespace EncompassRest.Tests
             {
                 try
                 {
-                    await client.BusinessContacts.DeleteContactAsync(contactId).ConfigureAwait(false);
+                    await client.BusinessContacts.DeleteContactAsync(contactId);
                 }
                 catch
                 {

--- a/src/EncompassRest.Tests/FieldReaderTests.cs
+++ b/src/EncompassRest.Tests/FieldReaderTests.cs
@@ -12,7 +12,7 @@ namespace EncompassRest.Tests
         [TestMethod]
         public async Task FieldReader_GetValues()
         {
-            var client = await GetTestClientAsync().ConfigureAwait(false);
+            var client = await GetTestClientAsync();
             var loan = new Loan(client);
             var fieldValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -39,7 +39,13 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
     }

--- a/src/EncompassRest.Tests/LoanAssociateMilestoneTests.cs
+++ b/src/EncompassRest.Tests/LoanAssociateMilestoneTests.cs
@@ -16,31 +16,42 @@ namespace EncompassRest.Tests
             var client = await GetTestClientAsync();
 
             var loanId = await client.Loans.CreateLoanAsync(new Loan(client));
-            var loanApis = client.Loans.GetLoanApis(loanId);
-            var associates = await loanApis.Associates.GetAssociatesAsync();
-            foreach (var associate in associates)
+            try
             {
-                Assert.AreEqual(0, associate.ExtensionData.Count);
+                var loanApis = client.Loans.GetLoanApis(loanId);
+                var associates = await loanApis.Associates.GetAssociatesAsync();
+                foreach (var associate in associates)
+                {
+                    Assert.AreEqual(0, associate.ExtensionData.Count);
+                }
+                var milestones = await loanApis.Milestones.GetMilestonesAsync();
+                foreach (var milestone in milestones)
+                {
+                    Assert.AreEqual(0, milestone.ExtensionData.Count);
+                    Assert.AreEqual(0, milestone.LoanAssociate.ExtensionData.Count);
+                    var retrievedMilestone = await loanApis.Milestones.GetMilestoneAsync(milestone.Id);
+                    Assert.AreEqual(milestone.ToString(), retrievedMilestone.ToString());
+                }
+                var milestoneFreeRoles = await loanApis.MilestoneFreeRoles.GetMilestoneFreeRolesAsync();
+                foreach (var milestoneFreeRole in milestoneFreeRoles)
+                {
+                    Assert.AreEqual(0, milestoneFreeRole.ExtensionData.Count);
+                    Assert.AreEqual(0, milestoneFreeRole.LoanAssociate.ExtensionData.Count);
+                    var retrievedMilestoneFreeRole = await loanApis.MilestoneFreeRoles.GetMilestoneFreeRoleAsync(milestoneFreeRole.Id);
+                    Assert.AreEqual(milestoneFreeRole.ToString(), retrievedMilestoneFreeRole.ToString());
+                }
             }
-            var milestones = await loanApis.Milestones.GetMilestonesAsync();
-            foreach (var milestone in milestones)
+            finally
             {
-                Assert.AreEqual(0, milestone.ExtensionData.Count);
-                Assert.AreEqual(0, milestone.LoanAssociate.ExtensionData.Count);
-                var retrievedMilestone = await loanApis.Milestones.GetMilestoneAsync(milestone.Id);
-                Assert.AreEqual(milestone.ToString(), retrievedMilestone.ToString());
+                try
+                {
+                    await Task.Delay(5000);
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
-            var milestoneFreeRoles = await loanApis.MilestoneFreeRoles.GetMilestoneFreeRolesAsync();
-            foreach (var milestoneFreeRole in milestoneFreeRoles)
-            {
-                Assert.AreEqual(0, milestoneFreeRole.ExtensionData.Count);
-                Assert.AreEqual(0, milestoneFreeRole.LoanAssociate.ExtensionData.Count);
-                var retrievedMilestoneFreeRole = await loanApis.MilestoneFreeRoles.GetMilestoneFreeRoleAsync(milestoneFreeRole.Id);
-                Assert.AreEqual(milestoneFreeRole.ToString(), retrievedMilestoneFreeRole.ToString());
-            }
-
-            await Task.Delay(5000);
-            Assert.IsTrue(await client.Loans.DeleteLoanAsync(loanId));
         }
 
         [TestMethod]
@@ -87,12 +98,17 @@ namespace EncompassRest.Tests
                     milestones = await milestonesApi.GetMilestonesAsync();
                     nextMilestone = milestones.First(ms => ms.Id == nextMilestone.Id);
                     Assert.IsNull(nextMilestone.LoanAssociate.Id);
-
-                    await Task.Delay(5000);
                 }
                 finally
                 {
-                    await client.Loans.DeleteLoanAsync(loanId);
+                    try
+                    {
+                        await Task.Delay(5000);
+                        await client.Loans.DeleteLoanAsync(loanId);
+                    }
+                    catch
+                    {
+                    }
                 }
             }
         }
@@ -119,7 +135,13 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
     }

--- a/src/EncompassRest.Tests/LoanAttachmentTests.cs
+++ b/src/EncompassRest.Tests/LoanAttachmentTests.cs
@@ -104,8 +104,14 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await Task.Delay(5000);
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await Task.Delay(5000);
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
     }

--- a/src/EncompassRest.Tests/LoanAttachmentTests.cs
+++ b/src/EncompassRest.Tests/LoanAttachmentTests.cs
@@ -14,7 +14,9 @@ namespace EncompassRest.Tests
         [TestMethod]
         public void LoanAttachment_Serialization()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var loanAttachment = new LoanAttachment { AttachmentType = AttachmentType.Image };
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.AreEqual(@"{""attachmentType"":1}", loanAttachment.ToJson());
         }
 
@@ -27,12 +29,7 @@ namespace EncompassRest.Tests
             var loanId = await client.Loans.CreateLoanAsync(loan);
             try
             {
-                var attachment = new LoanAttachment
-                {
-                    Title = "Testing Attachment",
-                    FileWithExtension = "Text.txt",
-                    CreateReason = AttachmentCreateReason.Upload
-                };
+                var attachment = new LoanAttachment("Testing Attachment", "Text.txt", AttachmentCreateReason.Upload);
                 var text = "TESTING, TESTING, 1, 2, 3";
                 var attachmentId = await loan.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
                 Assert.IsFalse(string.IsNullOrEmpty(attachmentId));
@@ -56,6 +53,7 @@ namespace EncompassRest.Tests
                 }
 
                 attachment = await loan.Attachments.GetAttachmentAsync(attachmentId, true);
+                Assert.AreEqual("Testing Attachment", attachment.Title);
                 Assert.IsFalse(string.IsNullOrEmpty(attachment.MediaUrl));
                 retrievedText = Encoding.UTF8.GetString(await attachment.DownloadAsync());
                 Assert.AreEqual(text, retrievedText);
@@ -65,12 +63,12 @@ namespace EncompassRest.Tests
                     Assert.AreEqual(text, sr.ReadToEnd());
                 }
 
-                var newAttachment = new LoanAttachment
-                {
-                    Title = "Bob",
-                    FileWithExtension = "Bobby.txt",
-                    CreateReason = AttachmentCreateReason.Upload
-                };
+                attachment = new LoanAttachment(attachmentId) { Title = "Updated Title" };
+                await loan.Attachments.UpdateAttachmentAsync(attachment);
+                attachment = await loan.Attachments.GetAttachmentAsync(attachmentId);
+                Assert.AreEqual("Updated Title", attachment.Title);
+
+                var newAttachment = new LoanAttachment("Bob", "Bobby.txt", AttachmentCreateReason.Upload);
                 var newText = "This is a test of the emergency broadcast system, this is only a test.";
                 var newAttachmentId = await loan.Attachments.UploadAttachmentAsync(newAttachment, new MemoryStream(Encoding.UTF8.GetBytes(newText)), true);
                 Assert.IsFalse(string.IsNullOrEmpty(newAttachmentId));
@@ -94,6 +92,7 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(newText, newRetrievedText);
 
                 newAttachment = await loan.Attachments.GetAttachmentAsync(newAttachmentId, true);
+                Assert.AreEqual("Bob", newAttachment.Title);
                 Assert.IsFalse(string.IsNullOrEmpty(newAttachment.MediaUrl));
                 newRetrievedText = Encoding.UTF8.GetString(await newAttachment.DownloadAsync());
                 Assert.AreEqual(newText, newRetrievedText);

--- a/src/EncompassRest.Tests/LoanConditionsTests.cs
+++ b/src/EncompassRest.Tests/LoanConditionsTests.cs
@@ -41,7 +41,13 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
 
@@ -78,7 +84,13 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
 
@@ -115,7 +127,13 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
     }

--- a/src/EncompassRest.Tests/LoanDocumentTests.cs
+++ b/src/EncompassRest.Tests/LoanDocumentTests.cs
@@ -1,17 +1,22 @@
-﻿using EncompassRest.Loans.Documents;
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using EncompassRest.Loans;
+using EncompassRest.Loans.Attachments;
+using EncompassRest.Loans.Documents;
 using EncompassRest.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EncompassRest.Tests
 {
     [TestClass]
-    public class LoanDocumentTests
+    public class LoanDocumentTests : TestBaseClass
     {
         [TestMethod]
         public void LoanDocument_Serialization()
         {
-            var document = new LoanDocument { Title = "Mortgage Insurance" };
-            Assert.AreEqual(@"{""title"":""Mortgage Insurance""}", document.ToJson());
+            var document = new LoanDocument("Mortgage Insurance", "All");
+            Assert.AreEqual(@"{""title"":""Mortgage Insurance"",""applicationId"":""All""}", document.ToJson());
             document.Dirty = false;
             Assert.AreEqual("{}", document.ToJson());
             document.Status = "expected";
@@ -26,6 +31,61 @@ namespace EncompassRest.Tests
             document.Status = DocumentStatus.Added;
             Assert.AreEqual("added", document.Status.Value);
             Assert.AreEqual(@"{""status"":""added""}", document.ToJson());
+        }
+
+        [TestMethod]
+        public async Task LoanDocument_Upload()
+        {
+            var client = await GetTestClientAsync();
+
+            var loan = new Loan(client);
+            var loanId = await client.Loans.CreateLoanAsync(loan);
+            try
+            {
+                var document = new LoanDocument("Final 1003", "All");
+                var documentId = await loan.Documents.CreateDocumentAsync(document, true);
+                Assert.IsFalse(string.IsNullOrEmpty(documentId));
+
+                document = await loan.Documents.GetDocumentAsync(documentId);
+                Assert.AreEqual("Final 1003", document.Title);
+                Assert.AreEqual("All", document.ApplicationId);
+                Assert.AreEqual(0, document.Attachments.Count);
+
+                document = new LoanDocument(documentId) { Title = "Updated Title" };
+                await loan.Documents.UpdateDocumentAsync(document);
+                document = await loan.Documents.GetDocumentAsync(documentId);
+                Assert.AreEqual("Updated Title", document.Title);
+                Assert.AreEqual("All", document.ApplicationId);
+                Assert.AreEqual(0, document.Attachments.Count);
+
+                var attachment = new LoanAttachment("Testing Attachment", "Text.txt", AttachmentCreateReason.Upload);
+                var text = "TESTING, TESTING, 1, 2, 3";
+                var attachmentId = await loan.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
+                Assert.IsFalse(string.IsNullOrEmpty(attachmentId));
+                await Task.Delay(10000);
+                var retrievedText = Encoding.UTF8.GetString(await loan.Attachments.DownloadAttachmentAsync(attachmentId));
+                Assert.AreEqual(text, retrievedText);
+                var stream = await loan.Attachments.DownloadAttachmentStreamAsync(attachmentId);
+                using (var sr = new StreamReader(stream, Encoding.UTF8))
+                {
+                    Assert.AreEqual(text, sr.ReadToEnd());
+                }
+
+                var entityReference = new EntityReference(attachmentId, EntityType.Attachment);
+                await loan.Documents.AssignDocumentAttachmentsAsync(documentId, AssignmentAction.Add, new[] { entityReference });
+
+                document = await loan.Documents.GetDocumentAsync(documentId);
+                Assert.AreEqual("Updated Title", document.Title);
+                Assert.AreEqual("All", document.ApplicationId);
+                Assert.AreEqual(1, document.Attachments.Count);
+                Assert.AreEqual(attachmentId, document.Attachments[0].EntityId);
+                Assert.AreEqual(entityReference.EntityType.Value, document.Attachments[0].EntityType.Value);
+            }
+            finally
+            {
+                await Task.Delay(5000);
+                await client.Loans.DeleteLoanAsync(loanId);
+            }
         }
     }
 }

--- a/src/EncompassRest.Tests/LoanDocumentTests.cs
+++ b/src/EncompassRest.Tests/LoanDocumentTests.cs
@@ -83,8 +83,14 @@ namespace EncompassRest.Tests
             }
             finally
             {
-                await Task.Delay(5000);
-                await client.Loans.DeleteLoanAsync(loanId);
+                try
+                {
+                    await Task.Delay(5000);
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
             }
         }
     }

--- a/src/EncompassRest.Tests/ResourceLocksTest.cs
+++ b/src/EncompassRest.Tests/ResourceLocksTest.cs
@@ -1,5 +1,6 @@
 ﻿using EncompassRest.Loans;
 using EncompassRest.ResourceLocks;
+using EnumsNET;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 
@@ -14,23 +15,38 @@ namespace EncompassRest.Tests
             var client = await GetTestClientAsync();
             var loan = new Loan(client);
             var loanId = await client.Loans.CreateLoanAsync(loan, true);
-            Assert.IsTrue((await loan.LoanApis.GetLocksAsync()).Count == 0);
 
-            var lockId = await loan.LoanApis.LockAsync(ResourceLockType.Exclusive);
-            var loanLock = await loan.LoanApis.GetLockAsync(lockId);
-            Assert.AreEqual(loanLock.LockType.ToString(), ResourceLockType.Exclusive.ToString());
+            try
+            {
+                Assert.IsTrue((await loan.LoanApis.GetLocksAsync()).Count == 0);
 
-            var locks = await loan.LoanApis.GetLocksAsync();
-            var testLock = locks.Find(x => x.Id == lockId);
-            Assert.IsNotNull(testLock);
-            Assert.IsTrue(locks.Count == 1);
+                var lockId = await loan.LoanApis.LockAsync(ResourceLockType.Exclusive);
+                Assert.IsFalse(string.IsNullOrEmpty(lockId));
+                var loanLock = await loan.LoanApis.GetLockAsync(lockId);
+                Assert.AreEqual(ResourceLockType.Exclusive.GetName(), loanLock.LockType.Value);
+                Assert.AreEqual(EntityType.Loan.GetName(), loanLock.Resource.EntityType.Value);
+                Assert.AreEqual(loanId, loanLock.Resource.EntityId);
 
-            Assert.IsTrue(await loan.LoanApis.UnlockAsync(lockId));
+                var locks = await loan.LoanApis.GetLocksAsync();
+                var testLock = locks.Find(x => x.Id == lockId);
+                Assert.IsNotNull(testLock);
+                Assert.IsTrue(locks.Count == 1);
 
-            Assert.IsTrue((await loan.LoanApis.GetLocksAsync()).Count == 0);
+                Assert.IsTrue(await loan.LoanApis.UnlockAsync(lockId));
 
-            await Task.Delay(5000);
-            Assert.IsTrue(await client.Loans.DeleteLoanAsync(loanId).ConfigureAwait(false));
+                Assert.IsTrue((await loan.LoanApis.GetLocksAsync()).Count == 0);
+            }
+            finally
+            {
+                try
+                {
+                    await Task.Delay(5000);
+                    await client.Loans.DeleteLoanAsync(loanId);
+                }
+                catch
+                {
+                }
+            }
         }
     }
 }

--- a/src/EncompassRest.Tests/SchemaTests.cs
+++ b/src/EncompassRest.Tests/SchemaTests.cs
@@ -92,7 +92,7 @@ namespace EncompassRest.Tests
                 { "1109", 150000M },
                 { "100", true }
             };
-            var loan = await client.Schema.GenerateContractAsync(fieldValues).ConfigureAwait(false);
+            var loan = await client.Schema.GenerateContractAsync(fieldValues);
             Assert.IsTrue(loan.Dirty);
             Assert.AreEqual((string)fieldValues["1393"], loan.Fields["1393"].ToString());
             Assert.AreEqual((decimal)fieldValues["1109"], loan.Fields["1109"].ToDecimal());

--- a/src/EncompassRest.Tests/TestBaseClass.cs
+++ b/src/EncompassRest.Tests/TestBaseClass.cs
@@ -30,7 +30,7 @@ namespace EncompassRest.Tests
                             credentials = JsonHelper.FromJson<TestClientCredentials>(sr);
                         }
                     }
-                    client = await EncompassRestClient.CreateAsync(credentials.Parameters, tc => tc.FromUserCredentialsAsync(credentials.InstanceId, credentials.UserId, credentials.Password)).ConfigureAwait(false);
+                    client = await EncompassRestClient.CreateAsync(credentials.Parameters, tc => tc.FromUserCredentialsAsync(credentials.InstanceId, credentials.UserId, credentials.Password));
                     Console.WriteLine("Using test client credentials file");
                 }
                 else

--- a/src/EncompassRest/AssignmentAction.cs
+++ b/src/EncompassRest/AssignmentAction.cs
@@ -1,8 +1,12 @@
-﻿namespace EncompassRest
+﻿using System.Runtime.Serialization;
+
+namespace EncompassRest
 {
     public enum AssignmentAction
     {
+        [EnumMember(Value = "add")]
         Add = 0,
+        [EnumMember(Value = "remove")]
         Remove = 1
     }
 }

--- a/src/EncompassRest/CanonicalFieldExtensions.cs
+++ b/src/EncompassRest/CanonicalFieldExtensions.cs
@@ -4,7 +4,7 @@ namespace EncompassRest
 {
     public static class CanonicalFieldExtensions
     {
-        public static string GetCanonicalName(this CanonicalLoanField value) => $"Loan.{value.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)}";
+        public static string GetCanonicalName(this CanonicalLoanField value) => $"Loan.{value.GetValue()}";
 
         public static bool IsDateValued(this CanonicalLoanField value) => value >= 0 && (int)value < 100;
 
@@ -12,7 +12,7 @@ namespace EncompassRest
 
         public static bool IsStringValued(this CanonicalLoanField value) => (int)value >= 200;
 
-        public static string GetCanonicalName(this CanonicalContactField value) => $"Contact.{value.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)}";
+        public static string GetCanonicalName(this CanonicalContactField value) => $"Contact.{value.GetValue()}";
 
         public static bool IsDateValued(this CanonicalContactField value) => value >= 0 && (int)value < 100;
 

--- a/src/EncompassRest/ClientParameters.cs
+++ b/src/EncompassRest/ClientParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EncompassRest.Utilities;
+using Newtonsoft.Json;
 
 namespace EncompassRest
 {
@@ -15,6 +16,7 @@ namespace EncompassRest
 
         public TimeSpan Timeout { get; set; }
 
+        [JsonIgnore]
         public CommonCache CommonCache { get; set; }
 
         public CacheInitialization CustomFieldsCacheInitialization { get; set; }

--- a/src/EncompassRest/Contacts/BorrowerContact.cs
+++ b/src/EncompassRest/Contacts/BorrowerContact.cs
@@ -6,14 +6,17 @@ namespace EncompassRest.Contacts
 {
     public sealed class BorrowerContact : Contact
     {
-        internal override string ApiPath => "encompass/v1/borrowerContacts";
-
         private DirtyValue<string> _employerName;
-        public string EmployerName { get => _employerName; set => SetField(ref _employerName, value); }
         private DirtyValue<DateTime?> _birthdate;
-        public DateTime? Birthdate { get => _birthdate; set => SetField(ref _birthdate, value); }
         private DirtyValue<string> _referral;
+
+        public string EmployerName { get => _employerName; set => SetField(ref _employerName, value); }
+        
+        public DateTime? Birthdate { get => _birthdate; set => SetField(ref _birthdate, value); }
+        
         public string Referral { get => _referral; set => SetField(ref _referral, value); }
+
+        internal override string ApiPath => "encompass/v1/borrowerContacts";
 
         /// <summary>
         /// Borrower contact creation constructor

--- a/src/EncompassRest/Contacts/BorrowerContact.cs
+++ b/src/EncompassRest/Contacts/BorrowerContact.cs
@@ -1,5 +1,6 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
 
 namespace EncompassRest.Contacts
 {
@@ -15,8 +16,32 @@ namespace EncompassRest.Contacts
         public string Referral { get => _referral; set => SetField(ref _referral, value); }
 
         /// <summary>
-        /// BorrowerContact creation constructor
+        /// Borrower contact creation constructor
         /// </summary>
+        /// <param name="firstName"></param>
+        /// <param name="personalEmail"></param>
+        public BorrowerContact(string firstName, string personalEmail)
+            : base(firstName, personalEmail)
+        {
+        }
+
+        /// <summary>
+        /// Borrower contact update constructor
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="contactId"></param>
+        /// <param name="firstName"></param>
+        /// <param name="personalEmail"></param>
+        public BorrowerContact(EncompassRestClient client, string contactId, string firstName, string personalEmail)
+            : base(client, contactId, firstName, personalEmail)
+        {
+        }
+
+        /// <summary>
+        /// Borrower contact deserialization constructor
+        /// </summary>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [JsonConstructor]
         public BorrowerContact()
         {
@@ -27,9 +52,11 @@ namespace EncompassRest.Contacts
         /// </summary>
         /// <param name="client"></param>
         /// <param name="contactId"></param>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public BorrowerContact(EncompassRestClient client, string contactId)
-            : base(client, contactId)
         {
+            Initialize(client, contactId);
         }
     }
 }

--- a/src/EncompassRest/Contacts/BusinessContact.cs
+++ b/src/EncompassRest/Contacts/BusinessContact.cs
@@ -1,4 +1,6 @@
-﻿using EncompassRest.Utilities;
+﻿using System;
+using System.ComponentModel;
+using EncompassRest.Utilities;
 using EnumsNET;
 using Newtonsoft.Json;
 
@@ -20,11 +22,35 @@ namespace EncompassRest.Contacts
         private DirtyValue<bool?> _noSpam;
         public bool? NoSpam { get => _noSpam; set => SetField(ref _noSpam, value); }
         private DirtyValue<int?> _fees;
-        public int? Fees { get => Fees; set => SetField(ref _fees, value); }
+        public int? Fees { get => _fees; set => SetField(ref _fees, value); }
 
         /// <summary>
-        /// BusinessContact creation constructor
+        /// Business contact creation constructor
         /// </summary>
+        /// <param name="firstName"></param>
+        /// <param name="personalEmail"></param>
+        public BusinessContact(string firstName, string personalEmail)
+            : base(firstName, personalEmail)
+        {
+        }
+
+        /// <summary>
+        /// Business contact update constructor
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="contactId"></param>
+        /// <param name="firstName"></param>
+        /// <param name="personalEmail"></param>
+        public BusinessContact(EncompassRestClient client, string contactId, string firstName, string personalEmail)
+            : base(client, contactId, firstName, personalEmail)
+        {
+        }
+
+        /// <summary>
+        /// Business contact deserialization constructor
+        /// </summary>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [JsonConstructor]
         public BusinessContact()
         {
@@ -35,9 +61,11 @@ namespace EncompassRest.Contacts
         /// </summary>
         /// <param name="client"></param>
         /// <param name="contactId"></param>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public BusinessContact(EncompassRestClient client, string contactId)
-            : base(client, contactId)
         {
+            Initialize(client, contactId);
         }
     }
 }

--- a/src/EncompassRest/Contacts/BusinessContact.cs
+++ b/src/EncompassRest/Contacts/BusinessContact.cs
@@ -8,21 +8,27 @@ namespace EncompassRest.Contacts
 {
     public sealed class BusinessContact : Contact
     {
-        internal override string ApiPath => "encompass/v1/businessContacts";
-
         private DirtyValue<BusinessContactCategory?> _categoryId;
+        private DirtyValue<string> _companyName;
+        private BusinessContactLicense _personalContactLicense;
+        private BusinessContactLicense _businessContactLicense;
+        private DirtyValue<bool?> _noSpam;
+        private DirtyValue<int?> _fees;
+
         [EnumFormat(EnumFormat.DecimalValue)]
         public BusinessContactCategory? CategoryId { get => _categoryId; set => SetField(ref _categoryId, value); }
-        private DirtyValue<string> _companyName;
+
         public string CompanyName { get => _companyName; set => SetField(ref _companyName, value); }
-        private BusinessContactLicense _personalContactLicense;
+
         public BusinessContactLicense PersonalContactLicense { get => GetField(ref _personalContactLicense); set => SetField(ref _personalContactLicense, value); }
-        private BusinessContactLicense _businessContactLicense;
+
         public BusinessContactLicense BusinessContactLicense { get => GetField(ref _businessContactLicense); set => SetField(ref _businessContactLicense, value); }
-        private DirtyValue<bool?> _noSpam;
+
         public bool? NoSpam { get => _noSpam; set => SetField(ref _noSpam, value); }
-        private DirtyValue<int?> _fees;
+
         public int? Fees { get => _fees; set => SetField(ref _fees, value); }
+
+        internal override string ApiPath => "encompass/v1/businessContacts";
 
         /// <summary>
         /// Business contact creation constructor

--- a/src/EncompassRest/Contacts/BusinessContactLicense.cs
+++ b/src/EncompassRest/Contacts/BusinessContactLicense.cs
@@ -5,14 +5,19 @@ namespace EncompassRest.Contacts
     public sealed class BusinessContactLicense : DirtyExtensibleObject
     {
         private DirtyValue<string> _licenseAuthName;
-        public string LicenseAuthName { get => _licenseAuthName; set => SetField(ref _licenseAuthName, value); }
         private DirtyValue<string> _licenseAuthType;
-        public string LicenseAuthType { get => _licenseAuthType; set => SetField(ref _licenseAuthType, value); }
         private DirtyValue<DateTime?> _licenseIssueDate;
-        public DateTime? LicenseIssueDate { get => _licenseIssueDate; set => SetField(ref _licenseIssueDate, value); }
         private DirtyValue<string> _licenseNumber;
-        public string LicenseNumber { get => _licenseNumber; set => SetField(ref _licenseNumber, value); }
         private DirtyValue<string> _licenseStateCode;
+
+        public string LicenseAuthName { get => _licenseAuthName; set => SetField(ref _licenseAuthName, value); }
+
+        public string LicenseAuthType { get => _licenseAuthType; set => SetField(ref _licenseAuthType, value); }
+
+        public DateTime? LicenseIssueDate { get => _licenseIssueDate; set => SetField(ref _licenseIssueDate, value); }
+
+        public string LicenseNumber { get => _licenseNumber; set => SetField(ref _licenseNumber, value); }
+
         public string LicenseStateCode { get => _licenseStateCode; set => SetField(ref _licenseStateCode, value); }
     }
 }

--- a/src/EncompassRest/Contacts/Contact.cs
+++ b/src/EncompassRest/Contacts/Contact.cs
@@ -46,9 +46,19 @@ namespace EncompassRest.Contacts
         [JsonIgnore]
         public ContactNotes Notes { get; private set; }
 
-        internal Contact(EncompassRestClient client, string contactId)
+        internal Contact(EncompassRestClient client, string contactId, string firstName, string personalEmail)
+            : this(firstName, personalEmail)
         {
             Initialize(client, contactId);
+        }
+
+        internal Contact(string firstName, string personalEmail)
+        {
+            Preconditions.NotNullOrEmpty(firstName, nameof(firstName));
+            Preconditions.NotNullOrEmpty(personalEmail, nameof(personalEmail));
+
+            FirstName = firstName;
+            PersonalEmail = personalEmail;
         }
 
         internal Contact()

--- a/src/EncompassRest/Contacts/Contact.cs
+++ b/src/EncompassRest/Contacts/Contact.cs
@@ -7,35 +7,50 @@ namespace EncompassRest.Contacts
     public abstract class Contact : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _firstName;
-        public string FirstName { get => _firstName; set => SetField(ref _firstName, value); }
         private DirtyValue<string> _lastName;
-        public string LastName { get => _lastName; set => SetField(ref _lastName, value); }
         private DirtyValue<string> _ownerId;
-        public string OwnerId { get => _ownerId; set => SetField(ref _ownerId, value); }
         private DirtyValue<ContactAccessLevel?> _accessLevel;
+        private ContactAddress _currentMailingAddress;
+        private DirtyValue<string> _businessWebUrl;
+        private DirtyValue<string> _jobTitle;
+        private DirtyValue<string> _workPhone;
+        private DirtyValue<string> _homePhone;
+        private DirtyValue<string> _mobilePhone;
+        private DirtyValue<string> _faxNumber;
+        private DirtyValue<string> _personalEmail;
+        private DirtyValue<string> _businessEmail;
+        private DirtyValue<string> _salutation;
+        private DirtyValue<string> _id;
+
+        public string FirstName { get => _firstName; set => SetField(ref _firstName, value); }
+
+        public string LastName { get => _lastName; set => SetField(ref _lastName, value); }
+
+        public string OwnerId { get => _ownerId; set => SetField(ref _ownerId, value); }
+
         [EnumFormat(EnumFormat.DecimalValue)]
         public ContactAccessLevel? AccessLevel { get => _accessLevel; set => SetField(ref _accessLevel, value); }
-        private ContactAddress _currentMailingAddress;
+
         public ContactAddress CurrentMailingAddress { get => GetField(ref _currentMailingAddress); set => SetField(ref _currentMailingAddress, value); }
-        private DirtyValue<string> _businessWebUrl;
+
         public string BusinessWebUrl { get => _businessWebUrl; set => SetField(ref _businessWebUrl, value); }
-        private DirtyValue<string> _jobTitle;
+
         public string JobTitle { get => _jobTitle; set => SetField(ref _jobTitle, value); }
-        private DirtyValue<string> _workPhone;
+
         public string WorkPhone { get => _workPhone; set => SetField(ref _workPhone, value); }
-        private DirtyValue<string> _homePhone;
+
         public string HomePhone { get => _homePhone; set => SetField(ref _homePhone, value); }
-        private DirtyValue<string> _mobilePhone;
+
         public string MobilePhone { get => _mobilePhone; set => SetField(ref _mobilePhone, value); }
-        private DirtyValue<string> _faxNumber;
+
         public string FaxNumber { get => _faxNumber; set => SetField(ref _faxNumber, value); }
-        private DirtyValue<string> _personalEmail;
+
         public string PersonalEmail { get => _personalEmail; set => SetField(ref _personalEmail, value); }
-        private DirtyValue<string> _businessEmail;
+
         public string BusinessEmail { get => _businessEmail; set => SetField(ref _businessEmail, value); }
-        private DirtyValue<string> _salutation;
+
         public string Salutation { get => _salutation; set => SetField(ref _salutation, value); }
-        private DirtyValue<string> _id;
+
         public string Id { get => _id; set => SetField(ref _id, value); }
 
         internal abstract string ApiPath { get; }

--- a/src/EncompassRest/Contacts/ContactAddress.cs
+++ b/src/EncompassRest/Contacts/ContactAddress.cs
@@ -3,14 +3,19 @@
     public sealed class ContactAddress : DirtyExtensibleObject
     {
         private DirtyValue<string> _street1;
-        public string Street1 { get => _street1; set => SetField(ref _street1, value); }
         private DirtyValue<string> _street2;
-        public string Street2 { get => _street2; set => SetField(ref _street2, value); }
         private DirtyValue<string> _city;
-        public string City { get => _city; set => SetField(ref _city, value); }
         private DirtyValue<string> _state;
-        public string State { get => _state; set => SetField(ref _state, value); }
         private DirtyValue<string> _zip;
+
+        public string Street1 { get => _street1; set => SetField(ref _street1, value); }
+
+        public string Street2 { get => _street2; set => SetField(ref _street2, value); }
+
+        public string City { get => _city; set => SetField(ref _city, value); }
+
+        public string State { get => _state; set => SetField(ref _state, value); }
+
         public string Zip { get => _zip; set => SetField(ref _zip, value); }
     }
 }

--- a/src/EncompassRest/Contacts/ContactGroup.cs
+++ b/src/EncompassRest/Contacts/ContactGroup.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.ComponentModel;
 using EncompassRest.Utilities;
+using EnumsNET;
 using Newtonsoft.Json;
 
 namespace EncompassRest.Contacts
@@ -10,23 +12,15 @@ namespace EncompassRest.Contacts
         private DirtyValue<string> _id;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get => _id; set => SetField(ref _id, value); }
-        private DirtyValue<StringEnumValue<ContactType>> _contactType;
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        private StringEnumValue<ContactType> _contactType;
+        [JsonRequired]
         public StringEnumValue<ContactType> ContactType { get => _contactType; set => SetField(ref _contactType, value); }
-        private DirtyValue<StringEnumValue<ContactGroupType>> _groupType;
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        private StringEnumValue<ContactGroupType> _groupType;
+        [JsonRequired]
         public StringEnumValue<ContactGroupType> GroupType { get => _groupType; set => SetField(ref _groupType, value); }
-        private DirtyValue<string> _name;
-        public string Name
-        {
-            get => _name;
-            set
-            {
-                Preconditions.NotNullOrEmpty(value, nameof(Name));
-
-                SetField(ref _name, value);
-            }
-        }
+        private string _name;
+        [JsonRequired]
+        public string Name { get => _name; set => SetField(ref _name, value); }
         private DirtyValue<string> _description;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get => _description; set => SetField(ref _description, value); }
@@ -34,9 +28,83 @@ namespace EncompassRest.Contacts
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? CreatedDate { get => _createdDate; private set => SetField(ref _createdDate, value); }
 
+        /// <summary>
+        /// Contact group creation constructor
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="contactType"></param>
+        /// <param name="groupType"></param>
+        public ContactGroup(string name, ContactType contactType, ContactGroupType groupType)
+            : this(name, contactType.Validate(nameof(contactType)).GetValue(), groupType.Validate(nameof(groupType)).GetValue())
+        {
+        }
+
+        /// <summary>
+        /// Contact group creation constructor
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="contactType"></param>
+        /// <param name="groupType"></param>
+        public ContactGroup(string name, string contactType, string groupType)
+        {
+            Preconditions.NotNullOrEmpty(name, nameof(name));
+            Preconditions.NotNullOrEmpty(contactType, nameof(contactType));
+            Preconditions.NotNullOrEmpty(groupType, nameof(groupType));
+
+            Name = name;
+            ContactType = contactType;
+            GroupType = groupType;
+        }
+
+        /// <summary>
+        /// Contact group update constructor
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="name"></param>
+        /// <param name="contactType"></param>
+        /// <param name="groupType"></param>
+        public ContactGroup(string id, string name, ContactType contactType, ContactGroupType groupType)
+            : this(id, name, contactType.Validate(nameof(contactType)).GetValue(), groupType.Validate(nameof(groupType)).GetValue())
+        {
+        }
+
+        /// <summary>
+        /// Contact group update constructor
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="name"></param>
+        /// <param name="contactType"></param>
+        /// <param name="groupType"></param>
+        public ContactGroup(string id, string name, string contactType, string groupType)
+        {
+            Preconditions.NotNullOrEmpty(id, nameof(id));
+            Preconditions.NotNullOrEmpty(name, nameof(name));
+            Preconditions.NotNullOrEmpty(contactType, nameof(contactType));
+            Preconditions.NotNullOrEmpty(groupType, nameof(groupType));
+
+            Id = id;
+            Name = name;
+            ContactType = contactType;
+            GroupType = groupType;
+        }
+
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ContactGroup(string name)
         {
+            Preconditions.NotNullOrEmpty(name, nameof(name));
+
             Name = name;
+        }
+
+        /// <summary>
+        /// Contact group deserialization constructor
+        /// </summary>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonConstructor]
+        public ContactGroup()
+        {
         }
     }
 }

--- a/src/EncompassRest/Contacts/ContactGroup.cs
+++ b/src/EncompassRest/Contacts/ContactGroup.cs
@@ -10,21 +10,27 @@ namespace EncompassRest.Contacts
     public sealed class ContactGroup : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _id;
+        private StringEnumValue<ContactType> _contactType;
+        private StringEnumValue<ContactGroupType> _groupType;
+        private string _name;
+        private DirtyValue<string> _description;
+        private NeverSerializeValue<DateTime?> _createdDate;
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get => _id; set => SetField(ref _id, value); }
-        private StringEnumValue<ContactType> _contactType;
+
         [JsonRequired]
         public StringEnumValue<ContactType> ContactType { get => _contactType; set => SetField(ref _contactType, value); }
-        private StringEnumValue<ContactGroupType> _groupType;
+
         [JsonRequired]
         public StringEnumValue<ContactGroupType> GroupType { get => _groupType; set => SetField(ref _groupType, value); }
-        private string _name;
+
         [JsonRequired]
         public string Name { get => _name; set => SetField(ref _name, value); }
-        private DirtyValue<string> _description;
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get => _description; set => SetField(ref _description, value); }
-        private NeverSerializeValue<DateTime?> _createdDate;
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? CreatedDate { get => _createdDate; private set => SetField(ref _createdDate, value); }
 

--- a/src/EncompassRest/Contacts/ContactGroups.cs
+++ b/src/EncompassRest/Contacts/ContactGroups.cs
@@ -13,16 +13,17 @@ namespace EncompassRest.Contacts
         {
         }
 
-        public Task<List<ContactGroup>> GetGroupsAsync(ContactType contactType, ContactGroupType? groupType = null, CancellationToken cancellationToken = default)
+        public Task<List<ContactGroup>> GetGroupsAsync(ContactType contactType, ContactGroupType? groupType = null, CancellationToken cancellationToken = default) => GetGroupsAsync(contactType.Validate(nameof(contactType)).GetValue(), groupType?.Validate(nameof(groupType)).GetValue(), cancellationToken);
+
+        public Task<List<ContactGroup>> GetGroupsAsync(string contactType, string groupType = null, CancellationToken cancellationToken = default)
         {
-            contactType.Validate(nameof(contactType));
+            Preconditions.NotNullOrEmpty(contactType, nameof(contactType));
 
             var queryParameters = new QueryParameters();
-            queryParameters.Add(nameof(contactType), contactType.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name));
-            if (groupType.HasValue)
+            queryParameters.Add(nameof(contactType), contactType);
+            if (!string.IsNullOrEmpty(groupType))
             {
-                groupType.GetValueOrDefault().Validate(nameof(groupType));
-                queryParameters.Add(nameof(groupType), groupType.GetValueOrDefault().AsString(EnumFormat.EnumMemberValue, EnumFormat.Name));
+                queryParameters.Add(nameof(groupType), groupType);
             }
 
             return GetDirtyListAsync<ContactGroup>(null, queryParameters.ToString(), nameof(GetGroupsAsync), null, cancellationToken);
@@ -91,13 +92,15 @@ namespace EncompassRest.Contacts
             return PostRawAsync(null, queryString, new JsonStringContent(group), nameof(CreateGroupRawAsync), null, cancellationToken);
         }
 
-        public Task AssignGroupContactsAsync(string groupId, AssignmentAction action, IEnumerable<EntityReference> contacts, CancellationToken cancellationToken = default)
+        public Task AssignGroupContactsAsync(string groupId, AssignmentAction action, IEnumerable<EntityReference> contacts, CancellationToken cancellationToken = default) => AssignGroupContactsAsync(groupId, action.Validate(nameof(action)).GetValue(), contacts, cancellationToken);
+
+        public Task AssignGroupContactsAsync(string groupId, string action, IEnumerable<EntityReference> contacts, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(groupId, nameof(groupId));
-            action.Validate(nameof(action));
+            Preconditions.NotNullOrEmpty(action, nameof(action));
             Preconditions.NotNullOrEmpty(contacts, nameof(contacts));
 
-            var queryParameters = new QueryParameters(new QueryParameter(nameof(action), action.AsString(EnumJsonConverter.CamelCaseNameFormat)));
+            var queryParameters = new QueryParameters(new QueryParameter(nameof(action), action));
             return PatchAsync($"{groupId}/contacts", queryParameters.ToString(), JsonStreamContent.Create(contacts), nameof(AssignGroupContactsAsync), groupId, cancellationToken);
         }
 

--- a/src/EncompassRest/Contacts/ContactListParameters.cs
+++ b/src/EncompassRest/Contacts/ContactListParameters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using EncompassRest.Filters;
 using Newtonsoft.Json;
@@ -32,11 +33,13 @@ namespace EncompassRest.Contacts
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public StringEnumValue<ContactLoanMatchType> LoanMatchType { get; set; }
 
+        [JsonConstructor]
         public ContactListParameters()
         {
         }
 
-        [Obsolete("Explicitly set the Fields property in the initializer")]
+        [Obsolete("Use another constructor and explicitly set the Fields property in the initializer instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ContactListParameters(IEnumerable<string> fields)
         {
             Fields = fields;

--- a/src/EncompassRest/Contacts/ContactNote.cs
+++ b/src/EncompassRest/Contacts/ContactNote.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.ComponentModel;
+using EncompassRest.Utilities;
 using Newtonsoft.Json;
 
 namespace EncompassRest.Contacts
@@ -22,5 +24,37 @@ namespace EncompassRest.Contacts
         public string Details { get => _details; set => SetField(ref _details, value); }
         [IdPropertyName(nameof(NoteId))]
         string IIdentifiable.Id { get => NoteId; set => NoteId = value; }
+
+        /// <summary>
+        /// Contact note creation constructor
+        /// </summary>
+        /// <param name="subject"></param>
+        /// <param name="details"></param>
+        public ContactNote(string subject, string details)
+        {
+            Preconditions.NotNullOrEmpty(subject, nameof(subject));
+            Preconditions.NotNullOrEmpty(details, nameof(details));
+
+            Subject = subject;
+            Details = details;
+        }
+
+        /// <summary>
+        /// Contact note update constructor
+        /// </summary>
+        /// <param name="noteId"></param>
+        public ContactNote(string noteId)
+        {
+            Preconditions.NotNullOrEmpty(noteId, nameof(noteId));
+
+            NoteId = noteId;
+        }
+
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonConstructor]
+        public ContactNote()
+        {
+        }
     }
 }

--- a/src/EncompassRest/Contacts/ContactNote.cs
+++ b/src/EncompassRest/Contacts/ContactNote.cs
@@ -8,20 +8,26 @@ namespace EncompassRest.Contacts
     public sealed class ContactNote : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<int?> _noteIdInt;
+        private DirtyValue<string> _subject;
+        private DirtyValue<DateTime?> _timestamp;
+        private DirtyValue<string> _details;
+
         [JsonProperty("noteId")]
         public int? NoteIdInt { get => _noteIdInt; set => SetField(ref _noteIdInt, value); }
+
         [JsonIgnore]
         public string NoteId
         {
             get => NoteIdInt?.ToString();
             set => NoteIdInt = value != null && int.TryParse(value, out var noteId) ? noteId : (int?)null;
         }
-        private DirtyValue<string> _subject;
+
         public string Subject { get => _subject; set => SetField(ref _subject, value); }
-        private DirtyValue<DateTime?> _timestamp;
+
         public DateTime? Timestamp { get => _timestamp; set => SetField(ref _timestamp, value); }
-        private DirtyValue<string> _details;
+
         public string Details { get => _details; set => SetField(ref _details, value); }
+
         [IdPropertyName(nameof(NoteId))]
         string IIdentifiable.Id { get => NoteId; set => NoteId = value; }
 

--- a/src/EncompassRest/Contacts/ContactNotes.cs
+++ b/src/EncompassRest/Contacts/ContactNotes.cs
@@ -56,6 +56,7 @@ namespace EncompassRest.Contacts
             Preconditions.NotNull(note, nameof(note));
             Preconditions.NotNullOrEmpty(note.NoteId, $"{nameof(note)}.{nameof(note.NoteId)}");
 
+            note.Dirty = true; // To be removed if Ellie Mae updates API to only update provided properties.
             return PatchPopulateDirtyAsync(note.NoteId, JsonStreamContent.Create(note), nameof(UpdateNoteAsync), note.NoteId, note, populate, cancellationToken);
         }
 

--- a/src/EncompassRest/Contacts/Contacts.cs
+++ b/src/EncompassRest/Contacts/Contacts.cs
@@ -55,6 +55,7 @@ namespace EncompassRest.Contacts
             Preconditions.NotNullOrEmpty(contact.Id, $"{nameof(contact)}.{nameof(contact.Id)}");
 
             contact.Initialize(Client, contact.Id);
+            contact.Dirty = true; // To be removed if Ellie Mae updates API to only update provided properties.
             return PatchPopulateDirtyAsync(contact.Id, JsonStreamContent.Create(contact), nameof(UpdateContactAsync), contact.Id, contact, populate, cancellationToken);
         }
 

--- a/src/EncompassRest/CustomDataObjects/CustomDataObject.cs
+++ b/src/EncompassRest/CustomDataObjects/CustomDataObject.cs
@@ -9,6 +9,8 @@ namespace EncompassRest.CustomDataObjects
     public sealed class CustomDataObject : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _name;
+        private DirtyValue<byte[]> _dataObject;
+
         public string Name
         {
             get => _name;
@@ -19,7 +21,7 @@ namespace EncompassRest.CustomDataObjects
                 SetField(ref _name, value);
             }
         }
-        private DirtyValue<byte[]> _dataObject;
+
         public byte[] DataObject
         {
             get => _dataObject;
@@ -30,6 +32,7 @@ namespace EncompassRest.CustomDataObjects
                 SetField(ref _dataObject, value);
             }
         }
+
         [IdPropertyName(nameof(Name))]
         string IIdentifiable.Id { get => Name; set => Name = value; }
 

--- a/src/EncompassRest/CustomDataObjects/CustomDataObject.cs
+++ b/src/EncompassRest/CustomDataObjects/CustomDataObject.cs
@@ -40,7 +40,7 @@ namespace EncompassRest.CustomDataObjects
             DataObject = dataObject;
         }
 
-        [Obsolete("Use a different constructor instead.")]
+        [Obsolete("Use another constructor instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CustomDataObject()
         {

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -10,6 +10,7 @@ using EncompassRest.Token;
 using EncompassRest.Utilities;
 using EncompassRest.Contacts;
 using EncompassRest.CustomDataObjects;
+using System.ComponentModel;
 
 namespace EncompassRest
 {
@@ -48,6 +49,7 @@ namespace EncompassRest
         }
 
         [Obsolete("Use the ClientParameters overload instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Task<EncompassRestClient> CreateFromUserCredentialsAsync(string apiClientId, string apiClientSecret, string instanceId, string userId, string password, CancellationToken cancellationToken = default) =>
             CreateFromUserCredentialsAsync(new ClientParameters(apiClientId, apiClientSecret), instanceId, userId, password, cancellationToken);
 
@@ -65,6 +67,7 @@ namespace EncompassRest
         }
 
         [Obsolete("Use the ClientParameters overload instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Task<EncompassRestClient> CreateFromAuthorizationCodeAsync(string apiClientId, string apiClientSecret, string redirectUri, string authorizationCode, CancellationToken cancellationToken = default) =>
             CreateFromAuthorizationCodeAsync(new ClientParameters(apiClientId, apiClientSecret), redirectUri, authorizationCode, cancellationToken);
 
@@ -80,6 +83,7 @@ namespace EncompassRest
         }
 
         [Obsolete("Use CreateFromAccessTokenAsync instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static EncompassRestClient CreateFromAccessToken(ClientParameters parameters, string accessToken)
         {
             Preconditions.NotNull(parameters, nameof(parameters));
@@ -91,8 +95,8 @@ namespace EncompassRest
         }
 
         [Obsolete("Use the ClientParameters overload instead.")]
-        public static EncompassRestClient CreateFromAccessToken(string apiClientId, string apiClientSecret, string accessToken) =>
-            CreateFromAccessToken(new ClientParameters(apiClientId, apiClientSecret), accessToken);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static EncompassRestClient CreateFromAccessToken(string apiClientId, string apiClientSecret, string accessToken) => CreateFromAccessToken(new ClientParameters(apiClientId, apiClientSecret), accessToken);
         
         private readonly Func<TokenCreator, Task<string>> _tokenInitializer;
         private int _timeoutRetryCount;

--- a/src/EncompassRest/EntityReference.cs
+++ b/src/EncompassRest/EntityReference.cs
@@ -1,5 +1,12 @@
-﻿namespace EncompassRest
+﻿using System;
+using System.ComponentModel;
+using EncompassRest.Utilities;
+using EnumsNET;
+using Newtonsoft.Json;
+
+namespace EncompassRest
 {
+    [Entity(PropertiesToAlwaysSerialize = nameof(EntityType))]
     public class EntityReference : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _entityId;
@@ -13,5 +20,26 @@
 
         [IdPropertyName(nameof(EntityId))]
         string IIdentifiable.Id { get => EntityId; set => EntityId = value; }
+
+        public EntityReference(string entityId, EntityType entityType)
+            : this(entityId, entityType.Validate(nameof(entityType)).GetValue())
+        {
+        }
+        
+        public EntityReference(string entityId, string entityType)
+        {
+            Preconditions.NotNullOrEmpty(entityId, nameof(entityId));
+            Preconditions.NotNullOrEmpty(entityType, nameof(entityType));
+
+            EntityId = entityId;
+            EntityType = entityType;
+        }
+
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonConstructor]
+        public EntityReference()
+        {
+        }
     }
 }

--- a/src/EncompassRest/EntityReference.cs
+++ b/src/EncompassRest/EntityReference.cs
@@ -10,12 +10,16 @@ namespace EncompassRest
     public class EntityReference : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _entityId;
-        public string EntityId { get => _entityId; set => SetField(ref _entityId, value); }
         private DirtyValue<StringEnumValue<EntityType>> _entityType;
-        public StringEnumValue<EntityType> EntityType { get => _entityType; set => SetField(ref _entityType, value); }
         private DirtyValue<string> _entityName;
-        public string EntityName { get => _entityName; set => SetField(ref _entityName, value); }
         private DirtyValue<string> _entityUri;
+
+        public string EntityId { get => _entityId; set => SetField(ref _entityId, value); }
+
+        public StringEnumValue<EntityType> EntityType { get => _entityType; set => SetField(ref _entityType, value); }
+
+        public string EntityName { get => _entityName; set => SetField(ref _entityName, value); }
+
         public string EntityUri { get => _entityUri; set => SetField(ref _entityUri, value); }
 
         [IdPropertyName(nameof(EntityId))]

--- a/src/EncompassRest/ExtensibleObject.cs
+++ b/src/EncompassRest/ExtensibleObject.cs
@@ -10,6 +10,7 @@ namespace EncompassRest
     public abstract class ExtensibleObject : SerializableObject
     {
         private protected DirtyDictionary<string, object> _extensionData;
+
         /// <summary>
         /// Extension Data
         /// </summary>

--- a/src/EncompassRest/Extensions.cs
+++ b/src/EncompassRest/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using EncompassRest.Utilities;
+using EnumsNET;
 
 namespace EncompassRest
 {
@@ -27,5 +28,7 @@ namespace EncompassRest
             }
             return list.FirstOrDefault(v => string.Equals(((IIdentifiable)v)?.Id, id, StringComparison.OrdinalIgnoreCase));
         }
+
+        internal static string GetValue<TEnum>(this TEnum value) where TEnum : struct, Enum => value.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name);
     }
 }

--- a/src/EncompassRest/LoanPipeline/PipelineFieldDefinition.cs
+++ b/src/EncompassRest/LoanPipeline/PipelineFieldDefinition.cs
@@ -6,21 +6,37 @@ namespace EncompassRest.LoanPipeline
     public sealed class PipelineFieldDefinition : ExtensibleObject
     {
         public int BorrowerPair { get; set; }
+
         public bool IsLoanDataField { get; set; }
+
         public StringEnumValue<FieldDefinitionCategory> Category { get; set; }
+
         public string FieldID { get; set; }
+
         public FieldDefinition FieldDefinition { get; set; }
+
         public int DataSource { get; set; }
+
         public string Name { get; set; }
+
         public string Description { get; set; }
+
         public int FieldType { get; set; }
+
         public bool Selectable { get; set; }
+
         public string CriterionFieldName { get; set; }
+
         public SortTerm SortTerm { get; set; }
+
         public bool IsDatabaseField { get; set; }
+
         public int ReportingDatabaseColumnType { get; set; }
+
         public int? DisplayType { get; set; }
+
         public List<string> RelatedFields { get; set; }
+
         public bool? IsVolatile { get; set; }
     }
 }

--- a/src/EncompassRest/LoanPipeline/SortTerm.cs
+++ b/src/EncompassRest/LoanPipeline/SortTerm.cs
@@ -3,6 +3,7 @@
     public sealed class SortTerm : ExtensibleObject
     {
         public string FieldName { get; set; }
+
         public bool UseNull { get; set; }
     }
 }

--- a/src/EncompassRest/Loans/Attachments/Image.cs
+++ b/src/EncompassRest/Loans/Attachments/Image.cs
@@ -3,17 +3,24 @@
     public abstract class Image : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _imageKey;
-        public string ImageKey { get => _imageKey; set => SetField(ref _imageKey, value); }
         private DirtyValue<string> _zipKey;
-        public string ZipKey { get => _zipKey; set => SetField(ref _zipKey, value); }
         private DirtyValue<int?> _width;
-        public int? Width { get => _width; set => SetField(ref _width, value); }
         private DirtyValue<int?> _height;
-        public int? Height { get => _height; set => SetField(ref _height, value); }
         private DirtyValue<float?> _horizontalResolution;
-        public float? HorizontalResolution { get => _horizontalResolution; set => SetField(ref _horizontalResolution, value); }
         private DirtyValue<float?> _verticalResolution;
+
+        public string ImageKey { get => _imageKey; set => SetField(ref _imageKey, value); }
+
+        public string ZipKey { get => _zipKey; set => SetField(ref _zipKey, value); }
+
+        public int? Width { get => _width; set => SetField(ref _width, value); }
+
+        public int? Height { get => _height; set => SetField(ref _height, value); }
+
+        public float? HorizontalResolution { get => _horizontalResolution; set => SetField(ref _horizontalResolution, value); }
+
         public float? VeriticalResolution { get => _verticalResolution; set => SetField(ref _verticalResolution, value); }
+
         [IdPropertyName(nameof(ImageKey))]
         string IIdentifiable.Id { get => ImageKey; set => ImageKey = value; }
     }

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +12,7 @@ namespace EncompassRest.Loans.Attachments
 {
     public sealed class LoanAttachment : DirtyExtensibleObject, IIdentifiable
     {
-        private DirtyValue<string> _attachmentId;
+        private NeverSerializeValue<string> _attachmentId;
         public string AttachmentId { get => _attachmentId; set => SetField(ref _attachmentId, value); }
         private DirtyValue<DateTime?> _dateCreated;
         public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
@@ -46,6 +47,43 @@ namespace EncompassRest.Loans.Attachments
         string IIdentifiable.Id { get => AttachmentId; set => AttachmentId = value; }
 
         internal LoanAttachments Attachments;
+
+        /// <summary>
+        /// Loan attachment creation constructor
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="fileWithExtension"></param>
+        /// <param name="createReason"></param>
+        public LoanAttachment(string title, string fileWithExtension, AttachmentCreateReason createReason)
+        {
+            Preconditions.NotNullOrEmpty(title, nameof(title));
+            Preconditions.NotNullOrEmpty(fileWithExtension, nameof(fileWithExtension));
+
+            Title = title;
+            FileWithExtension = fileWithExtension;
+            CreateReason = createReason;
+        }
+
+        /// <summary>
+        /// Loan attachment update constructor
+        /// </summary>
+        /// <param name="attachmentId"></param>
+        public LoanAttachment(string attachmentId)
+        {
+            Preconditions.NotNullOrEmpty(attachmentId, nameof(attachmentId));
+
+            AttachmentId = attachmentId;
+        }
+
+        /// <summary>
+        /// Loan attachment deserialization constructor
+        /// </summary>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonConstructor]
+        public LoanAttachment()
+        {
+        }
 
         public async Task<byte[]> DownloadAsync(CancellationToken cancellationToken = default)
         {

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -13,36 +13,51 @@ namespace EncompassRest.Loans.Attachments
     public sealed class LoanAttachment : DirtyExtensibleObject, IIdentifiable
     {
         private NeverSerializeValue<string> _attachmentId;
-        public string AttachmentId { get => _attachmentId; set => SetField(ref _attachmentId, value); }
         private DirtyValue<DateTime?> _dateCreated;
-        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
         private DirtyValue<string> _createdBy;
-        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
         private DirtyValue<string> _createdByName;
-        public string CreatedByName { get => _createdByName; set => SetField(ref _createdByName, value); }
         private DirtyValue<AttachmentCreateReason?> _createReason;
+        private DirtyValue<AttachmentType?> _attachmentType;
+        private DirtyValue<long?> _fileSize;
+        private DirtyValue<bool?> _isActive;
+        private DirtyList<PageImage> _pages;
+        private DirtyValue<int?> _rotation;
+        private DirtyValue<string> _title;
+        private DirtyValue<string> _fileWithExtension;
+        private EntityReference _document;
+        private NeverSerializeValue<string> _mediaUrl;
+
+        public string AttachmentId { get => _attachmentId; set => SetField(ref _attachmentId, value); }
+
+        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
+
+        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
+
+        public string CreatedByName { get => _createdByName; set => SetField(ref _createdByName, value); }
+
         [EnumFormat(EnumFormat.DecimalValue)]
         public AttachmentCreateReason? CreateReason { get => _createReason; set => SetField(ref _createReason, value); }
-        private DirtyValue<AttachmentType?> _attachmentType;
+
         [EnumFormat(EnumFormat.DecimalValue)]
         public AttachmentType? AttachmentType { get => _attachmentType; set => SetField(ref _attachmentType, value); }
-        private DirtyValue<long?> _fileSize;
+
         public long? FileSize { get => _fileSize; set => SetField(ref _fileSize, value); }
-        private DirtyValue<bool?> _isActive;
+
         public bool? IsActive { get => _isActive; set => SetField(ref _isActive, value); }
-        private DirtyList<PageImage> _pages;
+
         public IList<PageImage> Pages { get => GetField(ref _pages); set => SetField(ref _pages, value); }
-        private DirtyValue<int?> _rotation;
+
         public int? Rotation { get => _rotation; set => SetField(ref _rotation, value); }
-        private DirtyValue<string> _title;
+
         public string Title { get => _title; set => SetField(ref _title, value); }
-        private DirtyValue<string> _fileWithExtension;
+
         public string FileWithExtension { get => _fileWithExtension; set => SetField(ref _fileWithExtension, value); }
-        private EntityReference _document;
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public EntityReference Document { get => _document; set => SetField(ref _document, value); }
-        private NeverSerializeValue<string> _mediaUrl;
+
         public string MediaUrl { get => _mediaUrl; set => SetField(ref _mediaUrl, value); }
+
         [IdPropertyName(nameof(AttachmentId))]
         string IIdentifiable.Id { get => AttachmentId; set => AttachmentId = value; }
 

--- a/src/EncompassRest/Loans/Attachments/PageAnnotation.cs
+++ b/src/EncompassRest/Loans/Attachments/PageAnnotation.cs
@@ -7,20 +7,28 @@ namespace EncompassRest.Loans.Attachments
     public sealed class PageAnnotation : DirtyExtensibleObject
     {
         private DirtyValue<DateTime?> _dateCreated;
-        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
         private DirtyValue<string> _createdBy;
-        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
         private DirtyValue<string> _text;
-        public string Text { get => _text; set => SetField(ref _text, value); }
         private DirtyValue<int?> _left;
-        public int? Left { get => _left; set => SetField(ref _left, value); }
         private DirtyValue<int?> _top;
-        public int? Top { get => _top; set => SetField(ref _top, value); }
         private DirtyValue<int?> _width;
-        public int? Width { get => _width; set => SetField(ref _width, value); }
         private DirtyValue<int?> _height;
-        public int? Height { get => _height; set => SetField(ref _height, value); }
         private DirtyValue<AnnotationVisibilityType?> _visibilityType;
+
+        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
+
+        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
+
+        public string Text { get => _text; set => SetField(ref _text, value); }
+
+        public int? Left { get => _left; set => SetField(ref _left, value); }
+
+        public int? Top { get => _top; set => SetField(ref _top, value); }
+
+        public int? Width { get => _width; set => SetField(ref _width, value); }
+
+        public int? Height { get => _height; set => SetField(ref _height, value); }
+
         [EnumFormat(EnumFormat.DecimalValue)]
         public AnnotationVisibilityType? VisibilityType { get => _visibilityType; set => SetField(ref _visibilityType, value); }
     }

--- a/src/EncompassRest/Loans/Attachments/PageImage.cs
+++ b/src/EncompassRest/Loans/Attachments/PageImage.cs
@@ -5,14 +5,19 @@ namespace EncompassRest.Loans.Attachments
     public sealed class PageImage : Image
     {
         private DirtyValue<string> _nativeKey;
-        public string NativeKey { get => _nativeKey; set => SetField(ref _nativeKey, value); }
         private DirtyValue<int?> _rotation;
-        public int? Rotation { get => _rotation; set => SetField(ref _rotation, value); }
         private DirtyValue<long?> _fileSize;
-        public long? FileSize { get => _fileSize; set => SetField(ref _fileSize, value); }
         private PageThumbnail _thumbnail;
-        public PageThumbnail Thumbnail { get => GetField(ref _thumbnail); set => SetField(ref _thumbnail, value); }
         private DirtyList<PageAnnotation> _annotations;
+
+        public string NativeKey { get => _nativeKey; set => SetField(ref _nativeKey, value); }
+
+        public int? Rotation { get => _rotation; set => SetField(ref _rotation, value); }
+
+        public long? FileSize { get => _fileSize; set => SetField(ref _fileSize, value); }
+
+        public PageThumbnail Thumbnail { get => GetField(ref _thumbnail); set => SetField(ref _thumbnail, value); }
+
         public IList<PageAnnotation> Annotations { get => GetField(ref _annotations); set => SetField(ref _annotations, value); }
     }
 }

--- a/src/EncompassRest/Loans/Conditions/ConditionComment.cs
+++ b/src/EncompassRest/Loans/Conditions/ConditionComment.cs
@@ -5,18 +5,25 @@ namespace EncompassRest.Loans.Conditions
     public sealed class ConditionComment : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _commentId;
-        public string CommentId { get => _commentId; set => SetField(ref _commentId, value); }
         private DirtyValue<string> _comments;
-        public string Comments { get => _comments; set => SetField(ref _comments, value); }
         private DirtyValue<int?> _forRoleId;
-        public int? ForRoleId { get => _forRoleId; set => SetField(ref _forRoleId, value); }
         private EntityReference _forRole;
-        public EntityReference ForRole { get => GetField(ref _forRole); set => SetField(ref _forRole, value); }
         private DirtyValue<DateTime?> _dateCreated;
-        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
         private DirtyValue<string> _createdBy;
-        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
         private DirtyValue<string> _createdByName;
+
+        public string CommentId { get => _commentId; set => SetField(ref _commentId, value); }
+
+        public string Comments { get => _comments; set => SetField(ref _comments, value); }
+
+        public int? ForRoleId { get => _forRoleId; set => SetField(ref _forRoleId, value); }
+
+        public EntityReference ForRole { get => GetField(ref _forRole); set => SetField(ref _forRole, value); }
+
+        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
+
+        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
+
         public string CreatedByName { get => _createdByName; set => SetField(ref _createdByName, value); }
 
         [IdPropertyName(nameof(CommentId))]

--- a/src/EncompassRest/Loans/Conditions/LoanCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/LoanCondition.cs
@@ -6,60 +6,88 @@ namespace EncompassRest.Loans.Conditions
     public abstract class LoanCondition : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _id;
-        public string Id { get => _id; set => SetField(ref _id, value); }
         private DirtyValue<string> _templateId;
-        public string TemplateId { get => _templateId; set => SetField(ref _templateId, value); }
         private DirtyValue<StringEnumValue<ConditionType>> _conditionType;
-        public StringEnumValue<ConditionType> ConditionType { get => _conditionType; set => SetField(ref _conditionType, value); }
         private DirtyValue<bool?> _isRemoved;
-        public bool? IsRemoved { get => _isRemoved; set => SetField(ref _isRemoved, value); }
         private DirtyValue<string> _title;
-        public string Title { get => _title; set => SetField(ref _title, value); }
         private DirtyValue<string> _description;
-        public string Description { get => _description; set => SetField(ref _description, value); }
         private EntityReference _application;
-        public EntityReference Application { get => GetField(ref _application); set => SetField(ref _application, value); }
         private DirtyValue<bool?> _forAllApplications;
-        public bool? ForAllApplications { get => _forAllApplications; set => SetField(ref _forAllApplications, value); }
         private DirtyValue<StringEnumValue<ConditionSource>> _source;
-        public StringEnumValue<ConditionSource> Source { get => _source; set => SetField(ref _source, value); }
         private DirtyValue<DateTime?> _expectedDate;
-        public DateTime? ExpectedDate { get => _expectedDate; set => SetField(ref _expectedDate, value); }
         private DirtyValue<StringEnumValue<ConditionStatus>> _status;
-        public StringEnumValue<ConditionStatus> Status { get => _status; set => SetField(ref _status, value); }
         private DirtyValue<DateTime?> _statusDate;
-        public DateTime? StatusDate { get => _statusDate; set => SetField(ref _statusDate, value); }
         private DirtyValue<int?> _daysToReceive;
-        public int? DaysToReceive { get => _daysToReceive; set => SetField(ref _daysToReceive, value); }
         private DirtyValue<string> _requestedFrom;
-        public string RequestedFrom { get => _requestedFrom; set => SetField(ref _requestedFrom, value); }
         private DirtyValue<DateTime?> _createdDate;
-        public DateTime? CreatedDate { get => _createdDate; set => SetField(ref _createdDate, value); }
         private EntityReference _createdBy;
-        public EntityReference CreatedBy { get => GetField(ref _createdBy); set => SetField(ref _createdBy, value); }
         private DirtyValue<bool?> _isRequested;
-        public bool? IsRequested { get => _isRequested; set => SetField(ref _isRequested, value); }
         private DirtyValue<DateTime?> _requestedDate;
-        public DateTime? RequestedDate { get => _requestedDate; set => SetField(ref _requestedDate, value); }
         private EntityReference _requestedBy;
-        public EntityReference RequestedBy { get => GetField(ref _requestedBy); set => SetField(ref _requestedBy, value); }
         private DirtyValue<bool?> _isRerequested;
-        public bool? IsRerequested { get => _isRerequested; set => SetField(ref _isRerequested, value); }
         private DirtyValue<DateTime?> _rerequestedDate;
-        public DateTime? RerequestedDate { get => _rerequestedDate; set => SetField(ref _rerequestedDate, value); }
         private EntityReference _rerequestedBy;
-        public EntityReference RerequestedBy { get => GetField(ref _rerequestedBy); set => SetField(ref _rerequestedBy, value); }
         private DirtyValue<bool?> _isReceived;
-        public bool? IsReceived { get => _isReceived; set => SetField(ref _isReceived, value); }
         private DirtyValue<DateTime?> _receivedDate;
-        public DateTime? ReceivedDate { get => _receivedDate; set => SetField(ref _receivedDate, value); }
         private EntityReference _receivedBy;
-        public EntityReference ReceivedBy { get => GetField(ref _receivedBy); set => SetField(ref _receivedBy, value); }
         private DirtyValue<bool?> _isAddedToConditionSet;
-        public bool? IsAddedToConditionSet { get => _isAddedToConditionSet; set => SetField(ref _isAddedToConditionSet, value); }
         private DirtyList<ConditionComment> _comments;
-        public IList<ConditionComment> Comments { get => GetField(ref _comments); set => SetField(ref _comments, value); }
         private DirtyList<EntityReference> _documents;
+
+        public string Id { get => _id; set => SetField(ref _id, value); }
+
+        public string TemplateId { get => _templateId; set => SetField(ref _templateId, value); }
+
+        public StringEnumValue<ConditionType> ConditionType { get => _conditionType; set => SetField(ref _conditionType, value); }
+
+        public bool? IsRemoved { get => _isRemoved; set => SetField(ref _isRemoved, value); }
+
+        public string Title { get => _title; set => SetField(ref _title, value); }
+
+        public string Description { get => _description; set => SetField(ref _description, value); }
+
+        public EntityReference Application { get => GetField(ref _application); set => SetField(ref _application, value); }
+
+        public bool? ForAllApplications { get => _forAllApplications; set => SetField(ref _forAllApplications, value); }
+
+        public StringEnumValue<ConditionSource> Source { get => _source; set => SetField(ref _source, value); }
+
+        public DateTime? ExpectedDate { get => _expectedDate; set => SetField(ref _expectedDate, value); }
+
+        public StringEnumValue<ConditionStatus> Status { get => _status; set => SetField(ref _status, value); }
+
+        public DateTime? StatusDate { get => _statusDate; set => SetField(ref _statusDate, value); }
+
+        public int? DaysToReceive { get => _daysToReceive; set => SetField(ref _daysToReceive, value); }
+
+        public string RequestedFrom { get => _requestedFrom; set => SetField(ref _requestedFrom, value); }
+
+        public DateTime? CreatedDate { get => _createdDate; set => SetField(ref _createdDate, value); }
+
+        public EntityReference CreatedBy { get => GetField(ref _createdBy); set => SetField(ref _createdBy, value); }
+
+        public bool? IsRequested { get => _isRequested; set => SetField(ref _isRequested, value); }
+
+        public DateTime? RequestedDate { get => _requestedDate; set => SetField(ref _requestedDate, value); }
+
+        public EntityReference RequestedBy { get => GetField(ref _requestedBy); set => SetField(ref _requestedBy, value); }
+
+        public bool? IsRerequested { get => _isRerequested; set => SetField(ref _isRerequested, value); }
+
+        public DateTime? RerequestedDate { get => _rerequestedDate; set => SetField(ref _rerequestedDate, value); }
+
+        public EntityReference RerequestedBy { get => GetField(ref _rerequestedBy); set => SetField(ref _rerequestedBy, value); }
+
+        public bool? IsReceived { get => _isReceived; set => SetField(ref _isReceived, value); }
+
+        public DateTime? ReceivedDate { get => _receivedDate; set => SetField(ref _receivedDate, value); }
+
+        public EntityReference ReceivedBy { get => GetField(ref _receivedBy); set => SetField(ref _receivedBy, value); }
+
+        public bool? IsAddedToConditionSet { get => _isAddedToConditionSet; set => SetField(ref _isAddedToConditionSet, value); }
+
+        public IList<ConditionComment> Comments { get => GetField(ref _comments); set => SetField(ref _comments, value); }
+
         public IList<EntityReference> Documents { get => GetField(ref _documents); set => SetField(ref _documents, value); }
 
         internal LoanCondition()

--- a/src/EncompassRest/Loans/Conditions/PostClosingCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/PostClosingCondition.cs
@@ -5,18 +5,25 @@ namespace EncompassRest.Loans.Conditions
     public sealed class PostClosingCondition : LoanCondition
     {
         private DirtyValue<string> _recipient;
-        public string Recipient { get => _recipient; set => SetField(ref _recipient, value); }
         private DirtyValue<bool?> _isSent;
-        public bool? IsSent { get => _isSent; set => SetField(ref _isSent, value); }
         private DirtyValue<DateTime?> _sentDate;
-        public DateTime? SentDate { get => _sentDate; set => SetField(ref _sentDate, value); }
         private EntityReference _sentBy;
-        public EntityReference SentBy { get => GetField(ref _sentBy); set => SetField(ref _sentBy, value); }
         private DirtyValue<bool?> _isCleared;
-        private bool? IsCleared { get => _isCleared; set => SetField(ref _isCleared, value); }
         private DirtyValue<DateTime?> _clearedDate;
-        public DateTime? ClearedDate { get => _clearedDate; set => SetField(ref _clearedDate, value); }
         private EntityReference _clearedBy;
+
+        public string Recipient { get => _recipient; set => SetField(ref _recipient, value); }
+
+        public bool? IsSent { get => _isSent; set => SetField(ref _isSent, value); }
+
+        public DateTime? SentDate { get => _sentDate; set => SetField(ref _sentDate, value); }
+
+        public EntityReference SentBy { get => GetField(ref _sentBy); set => SetField(ref _sentBy, value); }
+
+        private bool? IsCleared { get => _isCleared; set => SetField(ref _isCleared, value); }
+
+        public DateTime? ClearedDate { get => _clearedDate; set => SetField(ref _clearedDate, value); }
+
         public EntityReference ClearedBy { get => GetField(ref _clearedBy); set => SetField(ref _clearedBy, value); }
     }
 }

--- a/src/EncompassRest/Loans/Conditions/PreliminaryCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/PreliminaryCondition.cs
@@ -5,16 +5,22 @@ namespace EncompassRest.Loans.Conditions
     public sealed class PreliminaryCondition : LoanCondition
     {
         private DirtyValue<bool?> _uwAccess;
-        public bool? UWAccess { get => _uwAccess; set => SetField(ref _uwAccess, value); }
         private DirtyValue<StringEnumValue<PriorToMilestone>> _priorTo;
-        public StringEnumValue<PriorToMilestone> PriorTo { get => _priorTo; set => SetField(ref _priorTo, value); }
         private DirtyValue<StringEnumValue<ConditionCategory>> _category;
-        public StringEnumValue<ConditionCategory> Category { get => _category; set => SetField(ref _category, value); }
         private DirtyValue<bool?> _isFulfilled;
-        public bool? IsFulfilled { get => _isFulfilled; set => SetField(ref _isFulfilled, value); }
         private DirtyValue<DateTime?> _fulfilledDate;
-        public DateTime? FulfilledDate { get => _fulfilledDate; set => SetField(ref _fulfilledDate, value); }
         private EntityReference _fulfilledBy;
+
+        public bool? UWAccess { get => _uwAccess; set => SetField(ref _uwAccess, value); }
+
+        public StringEnumValue<PriorToMilestone> PriorTo { get => _priorTo; set => SetField(ref _priorTo, value); }
+
+        public StringEnumValue<ConditionCategory> Category { get => _category; set => SetField(ref _category, value); }
+
+        public bool? IsFulfilled { get => _isFulfilled; set => SetField(ref _isFulfilled, value); }
+
+        public DateTime? FulfilledDate { get => _fulfilledDate; set => SetField(ref _fulfilledDate, value); }
+
         public EntityReference FulfilledBy { get => GetField(ref _fulfilledBy); set => SetField(ref _fulfilledBy, value); }
     }
 }

--- a/src/EncompassRest/Loans/Conditions/UnderwritingCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/UnderwritingCondition.cs
@@ -5,48 +5,70 @@ namespace EncompassRest.Loans.Conditions
     public sealed class UnderwritingCondition : LoanCondition
     {
         private DirtyValue<StringEnumValue<PriorToMilestone>> _priorTo;
-        public StringEnumValue<PriorToMilestone> PriorTo { get => _priorTo; set => SetField(ref _priorTo, value); }
         private DirtyValue<StringEnumValue<ConditionCategory>> _category;
-        public StringEnumValue<ConditionCategory> Category { get => _category; set => SetField(ref _category, value); }
         private DirtyValue<string> _ownerRole;
-        public string OwnerRole { get => _ownerRole; set => SetField(ref _ownerRole, value); }
         private DirtyValue<bool?> _allowToClear;
-        public bool? AllowToClear { get => _allowToClear; set => SetField(ref _allowToClear, value); }
         private DirtyValue<bool?> _printExternally;
-        public bool? PrintExternally { get => _printExternally; set => SetField(ref _printExternally, value); }
         private DirtyValue<bool?> _printInternally;
-        public bool? PrintInternally { get => _printInternally; set => SetField(ref _printInternally, value); }
         private DirtyValue<DateTime?> _expirationDate;
-        public DateTime? ExpirationDate { get => _expirationDate; set => SetField(ref _expirationDate, value); }
         private DirtyValue<bool?> _isFulfilled;
-        public bool? IsFulfilled { get => _isFulfilled; set => SetField(ref _isFulfilled, value); }
         private DirtyValue<DateTime?> _fulfilledDate;
-        public DateTime? FulfilledDate { get => _fulfilledDate; set => SetField(ref _fulfilledDate, value); }
         private EntityReference _fulfilledBy;
-        public EntityReference FulfilledBy { get => GetField(ref _fulfilledBy); set => SetField(ref _fulfilledBy, value); }
         private DirtyValue<bool?> _isReviewed;
-        public bool? IsReviewed { get => _isReviewed; set => SetField(ref _isReviewed, value); }
         private DirtyValue<DateTime?> _reviewedDate;
-        public DateTime? ReviewedDate { get => _reviewedDate; set => SetField(ref _reviewedDate, value); }
         private EntityReference _reviewedBy;
-        public EntityReference ReviewedBy { get => GetField(ref _reviewedBy); set => SetField(ref _reviewedBy, value); }
         private DirtyValue<bool?> _isRejected;
-        public bool? IsRejected { get => _isRejected; set => SetField(ref _isRejected, value); }
         private DirtyValue<DateTime?> _rejectedDate;
-        public DateTime? RejectedDate { get => _rejectedDate; set => SetField(ref _rejectedDate, value); }
         private EntityReference _rejectedBy;
-        public EntityReference RejectedBy { get => GetField(ref _rejectedBy); set => SetField(ref _rejectedBy, value); }
         private DirtyValue<bool?> _isCleared;
-        private bool? IsCleared { get => _isCleared; set => SetField(ref _isCleared, value); }
         private DirtyValue<DateTime?> _clearedDate;
-        public DateTime? ClearedDate { get => _clearedDate; set => SetField(ref _clearedDate, value); }
         private EntityReference _clearedBy;
-        public EntityReference ClearedBy { get => GetField(ref _clearedBy); set => SetField(ref _clearedBy, value); }
         private DirtyValue<bool?> _isWaived;
-        public bool? IsWaived { get => _isWaived; set => SetField(ref _isWaived, value); }
         private DirtyValue<DateTime?> _waivedDate;
-        public DateTime? WaivedDate { get => _waivedDate; set => SetField(ref _waivedDate, value); }
         private EntityReference _waivedBy;
+
+        public StringEnumValue<PriorToMilestone> PriorTo { get => _priorTo; set => SetField(ref _priorTo, value); }
+
+        public StringEnumValue<ConditionCategory> Category { get => _category; set => SetField(ref _category, value); }
+
+        public string OwnerRole { get => _ownerRole; set => SetField(ref _ownerRole, value); }
+
+        public bool? AllowToClear { get => _allowToClear; set => SetField(ref _allowToClear, value); }
+
+        public bool? PrintExternally { get => _printExternally; set => SetField(ref _printExternally, value); }
+
+        public bool? PrintInternally { get => _printInternally; set => SetField(ref _printInternally, value); }
+
+        public DateTime? ExpirationDate { get => _expirationDate; set => SetField(ref _expirationDate, value); }
+
+        public bool? IsFulfilled { get => _isFulfilled; set => SetField(ref _isFulfilled, value); }
+
+        public DateTime? FulfilledDate { get => _fulfilledDate; set => SetField(ref _fulfilledDate, value); }
+
+        public EntityReference FulfilledBy { get => GetField(ref _fulfilledBy); set => SetField(ref _fulfilledBy, value); }
+
+        public bool? IsReviewed { get => _isReviewed; set => SetField(ref _isReviewed, value); }
+
+        public DateTime? ReviewedDate { get => _reviewedDate; set => SetField(ref _reviewedDate, value); }
+
+        public EntityReference ReviewedBy { get => GetField(ref _reviewedBy); set => SetField(ref _reviewedBy, value); }
+
+        public bool? IsRejected { get => _isRejected; set => SetField(ref _isRejected, value); }
+
+        public DateTime? RejectedDate { get => _rejectedDate; set => SetField(ref _rejectedDate, value); }
+
+        public EntityReference RejectedBy { get => GetField(ref _rejectedBy); set => SetField(ref _rejectedBy, value); }
+
+        private bool? IsCleared { get => _isCleared; set => SetField(ref _isCleared, value); }
+
+        public DateTime? ClearedDate { get => _clearedDate; set => SetField(ref _clearedDate, value); }
+
+        public EntityReference ClearedBy { get => GetField(ref _clearedBy); set => SetField(ref _clearedBy, value); }
+
+        public bool? IsWaived { get => _isWaived; set => SetField(ref _isWaived, value); }
+
+        public DateTime? WaivedDate { get => _waivedDate; set => SetField(ref _waivedDate, value); }
+
         public EntityReference WaivedBy { get => GetField(ref _waivedBy); set => SetField(ref _waivedBy, value); }
     }
 }

--- a/src/EncompassRest/Loans/Documents/DocumentComment.cs
+++ b/src/EncompassRest/Loans/Documents/DocumentComment.cs
@@ -5,21 +5,30 @@ namespace EncompassRest.Loans.Documents
     public sealed class DocumentComment : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _comments;
-        public string Comments { get => _comments; set => SetField(ref _comments, value); }
         private DirtyValue<int?> _forRoleId;
-        public int? ForRoleId { get => _forRoleId; set => SetField(ref _forRoleId, value); }
         private DirtyValue<string> _commentId;
-        public string CommentId { get => _commentId; set => SetField(ref _commentId, value); }
         private DirtyValue<DateTime?> _dateCreated;
-        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
         private DirtyValue<string> _createdBy;
-        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
         private DirtyValue<string> _createdByName;
-        public string CreatedByName { get => _createdByName; set => SetField(ref _createdByName, value); }
         private DirtyValue<DateTime?> _dateReviewed;
-        public DateTime? DateReviewed { get => _dateReviewed; set => SetField(ref _dateReviewed, value); }
         private DirtyValue<string> _reviewedBy;
+
+        public string Comments { get => _comments; set => SetField(ref _comments, value); }
+
+        public int? ForRoleId { get => _forRoleId; set => SetField(ref _forRoleId, value); }
+
+        public string CommentId { get => _commentId; set => SetField(ref _commentId, value); }
+
+        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
+
+        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
+
+        public string CreatedByName { get => _createdByName; set => SetField(ref _createdByName, value); }
+
+        public DateTime? DateReviewed { get => _dateReviewed; set => SetField(ref _dateReviewed, value); }
+
         public string ReviewedBy { get => _reviewedBy; set => SetField(ref _reviewedBy, value); }
+
         [IdPropertyName(nameof(CommentId))]
         string IIdentifiable.Id { get => CommentId; set => CommentId = value; }
     }

--- a/src/EncompassRest/Loans/Documents/LoanDocument.cs
+++ b/src/EncompassRest/Loans/Documents/LoanDocument.cs
@@ -9,87 +9,129 @@ namespace EncompassRest.Loans.Documents
     public sealed class LoanDocument : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _documentId;
-        public string DocumentId { get => _documentId; set => SetField(ref _documentId, value); }
         private DirtyValue<string> _titleWithIndex;
-        public string TitleWithIndex { get => _titleWithIndex; set => SetField(ref _titleWithIndex, value); }
         private DirtyValue<string> _applicationName;
-        public string ApplicationName { get => _applicationName; set => SetField(ref _applicationName, value); }
         private DirtyValue<string> _milestoneId;
-        public string MilestoneId { get => _milestoneId; set => SetField(ref _milestoneId, value); }
         private DirtyValue<bool?> _webCenterAllowed;
-        public bool? WebCenterAllowed { get => _webCenterAllowed; set => SetField(ref _webCenterAllowed, value); }
         private DirtyValue<bool?> _tpoAllowed;
-        public bool? TpoAllowed { get => _tpoAllowed; set => SetField(ref _tpoAllowed, value); }
         private DirtyValue<bool?> _thirdPartyAllowed;
-        public bool? ThirdPartyAllowed { get => _thirdPartyAllowed; set => SetField(ref _thirdPartyAllowed, value); }
         private DirtyValue<bool?> _isRequested;
-        public bool? IsRequested { get => _isRequested; set => SetField(ref _isRequested, value); }
         private DirtyValue<string> _requestedBy;
-        public string RequestedBy { get => _requestedBy; set => SetField(ref _requestedBy, value); }
         private DirtyValue<bool?> _isRerequested;
-        public bool? IsRerequested { get => _isRerequested; set => SetField(ref _isRerequested, value); }
         private DirtyValue<DateTime?> _dateRerequested;
-        public DateTime? DateRerequested { get => _dateRerequested; set => SetField(ref _dateRerequested, value); }
         private DirtyValue<string> _rerequestedBy;
-        public string RerequestedBy { get => _rerequestedBy; set => SetField(ref _rerequestedBy, value); }
         private DirtyValue<int?> _daysDue;
-        public int? DaysDue { get => _daysDue; set => SetField(ref _daysDue, value); }
         private DirtyValue<bool?> _isReceived;
-        public bool? IsReceived { get => _isReceived; set => SetField(ref _isReceived, value); }
         private DirtyValue<string> _receivedBy;
-        public string ReceivedBy { get => _receivedBy; set => SetField(ref _receivedBy, value); }
         private DirtyValue<int?> _daysTillExpire;
-        public int? DaysTillExpire { get => _daysTillExpire; set => SetField(ref _daysTillExpire, value); }
         private DirtyValue<bool?> _isReviewed;
-        public bool? IsReviewed { get => _isReviewed; set => SetField(ref _isReviewed, value); }
         private DirtyValue<string> _reviewedBy;
-        public string ReviewedBy { get => _reviewedBy; set => SetField(ref _reviewedBy, value); }
         private DirtyValue<bool?> _isReadyForUw;
-        public bool? IsReadyForUw { get => _isReadyForUw; set => SetField(ref _isReadyForUw, value); }
         private DirtyValue<string> _readyForUwBy;
-        public string ReadyForUwBy { get => _readyForUwBy; set => SetField(ref _readyForUwBy, value); }
         private DirtyValue<bool?> _isReadyToShip;
-        public bool? IsReadyToShip { get => _isReadyToShip; set => SetField(ref _isReadyToShip, value); }
         private DirtyValue<string> _readyToShipBy;
-        public string ReadyToShipBy { get => _readyToShipBy; set => SetField(ref _readyToShipBy, value); }
         private DirtyValue<DateTime?> _dateExpires;
-        public DateTime? DateExpires { get => _dateExpires; set => SetField(ref _dateExpires, value); }
         private DirtyValue<string> _createdBy;
-        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
         private DirtyValue<DateTime?> _dateCreated;
-        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
         private DirtyValue<string> _title;
-        public string Title { get => _title; set => SetField(ref _title, value); }
         private DirtyValue<string> _description;
-        public string Description { get => _description; set => SetField(ref _description, value); }
         private DirtyValue<string> _requestedFrom;
-        public string RequestedFrom { get => _requestedFrom; set => SetField(ref _requestedFrom, value); }
         private DirtyValue<string> _applicationId;
-        public string ApplicationId { get => _applicationId; set => SetField(ref _applicationId, value); }
         private DirtyValue<string> _emnSignature;
-        public string EmnSignature { get => _emnSignature; set => SetField(ref _emnSignature, value); }
         private DirtyValue<StringEnumValue<DocumentStatus>> _status;
-        public StringEnumValue<DocumentStatus> Status { get => _status; set => SetField(ref _status, value); }
         private DirtyValue<DateTime?> _statusDate;
-        public DateTime? StatusDate { get => _statusDate; set => SetField(ref _statusDate, value); }
         private DirtyValue<DateTime?> _dateRequested;
-        public DateTime? DateRequested { get => _dateRequested; set => SetField(ref _dateRequested, value); }
         private DirtyValue<DateTime?> _dateExpected;
-        public DateTime? DateExpected { get => _dateExpected; set => SetField(ref _dateExpected, value); }
         private DirtyValue<DateTime?> _dateReceived;
-        public DateTime? DateReceived { get => _dateReceived; set => SetField(ref _dateReceived, value); }
         private DirtyValue<DateTime?> _dateReviewed;
-        public DateTime? DateReviewed { get => _dateReviewed; set => SetField(ref _dateReviewed, value); }
         private DirtyValue<DateTime?> _dateReadyForUw;
-        public DateTime? DateReadyForUw { get => _dateReadyForUw; set => SetField(ref _dateReadyForUw, value); }
         private DirtyValue<DateTime?> _dateReadyToShip;
-        public DateTime? DateReadyToShip { get => _dateReadyToShip; set => SetField(ref _dateReadyToShip, value); }
         private DirtyList<DocumentComment> _comments;
-        public IList<DocumentComment> Comments { get => GetField(ref _comments); set => SetField(ref _comments, value); }
         private DirtyList<FileAttachmentReference> _attachments;
-        public IList<FileAttachmentReference> Attachments { get => GetField(ref _attachments); set => SetField(ref _attachments, value); }
         private DirtyList<EntityReference> _roles;
+
+        public string DocumentId { get => _documentId; set => SetField(ref _documentId, value); }
+
+        public string TitleWithIndex { get => _titleWithIndex; set => SetField(ref _titleWithIndex, value); }
+
+        public string ApplicationName { get => _applicationName; set => SetField(ref _applicationName, value); }
+
+        public string MilestoneId { get => _milestoneId; set => SetField(ref _milestoneId, value); }
+
+        public bool? WebCenterAllowed { get => _webCenterAllowed; set => SetField(ref _webCenterAllowed, value); }
+
+        public bool? TpoAllowed { get => _tpoAllowed; set => SetField(ref _tpoAllowed, value); }
+
+        public bool? ThirdPartyAllowed { get => _thirdPartyAllowed; set => SetField(ref _thirdPartyAllowed, value); }
+
+        public bool? IsRequested { get => _isRequested; set => SetField(ref _isRequested, value); }
+
+        public string RequestedBy { get => _requestedBy; set => SetField(ref _requestedBy, value); }
+
+        public bool? IsRerequested { get => _isRerequested; set => SetField(ref _isRerequested, value); }
+
+        public DateTime? DateRerequested { get => _dateRerequested; set => SetField(ref _dateRerequested, value); }
+
+        public string RerequestedBy { get => _rerequestedBy; set => SetField(ref _rerequestedBy, value); }
+
+        public int? DaysDue { get => _daysDue; set => SetField(ref _daysDue, value); }
+
+        public bool? IsReceived { get => _isReceived; set => SetField(ref _isReceived, value); }
+
+        public string ReceivedBy { get => _receivedBy; set => SetField(ref _receivedBy, value); }
+
+        public int? DaysTillExpire { get => _daysTillExpire; set => SetField(ref _daysTillExpire, value); }
+
+        public bool? IsReviewed { get => _isReviewed; set => SetField(ref _isReviewed, value); }
+
+        public string ReviewedBy { get => _reviewedBy; set => SetField(ref _reviewedBy, value); }
+
+        public bool? IsReadyForUw { get => _isReadyForUw; set => SetField(ref _isReadyForUw, value); }
+
+        public string ReadyForUwBy { get => _readyForUwBy; set => SetField(ref _readyForUwBy, value); }
+
+        public bool? IsReadyToShip { get => _isReadyToShip; set => SetField(ref _isReadyToShip, value); }
+
+        public string ReadyToShipBy { get => _readyToShipBy; set => SetField(ref _readyToShipBy, value); }
+
+        public DateTime? DateExpires { get => _dateExpires; set => SetField(ref _dateExpires, value); }
+
+        public string CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
+
+        public DateTime? DateCreated { get => _dateCreated; set => SetField(ref _dateCreated, value); }
+
+        public string Title { get => _title; set => SetField(ref _title, value); }
+
+        public string Description { get => _description; set => SetField(ref _description, value); }
+
+        public string RequestedFrom { get => _requestedFrom; set => SetField(ref _requestedFrom, value); }
+
+        public string ApplicationId { get => _applicationId; set => SetField(ref _applicationId, value); }
+
+        public string EmnSignature { get => _emnSignature; set => SetField(ref _emnSignature, value); }
+
+        public StringEnumValue<DocumentStatus> Status { get => _status; set => SetField(ref _status, value); }
+
+        public DateTime? StatusDate { get => _statusDate; set => SetField(ref _statusDate, value); }
+
+        public DateTime? DateRequested { get => _dateRequested; set => SetField(ref _dateRequested, value); }
+
+        public DateTime? DateExpected { get => _dateExpected; set => SetField(ref _dateExpected, value); }
+
+        public DateTime? DateReceived { get => _dateReceived; set => SetField(ref _dateReceived, value); }
+
+        public DateTime? DateReviewed { get => _dateReviewed; set => SetField(ref _dateReviewed, value); }
+
+        public DateTime? DateReadyForUw { get => _dateReadyForUw; set => SetField(ref _dateReadyForUw, value); }
+
+        public DateTime? DateReadyToShip { get => _dateReadyToShip; set => SetField(ref _dateReadyToShip, value); }
+
+        public IList<DocumentComment> Comments { get => GetField(ref _comments); set => SetField(ref _comments, value); }
+
+        public IList<FileAttachmentReference> Attachments { get => GetField(ref _attachments); set => SetField(ref _attachments, value); }
+
         public IList<EntityReference> Roles { get => GetField(ref _roles); set => SetField(ref _roles, value); }
+
         [IdPropertyName(nameof(DocumentId))]
         string IIdentifiable.Id { get => DocumentId; set => DocumentId = value; }
 

--- a/src/EncompassRest/Loans/Documents/LoanDocument.cs
+++ b/src/EncompassRest/Loans/Documents/LoanDocument.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using EncompassRest.Utilities;
+using Newtonsoft.Json;
 
 namespace EncompassRest.Loans.Documents
 {
@@ -89,5 +92,40 @@ namespace EncompassRest.Loans.Documents
         public IList<EntityReference> Roles { get => GetField(ref _roles); set => SetField(ref _roles, value); }
         [IdPropertyName(nameof(DocumentId))]
         string IIdentifiable.Id { get => DocumentId; set => DocumentId = value; }
+
+        /// <summary>
+        /// Loan document creation constructor
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="applicationId">Identifies which borrower pair (or “All”) the document will be assigned to.</param>
+        public LoanDocument(string title, string applicationId)
+        {
+            Preconditions.NotNullOrEmpty(title, nameof(title));
+            Preconditions.NotNullOrEmpty(applicationId, nameof(applicationId));
+
+            Title = title;
+            ApplicationId = applicationId;
+        }
+
+        /// <summary>
+        /// Loan document update constructor
+        /// </summary>
+        /// <param name="documentId"></param>
+        public LoanDocument(string documentId)
+        {
+            Preconditions.NotNullOrEmpty(documentId, nameof(documentId));
+
+            DocumentId = documentId;
+        }
+
+        /// <summary>
+        /// Loan document deserialization constructor
+        /// </summary>
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonConstructor]
+        public LoanDocument()
+        {
+        }
     }
 }

--- a/src/EncompassRest/Loans/Documents/LoanDocuments.cs
+++ b/src/EncompassRest/Loans/Documents/LoanDocuments.cs
@@ -80,13 +80,15 @@ namespace EncompassRest.Loans.Documents
             return PatchRawAsync(documentId, queryString, new JsonStringContent(document), nameof(UpdateDocumentRawAsync), documentId, cancellationToken);
         }
 
-        public Task AssignDocumentAttachmentsAsync(string documentId, AssignmentAction action, IEnumerable<EntityReference> attachmentEntities, CancellationToken cancellationToken = default)
+        public Task AssignDocumentAttachmentsAsync(string documentId, AssignmentAction action, IEnumerable<EntityReference> attachmentEntities, CancellationToken cancellationToken = default) => AssignDocumentAttachmentsAsync(documentId, action.Validate(nameof(action)).GetValue(), attachmentEntities, cancellationToken);
+
+        public Task AssignDocumentAttachmentsAsync(string documentId, string action, IEnumerable<EntityReference> attachmentEntities, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(documentId, nameof(documentId));
-            action.Validate(nameof(action));
+            Preconditions.NotNullOrEmpty(action, nameof(action));
             Preconditions.NotNullOrEmpty(attachmentEntities, nameof(attachmentEntities));
 
-            var queryParameters = new QueryParameters(new QueryParameter(nameof(action), action.AsString(EnumJsonConverter.CamelCaseNameFormat)));
+            var queryParameters = new QueryParameters(new QueryParameter(nameof(action), action));
             return PatchAsync($"{documentId}/attachments", queryParameters.ToString(), JsonStreamContent.Create(attachmentEntities), nameof(AssignDocumentAttachmentsAsync), documentId, cancellationToken);
         }
 

--- a/src/EncompassRest/Loans/EntityCustomizations.cs
+++ b/src/EncompassRest/Loans/EntityCustomizations.cs
@@ -28,7 +28,7 @@ namespace EncompassRest.Loans
     partial class LoanAssociate
     {
         public LoanAssociate(string id, LoanAssociateType loanAssociateType)
-            : this(id, loanAssociateType.Validate(nameof(loanAssociateType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(id, loanAssociateType.Validate(nameof(loanAssociateType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Loans/EntityCustomizations.cs
+++ b/src/EncompassRest/Loans/EntityCustomizations.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using EncompassRest.Loans.Enums;
+﻿using EncompassRest.Loans.Enums;
 using EncompassRest.Utilities;
 using EnumsNET;
 using Newtonsoft.Json;

--- a/src/EncompassRest/Loans/FileAttachmentReference.cs
+++ b/src/EncompassRest/Loans/FileAttachmentReference.cs
@@ -1,10 +1,33 @@
-﻿namespace EncompassRest.Loans
+﻿using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace EncompassRest.Loans
 {
     public sealed class FileAttachmentReference : EntityReference
     {
         private DirtyValue<string> _refId;
-        public string RefId { get => _refId; set => SetField(ref _refId, value); }
         private DirtyValue<bool?> _isActive;
+
+        public string RefId { get => _refId; set => SetField(ref _refId, value); }
+
         public bool? IsActive { get => _isActive; set => SetField(ref _isActive, value); }
+
+        public FileAttachmentReference(string entityId, EntityType entityType)
+            : base(entityId, entityType)
+        {
+        }
+
+        public FileAttachmentReference(string entityId, string entityType)
+            : base(entityId, entityType)
+        {
+        }
+
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonConstructor]
+        public FileAttachmentReference()
+        {
+        }
     }
 }

--- a/src/EncompassRest/Loans/LoanApis.cs
+++ b/src/EncompassRest/Loans/LoanApis.cs
@@ -61,14 +61,14 @@ namespace EncompassRest.Loans
 
         public Task<string> LockAsync(ResourceLockType lockType, CancellationToken cancellationToken = default) => LockAsync(lockType, false, cancellationToken);
 
-        public Task<string> LockAsync(ResourceLockType lockType, bool force, CancellationToken cancellationToken = default) => LockAsync(lockType.Validate(nameof(lockType)).AsString(), force, cancellationToken);
+        public Task<string> LockAsync(ResourceLockType lockType, bool force, CancellationToken cancellationToken = default) => LockAsync(lockType.Validate(nameof(lockType)).GetValue(), force, cancellationToken);
 
         public Task<string> LockAsync(string lockType, CancellationToken cancellationToken = default) => LockAsync(lockType, false, cancellationToken);
 
-        public Task<string> LockAsync(string lockType, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.LockResourceAsync(lockType, LoanId, EntityType.Loan, force, cancellationToken);
+        public Task<string> LockAsync(string lockType, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.LockResourceAsync(lockType, LoanId, EntityType.Loan.GetName(), force, cancellationToken);
 
         public Task<bool> UnlockAsync(string lockId, CancellationToken cancellationToken = default) => UnlockAsync(lockId, false, cancellationToken);
 
-        public Task<bool> UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.UnlockResourceAsync(lockId, LoanId, EntityType.Loan, force, cancellationToken);
+        public Task<bool> UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.UnlockResourceAsync(lockId, LoanId, EntityType.Loan.GetName(), force, cancellationToken);
     }
 }

--- a/src/EncompassRest/Loans/LoanCustomizations.cs
+++ b/src/EncompassRest/Loans/LoanCustomizations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using EncompassRest.Loans.Attachments;
 using EncompassRest.Loans.Documents;
@@ -95,6 +96,7 @@ namespace EncompassRest.Loans
         /// </summary>
         [JsonConstructor]
         [Obsolete("Use EncompassRestClient parameter constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Loan()
         {
         }

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -35,7 +35,7 @@ namespace EncompassRest.Loans
 
         public Task<Loan> GetLoanAsync(string loanId, CancellationToken cancellationToken = default) => GetLoanAsync(loanId, (IEnumerable<string>)null, cancellationToken);
 
-        public Task<Loan> GetLoanAsync(string loanId, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default) => GetLoanAsync(loanId, entities?.Select(e => e.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)), cancellationToken);
+        public Task<Loan> GetLoanAsync(string loanId, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default) => GetLoanAsync(loanId, entities?.Select(e => e.Validate(nameof(entities)).GetValue()), cancellationToken);
 
         public async Task<Loan> GetLoanAsync(string loanId, IEnumerable<string> entities, CancellationToken cancellationToken = default)
         {

--- a/src/EncompassRest/Loans/MilestoneFreeRoles/LoanMilestoneFreeRole.cs
+++ b/src/EncompassRest/Loans/MilestoneFreeRoles/LoanMilestoneFreeRole.cs
@@ -3,8 +3,10 @@
     public sealed class LoanMilestoneFreeRole : DirtyExtensibleObject
     {
         private DirtyValue<string> _id;
-        public string Id { get => _id; set => SetField(ref _id, value); }
         private LoanAssociate _loanAssociate;
+
+        public string Id { get => _id; set => SetField(ref _id, value); }
+        
         public LoanAssociate LoanAssociate { get => GetField(ref _loanAssociate); set => SetField(ref _loanAssociate, value); }
     }
 }

--- a/src/EncompassRest/Loans/Milestones/LoanMilestone.cs
+++ b/src/EncompassRest/Loans/Milestones/LoanMilestone.cs
@@ -6,26 +6,37 @@ namespace EncompassRest.Loans.Milestones
     public sealed class LoanMilestone : DirtyExtensibleObject
     {
         private DirtyValue<string> _id;
-        public string Id { get => _id; set => SetField(ref _id, value); }
         private DirtyValue<DateTime?> _startDate;
-        public DateTime? StartDate { get => _startDate; set => SetField(ref _startDate, value); }
         private LoanAssociate _loanAssociate;
-        public LoanAssociate LoanAssociate { get => GetField(ref _loanAssociate); set => SetField(ref _loanAssociate, value); }
         private DirtyValue<int?> _expectedDays;
-        public int? ExpectedDays { get => _expectedDays; set => SetField(ref _expectedDays, value); }
         private DirtyValue<bool?> _doneIndicator;
-        public bool? DoneIndicator { get => _doneIndicator; set => SetField(ref _doneIndicator, value); }
         private DirtyValue<int?> _actualDays;
-        public int? ActualDays { get => _actualDays; set => SetField(ref _actualDays, value); }
         private DirtyValue<bool?> _reviewedIndicator;
-        public bool? ReviewedIndicator { get => _reviewedIndicator; set => SetField(ref _reviewedIndicator, value); }
         private DirtyValue<bool?> _roleRequired;
-        public bool? RoleRequired { get => _roleRequired; set => SetField(ref _roleRequired, value); }
         private DirtyValue<string> _milestoneName;
-        public string MilestoneName { get => _milestoneName; set => SetField(ref _milestoneName, value); }
         private DirtyValue<string> _milestoneIdString;
-        public string MilestoneIdString { get => _milestoneIdString; set => SetField(ref _milestoneIdString, value); }
         private DirtyValue<string> _comments;
+
+        public string Id { get => _id; set => SetField(ref _id, value); }
+
+        public DateTime? StartDate { get => _startDate; set => SetField(ref _startDate, value); }
+
+        public LoanAssociate LoanAssociate { get => GetField(ref _loanAssociate); set => SetField(ref _loanAssociate, value); }
+
+        public int? ExpectedDays { get => _expectedDays; set => SetField(ref _expectedDays, value); }
+
+        public bool? DoneIndicator { get => _doneIndicator; set => SetField(ref _doneIndicator, value); }
+
+        public int? ActualDays { get => _actualDays; set => SetField(ref _actualDays, value); }
+
+        public bool? ReviewedIndicator { get => _reviewedIndicator; set => SetField(ref _reviewedIndicator, value); }
+
+        public bool? RoleRequired { get => _roleRequired; set => SetField(ref _roleRequired, value); }
+
+        public string MilestoneName { get => _milestoneName; set => SetField(ref _milestoneName, value); }
+
+        public string MilestoneIdString { get => _milestoneIdString; set => SetField(ref _milestoneIdString, value); }
+
         public string Comments { get => _comments; set => SetField(ref _comments, value); }
     }
 }

--- a/src/EncompassRest/Loans/Milestones/LoanMilestones.cs
+++ b/src/EncompassRest/Loans/Milestones/LoanMilestones.cs
@@ -33,7 +33,7 @@ namespace EncompassRest.Loans.Milestones
 
         public Task UpdateMilestoneAsync(LoanMilestone milestone, CancellationToken cancellationToken = default) => UpdateMilestoneAsync(milestone, null, cancellationToken);
 
-        public Task UpdateMilestoneAsync(LoanMilestone milestone, MilestoneAction action, CancellationToken cancellationToken = default) => UpdateMilestoneAsync(milestone, action.Validate(nameof(action)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name), cancellationToken);
+        public Task UpdateMilestoneAsync(LoanMilestone milestone, MilestoneAction action, CancellationToken cancellationToken = default) => UpdateMilestoneAsync(milestone, action.Validate(nameof(action)).GetValue(), cancellationToken);
 
         public Task UpdateMilestoneAsync(LoanMilestone milestone, string action, CancellationToken cancellationToken = default)
         {

--- a/src/EncompassRest/ResourceLocks/ResourceLock.cs
+++ b/src/EncompassRest/ResourceLocks/ResourceLock.cs
@@ -5,14 +5,19 @@ namespace EncompassRest.ResourceLocks
     public sealed class ResourceLock : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _id;
-        public string Id { get => _id; set => SetField(ref _id, value); }
-        private EntityReference _resource; 
-        public EntityReference Resource { get => GetField(ref _resource); set => SetField(ref _resource, value); }
+        private EntityReference _resource;
         private DirtyValue<string> _userId;
-        public string UserId { get => _userId; set => SetField(ref _userId, value); }
         private DirtyValue<StringEnumValue<ResourceLockType>> _lockType;
-        public StringEnumValue<ResourceLockType> LockType { get => _lockType; set => SetField(ref _lockType, value); }
         private DirtyValue<DateTime?> _lockTime;
+
+        public string Id { get => _id; set => SetField(ref _id, value); }
+
+        public EntityReference Resource { get => GetField(ref _resource); set => SetField(ref _resource, value); }
+
+        public string UserId { get => _userId; set => SetField(ref _userId, value); }
+
+        public StringEnumValue<ResourceLockType> LockType { get => _lockType; set => SetField(ref _lockType, value); }
+
         public DateTime? LockTime { get => _lockTime; set => SetField(ref _lockTime, value); }
     }
 }

--- a/src/EncompassRest/ResourceLocks/ResourceLocks.cs
+++ b/src/EncompassRest/ResourceLocks/ResourceLocks.cs
@@ -21,7 +21,7 @@ namespace EncompassRest.ResourceLocks
             return GetResourceLockAsync(resourceLock.Id, resourceLock.Resource.EntityId, resourceLock.Resource.EntityType, cancellationToken);
         }
 
-        public Task<ResourceLock> GetResourceLockAsync(string lockId, string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) => GetResourceLockAsync(lockId, resourceId, resourceType.AsString(), cancellationToken);
+        public Task<ResourceLock> GetResourceLockAsync(string lockId, string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) => GetResourceLockAsync(lockId, resourceId, resourceType.Validate(nameof(resourceType)).GetName(), cancellationToken);
 
         public Task<ResourceLock> GetResourceLockAsync(string lockId, string resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
@@ -44,7 +44,7 @@ namespace EncompassRest.ResourceLocks
             return GetRawAsync(lockId, queryString, nameof(GetResourceLockRawAsync), lockId, cancellationToken);
         }
 
-        public Task<List<ResourceLock>> GetResourceLocksAsync(string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) => GetResourceLocksAsync(resourceId, resourceType.AsString(), cancellationToken);
+        public Task<List<ResourceLock>> GetResourceLocksAsync(string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) => GetResourceLocksAsync(resourceId, resourceType.Validate(nameof(resourceType)).GetName(), cancellationToken);
 
         public Task<List<ResourceLock>> GetResourceLocksAsync(string resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
@@ -87,13 +87,7 @@ namespace EncompassRest.ResourceLocks
         }
 
         public Task<string> LockResourceAsync(ResourceLockType lockType, string resourceId, EntityType resourceType, bool force, CancellationToken cancellationToken = default) =>
-            LockResourceAsync(lockType.AsString(), resourceId, resourceType.AsString(), force, cancellationToken);
-
-        public Task<string> LockResourceAsync(string lockType, string resourceId, EntityType resourceType, bool force, CancellationToken cancellationToken = default) =>
-            LockResourceAsync(lockType, resourceId, resourceType.AsString(), force, cancellationToken);
-
-        public Task<string> LockResourceAsync(ResourceLockType lockType, string resourceId, string resourceType, bool force, CancellationToken cancellationToken = default) =>
-            LockResourceAsync(lockType.AsString(), resourceId, resourceType, force, cancellationToken);
+            LockResourceAsync(lockType.Validate(nameof(lockType)).GetValue(), resourceId, resourceType.Validate(nameof(resourceType)).GetName(), force, cancellationToken);
 
         public Task<string> LockResourceAsync(string lockType, string resourceId, string resourceType, bool force, CancellationToken cancellationToken = default)
         {
@@ -104,11 +98,7 @@ namespace EncompassRest.ResourceLocks
             var resourceLock = new ResourceLock
             {
                 LockType = lockType,
-                Resource = new EntityReference
-                {
-                    EntityId = resourceId,
-                    EntityType = resourceType
-                }
+                Resource = new EntityReference(resourceId, resourceType)
             };
 
             return LockResourceAsync(resourceLock, force, false, cancellationToken);
@@ -125,7 +115,7 @@ namespace EncompassRest.ResourceLocks
             UnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
 
         public Task<bool> UnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, bool force, CancellationToken cancellationToken = default) =>
-            UnlockResourceAsync(lockId, resourceId, resourceType.AsString(), force, cancellationToken);
+            UnlockResourceAsync(lockId, resourceId, resourceType.Validate(nameof(resourceType)).GetName(), force, cancellationToken);
 
         public Task<bool> UnlockResourceAsync(string lockId, string resourceId, string resourceType, CancellationToken cancellationToken = default) =>
             UnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);

--- a/src/EncompassRest/Schema/FieldDefinition.cs
+++ b/src/EncompassRest/Schema/FieldDefinition.cs
@@ -6,23 +6,40 @@ namespace EncompassRest.Schema
     public class FieldDefinition : ExtensibleObject
     {
         public string Description { get; set; }
+
         public string FieldID { get; set; }
+
         [EnumFormat(EnumFormat.DecimalValue)]
         public LoanFieldFormat Format { get; set; }
+
         public ParentFieldDefinition ParentField { get; set; }
+
         public string InstanceSpecifier { get; set; }
+
         public bool IsInstance { get; set; }
+
         public bool AllowInReportingDatabase { get; set; }
+
         public int ReportingDatabaseColumnSize { get; set; }
+
         public int Category { get; set; }
+
         public int MaxLength { get; set; }
+
         public int ReportingDatabaseColumnType { get; set; }
+
         public bool IsDateValued { get; set; }
+
         public FieldOptions FieldOptions { get; set; }
+
         public bool? AllowEdit { get; set; }
+
         public bool? EnforceMaxLengthDuringValidation { get; set; }
+
         public bool? RequiresBorrowerPredicate { get; set; }
+
         public bool? IsNumeric { get; set; }
+
         public bool? RequiresExclusiveLock { get; set; }
     }
 }

--- a/src/EncompassRest/Schema/FieldOptions.cs
+++ b/src/EncompassRest/Schema/FieldOptions.cs
@@ -7,6 +7,7 @@ namespace EncompassRest.Schema
     {
         [JsonProperty(ItemConverterType = typeof(FieldOptionConverter))]
         public List<FieldOption> Options { get; set; }
+
         public bool? RequireValueFromList { get; set; }
     }
 }

--- a/src/EncompassRest/Schema/InstancePattern.cs
+++ b/src/EncompassRest/Schema/InstancePattern.cs
@@ -8,8 +8,11 @@ namespace EncompassRest.Schema
     public sealed class InstancePattern : ExtensibleObject
     {
         public int IndexOffset { get; set; }
+
         public string IndexToken { get; set; }
+
         public int MaxIndex { get; set; }
+
         public Dictionary<string, string> Match { get; set; }
     }
 }

--- a/src/EncompassRest/Schema/IntListInstance.cs
+++ b/src/EncompassRest/Schema/IntListInstance.cs
@@ -29,14 +29,23 @@ namespace EncompassRest.Schema
         }
 
         public void Add(int item) => _values.Add(item);
+
         public void Clear() => _values.Clear();
+
         public bool Contains(int item) => _values.Contains(item);
+
         public void CopyTo(int[] array, int arrayIndex) => _values.CopyTo(array, arrayIndex);
+
         public IEnumerator<int> GetEnumerator() => ((IList<int>)_values).GetEnumerator();
+
         public int IndexOf(int item) => _values.IndexOf(item);
+
         public void Insert(int index, int item) => _values.Insert(index, item);
+
         public bool Remove(int item) => _values.Remove(item);
+
         public void RemoveAt(int index) => _values.RemoveAt(index);
+
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/EncompassRest/Schema/LoanSchema.cs
+++ b/src/EncompassRest/Schema/LoanSchema.cs
@@ -8,6 +8,7 @@ namespace EncompassRest.Schema
     public sealed class LoanSchema : ExtensibleObject
     {
         public string SchemaVersion { get; set; }
+
         public Dictionary<string, EntitySchema> EntityTypes { get; set; }
     }
 }

--- a/src/EncompassRest/Schema/ParentFieldDefinition.cs
+++ b/src/EncompassRest/Schema/ParentFieldDefinition.cs
@@ -3,6 +3,7 @@
     public sealed class ParentFieldDefinition : FieldDefinition
     {
         public bool MultiInstance { get; set; }
+
         public int InstanceSpecifierType { get; set; }
     }
 }

--- a/src/EncompassRest/Schema/PropertySchema.cs
+++ b/src/EncompassRest/Schema/PropertySchema.cs
@@ -9,21 +9,36 @@ namespace EncompassRest.Schema
     public sealed class PropertySchema : ExtensibleObject
     {
         public StringEnumValue<LoanFieldFormat> Format { get; set; }
+
         public bool? ReadOnly { get; set; }
+
         public bool? Nullable { get; set; }
+
         public StringEnumValue<PropertySchemaType> Type { get; set; }
+
         [JsonProperty(ItemConverterType = typeof(FieldOptionConverter))]
         public List<FieldOption> AllowedValues { get; set; }
+
         public StringEnumValue<LoanEntity> EntityType { get; set; }
+
         public bool? Required { get; set; }
+
         public string Description { get; set; }
+
         public StringEnumValue<LoanEntity> ElementType { get; set; }
+
         public string FieldId { get; set; }
+
         public bool? FixedLength { get; set; }
+
         public List<string> KeyProperties { get; set; }
+
         public Dictionary<string, Instance> Instances { get; set; }
+
         public Dictionary<string, InstancePattern> InstancePatterns { get; set; }
+
         public Dictionary<string, List<string>> FieldInstances { get; set; }
+
         public Dictionary<string, List<string>> FieldPatterns { get; set; }
     }
 }

--- a/src/EncompassRest/Schema/Schema.cs
+++ b/src/EncompassRest/Schema/Schema.cs
@@ -23,7 +23,7 @@ namespace EncompassRest.Schema
 
         public Task<LoanSchema> GetLoanSchemaAsync(IEnumerable<string> entities, CancellationToken cancellationToken = default) => GetLoanSchemaAsync(false, entities, cancellationToken);
 
-        public Task<LoanSchema> GetLoanSchemaAsync(bool includeFieldExtensions, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default) => GetLoanSchemaAsync(includeFieldExtensions, entities?.Select(e => e.AsString()), cancellationToken);
+        public Task<LoanSchema> GetLoanSchemaAsync(bool includeFieldExtensions, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default) => GetLoanSchemaAsync(includeFieldExtensions, entities?.Select(e => e.Validate(nameof(entities)).GetName()), cancellationToken);
 
         public Task<LoanSchema> GetLoanSchemaAsync(bool includeFieldExtensions, IEnumerable<string> entities, CancellationToken cancellationToken = default)
         {

--- a/src/EncompassRest/Schema/StringDictionaryInstance.cs
+++ b/src/EncompassRest/Schema/StringDictionaryInstance.cs
@@ -33,15 +33,25 @@ namespace EncompassRest.Schema
         }
 
         public void Add(string key, string value) => _dictionary.Add(key, value);
+
         public void Add(KeyValuePair<string, string> item) => ((IDictionary<string, string>)_dictionary).Add(item);
+
         public void Clear() => _dictionary.Clear();
+
         public bool Contains(KeyValuePair<string, string> item) => ((IDictionary<string, string>)_dictionary).Contains(item);
+
         public bool ContainsKey(string key) => _dictionary.ContainsKey(key);
+
         public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex) => ((IDictionary<string, string>)_dictionary).CopyTo(array, arrayIndex);
+
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => ((IDictionary<string, string>)_dictionary).GetEnumerator();
+
         public bool Remove(string key) => _dictionary.Remove(key);
+
         public bool Remove(KeyValuePair<string, string> item) => ((IDictionary<string, string>)_dictionary).Remove(item);
+
         public bool TryGetValue(string key, out string value) => _dictionary.TryGetValue(key, out value);
+
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/EncompassRest/Schema/StringListInstance.cs
+++ b/src/EncompassRest/Schema/StringListInstance.cs
@@ -29,14 +29,23 @@ namespace EncompassRest.Schema
         }
 
         public void Add(string item) => _values.Add(item);
+
         public void Clear() => _values.Clear();
+
         public bool Contains(string item) => _values.Contains(item);
+
         public void CopyTo(string[] array, int arrayIndex) => _values.CopyTo(array, arrayIndex);
+
         public IEnumerator<string> GetEnumerator() => ((IList<string>)_values).GetEnumerator();
+
         public int IndexOf(string item) => _values.IndexOf(item);
+
         public void Insert(int index, string item) => _values.Insert(index, item);
+
         public bool Remove(string item) => _values.Remove(item);
+
         public void RemoveAt(int index) => _values.RemoveAt(index);
+
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/EncompassRest/Services/AUS/AUSOptions.cs
+++ b/src/EncompassRest/Services/AUS/AUSOptions.cs
@@ -27,7 +27,7 @@ namespace EncompassRest.Services.AUS
         public string CreditProviderAffiliateCode { get; set; }
 
         public AUSOptions(AUSRequestType requestType)
-            : this(requestType.Validate(nameof(requestType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(requestType.Validate(nameof(requestType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/AUS/AUSProduct.cs
+++ b/src/EncompassRest/Services/AUS/AUSProduct.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EnumsNET;
 using Newtonsoft.Json;
 
 namespace EncompassRest.Services.AUS
@@ -34,7 +33,7 @@ namespace EncompassRest.Services.AUS
         }
 
         public AUSProduct(EntityReference entityRef, AUSOptions options)
-            : this(entityRef, options, ServiceType.AUS.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(entityRef, options, ServiceType.AUS.GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Appraisal/AppraisalOptions.cs
+++ b/src/EncompassRest/Services/Appraisal/AppraisalOptions.cs
@@ -66,7 +66,7 @@ namespace EncompassRest.Services.Appraisal
         public AppraisalPayment Payment { get; set; }
 
         public AppraisalOptions(AppraisalRequestType requestType)
-            : this(requestType.Validate(nameof(requestType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(requestType.Validate(nameof(requestType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Appraisal/AppraisalProduct.cs
+++ b/src/EncompassRest/Services/Appraisal/AppraisalProduct.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using EnumsNET;
 using Newtonsoft.Json;
 
 namespace EncompassRest.Services.Appraisal
@@ -36,7 +35,7 @@ namespace EncompassRest.Services.Appraisal
         }
 
         public AppraisalProduct(EntityReference entityRef, AppraisalOptions options)
-            : this(entityRef, options, ServiceType.Appraisal.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(entityRef, options, ServiceType.Appraisal.GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Credit/CreditOptions.cs
+++ b/src/EncompassRest/Services/Credit/CreditOptions.cs
@@ -44,7 +44,7 @@ namespace EncompassRest.Services.Credit
         public bool? FraudSearch { get; set; }
 
         public CreditOptions(CreditRequestType requestType)
-            : this(requestType.Validate(nameof(requestType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(requestType.Validate(nameof(requestType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Credit/CreditProduct.cs
+++ b/src/EncompassRest/Services/Credit/CreditProduct.cs
@@ -1,5 +1,4 @@
-﻿using EnumsNET;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace EncompassRest.Services.Credit
 {
@@ -11,7 +10,7 @@ namespace EncompassRest.Services.Credit
         public CreditPreferences Preferences { get; set; }
 
         public CreditProduct(EntityReference entityRef, CreditOptions options)
-            : this(entityRef, options, ServiceType.Credit.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(entityRef, options, ServiceType.Credit.GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Flood/FloodOptions.cs
+++ b/src/EncompassRest/Services/Flood/FloodOptions.cs
@@ -11,7 +11,7 @@ namespace EncompassRest.Services.Flood
         public FloodProductDetails ProductDetails { get; set; }
 
         public FloodOptions(FloodRequestType requestType)
-            : this(requestType.Validate(nameof(requestType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(requestType.Validate(nameof(requestType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Flood/FloodProduct.cs
+++ b/src/EncompassRest/Services/Flood/FloodProduct.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EnumsNET;
 using Newtonsoft.Json;
 
 namespace EncompassRest.Services.Flood
@@ -32,7 +31,7 @@ namespace EncompassRest.Services.Flood
         }
 
         public FloodProduct(EntityReference entityRef, FloodOptions options)
-            : base(entityRef, options, ServiceType.Flood.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : base(entityRef, options, ServiceType.Flood.GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Verification/EV4506TOptions.cs
+++ b/src/EncompassRest/Services/Verification/EV4506TOptions.cs
@@ -84,7 +84,7 @@ namespace EncompassRest.Services.Verification
         public IList<EV4506TResource> Resources { get; set; }
 
         public EV4506TOptions(EV4506TRequestType requestType)
-            : this(requestType.Validate(nameof(requestType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(requestType.Validate(nameof(requestType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Verification/EVVOEOptions.cs
+++ b/src/EncompassRest/Services/Verification/EVVOEOptions.cs
@@ -35,7 +35,7 @@ namespace EncompassRest.Services.Verification
         public string AlternateId { get; set; }
 
         public EVVOEOptions(EVVOERequestType requestType)
-            : this(requestType.Validate(nameof(requestType)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(requestType.Validate(nameof(requestType)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Services/Verification/VerificationProduct.cs
+++ b/src/EncompassRest/Services/Verification/VerificationProduct.cs
@@ -1,5 +1,4 @@
-﻿using EnumsNET;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace EncompassRest.Services.Verification
 {
@@ -9,7 +8,7 @@ namespace EncompassRest.Services.Verification
         public VerificationPreferences Preferences { get; set; }
 
         internal VerificationProduct(EntityReference entityRef, ServiceOptions options)
-            : this(entityRef, options, ServiceType.Verification.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(entityRef, options, ServiceType.Verification.GetValue())
         {
         }
 

--- a/src/EncompassRest/Settings/Loan/CustomFieldDefinition.cs
+++ b/src/EncompassRest/Settings/Loan/CustomFieldDefinition.cs
@@ -9,6 +9,7 @@ namespace EncompassRest.Settings.Loan
     public sealed class CustomFieldDefinition : DirtyExtensibleObject, IIdentifiable
     {
         private string _id;
+        [JsonRequired]
         public string Id { get => _id; set => SetField(ref _id, value); }
         private string _description;
         public string Description { get => _description; set => SetField(ref _description, value); }
@@ -32,7 +33,7 @@ namespace EncompassRest.Settings.Loan
         public bool IsCalculatedField { get => _isCalculatedField; internal set => SetField(ref _isCalculatedField, value); }
 
         public CustomFieldDefinition(string id, string description, LoanFieldFormat format)
-            : this(id, description, format.Validate(nameof(format)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(id, description, format.Validate(nameof(format)).GetValue())
         {
         }
         

--- a/src/EncompassRest/Settings/Loan/FieldAudit.cs
+++ b/src/EncompassRest/Settings/Loan/FieldAudit.cs
@@ -7,13 +7,14 @@ namespace EncompassRest.Settings.Loan
     public sealed class FieldAudit : DirtyExtensibleObject, IDirty, IIdentifiable
     {
         private string _fieldId;
+        [JsonRequired]
         public string FieldId { get => _fieldId; set => SetField(ref _fieldId, value); }
         private StringEnumValue<AuditData> _data;
         public StringEnumValue<AuditData> Data { get => _data; set => SetField(ref _data, value); }
         bool IDirty.Dirty { get => true; set { } }
 
         public FieldAudit(string fieldId, AuditData data)
-            : this(fieldId, data.Validate(nameof(data)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(fieldId, data.Validate(nameof(data)).GetValue())
         {
         }
 

--- a/src/EncompassRest/StringEnumValue.cs
+++ b/src/EncompassRest/StringEnumValue.cs
@@ -33,7 +33,7 @@ namespace EncompassRest
         }
 
         public StringEnumValue(TEnum? value)
-            : this(value?.Validate(nameof(value)).AsString(EnumFormat.EnumMemberValue, EnumFormat.Name))
+            : this(value?.Validate(nameof(value)).GetValue())
         {
         }
 

--- a/src/EncompassRest/Utilities/JsonHelper.cs
+++ b/src/EncompassRest/Utilities/JsonHelper.cs
@@ -312,9 +312,10 @@ namespace EncompassRest.Utilities
                     if (TypeData<DirtyExtensibleObject>.TypeInfo.IsAssignableFrom(objectTypeInfo))
                     {
                         var idPropertyName = DirtyExtensibleObject.GetIdPropertyName(objectTypeInfo);
+                        var backingFieldTypeInfo = GetBackingFieldInfo(objectType, idPropertyName)?.FieldInfo.FieldType.GetTypeInfo();
                         idPropertyName = CamelCaseNamingStrategy.GetPropertyName(idPropertyName, false);
                         var property = contract.Properties.GetClosestMatchProperty(idPropertyName);
-                        if (property != null)
+                        if (property != null && (backingFieldTypeInfo == null || !backingFieldTypeInfo.IsGenericType || backingFieldTypeInfo.IsGenericTypeDefinition || backingFieldTypeInfo.GetGenericTypeDefinition() != TypeData.OpenNeverSerializeValueType))
                         {
                             property.ShouldSerialize = o => ((IIdentifiable)o).Id != null;
                         }

--- a/src/EncompassRest/Utilities/TypeData.cs
+++ b/src/EncompassRest/Utilities/TypeData.cs
@@ -21,6 +21,8 @@ namespace EncompassRest.Utilities
 
         public static Type OpenDirtyDictionaryType = typeof(DirtyDictionary<,>);
 
+        public static Type OpenNeverSerializeValueType = typeof(NeverSerializeValue<>);
+
         public static TypeData Get(Type type) => s_typeDatas.GetOrAdd(type, t => new TypeData(t));
 
         private bool? _isNullable;

--- a/src/EncompassRest/Webhook/Webhook.cs
+++ b/src/EncompassRest/Webhook/Webhook.cs
@@ -18,7 +18,7 @@ namespace EncompassRest.Webhook
 
         public Task<string> GetResourcesRawAsync(string queryString = null, CancellationToken cancellationToken = default) => GetRawAsync("resources", queryString, nameof(GetResourcesRawAsync), null, cancellationToken);
 
-        public Task<WebhookResource> GetResourceAsync(WebhookResourceType resourceName, CancellationToken cancellationToken = default) => GetResourceAsync(resourceName.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name), cancellationToken);
+        public Task<WebhookResource> GetResourceAsync(WebhookResourceType resourceName, CancellationToken cancellationToken = default) => GetResourceAsync(resourceName.Validate(nameof(resourceName)).GetValue(), cancellationToken);
 
         public Task<WebhookResource> GetResourceAsync(string resourceName, CancellationToken cancellationToken = default)
         {
@@ -34,7 +34,7 @@ namespace EncompassRest.Webhook
             return GetRawAsync($"resources/{resourceName}", queryString, nameof(GetResourcesRawAsync), null, cancellationToken);
         }
 
-        public Task<List<StringEnumValue<WebhookResourceEvent>>> GetResourceEventsAsync(WebhookResourceType resourceName, CancellationToken cancellationToken = default) => GetResourceEventsAsync(resourceName.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name), cancellationToken);
+        public Task<List<StringEnumValue<WebhookResourceEvent>>> GetResourceEventsAsync(WebhookResourceType resourceName, CancellationToken cancellationToken = default) => GetResourceEventsAsync(resourceName.Validate(nameof(resourceName)).GetValue(), cancellationToken);
 
         public Task<List<StringEnumValue<WebhookResourceEvent>>> GetResourceEventsAsync(string resourceName, CancellationToken cancellationToken = default)
         {
@@ -66,7 +66,7 @@ namespace EncompassRest.Webhook
 
         public Task<List<WebhookSubscription>> GetSubscriptionsAsync(CancellationToken cancellationToken = default) => GetSubscriptionsAsync((IEnumerable<string>)null, null, cancellationToken);
 
-        public Task<List<WebhookSubscription>> GetSubscriptionsAsync(IEnumerable<WebhookResourceType> resources, IEnumerable<WebhookResourceEvent> events, CancellationToken cancellationToken = default) => GetSubscriptionsAsync(resources?.Select(r => r.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)), events?.Select(e => e.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)), cancellationToken);
+        public Task<List<WebhookSubscription>> GetSubscriptionsAsync(IEnumerable<WebhookResourceType> resources, IEnumerable<WebhookResourceEvent> events, CancellationToken cancellationToken = default) => GetSubscriptionsAsync(resources?.Select(r => r.Validate(nameof(resources)).GetValue()), events?.Select(e => e.Validate(nameof(events)).GetValue()), cancellationToken);
 
         public Task<List<WebhookSubscription>> GetSubscriptionsAsync(IEnumerable<string> resources, IEnumerable<string> events, CancellationToken cancellationToken = default)
         {

--- a/src/EncompassRest/Webhook/WebhookFilters.cs
+++ b/src/EncompassRest/Webhook/WebhookFilters.cs
@@ -5,6 +5,7 @@ namespace EncompassRest.Webhook
     public sealed class WebhookFilters : DirtyExtensibleObject, IDirty
     {
         private IList<string> _attributes;
+
         public IList<string> Attributes { get => GetField(ref _attributes); set => SetField(ref _attributes, value); }
 
         bool IDirty.Dirty { get => true; set { } }

--- a/src/EncompassRest/Webhook/WebhookSubscription.cs
+++ b/src/EncompassRest/Webhook/WebhookSubscription.cs
@@ -11,24 +11,33 @@ namespace EncompassRest.Webhook
     public sealed class WebhookSubscription : DirtyExtensibleObject, IIdentifiable
     {
         private string _endpoint;
+        private string _subscriptionId;
+        private StringEnumValue<WebhookResourceType> _resource;
+        private IList<StringEnumValue<WebhookResourceEvent>> _events;
+        private WebhookFilters _filters;
+        private NeverSerializeValue<string> _objectUrn;
+        private NeverSerializeValue<string> _clientId;
+        private NeverSerializeValue<string> _instanceId;
+
         [JsonRequired]
         public string Endpoint { get => _endpoint; set => SetField(ref _endpoint, value); }
-        private string _subscriptionId;
+
         public string SubscriptionId { get => _subscriptionId; set => SetField(ref _subscriptionId, value); }
-        private StringEnumValue<WebhookResourceType> _resource;
+
         [JsonRequired]
         public StringEnumValue<WebhookResourceType> Resource { get => _resource; set => SetField(ref _resource, value); }
-        private IList<StringEnumValue<WebhookResourceEvent>> _events;
+
         [JsonRequired]
         public IList<StringEnumValue<WebhookResourceEvent>> Events { get => GetField(ref _events); set => SetField(ref _events, value); }
-        private WebhookFilters _filters;
+
         public WebhookFilters Filters { get => GetField(ref _filters); set => SetField(ref _filters, value); }
-        private NeverSerializeValue<string> _objectUrn;
+
         public string ObjectUrn { get => _objectUrn; set => SetField(ref _objectUrn, value); }
-        private NeverSerializeValue<string> _clientId;
+
         public string ClientId { get => _clientId; set => SetField(ref _clientId, value); }
-        private NeverSerializeValue<string> _instanceId;
+
         public string InstanceId { get => _instanceId; set => SetField(ref _instanceId, value); }
+
         [IdPropertyName(nameof(SubscriptionId))]
         string IIdentifiable.Id { get => SubscriptionId; set => SubscriptionId = value; }
 

--- a/src/EncompassRest/Webhook/WebhookSubscription.cs
+++ b/src/EncompassRest/Webhook/WebhookSubscription.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using EncompassRest.Utilities;
 using EnumsNET;
@@ -31,7 +32,8 @@ namespace EncompassRest.Webhook
         [IdPropertyName(nameof(SubscriptionId))]
         string IIdentifiable.Id { get => SubscriptionId; set => SubscriptionId = value; }
 
-        [Obsolete("Use other constructor overloads instead.")]
+        [Obsolete("Use another constructor instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public WebhookSubscription(string endpoint)
         {
             Preconditions.NotNullOrEmpty(endpoint, nameof(endpoint));
@@ -40,7 +42,7 @@ namespace EncompassRest.Webhook
         }
 
         public WebhookSubscription(string endpoint, WebhookResourceType resource, IEnumerable<WebhookResourceEvent> events)
-            : this(endpoint, resource.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name), events?.Select(e => e.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)))
+            : this(endpoint, resource.Validate(nameof(resource)).GetValue(), events?.Select(e => e.Validate(nameof(events)).GetValue()))
         {
         }
 


### PR DESCRIPTION
Added constructor overloads for creation and updates for several classes to make it easier for consumers to know what properties are required.

Added a ContactGroups.GetGroupsAsync, ContactGroups.AssignGroupContactsAsync, and LoanDocuments.AssignDocumentAttachmentsAsync overload.

Marked many constructors as Obsolete and not editor browsable.

Added an internal GetValue enum extension method.

Fixed issue with updating LoanAttachment's.

Fixed BusinessContact.Fees getter.

Implemented a temporary fix for updating contacts and contact notes to not apply dirty checking due to Ellie Mae API issues.

Added JsonIgnore to ClientParameters.CommonCache.

Added more tests.

Closes #215 