### PR TITLE
Added support for user apis

### DIFF
--- a/src/EncompassRest.Tests/ContactsTests.cs
+++ b/src/EncompassRest.Tests/ContactsTests.cs
@@ -131,7 +131,7 @@ namespace EncompassRest.Tests
 
             foreach (var contactFieldDefinition in allContactFieldDefinitions)
             {
-                Assert.AreEqual(0, contactFieldDefinition.ExtensionData.Count);
+                AssertNoExtensionData(contactFieldDefinition, "ContactFieldDefinition", contactFieldDefinition.CanonicalName);
             }
 
             var existingCategories = new HashSet<string>(Enums.GetMembers<FieldDefinitionCategory>().Select(m => m.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name)), StringComparer.Ordinal);
@@ -164,7 +164,7 @@ namespace EncompassRest.Tests
 
             foreach (var contact in allContacts)
             {
-                Assert.AreEqual(0, contact.ExtensionData.Count);
+                AssertNoExtensionData(contact, "Contact", contact.Id);
                 Assert.IsFalse(string.IsNullOrEmpty(contact.Id));
                 Assert.IsNotNull(contact.Fields);
                 Assert.AreEqual(fields.Length, contact.Fields.Count);

--- a/src/EncompassRest.Tests/FieldReaderTests.cs
+++ b/src/EncompassRest.Tests/FieldReaderTests.cs
@@ -34,7 +34,7 @@ namespace EncompassRest.Tests
                 {
                     Assert.IsTrue(fieldValues.TryGetValue(loanFieldValue.FieldId, out var value));
                     Assert.AreEqual(value, loanFieldValue.Value);
-                    Assert.AreEqual(0, loanFieldValue.ExtensionData.Count);
+                    AssertNoExtensionData(loanFieldValue, "LoanFieldValue", loanFieldValue.FieldId);
                 }
             }
             finally

--- a/src/EncompassRest.Tests/LoanAssociateMilestoneTests.cs
+++ b/src/EncompassRest.Tests/LoanAssociateMilestoneTests.cs
@@ -22,21 +22,19 @@ namespace EncompassRest.Tests
                 var associates = await loanApis.Associates.GetAssociatesAsync();
                 foreach (var associate in associates)
                 {
-                    Assert.AreEqual(0, associate.ExtensionData.Count);
+                    AssertNoExtensionData(associate, "Associate", associate.Id);
                 }
                 var milestones = await loanApis.Milestones.GetMilestonesAsync();
                 foreach (var milestone in milestones)
                 {
-                    Assert.AreEqual(0, milestone.ExtensionData.Count);
-                    Assert.AreEqual(0, milestone.LoanAssociate.ExtensionData.Count);
+                    AssertNoExtensionData(milestone, "Milestone", milestone.MilestoneName);
                     var retrievedMilestone = await loanApis.Milestones.GetMilestoneAsync(milestone.Id);
                     Assert.AreEqual(milestone.ToString(), retrievedMilestone.ToString());
                 }
                 var milestoneFreeRoles = await loanApis.MilestoneFreeRoles.GetMilestoneFreeRolesAsync();
                 foreach (var milestoneFreeRole in milestoneFreeRoles)
                 {
-                    Assert.AreEqual(0, milestoneFreeRole.ExtensionData.Count);
-                    Assert.AreEqual(0, milestoneFreeRole.LoanAssociate.ExtensionData.Count);
+                    AssertNoExtensionData(milestoneFreeRole, "MilestoneFreeRole", milestoneFreeRole.Id);
                     var retrievedMilestoneFreeRole = await loanApis.MilestoneFreeRoles.GetMilestoneFreeRoleAsync(milestoneFreeRole.Id);
                     Assert.AreEqual(milestoneFreeRole.ToString(), retrievedMilestoneFreeRole.ToString());
                 }

--- a/src/EncompassRest.Tests/LoanAttachmentTests.cs
+++ b/src/EncompassRest.Tests/LoanAttachmentTests.cs
@@ -31,12 +31,12 @@ namespace EncompassRest.Tests
             {
                 var attachment = new LoanAttachment("Testing Attachment", "Text.txt", AttachmentCreateReason.Upload);
                 var text = "TESTING, TESTING, 1, 2, 3";
-                var attachmentId = await loan.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
+                var attachmentId = await loan.LoanApis.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
                 Assert.IsFalse(string.IsNullOrEmpty(attachmentId));
                 await Task.Delay(10000);
-                var retrievedText = Encoding.UTF8.GetString(await loan.Attachments.DownloadAttachmentAsync(attachmentId));
+                var retrievedText = Encoding.UTF8.GetString(await loan.LoanApis.Attachments.DownloadAttachmentAsync(attachmentId));
                 Assert.AreEqual(text, retrievedText);
-                var stream = await loan.Attachments.DownloadAttachmentStreamAsync(attachmentId);
+                var stream = await loan.LoanApis.Attachments.DownloadAttachmentStreamAsync(attachmentId);
                 using (var sr = new StreamReader(stream, Encoding.UTF8))
                 {
                     Assert.AreEqual(text, sr.ReadToEnd());
@@ -52,7 +52,7 @@ namespace EncompassRest.Tests
                     Assert.AreEqual(text, sr.ReadToEnd());
                 }
 
-                attachment = await loan.Attachments.GetAttachmentAsync(attachmentId, true);
+                attachment = await loan.LoanApis.Attachments.GetAttachmentAsync(attachmentId, true);
                 Assert.AreEqual("Testing Attachment", attachment.Title);
                 Assert.IsFalse(string.IsNullOrEmpty(attachment.MediaUrl));
                 retrievedText = Encoding.UTF8.GetString(await attachment.DownloadAsync());
@@ -64,18 +64,18 @@ namespace EncompassRest.Tests
                 }
 
                 attachment = new LoanAttachment(attachmentId) { Title = "Updated Title" };
-                await loan.Attachments.UpdateAttachmentAsync(attachment);
-                attachment = await loan.Attachments.GetAttachmentAsync(attachmentId);
+                await loan.LoanApis.Attachments.UpdateAttachmentAsync(attachment);
+                attachment = await loan.LoanApis.Attachments.GetAttachmentAsync(attachmentId);
                 Assert.AreEqual("Updated Title", attachment.Title);
 
                 var newAttachment = new LoanAttachment("Bob", "Bobby.txt", AttachmentCreateReason.Upload);
                 var newText = "This is a test of the emergency broadcast system, this is only a test.";
-                var newAttachmentId = await loan.Attachments.UploadAttachmentAsync(newAttachment, new MemoryStream(Encoding.UTF8.GetBytes(newText)), true);
+                var newAttachmentId = await loan.LoanApis.Attachments.UploadAttachmentAsync(newAttachment, new MemoryStream(Encoding.UTF8.GetBytes(newText)), true);
                 Assert.IsFalse(string.IsNullOrEmpty(newAttachmentId));
                 await Task.Delay(10000);
-                var newRetrievedText = Encoding.UTF8.GetString(await loan.Attachments.DownloadAttachmentAsync(newAttachmentId));
+                var newRetrievedText = Encoding.UTF8.GetString(await loan.LoanApis.Attachments.DownloadAttachmentAsync(newAttachmentId));
                 Assert.AreEqual(newText, newRetrievedText);
-                var newStream = await loan.Attachments.DownloadAttachmentStreamAsync(newAttachmentId);
+                var newStream = await loan.LoanApis.Attachments.DownloadAttachmentStreamAsync(newAttachmentId);
                 using (var newSr = new StreamReader(newStream, Encoding.UTF8))
                 {
                     Assert.AreEqual(newText, newSr.ReadToEnd());
@@ -91,7 +91,7 @@ namespace EncompassRest.Tests
                 newRetrievedText = Encoding.UTF8.GetString(await newAttachment.DownloadAsync());
                 Assert.AreEqual(newText, newRetrievedText);
 
-                newAttachment = await loan.Attachments.GetAttachmentAsync(newAttachmentId, true);
+                newAttachment = await loan.LoanApis.Attachments.GetAttachmentAsync(newAttachmentId, true);
                 Assert.AreEqual("Bob", newAttachment.Title);
                 Assert.IsFalse(string.IsNullOrEmpty(newAttachment.MediaUrl));
                 newRetrievedText = Encoding.UTF8.GetString(await newAttachment.DownloadAsync());

--- a/src/EncompassRest.Tests/LoanConditionsTests.cs
+++ b/src/EncompassRest.Tests/LoanConditionsTests.cs
@@ -31,13 +31,13 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(addedCondition.Title, conditions[0].Title);
                 Assert.AreEqual(addedCondition.Source.Value, conditions[0].Source.Value);
                 Assert.AreEqual(addedCondition.ForAllApplications, conditions[0].ForAllApplications);
-                Assert.AreEqual(0, conditions[0].ExtensionData.Count);
+                AssertNoExtensionData(conditions[0], "Conditions[0]", conditions[0].Title);
                 var retrievedCondition = await underwritingConditions.GetConditionAsync(conditionId);
                 Assert.IsNotNull(retrievedCondition);
                 Assert.AreEqual(addedCondition.Title, retrievedCondition.Title);
                 Assert.AreEqual(addedCondition.Source.Value, retrievedCondition.Source.Value);
                 Assert.AreEqual(addedCondition.ForAllApplications, retrievedCondition.ForAllApplications);
-                Assert.AreEqual(0, retrievedCondition.ExtensionData.Count);
+                AssertNoExtensionData(retrievedCondition, "RetrievedCondition", retrievedCondition.Title);
             }
             finally
             {
@@ -74,13 +74,13 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(addedCondition.Title, conditions[0].Title);
                 Assert.AreEqual(addedCondition.Source.Value, conditions[0].Source.Value);
                 Assert.AreEqual(addedCondition.ForAllApplications, conditions[0].ForAllApplications);
-                Assert.AreEqual(0, conditions[0].ExtensionData.Count);
+                AssertNoExtensionData(conditions[0], "Conditions[0]", conditions[0].Title);
                 var retrievedCondition = await postClosingConditions.GetConditionAsync(conditionId);
                 Assert.IsNotNull(retrievedCondition);
                 Assert.AreEqual(addedCondition.Title, retrievedCondition.Title);
                 Assert.AreEqual(addedCondition.Source.Value, retrievedCondition.Source.Value);
                 Assert.AreEqual(addedCondition.ForAllApplications, retrievedCondition.ForAllApplications);
-                Assert.AreEqual(0, retrievedCondition.ExtensionData.Count);
+                AssertNoExtensionData(retrievedCondition, "RetrievedCondition", retrievedCondition.Title);
             }
             finally
             {
@@ -117,13 +117,13 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(addedCondition.Title, conditions[0].Title);
                 Assert.AreEqual(addedCondition.Source.Value, conditions[0].Source.Value);
                 Assert.AreEqual(addedCondition.ForAllApplications, conditions[0].ForAllApplications);
-                Assert.AreEqual(0, conditions[0].ExtensionData.Count);
+                AssertNoExtensionData(conditions[0], "Conditions[0]", conditions[0].Title);
                 var retrievedCondition = await preliminaryConditions.GetConditionAsync(conditionId);
                 Assert.IsNotNull(retrievedCondition);
                 Assert.AreEqual(addedCondition.Title, retrievedCondition.Title);
                 Assert.AreEqual(addedCondition.Source.Value, retrievedCondition.Source.Value);
                 Assert.AreEqual(addedCondition.ForAllApplications, retrievedCondition.ForAllApplications);
-                Assert.AreEqual(0, retrievedCondition.ExtensionData.Count);
+                AssertNoExtensionData(retrievedCondition, "RetrievedCondition", retrievedCondition.Title);
             }
             finally
             {

--- a/src/EncompassRest.Tests/LoanDocumentTests.cs
+++ b/src/EncompassRest.Tests/LoanDocumentTests.cs
@@ -43,43 +43,43 @@ namespace EncompassRest.Tests
             try
             {
                 var document = new LoanDocument("Final 1003", "All");
-                var documentId = await loan.Documents.CreateDocumentAsync(document, true);
+                var documentId = await loan.LoanApis.Documents.CreateDocumentAsync(document, true);
                 Assert.IsFalse(string.IsNullOrEmpty(documentId));
 
-                document = await loan.Documents.GetDocumentAsync(documentId);
+                document = await loan.LoanApis.Documents.GetDocumentAsync(documentId);
                 Assert.AreEqual("Final 1003", document.Title);
                 Assert.AreEqual("All", document.ApplicationId);
                 Assert.AreEqual(0, document.Attachments.Count);
 
                 document = new LoanDocument(documentId) { Title = "Updated Title" };
-                await loan.Documents.UpdateDocumentAsync(document);
-                document = await loan.Documents.GetDocumentAsync(documentId);
+                await loan.LoanApis.Documents.UpdateDocumentAsync(document);
+                document = await loan.LoanApis.Documents.GetDocumentAsync(documentId);
                 Assert.AreEqual("Updated Title", document.Title);
                 Assert.AreEqual("All", document.ApplicationId);
                 Assert.AreEqual(0, document.Attachments.Count);
 
                 var attachment = new LoanAttachment("Testing Attachment", "Text.txt", AttachmentCreateReason.Upload);
                 var text = "TESTING, TESTING, 1, 2, 3";
-                var attachmentId = await loan.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
+                var attachmentId = await loan.LoanApis.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
                 Assert.IsFalse(string.IsNullOrEmpty(attachmentId));
                 await Task.Delay(10000);
-                var retrievedText = Encoding.UTF8.GetString(await loan.Attachments.DownloadAttachmentAsync(attachmentId));
+                var retrievedText = Encoding.UTF8.GetString(await loan.LoanApis.Attachments.DownloadAttachmentAsync(attachmentId));
                 Assert.AreEqual(text, retrievedText);
-                var stream = await loan.Attachments.DownloadAttachmentStreamAsync(attachmentId);
+                var stream = await loan.LoanApis.Attachments.DownloadAttachmentStreamAsync(attachmentId);
                 using (var sr = new StreamReader(stream, Encoding.UTF8))
                 {
                     Assert.AreEqual(text, sr.ReadToEnd());
                 }
 
                 var entityReference = new EntityReference(attachmentId, EntityType.Attachment);
-                await loan.Documents.AssignDocumentAttachmentsAsync(documentId, AssignmentAction.Add, new[] { entityReference });
+                await loan.LoanApis.Documents.AssignDocumentAttachmentsAsync(documentId, AssignmentAction.Add, new[] { entityReference });
 
-                document = await loan.Documents.GetDocumentAsync(documentId);
+                document = await loan.LoanApis.Documents.GetDocumentAsync(documentId);
                 Assert.AreEqual("Updated Title", document.Title);
                 Assert.AreEqual("All", document.ApplicationId);
                 Assert.AreEqual(1, document.Attachments.Count);
                 Assert.AreEqual(attachmentId, document.Attachments[0].EntityId);
-                Assert.AreEqual(entityReference.EntityType.Value, document.Attachments[0].EntityType.Value);
+                Assert.AreEqual(entityReference.EntityType.EnumValue, document.Attachments[0].EntityType.EnumValue);
             }
             finally
             {

--- a/src/EncompassRest.Tests/PipelineTests.cs
+++ b/src/EncompassRest.Tests/PipelineTests.cs
@@ -37,36 +37,7 @@ namespace EncompassRest.Tests
             var newCanonicalFieldNames = canonicalFieldNames.Except(existingCanonicalFieldNames, StringComparer.OrdinalIgnoreCase).ToList();
             Assert.AreEqual(0, newCanonicalFieldNames.Count, $"{nameof(CanonicalLoanField)}: {string.Join(", ", newCanonicalFieldNames)}");
 
-            Assert.AreEqual(0, canonicalNames.ExtensionData.Count, $"CanonicalNames has the following ExtensionData {JsonHelper.ToJson(canonicalNames.ExtensionData)}");
-
-            foreach (var pipelineFieldDef in canonicalNames.PipelineLoanReportFieldDefs)
-            {
-                Assert.AreEqual(0, pipelineFieldDef.ExtensionData.Count, $"CanonicalNames.PipelineLoanReportFieldDef has the following ExtensionData {JsonHelper.ToJson(pipelineFieldDef.ExtensionData)}");
-
-                ValidateNoExtensionData(pipelineFieldDef.FieldDefinition);
-            }
-        }
-
-        private void ValidateNoExtensionData(FieldDefinition fieldDefinition)
-        {
-            Assert.AreEqual(0, fieldDefinition.ExtensionData.Count, $"CanonicalNames.PipelineLoanReportFieldDef.FieldDefinition has the following ExtensionData {JsonHelper.ToJson(fieldDefinition.ExtensionData)}");
-
-            var fieldOptions = fieldDefinition.FieldOptions;
-            if (fieldOptions != null)
-            {
-                Assert.AreEqual(0, fieldOptions.ExtensionData.Count, $"CanonicalNames.PipelineLoanReportFieldDef.FieldDefinition.FieldOptions has the following ExtensionData {JsonHelper.ToJson(fieldOptions.ExtensionData)}");
-
-                foreach (var option in fieldOptions.Options)
-                {
-                    Assert.AreEqual(0, option.ExtensionData.Count, $"CanonicalNames.PipelineLoanReportFieldDef.FieldDefinition.FieldOptions.Options has the following ExtensionData {JsonHelper.ToJson(option.ExtensionData)}");
-                }
-            }
-
-            var parentField = fieldDefinition.ParentField;
-            if (parentField != null)
-            {
-                ValidateNoExtensionData(parentField);
-            }
+            AssertNoExtensionData(canonicalNames, "CanonicalNames", "CanonicalNames");
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/SchemaTests.cs
+++ b/src/EncompassRest.Tests/SchemaTests.cs
@@ -52,33 +52,7 @@ namespace EncompassRest.Tests
             var newFormats = formats.Except(existingFormats).ToList();
             Assert.AreEqual(0, newFormats.Count, $"{nameof(LoanFieldFormat)}: {string.Join(", ", newFormats)}");
 
-            Assert.AreEqual(0, loanSchema.ExtensionData.Count);
-
-            foreach (var entitySchema in loanSchema.EntityTypes.Values)
-            {
-                Assert.AreEqual(0, entitySchema.ExtensionData.Count);
-
-                foreach (var propertySchema in entitySchema.Properties.Values)
-                {
-                    Assert.AreEqual(0, propertySchema.ExtensionData.Count);
-
-                    if (propertySchema.AllowedValues != null)
-                    {
-                        foreach (var option in propertySchema.AllowedValues)
-                        {
-                            Assert.AreEqual(0, option.ExtensionData.Count);
-                        }
-                    }
-
-                    if (propertySchema.InstancePatterns != null)
-                    {
-                        foreach (var instancePattern in propertySchema.InstancePatterns.Values)
-                        {
-                            Assert.AreEqual(0, instancePattern.ExtensionData.Count);
-                        }
-                    }
-                }
-            }
+            AssertNoExtensionData(loanSchema, "LoanSchema", "LoanSchema");
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/ServicesTests.cs
+++ b/src/EncompassRest.Tests/ServicesTests.cs
@@ -18,11 +18,7 @@ namespace EncompassRest.Tests
         {
             var parameters = new OrderCreditParameters(
                 new CreditProduct(
-                    new EntityReference
-                    {
-                        EntityId = "0b683692-c314-4a03-9e75-f382397d3141#_borrower1",
-                        EntityType = "urn:elli:encompass:loan:borrower"
-                    },
+                    new EntityReference("0b683692-c314-4a03-9e75-f382397d3141#_borrower1", "urn:elli:encompass:loan:borrower"),
                     new CreditOptions(CreditRequestType.NewRequest)
                     {
                         DigiCert = true,
@@ -51,11 +47,7 @@ namespace EncompassRest.Tests
         {
             var parameters = new OrderEV4506TParameters(
                 new EV4506TProduct(
-                    new EntityReference
-                    {
-                        EntityId = "0b683692-c314-4a03-9e75-f382397d3141#_borrower1",
-                        EntityType = "urn:elli:encompass:loan:borrower"
-                    },
+                    new EntityReference("0b683692-c314-4a03-9e75-f382397d3141#_borrower1", "urn:elli:encompass:loan:borrower"),
                     new EV4506TOptions(EV4506TRequestType.NewRequest)
                     {
                         DigiCert = true,
@@ -82,11 +74,7 @@ namespace EncompassRest.Tests
         {
             var parameters = new OrderEVVOEParameters(
                 new EVVOEProduct(
-                    new EntityReference
-                    {
-                        EntityId = "0b683692-c314-4a03-9e75-f382397d3141#_borrower1",
-                        EntityType = "urn:elli:encompass:loan:borrower"
-                    },
+                    new EntityReference("0b683692-c314-4a03-9e75-f382397d3141#_borrower1", "urn:elli:encompass:loan:borrower"),
                     new EVVOEOptions(EVVOERequestType.OrderVerification)
                     {
                         DigiCert = true,
@@ -113,11 +101,7 @@ namespace EncompassRest.Tests
         {
             var parameters = new OrderAUSParameters(
                 new AUSProduct(
-                    new EntityReference
-                    {
-                        EntityId = "0b683692-c314-4a03-9e75-f382397d3141#_borrower1",
-                        EntityType = "urn:elli:encompass:loan:borrower"
-                    },
+                    new EntityReference("0b683692-c314-4a03-9e75-f382397d3141#_borrower1", "urn:elli:encompass:loan:borrower"),
                     new AUSOptions(AUSRequestType.NewOrder)
                     {
                         AUSReportIdentifier = "123",
@@ -150,11 +134,7 @@ namespace EncompassRest.Tests
         {
             var parameters = new OrderAppraisalParameters(
                 new AppraisalProduct(
-                    new EntityReference
-                    {
-                        EntityId = "0b683692-c314-4a03-9e75-f382397d3141#_borrower1",
-                        EntityType = "urn:elli:encompass:loan:borrower"
-                    },
+                    new EntityReference("0b683692-c314-4a03-9e75-f382397d3141#_borrower1", "urn:elli:encompass:loan:borrower"),
                     new AppraisalOptions(AppraisalRequestType.NewOrder)
                     {
                         LoanPurpose = AppraisalLoanPurpose.Purchase,
@@ -190,11 +170,7 @@ namespace EncompassRest.Tests
         {
             var parameters = new OrderFloodParameters(
                 new FloodProduct(
-                    new EntityReference
-                    {
-                        EntityId = "0b683692-c314-4a03-9e75-f382397d3141#_borrower1",
-                        EntityType = "urn:elli:encompass:loan:borrower"
-                    },
+                    new EntityReference("0b683692-c314-4a03-9e75-f382397d3141#_borrower1", "urn:elli:encompass:loan:borrower"),
                     new FloodOptions(FloodRequestType.NewRequest)
                     {
                         ProductDetails = new FloodProductDetails

--- a/src/EncompassRest.Tests/UserTests.cs
+++ b/src/EncompassRest.Tests/UserTests.cs
@@ -1,0 +1,92 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using EncompassRest.Company.Users.Rights;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EncompassRest.Tests
+{
+    [TestClass]
+    public class UserTests : TestBaseClass
+    {
+        [TestMethod]
+        public async Task User_NoExtensionData()
+        {
+            var client = await GetTestClientAsync();
+            var users = await client.Company.Users.GetUsersAsync();
+            Assert.IsTrue(users.Count > 0);
+            foreach (var user in users)
+            {
+                Assert.IsNotNull(user.Client);
+                Assert.IsNotNull(user.UserApis);
+                AssertNoExtensionData(user, "User", user.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task UserRights_NoExtensionData()
+        {
+            var client = await GetTestClientAsync();
+            var users = await client.Company.Users.GetUsersAsync();
+            Assert.IsTrue(users.Count > 0);
+            foreach (var user in users)
+            {
+                if (user.Id.All(c => char.IsLetter(c)))
+                {
+                    var effectiveRights = await user.UserApis.Rights.GetRightsAsync(UserRightsType.Effective);
+                    AssertNoExtensionData(effectiveRights, "EffectiveRights", user.Id);
+
+                    var assignedRights = await user.UserApis.Rights.GetRightsAsync(UserRightsType.Assigned);
+                    AssertNoExtensionData(assignedRights, "AssignedRights", user.Id);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task UserGroups_NoExtensionData()
+        {
+            var client = await GetTestClientAsync();
+            var users = await client.Company.Users.GetUsersAsync();
+            Assert.IsTrue(users.Count > 0);
+            foreach (var user in users)
+            {
+                if (user.Id.All(c => char.IsLetter(c)))
+                {
+                    var groups = await user.UserApis.Groups.GetGroupsAsync();
+                    AssertNoExtensionData(groups, "UserGroup", user.Id);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task UserCompensation_NoExtensionData()
+        {
+            var client = await GetTestClientAsync();
+            var users = await client.Company.Users.GetUsersAsync();
+            Assert.IsTrue(users.Count > 0);
+            foreach (var user in users)
+            {
+                if (user.Id.All(c => char.IsLetter(c)))
+                {
+                    var compensation = await user.UserApis.Compensation.GetCompensationPlansAsync();
+                    AssertNoExtensionData(compensation, "Compensation", user.Id);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task UserLicenses_NoExtensionData()
+        {
+            var client = await GetTestClientAsync();
+            var users = await client.Company.Users.GetUsersAsync();
+            Assert.IsTrue(users.Count > 0);
+            foreach (var user in users)
+            {
+                if (user.Id.All(c => char.IsLetter(c)))
+                {
+                    var licenses = await user.UserApis.Licenses.GetLicenseDetailsAsync();
+                    AssertNoExtensionData(licenses, "License", user.Id);
+                }
+            }
+        }
+    }
+}

--- a/src/EncompassRest.Tests/WebhookTests.cs
+++ b/src/EncompassRest.Tests/WebhookTests.cs
@@ -21,11 +21,7 @@ namespace EncompassRest.Tests
 
             foreach (var resource in resources)
             {
-                Assert.AreEqual(0, resource.ExtensionData.Count);
-                foreach (var @event in resource.Events)
-                {
-                    Assert.AreEqual(0, @event.ExtensionData.Count);
-                }
+                AssertNoExtensionData(resource, "Resource", resource.Name);
             }
 
             Assert.IsTrue(resources.All(r => r.Name.EnumValue.HasValue));

--- a/src/EncompassRest/Company/Company.cs
+++ b/src/EncompassRest/Company/Company.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading;
+
+namespace EncompassRest.Company
+{
+    /// <summary>
+    /// Company Apis
+    /// </summary>
+    public sealed class Company : ApiObject
+    {
+        private Users.Users _users;
+        private GlobalCustomDataObjects _globalCustomDataObjects;
+
+        /// <summary>
+        /// Users Apis
+        /// </summary>
+        public Users.Users Users
+        {
+            get
+            {
+                var users = _users;
+                return users ?? Interlocked.CompareExchange(ref _users, (users = new Users.Users(Client)), null) ?? users;
+            }
+        }
+
+        /// <summary>
+        /// Global Custom Data Objects Apis
+        /// </summary>
+        public GlobalCustomDataObjects GlobalCustomDataObjects
+        {
+            get
+            {
+                var globalCustomDataObjects = _globalCustomDataObjects;
+                return globalCustomDataObjects ?? Interlocked.CompareExchange(ref _globalCustomDataObjects, (globalCustomDataObjects = new GlobalCustomDataObjects(Client)), null) ?? globalCustomDataObjects;
+            }
+        }
+
+        internal Company(EncompassRestClient client)
+            : base(client, "encompass/v1/company")
+        {
+        }
+    }
+}

--- a/src/EncompassRest/Company/GlobalCustomDataObjects.cs
+++ b/src/EncompassRest/Company/GlobalCustomDataObjects.cs
@@ -1,0 +1,13 @@
+﻿namespace EncompassRest.Company
+{
+    /// <summary>
+    /// Global Custom Data Objects Apis
+    /// </summary>
+    public sealed class GlobalCustomDataObjects : CustomDataObjects.CustomDataObjects
+    {
+        internal GlobalCustomDataObjects(EncompassRestClient client)
+            : base(client, "encompass/v1/company/customObjects")
+        {
+        }
+    }
+}

--- a/src/EncompassRest/Company/Users/ConsumerConnectSite.cs
+++ b/src/EncompassRest/Company/Users/ConsumerConnectSite.cs
@@ -1,0 +1,30 @@
+﻿namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// ConsumerConnectSite
+    /// </summary>
+    public sealed class ConsumerConnectSite : DirtyExtensibleObject, IIdentifiable
+    {
+        private DirtyValue<bool> _useParentInformation;
+        private DirtyValue<string> _url;
+        private DirtyValue<string> _siteId;
+
+        /// <summary>
+        /// ConsumerConnectSite UseParentInformation
+        /// </summary>
+        public bool UseParentInformation { get => _useParentInformation; set => SetField(ref _useParentInformation, value); }
+
+        /// <summary>
+        /// ConsumerConnectSite Url
+        /// </summary>
+        public string Url { get => _url; set => SetField(ref _url, value); }
+
+        /// <summary>
+        /// ConsumerConnectSite SiteId
+        /// </summary>
+        public string SiteId { get => _siteId; set => SetField(ref _siteId, value); }
+
+        [IdPropertyName(nameof(SiteId))]
+        string IIdentifiable.Id { get => SiteId; set => SiteId = value; }
+    }
+}

--- a/src/EncompassRest/Company/Users/PeerLoanAccess.cs
+++ b/src/EncompassRest/Company/Users/PeerLoanAccess.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.Serialization;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// PeerLoanAccess
+    /// </summary>
+    public enum PeerLoanAccess
+    {
+        /// <summary>
+        /// ViewOnly
+        /// </summary>
+        [EnumMember(Value = "viewOnly")]
+        ViewOnly = 0,
+        /// <summary>
+        /// Edit
+        /// </summary>
+        [EnumMember(Value = "edit")]
+        Edit = 1,
+        /// <summary>
+        /// Disabled
+        /// </summary>
+        [EnumMember(Value = "disabled")]
+        Disabled = 2
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AUSTrackingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AUSTrackingRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AUSTrackingRights
+    /// </summary>
+    public sealed class AUSTrackingRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _createManualEntry;
+
+        /// <summary>
+        /// AUSTrackingRights CreateManualEntry
+        /// </summary>
+        public bool? CreateManualEntry { get => _createManualEntry; set => SetField(ref _createManualEntry, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessCorrespondentRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessCorrespondentRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessCorrespondentRights
+    /// </summary>
+    public sealed class AccessCorrespondentRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _registerCorrespondentLoan;
+
+        /// <summary>
+        /// AccessCorrespondentRights RegisterCorrespondentLoan
+        /// </summary>
+        public bool? RegisterCorrespondentLoan { get => _registerCorrespondentLoan; set => SetField(ref _registerCorrespondentLoan, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessRights
+    /// </summary>
+    public sealed class AccessRights : DirtyExtensibleObject
+    {
+        private MobileAccessRights _mobileAccess;
+
+        /// <summary>
+        /// AccessRights MobileAccess
+        /// </summary>
+        public MobileAccessRights MobileAccess { get => GetField(ref _mobileAccess); set => SetField(ref _mobileAccess, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessToContactsTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessToContactsTabRights.cs
@@ -1,0 +1,39 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessToContactsTabRights
+    /// </summary>
+    public sealed class AccessToContactsTabRights : ParentAccessRights
+    {
+        private BorrowerContactsRights _borrowerContacts;
+        private BusinessContactsRights _businessContacts;
+        private CampaignManagementRights _campaignManagement;
+        private DirtyValue<bool?> _contactSynchronization;
+        private DirtyValue<bool?> _contactUpdateOptOut;
+
+        /// <summary>
+        /// AccessToContactsTabRights BorrowerContacts
+        /// </summary>
+        public BorrowerContactsRights BorrowerContacts { get => GetField(ref _borrowerContacts); set => SetField(ref _borrowerContacts, value); }
+
+        /// <summary>
+        /// AccessToContactsTabRights BusinessContacts
+        /// </summary>
+        public BusinessContactsRights BusinessContacts { get => GetField(ref _businessContacts); set => SetField(ref _businessContacts, value); }
+
+        /// <summary>
+        /// AccessToContactsTabRights CampaignManagement
+        /// </summary>
+        public CampaignManagementRights CampaignManagement { get => GetField(ref _campaignManagement); set => SetField(ref _campaignManagement, value); }
+
+        /// <summary>
+        /// AccessToContactsTabRights ContactSynchronization
+        /// </summary>
+        public bool? ContactSynchronization { get => _contactSynchronization; set => SetField(ref _contactSynchronization, value); }
+
+        /// <summary>
+        /// AccessToContactsTabRights ContactUpdateOptOut
+        /// </summary>
+        public bool? ContactUpdateOptOut { get => _contactUpdateOptOut; set => SetField(ref _contactUpdateOptOut, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessToDashboardTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessToDashboardTabRights.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessToDashboardTabRights
+    /// </summary>
+    public sealed class AccessToDashboardTabRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _filterDatabyOrganization;
+        private DirtyValue<bool?> _filterDatabyUserGroup;
+        private DirtyValue<bool?> _managePersonalSnapshotTemplate;
+        private DirtyValue<bool?> _managePersonalView;
+
+        /// <summary>
+        /// AccessToDashboardTabRights FilterDatabyOrganization
+        /// </summary>
+        [JsonProperty("filterDatabyOrganization*")]
+        public bool? FilterDatabyOrganization { get => _filterDatabyOrganization; set => SetField(ref _filterDatabyOrganization, value); }
+
+        /// <summary>
+        /// AccessToDashboardTabRights FilterDatabyUserGroup
+        /// </summary>
+        [JsonProperty("filterDatabyUserGroup*")]
+        public bool? FilterDatabyUserGroup { get => _filterDatabyUserGroup; set => SetField(ref _filterDatabyUserGroup, value); }
+
+        /// <summary>
+        /// AccessToDashboardTabRights ManagePersonalSnapshotTemplate
+        /// </summary>
+        public bool? ManagePersonalSnapshotTemplate { get => _managePersonalSnapshotTemplate; set => SetField(ref _managePersonalSnapshotTemplate, value); }
+
+        /// <summary>
+        /// AccessToDashboardTabRights ManagePersonalView
+        /// </summary>
+        public bool? ManagePersonalView { get => _managePersonalView; set => SetField(ref _managePersonalView, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessToFeesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessToFeesRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessToFeesRights
+    /// </summary>
+    public sealed class AccessToFeesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _acceptFees;
+
+        /// <summary>
+        /// AccessToFeesRights AcceptFees
+        /// </summary>
+        public bool? AcceptFees { get => _acceptFees; set => SetField(ref _acceptFees, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessToManageAccountPageRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessToManageAccountPageRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessToManageAccountPageRights
+    /// </summary>
+    public sealed class AccessToManageAccountPageRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _accessBranchesTab;
+        private DirtyValue<bool?> _accessCompanyInfoTab;
+
+        /// <summary>
+        /// AccessToManageAccountPageRights AccessBranchesTab
+        /// </summary>
+        public bool? AccessBranchesTab { get => _accessBranchesTab; set => SetField(ref _accessBranchesTab, value); }
+
+        /// <summary>
+        /// AccessToManageAccountPageRights AccessCompanyInfoTab
+        /// </summary>
+        public bool? AccessCompanyInfoTab { get => _accessCompanyInfoTab; set => SetField(ref _accessCompanyInfoTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessToProductPricingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessToProductPricingRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessToProductPricingRights
+    /// </summary>
+    public sealed class AccessToProductPricingRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _viewLockHistory;
+
+        /// <summary>
+        /// AccessToProductPricingRights ViewLockHistory
+        /// </summary>
+        public bool? ViewLockHistory { get => _viewLockHistory; set => SetField(ref _viewLockHistory, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessToTPOTradeManagementRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessToTPOTradeManagementRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessToTPOTradeManagementRights
+    /// </summary>
+    public sealed class AccessToTPOTradeManagementRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _updateCorrespondentTrades;
+        private DirtyValue<bool?> _viewCorrespondentMasterCommitments;
+        private DirtyValue<bool?> _viewCorrespondentTrades;
+
+        /// <summary>
+        /// AccessToTPOTradeManagementRights UpdateCorrespondentTrades
+        /// </summary>
+        public bool? UpdateCorrespondentTrades { get => _updateCorrespondentTrades; set => SetField(ref _updateCorrespondentTrades, value); }
+
+        /// <summary>
+        /// AccessToTPOTradeManagementRights ViewCorrespondentMasterCommitments
+        /// </summary>
+        public bool? ViewCorrespondentMasterCommitments { get => _viewCorrespondentMasterCommitments; set => SetField(ref _viewCorrespondentMasterCommitments, value); }
+
+        /// <summary>
+        /// AccessToTPOTradeManagementRights ViewCorrespondentTrades
+        /// </summary>
+        public bool? ViewCorrespondentTrades { get => _viewCorrespondentTrades; set => SetField(ref _viewCorrespondentTrades, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AccessWholesaleRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AccessWholesaleRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AccessWholesaleRights
+    /// </summary>
+    public sealed class AccessWholesaleRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _registerWholesaleLoan;
+
+        /// <summary>
+        /// AccessWholesaleRights RegisterWholesaleLoan
+        /// </summary>
+        public bool? RegisterWholesaleLoan { get => _registerWholesaleLoan; set => SetField(ref _registerWholesaleLoan, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AddEditTPOFeesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AddEditTPOFeesRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AddEditTPOFeesRights
+    /// </summary>
+    public sealed class AddEditTPOFeesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteTPOFees;
+
+        /// <summary>
+        /// AddEditTPOFeesRights DeleteTPOFees
+        /// </summary>
+        public bool? DeleteTPOFees { get => _deleteTPOFees; set => SetField(ref _deleteTPOFees, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AddEditTPOWebCenterAdditionalDocumentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AddEditTPOWebCenterAdditionalDocumentsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AddEditTPOWebCenterAdditionalDocumentsRights
+    /// </summary>
+    public sealed class AddEditTPOWebCenterAdditionalDocumentsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteTPOWebCenterDocuments;
+
+        /// <summary>
+        /// AddEditTPOWebCenterAdditionalDocumentsRights DeleteTPOWebCenterDocuments
+        /// </summary>
+        public bool? DeleteTPOWebCenterDocuments { get => _deleteTPOWebCenterDocuments; set => SetField(ref _deleteTPOWebCenterDocuments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AddNotesToFileRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AddNotesToFileRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AddNotesToFileRights
+    /// </summary>
+    public sealed class AddNotesToFileRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteNotes;
+
+        /// <summary>
+        /// AddNotesToFileRights DeleteNotes
+        /// </summary>
+        public bool? DeleteNotes { get => _deleteNotes; set => SetField(ref _deleteNotes, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AdditionalServicesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AdditionalServicesRights.cs
@@ -1,0 +1,115 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AdditionalServicesRights
+    /// </summary>
+    public sealed class AdditionalServicesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _n4506TService;
+        private DirtyValue<bool?> _appraisalService;
+        private DirtyValue<bool?> _companyStatusOnline;
+        private DirtyValue<bool?> _complianceReviewSetup;
+        private DirtyValue<bool?> _dataTracConnection;
+        private DirtyValue<bool?> _eDocumentManagement;
+        private DirtyValue<bool?> _eDisclosureFulfillment;
+        private DirtyValue<bool?> _fannieMaeUCDTransfer;
+        private DirtyValue<bool?> _fannieMaeWorkflow;
+        private DirtyValue<bool?> _floodService;
+        private DirtyValue<bool?> _fraudService;
+        private DirtyValue<bool?> _freddieMacCAC;
+        private DirtyValue<bool?> _freddieMacOrderAlert;
+        private DirtyValue<bool?> _mortgageInsuranceService;
+        private DirtyValue<bool?> _titleService;
+        private DirtyValue<bool?> _tQLServices;
+        private DirtyValue<bool?> _valuationService;
+
+        /// <summary>
+        /// AdditionalServicesRights 4506TService
+        /// </summary>
+        [JsonProperty("4506TService")]
+        public bool? n4506TService { get => _n4506TService; set => SetField(ref _n4506TService, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights AppraisalService
+        /// </summary>
+        public bool? AppraisalService { get => _appraisalService; set => SetField(ref _appraisalService, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights CompanyStatusOnline
+        /// </summary>
+        public bool? CompanyStatusOnline { get => _companyStatusOnline; set => SetField(ref _companyStatusOnline, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights ComplianceReviewSetup
+        /// </summary>
+        public bool? ComplianceReviewSetup { get => _complianceReviewSetup; set => SetField(ref _complianceReviewSetup, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights DataTracConnection
+        /// </summary>
+        public bool? DataTracConnection { get => _dataTracConnection; set => SetField(ref _dataTracConnection, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights EDocumentManagement
+        /// </summary>
+        [JsonProperty("e-DocumentManagement")]
+        public bool? EDocumentManagement { get => _eDocumentManagement; set => SetField(ref _eDocumentManagement, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights EDisclosureFulfillment
+        /// </summary>
+        public bool? EDisclosureFulfillment { get => _eDisclosureFulfillment; set => SetField(ref _eDisclosureFulfillment, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights FannieMaeUCDTransfer
+        /// </summary>
+        public bool? FannieMaeUCDTransfer { get => _fannieMaeUCDTransfer; set => SetField(ref _fannieMaeUCDTransfer, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights FannieMaeWorkflow
+        /// </summary>
+        public bool? FannieMaeWorkflow { get => _fannieMaeWorkflow; set => SetField(ref _fannieMaeWorkflow, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights FloodService
+        /// </summary>
+        public bool? FloodService { get => _floodService; set => SetField(ref _floodService, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights FraudService
+        /// </summary>
+        public bool? FraudService { get => _fraudService; set => SetField(ref _fraudService, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights FreddieMacCAC
+        /// </summary>
+        public bool? FreddieMacCAC { get => _freddieMacCAC; set => SetField(ref _freddieMacCAC, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights FreddieMacOrderAlert
+        /// </summary>
+        public bool? FreddieMacOrderAlert { get => _freddieMacOrderAlert; set => SetField(ref _freddieMacOrderAlert, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights MortgageInsuranceService
+        /// </summary>
+        public bool? MortgageInsuranceService { get => _mortgageInsuranceService; set => SetField(ref _mortgageInsuranceService, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights TitleService
+        /// </summary>
+        public bool? TitleService { get => _titleService; set => SetField(ref _titleService, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights TQLServices
+        /// </summary>
+        public bool? TQLServices { get => _tQLServices; set => SetField(ref _tQLServices, value); }
+
+        /// <summary>
+        /// AdditionalServicesRights ValuationService
+        /// </summary>
+        public bool? ValuationService { get => _valuationService; set => SetField(ref _valuationService, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AdministrationSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AdministrationSettingsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AdministrationSettingsRights
+    /// </summary>
+    public sealed class AdministrationSettingsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _accessTPOConnectAdminSite;
+
+        /// <summary>
+        /// AdministrationSettingsRights AccessTPOConnectAdminSite
+        /// </summary>
+        public bool? AccessTPOConnectAdminSite { get => _accessTPOConnectAdminSite; set => SetField(ref _accessTPOConnectAdminSite, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AssignLoanTeamMembersRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AssignLoanTeamMembersRights.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AssignLoanTeamMembersRights
+    /// </summary>
+    public sealed class AssignLoanTeamMembersRights : DirtyExtensibleObject
+    {
+        private DirtyDictionary<string, bool> _freeRoles;
+        private DirtyDictionary<string, bool> _milestones;
+
+        /// <summary>
+        /// AssignLoanTeamMembersRights FreeRoles
+        /// </summary>
+        public IDictionary<string, bool> FreeRoles { get => GetField(ref _freeRoles); set => SetField(ref _freeRoles, value); }
+
+        /// <summary>
+        /// AssignLoanTeamMembersRights Milestones
+        /// </summary>
+        public IDictionary<string, bool> Milestones { get => GetField(ref _milestones); set => SetField(ref _milestones, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/AttachmentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/AttachmentsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// AttachmentsRights
+    /// </summary>
+    public sealed class AttachmentsRights : ParentAccessRights
+    {
+        private EditAttachmentsRights _editAttachments;
+
+        /// <summary>
+        /// AttachmentsRights EditAttachments
+        /// </summary>
+        public EditAttachmentsRights EditAttachments { get => GetField(ref _editAttachments); set => SetField(ref _editAttachments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/BasicInfoRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/BasicInfoRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// BasicInfoRights
+    /// </summary>
+    public sealed class BasicInfoRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editBasicInformation;
+
+        /// <summary>
+        /// BasicInfoRights EditBasicInformation
+        /// </summary>
+        public bool? EditBasicInformation { get => _editBasicInformation; set => SetField(ref _editBasicInformation, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/BorrowerContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/BorrowerContactsRights.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// BorrowerContactsRights
+    /// </summary>
+    public sealed class BorrowerContactsRights : ContactsClassRights
+    {
+        private OriginateLoanOrderCreditProductPricingRights _originateLoanOrderCreditProductPricing;
+        private DirtyValue<bool?> _reassignContacts;
+
+        /// <summary>
+        /// BorrowerContactsRights OriginateLoanOrderCreditProductPricing
+        /// </summary>
+        [JsonProperty("originateLoan/OrderCredit/ProductPricing")]
+        public OriginateLoanOrderCreditProductPricingRights OriginateLoanOrderCreditProductPricing { get => GetField(ref _originateLoanOrderCreditProductPricing); set => SetField(ref _originateLoanOrderCreditProductPricing, value); }
+
+        /// <summary>
+        /// BorrowerContactsRights ReassignContacts
+        /// </summary>
+        public bool? ReassignContacts { get => _reassignContacts; set => SetField(ref _reassignContacts, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/BusinessContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/BusinessContactsRights.cs
@@ -1,0 +1,9 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// BusinessContactsRights
+    /// </summary>
+    public sealed class BusinessContactsRights : ContactsClassRights
+    {
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/BusinessRulesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/BusinessRulesRights.cs
@@ -1,0 +1,111 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// BusinessRulesRights
+    /// </summary>
+    public sealed class BusinessRulesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _appraisalOrderManagement;
+        private DirtyValue<bool?> _automatedConditions;
+        private DirtyValue<bool?> _automatedPurchaseConditions;
+        private DirtyValue<bool?> _collateralTracking;
+        private DirtyValue<bool?> _fieldDataEntry;
+        private DirtyValue<bool?> _fieldTriggers;
+        private DirtyValue<bool?> _inputFormList;
+        private DirtyValue<bool?> _loanActionCompletion;
+        private DirtyValue<bool?> _loanFolderBusinessRule;
+        private DirtyValue<bool?> _loanFormPrinting;
+        private DirtyValue<bool?> _lOCompensationRule;
+        private DirtyValue<bool?> _milestoneCompletion;
+        private DirtyValue<bool?> _personaAccesstoFields;
+        private DirtyValue<bool?> _personaAccesstoLoanActions;
+        private DirtyValue<bool?> _personaAccesstoLoans;
+        private DirtyValue<bool?> _printAutoSelection;
+        private DirtyValue<bool?> _roleAccesstoDocuments;
+
+        /// <summary>
+        /// BusinessRulesRights AppraisalOrderManagement
+        /// </summary>
+        public bool? AppraisalOrderManagement { get => _appraisalOrderManagement; set => SetField(ref _appraisalOrderManagement, value); }
+
+        /// <summary>
+        /// BusinessRulesRights AutomatedConditions
+        /// </summary>
+        public bool? AutomatedConditions { get => _automatedConditions; set => SetField(ref _automatedConditions, value); }
+
+        /// <summary>
+        /// BusinessRulesRights AutomatedPurchaseConditions
+        /// </summary>
+        public bool? AutomatedPurchaseConditions { get => _automatedPurchaseConditions; set => SetField(ref _automatedPurchaseConditions, value); }
+
+        /// <summary>
+        /// BusinessRulesRights CollateralTracking
+        /// </summary>
+        public bool? CollateralTracking { get => _collateralTracking; set => SetField(ref _collateralTracking, value); }
+
+        /// <summary>
+        /// BusinessRulesRights FieldDataEntry
+        /// </summary>
+        public bool? FieldDataEntry { get => _fieldDataEntry; set => SetField(ref _fieldDataEntry, value); }
+
+        /// <summary>
+        /// BusinessRulesRights FieldTriggers
+        /// </summary>
+        public bool? FieldTriggers { get => _fieldTriggers; set => SetField(ref _fieldTriggers, value); }
+
+        /// <summary>
+        /// BusinessRulesRights InputFormList
+        /// </summary>
+        public bool? InputFormList { get => _inputFormList; set => SetField(ref _inputFormList, value); }
+
+        /// <summary>
+        /// BusinessRulesRights LoanActionCompletion
+        /// </summary>
+        public bool? LoanActionCompletion { get => _loanActionCompletion; set => SetField(ref _loanActionCompletion, value); }
+
+        /// <summary>
+        /// BusinessRulesRights LoanFolderBusinessRule
+        /// </summary>
+        public bool? LoanFolderBusinessRule { get => _loanFolderBusinessRule; set => SetField(ref _loanFolderBusinessRule, value); }
+
+        /// <summary>
+        /// BusinessRulesRights LoanFormPrinting
+        /// </summary>
+        public bool? LoanFormPrinting { get => _loanFormPrinting; set => SetField(ref _loanFormPrinting, value); }
+
+        /// <summary>
+        /// BusinessRulesRights LOCompensationRule
+        /// </summary>
+        public bool? LOCompensationRule { get => _lOCompensationRule; set => SetField(ref _lOCompensationRule, value); }
+
+        /// <summary>
+        /// BusinessRulesRights MilestoneCompletion
+        /// </summary>
+        public bool? MilestoneCompletion { get => _milestoneCompletion; set => SetField(ref _milestoneCompletion, value); }
+
+        /// <summary>
+        /// BusinessRulesRights PersonaAccesstoFields
+        /// </summary>
+        public bool? PersonaAccesstoFields { get => _personaAccesstoFields; set => SetField(ref _personaAccesstoFields, value); }
+
+        /// <summary>
+        /// BusinessRulesRights PersonaAccesstoLoanActions
+        /// </summary>
+        public bool? PersonaAccesstoLoanActions { get => _personaAccesstoLoanActions; set => SetField(ref _personaAccesstoLoanActions, value); }
+
+        /// <summary>
+        /// BusinessRulesRights PersonaAccesstoLoans
+        /// </summary>
+        public bool? PersonaAccesstoLoans { get => _personaAccesstoLoans; set => SetField(ref _personaAccesstoLoans, value); }
+
+        /// <summary>
+        /// BusinessRulesRights PrintAutoSelection
+        /// </summary>
+        public bool? PrintAutoSelection { get => _printAutoSelection; set => SetField(ref _printAutoSelection, value); }
+
+        /// <summary>
+        /// BusinessRulesRights RoleAccesstoDocuments
+        /// </summary>
+        public bool? RoleAccesstoDocuments { get => _roleAccesstoDocuments; set => SetField(ref _roleAccesstoDocuments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CampaignManagementRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CampaignManagementRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CampaignManagementRights
+    /// </summary>
+    public sealed class CampaignManagementRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _assignTasksToOthers;
+        private DirtyValue<bool?> _managePersonalCampaignTemplates;
+
+        /// <summary>
+        /// CampaignManagementRights AssignTasksToOthers
+        /// </summary>
+        public bool? AssignTasksToOthers { get => _assignTasksToOthers; set => SetField(ref _assignTasksToOthers, value); }
+
+        /// <summary>
+        /// CampaignManagementRights ManagePersonalCampaignTemplates
+        /// </summary>
+        public bool? ManagePersonalCampaignTemplates { get => _managePersonalCampaignTemplates; set => SetField(ref _managePersonalCampaignTemplates, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CancelSettingReportsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CancelSettingReportsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CancelSettingReportsRights
+    /// </summary>
+    public sealed class CancelSettingReportsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _cancelSettingsReportsSubmittedByOthers;
+
+        /// <summary>
+        /// CancelSettingReportsRights CancelSettingsReportsSubmittedByOthers
+        /// </summary>
+        public bool? CancelSettingsReportsSubmittedByOthers { get => _cancelSettingsReportsSubmittedByOthers; set => SetField(ref _cancelSettingsReportsSubmittedByOthers, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ChangeDisclosureInformationRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ChangeDisclosureInformationRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ChangeDisclosureInformationRights
+    /// </summary>
+    public sealed class ChangeDisclosureInformationRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _changeReasons;
+
+        /// <summary>
+        /// ChangeDisclosureInformationRights ChangeReasons
+        /// </summary>
+        public bool? ChangeReasons { get => _changeReasons; set => SetField(ref _changeReasons, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ClosingDocsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ClosingDocsRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ClosingDocsRights
+    /// </summary>
+    public sealed class ClosingDocsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _manageAltLenders;
+        private OrderClosingDocsRights _orderClosingDocs;
+        private ViewClosingDocumentDataRights _viewClosingDocumentData;
+
+        /// <summary>
+        /// ClosingDocsRights ManageAltLenders
+        /// </summary>
+        public bool? ManageAltLenders { get => _manageAltLenders; set => SetField(ref _manageAltLenders, value); }
+
+        /// <summary>
+        /// ClosingDocsRights OrderClosingDocs
+        /// </summary>
+        public OrderClosingDocsRights OrderClosingDocs { get => GetField(ref _orderClosingDocs); set => SetField(ref _orderClosingDocs, value); }
+
+        /// <summary>
+        /// ClosingDocsRights ViewClosingDocumentData
+        /// </summary>
+        public ViewClosingDocumentDataRights ViewClosingDocumentData { get => GetField(ref _viewClosingDocumentData); set => SetField(ref _viewClosingDocumentData, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CommitmentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CommitmentsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CommitmentsRights
+    /// </summary>
+    public sealed class CommitmentsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editCommitments;
+
+        /// <summary>
+        /// CommitmentsRights EditCommitments
+        /// </summary>
+        public bool? EditCommitments { get => _editCommitments; set => SetField(ref _editCommitments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CompanyDetailsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CompanyDetailsRights.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CompanyDetailsRights
+    /// </summary>
+    public sealed class CompanyDetailsRights : ParentAccessRights
+    {
+        private CreateEditBanksRights _createEditBanks;
+        private DirtyValue<bool?> _createOrganizations;
+        private DirtyValue<bool?> _deleteOrganizations;
+        private DirtyValue<bool?> _exportOrganizations;
+        private TPOContactsRights _tPOContacts;
+        private TPOOrganizationSettingsRights _tPOOrganizationSettings;
+
+        /// <summary>
+        /// CompanyDetailsRights CreateEditBanks
+        /// </summary>
+        [JsonProperty("create/EditBanks")]
+        public CreateEditBanksRights CreateEditBanks { get => GetField(ref _createEditBanks); set => SetField(ref _createEditBanks, value); }
+
+        /// <summary>
+        /// CompanyDetailsRights CreateOrganizations
+        /// </summary>
+        public bool? CreateOrganizations { get => _createOrganizations; set => SetField(ref _createOrganizations, value); }
+
+        /// <summary>
+        /// CompanyDetailsRights DeleteOrganizations
+        /// </summary>
+        public bool? DeleteOrganizations { get => _deleteOrganizations; set => SetField(ref _deleteOrganizations, value); }
+
+        /// <summary>
+        /// CompanyDetailsRights ExportOrganizations
+        /// </summary>
+        public bool? ExportOrganizations { get => _exportOrganizations; set => SetField(ref _exportOrganizations, value); }
+
+        /// <summary>
+        /// CompanyDetailsRights TPOContacts
+        /// </summary>
+        public TPOContactsRights TPOContacts { get => GetField(ref _tPOContacts); set => SetField(ref _tPOContacts, value); }
+
+        /// <summary>
+        /// CompanyDetailsRights TPOOrganizationSettings
+        /// </summary>
+        public TPOOrganizationSettingsRights TPOOrganizationSettings { get => GetField(ref _tPOOrganizationSettings); set => SetField(ref _tPOOrganizationSettings, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CompanySettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CompanySettingsRights.cs
@@ -1,0 +1,96 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CompanySettingsRights
+    /// </summary>
+    public sealed class CompanySettingsRights : DirtyExtensibleObject
+    {
+        private AdditionalServicesRights _additionalServices;
+        private DirtyValue<bool?> _automatedRequestForEConsent;
+        private BusinessRulesRights _businessRules;
+        private CompanyUserSetupRights _companyUserSetup;
+        private ContactSetupRights _contactSetup;
+        private DocsSetupRights _docsSetup;
+        private DynamicDataManagementRights _dynamicDataManagement;
+        private EFolderSetupRights _eFolderSetup;
+        private DirtyValue<bool?> _feeGroups;
+        private LoanSetupRights _loanSetup;
+        private PersonalTemplatesRights _personalTemplates;
+        private SecondarySetupRights _secondarySetup;
+        private SystemAdministrationRights _systemAdministration;
+        private TablesAndFeesRights _tablesAndFees;
+
+        /// <summary>
+        /// CompanySettingsRights AdditionalServices
+        /// </summary>
+        public AdditionalServicesRights AdditionalServices { get => GetField(ref _additionalServices); set => SetField(ref _additionalServices, value); }
+
+        /// <summary>
+        /// CompanySettingsRights AutomatedRequestForEConsent
+        /// </summary>
+        public bool? AutomatedRequestForEConsent { get => _automatedRequestForEConsent; set => SetField(ref _automatedRequestForEConsent, value); }
+
+        /// <summary>
+        /// CompanySettingsRights BusinessRules
+        /// </summary>
+        public BusinessRulesRights BusinessRules { get => GetField(ref _businessRules); set => SetField(ref _businessRules, value); }
+
+        /// <summary>
+        /// CompanySettingsRights CompanyUserSetup
+        /// </summary>
+        [JsonProperty("company/UserSetup")]
+        public CompanyUserSetupRights CompanyUserSetup { get => GetField(ref _companyUserSetup); set => SetField(ref _companyUserSetup, value); }
+
+        /// <summary>
+        /// CompanySettingsRights ContactSetup
+        /// </summary>
+        public ContactSetupRights ContactSetup { get => GetField(ref _contactSetup); set => SetField(ref _contactSetup, value); }
+
+        /// <summary>
+        /// CompanySettingsRights DocsSetup
+        /// </summary>
+        public DocsSetupRights DocsSetup { get => GetField(ref _docsSetup); set => SetField(ref _docsSetup, value); }
+
+        /// <summary>
+        /// CompanySettingsRights DynamicDataManagement
+        /// </summary>
+        public DynamicDataManagementRights DynamicDataManagement { get => GetField(ref _dynamicDataManagement); set => SetField(ref _dynamicDataManagement, value); }
+
+        /// <summary>
+        /// CompanySettingsRights EFolderSetup
+        /// </summary>
+        public EFolderSetupRights EFolderSetup { get => GetField(ref _eFolderSetup); set => SetField(ref _eFolderSetup, value); }
+
+        /// <summary>
+        /// CompanySettingsRights FeeGroups
+        /// </summary>
+        public bool? FeeGroups { get => _feeGroups; set => SetField(ref _feeGroups, value); }
+
+        /// <summary>
+        /// CompanySettingsRights LoanSetup
+        /// </summary>
+        public LoanSetupRights LoanSetup { get => GetField(ref _loanSetup); set => SetField(ref _loanSetup, value); }
+
+        /// <summary>
+        /// CompanySettingsRights PersonalTemplates
+        /// </summary>
+        public PersonalTemplatesRights PersonalTemplates { get => GetField(ref _personalTemplates); set => SetField(ref _personalTemplates, value); }
+
+        /// <summary>
+        /// CompanySettingsRights SecondarySetup
+        /// </summary>
+        public SecondarySetupRights SecondarySetup { get => GetField(ref _secondarySetup); set => SetField(ref _secondarySetup, value); }
+
+        /// <summary>
+        /// CompanySettingsRights SystemAdministration
+        /// </summary>
+        public SystemAdministrationRights SystemAdministration { get => GetField(ref _systemAdministration); set => SetField(ref _systemAdministration, value); }
+
+        /// <summary>
+        /// CompanySettingsRights TablesAndFees
+        /// </summary>
+        public TablesAndFeesRights TablesAndFees { get => GetField(ref _tablesAndFees); set => SetField(ref _tablesAndFees, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CompanyUserSetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CompanyUserSetupRights.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CompanyUserSetupRights
+    /// </summary>
+    public sealed class CompanyUserSetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _companyInformation;
+        private DirtyValue<bool?> _ellieMaeNetworkCompany;
+        private DirtyValue<bool?> _milestones;
+        private OrganizationsUserRights _organizationsUser;
+        private PersonasRights _personas;
+        private DirtyValue<bool?> _roles;
+        private DirtyValue<bool?> _servicesPasswordManager;
+        private DirtyValue<bool?> _userGroups;
+
+        /// <summary>
+        /// CompanyUserSetupRights CompanyInformation
+        /// </summary>
+        public bool? CompanyInformation { get => _companyInformation; set => SetField(ref _companyInformation, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights EllieMaeNetworkCompany
+        /// </summary>
+        [JsonProperty("ellie MaeNetworkCompany")]
+        public bool? EllieMaeNetworkCompany { get => _ellieMaeNetworkCompany; set => SetField(ref _ellieMaeNetworkCompany, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights Milestones
+        /// </summary>
+        public bool? Milestones { get => _milestones; set => SetField(ref _milestones, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights OrganizationsUser
+        /// </summary>
+        [JsonProperty("organizations/User")]
+        public OrganizationsUserRights OrganizationsUser { get => GetField(ref _organizationsUser); set => SetField(ref _organizationsUser, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights Personas
+        /// </summary>
+        public PersonasRights Personas { get => GetField(ref _personas); set => SetField(ref _personas, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights Roles
+        /// </summary>
+        public bool? Roles { get => _roles; set => SetField(ref _roles, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights ServicesPasswordManager
+        /// </summary>
+        public bool? ServicesPasswordManager { get => _servicesPasswordManager; set => SetField(ref _servicesPasswordManager, value); }
+
+        /// <summary>
+        /// CompanyUserSetupRights UserGroups
+        /// </summary>
+        public bool? UserGroups { get => _userGroups; set => SetField(ref _userGroups, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ConsumerConnectRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ConsumerConnectRights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ConsumerConnectRights
+    /// </summary>
+    public sealed class ConsumerConnectRights : DirtyExtensibleObject
+    {
+        private ConsumerConnectWebsiteBuilderSettingsRights _cosumerConnectWebsiteBuilderSettings;
+
+        /// <summary>
+        /// ConsumerConnectRights ConsumerConnectWebsiteBuilderSettings
+        /// </summary>
+        [JsonProperty("cosumerConnectWebsiteBuilderSettings")]
+        public ConsumerConnectWebsiteBuilderSettingsRights ConsumerConnectWebsiteBuilderSettings { get => GetField(ref _cosumerConnectWebsiteBuilderSettings); set => SetField(ref _cosumerConnectWebsiteBuilderSettings, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ConsumerConnectWebsiteBuilderSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ConsumerConnectWebsiteBuilderSettingsRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ConsumerConnectWebsiteBuilderSettingsRights
+    /// </summary>
+    public sealed class ConsumerConnectWebsiteBuilderSettingsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _webAdmin;
+        private DirtyValue<bool?> _webContent;
+
+        /// <summary>
+        /// ConsumerConnectWebsiteBuilderSettingsRights WebAdmin
+        /// </summary>
+        public bool? WebAdmin { get => _webAdmin; set => SetField(ref _webAdmin, value); }
+
+        /// <summary>
+        /// ConsumerConnectWebsiteBuilderSettingsRights WebContent
+        /// </summary>
+        public bool? WebContent { get => _webContent; set => SetField(ref _webContent, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ContactSetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ContactSetupRights.cs
@@ -1,0 +1,51 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ContactSetupRights
+    /// </summary>
+    public sealed class ContactSetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _borrowerContactStatus;
+        private DirtyValue<bool?> _borrowerCustomFields;
+        private DirtyValue<bool?> _borrwerContactUpdate;
+        private DirtyValue<bool?> _businessCategories;
+        private DirtyValue<bool?> _businessCustomFields;
+        private DirtyValue<bool?> _emailServerSettings;
+        private DirtyValue<bool?> _publicBusinessContactGroups;
+
+        /// <summary>
+        /// ContactSetupRights BorrowerContactStatus
+        /// </summary>
+        public bool? BorrowerContactStatus { get => _borrowerContactStatus; set => SetField(ref _borrowerContactStatus, value); }
+
+        /// <summary>
+        /// ContactSetupRights BorrowerCustomFields
+        /// </summary>
+        public bool? BorrowerCustomFields { get => _borrowerCustomFields; set => SetField(ref _borrowerCustomFields, value); }
+
+        /// <summary>
+        /// ContactSetupRights BorrwerContactUpdate
+        /// </summary>
+        public bool? BorrwerContactUpdate { get => _borrwerContactUpdate; set => SetField(ref _borrwerContactUpdate, value); }
+
+        /// <summary>
+        /// ContactSetupRights BusinessCategories
+        /// </summary>
+        public bool? BusinessCategories { get => _businessCategories; set => SetField(ref _businessCategories, value); }
+
+        /// <summary>
+        /// ContactSetupRights BusinessCustomFields
+        /// </summary>
+        public bool? BusinessCustomFields { get => _businessCustomFields; set => SetField(ref _businessCustomFields, value); }
+
+        /// <summary>
+        /// ContactSetupRights EmailServerSettings
+        /// </summary>
+        public bool? EmailServerSettings { get => _emailServerSettings; set => SetField(ref _emailServerSettings, value); }
+
+        /// <summary>
+        /// ContactSetupRights PublicBusinessContactGroups
+        /// </summary>
+        public bool? PublicBusinessContactGroups { get => _publicBusinessContactGroups; set => SetField(ref _publicBusinessContactGroups, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ContactsClassRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ContactsClassRights.cs
@@ -1,0 +1,67 @@
+﻿namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ContactsClassRights
+    /// </summary>
+    public abstract class ContactsClassRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _accessToLoanstab;
+        private DirtyValue<bool?> _createNewContacts;
+        private DirtyValue<bool?> _deleteContacts;
+        private DirtyValue<bool?> _duplicateContacts;
+        private DirtyValue<bool?> _exportContacts;
+        private DirtyValue<bool?> _importContacts;
+        private DirtyValue<bool?> _mailMerge;
+        private DirtyValue<bool?> _managePersonalCustomLetter;
+        private DirtyValue<bool?> _print;
+
+        /// <summary>
+        /// ContactsClassRights AccessToLoanstab
+        /// </summary>
+        public bool? AccessToLoanstab { get => _accessToLoanstab; set => SetField(ref _accessToLoanstab, value); }
+
+        /// <summary>
+        /// ContactsClassRights CreateNewContacts
+        /// </summary>
+        public bool? CreateNewContacts { get => _createNewContacts; set => SetField(ref _createNewContacts, value); }
+
+        /// <summary>
+        /// ContactsClassRights DeleteContacts
+        /// </summary>
+        public bool? DeleteContacts { get => _deleteContacts; set => SetField(ref _deleteContacts, value); }
+
+        /// <summary>
+        /// ContactsClassRights DuplicateContacts
+        /// </summary>
+        public bool? DuplicateContacts { get => _duplicateContacts; set => SetField(ref _duplicateContacts, value); }
+
+        /// <summary>
+        /// ContactsClassRights ExportContacts
+        /// </summary>
+        public bool? ExportContacts { get => _exportContacts; set => SetField(ref _exportContacts, value); }
+
+        /// <summary>
+        /// ContactsClassRights ImportContacts
+        /// </summary>
+        public bool? ImportContacts { get => _importContacts; set => SetField(ref _importContacts, value); }
+
+        /// <summary>
+        /// ContactsClassRights MailMerge
+        /// </summary>
+        public bool? MailMerge { get => _mailMerge; set => SetField(ref _mailMerge, value); }
+
+        /// <summary>
+        /// ContactsClassRights ManagePersonalCustomLetter
+        /// </summary>
+        public bool? ManagePersonalCustomLetter { get => _managePersonalCustomLetter; set => SetField(ref _managePersonalCustomLetter, value); }
+
+        /// <summary>
+        /// ContactsClassRights Print
+        /// </summary>
+        public bool? Print { get => _print; set => SetField(ref _print, value); }
+
+        internal ContactsClassRights()
+        {
+        }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ContactsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ContactsRights
+    /// </summary>
+    public sealed class ContactsRights : DirtyExtensibleObject
+    {
+        private AccessToContactsTabRights _accessToContactsTab;
+
+        /// <summary>
+        /// ContactsRights AccessToContactsTab
+        /// </summary>
+        public AccessToContactsTabRights AccessToContactsTab { get => GetField(ref _accessToContactsTab); set => SetField(ref _accessToContactsTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CreateEditBanksRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CreateEditBanksRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CreateEditBanksRights
+    /// </summary>
+    public sealed class CreateEditBanksRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteBanks;
+
+        /// <summary>
+        /// CreateEditBanksRights DeleteBanks
+        /// </summary>
+        public bool? DeleteBanks { get => _deleteBanks; set => SetField(ref _deleteBanks, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CreateManualEntryRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CreateManualEntryRights.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CreateManualEntryRights
+    /// </summary>
+    public sealed class CreateManualEntryRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _cD;
+        private DirtyValue<bool?> _lESSPLSafeHarbor;
+
+        /// <summary>
+        /// CreateManualEntryRights CD
+        /// </summary>
+        public bool? CD { get => _cD; set => SetField(ref _cD, value); }
+
+        /// <summary>
+        /// CreateManualEntryRights LESSPLSafeHarbor
+        /// </summary>
+        [JsonProperty("lE/SSPL/SafeHarbor")]
+        public bool? LESSPLSafeHarbor { get => _lESSPLSafeHarbor; set => SetField(ref _lESSPLSafeHarbor, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CurrentLoginsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CurrentLoginsRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CurrentLoginsRights
+    /// </summary>
+    public sealed class CurrentLoginsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _disableLogins;
+        private DirtyValue<bool?> _logUsersOut;
+
+        /// <summary>
+        /// CurrentLoginsRights DisableLogins
+        /// </summary>
+        public bool? DisableLogins { get => _disableLogins; set => SetField(ref _disableLogins, value); }
+
+        /// <summary>
+        /// CurrentLoginsRights LogUsersOut
+        /// </summary>
+        public bool? LogUsersOut { get => _logUsersOut; set => SetField(ref _logUsersOut, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsRights.cs
@@ -1,0 +1,39 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsRights
+    /// </summary>
+    public sealed class CustomFieldsRights : ParentAccessRights
+    {
+        private CustomFieldsTab1Rights _customFieldsTab1;
+        private CustomFieldsTab2Rights _customFieldsTab2;
+        private CustomFieldsTab3Rights _customFieldsTab3;
+        private CustomFieldsTab4Rights _customFieldsTab4;
+        private CustomFieldsTab5Rights _customFieldsTab5;
+
+        /// <summary>
+        /// CustomFieldsRights CustomFieldsTab1
+        /// </summary>
+        public CustomFieldsTab1Rights CustomFieldsTab1 { get => GetField(ref _customFieldsTab1); set => SetField(ref _customFieldsTab1, value); }
+
+        /// <summary>
+        /// CustomFieldsRights CustomFieldsTab2
+        /// </summary>
+        public CustomFieldsTab2Rights CustomFieldsTab2 { get => GetField(ref _customFieldsTab2); set => SetField(ref _customFieldsTab2, value); }
+
+        /// <summary>
+        /// CustomFieldsRights CustomFieldsTab3
+        /// </summary>
+        public CustomFieldsTab3Rights CustomFieldsTab3 { get => GetField(ref _customFieldsTab3); set => SetField(ref _customFieldsTab3, value); }
+
+        /// <summary>
+        /// CustomFieldsRights CustomFieldsTab4
+        /// </summary>
+        public CustomFieldsTab4Rights CustomFieldsTab4 { get => GetField(ref _customFieldsTab4); set => SetField(ref _customFieldsTab4, value); }
+
+        /// <summary>
+        /// CustomFieldsRights CustomFieldsTab5
+        /// </summary>
+        public CustomFieldsTab5Rights CustomFieldsTab5 { get => GetField(ref _customFieldsTab5); set => SetField(ref _customFieldsTab5, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsTab1Rights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsTab1Rights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsTab1Rights
+    /// </summary>
+    public sealed class CustomFieldsTab1Rights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTab1CustomFields;
+
+        /// <summary>
+        /// CustomFieldsTab1Rights EditTab1CustomFields
+        /// </summary>
+        public bool? EditTab1CustomFields { get => _editTab1CustomFields; set => SetField(ref _editTab1CustomFields, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsTab2Rights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsTab2Rights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsTab2Rights
+    /// </summary>
+    public sealed class CustomFieldsTab2Rights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTab2CustomFields;
+
+        /// <summary>
+        /// CustomFieldsTab2Rights EditTab2CustomFields
+        /// </summary>
+        public bool? EditTab2CustomFields { get => _editTab2CustomFields; set => SetField(ref _editTab2CustomFields, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsTab3Rights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsTab3Rights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsTab3Rights
+    /// </summary>
+    public sealed class CustomFieldsTab3Rights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTab3CustomFields;
+
+        /// <summary>
+        /// CustomFieldsTab3Rights EditTab3CustomFields
+        /// </summary>
+        public bool? EditTab3CustomFields { get => _editTab3CustomFields; set => SetField(ref _editTab3CustomFields, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsTab4Rights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsTab4Rights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsTab4Rights
+    /// </summary>
+    public sealed class CustomFieldsTab4Rights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTab4CustomFields;
+
+        /// <summary>
+        /// CustomFieldsTab4Rights EditTab4CustomFields
+        /// </summary>
+        public bool? EditTab4CustomFields { get => _editTab4CustomFields; set => SetField(ref _editTab4CustomFields, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsTab5Rights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsTab5Rights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsTab5Rights
+    /// </summary>
+    public sealed class CustomFieldsTab5Rights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTab5CustomFields;
+
+        /// <summary>
+        /// CustomFieldsTab5Rights EditTab5CustomFields
+        /// </summary>
+        public bool? EditTab5CustomFields { get => _editTab5CustomFields; set => SetField(ref _editTab5CustomFields, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/CustomFieldsTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/CustomFieldsTabRights.cs
@@ -1,0 +1,39 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// CustomFieldsTabRights
+    /// </summary>
+    public sealed class CustomFieldsTabRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _customFieldsTab1;
+        private DirtyValue<bool?> _customFieldsTab2;
+        private DirtyValue<bool?> _customFieldsTab3;
+        private DirtyValue<bool?> _customFieldsTab4;
+        private DirtyValue<bool?> _customFieldsTab5;
+
+        /// <summary>
+        /// CustomFieldsTabRights CustomFieldsTab1
+        /// </summary>
+        public bool? CustomFieldsTab1 { get => _customFieldsTab1; set => SetField(ref _customFieldsTab1, value); }
+
+        /// <summary>
+        /// CustomFieldsTabRights CustomFieldsTab2
+        /// </summary>
+        public bool? CustomFieldsTab2 { get => _customFieldsTab2; set => SetField(ref _customFieldsTab2, value); }
+
+        /// <summary>
+        /// CustomFieldsTabRights CustomFieldsTab3
+        /// </summary>
+        public bool? CustomFieldsTab3 { get => _customFieldsTab3; set => SetField(ref _customFieldsTab3, value); }
+
+        /// <summary>
+        /// CustomFieldsTabRights CustomFieldsTab4
+        /// </summary>
+        public bool? CustomFieldsTab4 { get => _customFieldsTab4; set => SetField(ref _customFieldsTab4, value); }
+
+        /// <summary>
+        /// CustomFieldsTabRights CustomFieldsTab5
+        /// </summary>
+        public bool? CustomFieldsTab5 { get => _customFieldsTab5; set => SetField(ref _customFieldsTab5, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DBARights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DBARights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DBARights
+    /// </summary>
+    public sealed class DBARights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editDBA;
+
+        /// <summary>
+        /// DBARights EditDBA
+        /// </summary>
+        public bool? EditDBA { get => _editDBA; set => SetField(ref _editDBA, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DashboardRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DashboardRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DashboardRights
+    /// </summary>
+    public sealed class DashboardRights : DirtyExtensibleObject
+    {
+        private AccessToDashboardTabRights _accessToDashboardTab;
+
+        /// <summary>
+        /// DashboardRights AccessToDashboardTab
+        /// </summary>
+        public AccessToDashboardTabRights AccessToDashboardTab { get => GetField(ref _accessToDashboardTab); set => SetField(ref _accessToDashboardTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DeleteNotesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DeleteNotesRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DeleteNotesRights
+    /// </summary>
+    public sealed class DeleteNotesRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _deleteFilePermanently;
+
+        /// <summary>
+        /// DeleteNotesRights DeleteFilePermanently
+        /// </summary>
+        public bool? DeleteFilePermanently { get => _deleteFilePermanently; set => SetField(ref _deleteFilePermanently, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DisclosureTrackingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DisclosureTrackingRights.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DisclosureTrackingRights
+    /// </summary>
+    public sealed class DisclosureTrackingRights : ParentAccessRights
+    {
+        private ChangeDisclosureInformationRights _changeDisclosureInformation;
+        private CreateManualEntryRights _createManualEntry;
+        private DirtyValue<bool?> _excludeIncludeRecords;
+        private DirtyValue<bool?> _manuallyFulfill;
+
+        /// <summary>
+        /// DisclosureTrackingRights ChangeDisclosureInformation
+        /// </summary>
+        public ChangeDisclosureInformationRights ChangeDisclosureInformation { get => GetField(ref _changeDisclosureInformation); set => SetField(ref _changeDisclosureInformation, value); }
+
+        /// <summary>
+        /// DisclosureTrackingRights CreateManualEntry
+        /// </summary>
+        public CreateManualEntryRights CreateManualEntry { get => GetField(ref _createManualEntry); set => SetField(ref _createManualEntry, value); }
+
+        /// <summary>
+        /// DisclosureTrackingRights ExcludeIncludeRecords
+        /// </summary>
+        [JsonProperty("exclude/IncludeRecords")]
+        public bool? ExcludeIncludeRecords { get => _excludeIncludeRecords; set => SetField(ref _excludeIncludeRecords, value); }
+
+        /// <summary>
+        /// DisclosureTrackingRights ManuallyFulfill
+        /// </summary>
+        public bool? ManuallyFulfill { get => _manuallyFulfill; set => SetField(ref _manuallyFulfill, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DocsSetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DocsSetupRights.cs
@@ -1,0 +1,45 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DocsSetupRights
+    /// </summary>
+    public sealed class DocsSetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _closingPlanCodes;
+        private DirtyValue<bool?> _closingStackingTemplates;
+        private DirtyValue<bool?> _complianceAuditSettings;
+        private DirtyValue<bool?> _eDisclosurePackages;
+        private DirtyValue<bool?> _eDisclosurePlanCodes;
+        private DirtyValue<bool?> _eDisclosureStackingTemplates;
+
+        /// <summary>
+        /// DocsSetupRights ClosingPlanCodes
+        /// </summary>
+        public bool? ClosingPlanCodes { get => _closingPlanCodes; set => SetField(ref _closingPlanCodes, value); }
+
+        /// <summary>
+        /// DocsSetupRights ClosingStackingTemplates
+        /// </summary>
+        public bool? ClosingStackingTemplates { get => _closingStackingTemplates; set => SetField(ref _closingStackingTemplates, value); }
+
+        /// <summary>
+        /// DocsSetupRights ComplianceAuditSettings
+        /// </summary>
+        public bool? ComplianceAuditSettings { get => _complianceAuditSettings; set => SetField(ref _complianceAuditSettings, value); }
+
+        /// <summary>
+        /// DocsSetupRights EDisclosurePackages
+        /// </summary>
+        public bool? EDisclosurePackages { get => _eDisclosurePackages; set => SetField(ref _eDisclosurePackages, value); }
+
+        /// <summary>
+        /// DocsSetupRights EDisclosurePlanCodes
+        /// </summary>
+        public bool? EDisclosurePlanCodes { get => _eDisclosurePlanCodes; set => SetField(ref _eDisclosurePlanCodes, value); }
+
+        /// <summary>
+        /// DocsSetupRights EDisclosureStackingTemplates
+        /// </summary>
+        public bool? EDisclosureStackingTemplates { get => _eDisclosureStackingTemplates; set => SetField(ref _eDisclosureStackingTemplates, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DuplicateLoansRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DuplicateLoansRights.cs
@@ -1,0 +1,9 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DuplicateLoansRights
+    /// </summary>
+    public sealed class DuplicateLoansRights : ParentAccessRights
+    {
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/DynamicDataManagementRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/DynamicDataManagementRights.cs
@@ -1,0 +1,33 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// DynamicDataManagementRights
+    /// </summary>
+    public sealed class DynamicDataManagementRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _dataTables;
+        private DirtyValue<bool?> _feeRules;
+        private DirtyValue<bool?> _fieldRules;
+        private DirtyValue<bool?> _globalDDMSettings;
+
+        /// <summary>
+        /// DynamicDataManagementRights DataTables
+        /// </summary>
+        public bool? DataTables { get => _dataTables; set => SetField(ref _dataTables, value); }
+
+        /// <summary>
+        /// DynamicDataManagementRights FeeRules
+        /// </summary>
+        public bool? FeeRules { get => _feeRules; set => SetField(ref _feeRules, value); }
+
+        /// <summary>
+        /// DynamicDataManagementRights FieldRules
+        /// </summary>
+        public bool? FieldRules { get => _fieldRules; set => SetField(ref _fieldRules, value); }
+
+        /// <summary>
+        /// DynamicDataManagementRights GlobalDDMSettings
+        /// </summary>
+        public bool? GlobalDDMSettings { get => _globalDDMSettings; set => SetField(ref _globalDDMSettings, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EDisclosuresRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EDisclosuresRights.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EDisclosuresRights
+    /// </summary>
+    public sealed class EDisclosuresRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addAdditionalDocs;
+        private DirtyValue<bool?> _deselectDocs;
+        private DirtyValue<bool?> _moveDocsUpDown;
+
+        /// <summary>
+        /// EDisclosuresRights AddAdditionalDocs
+        /// </summary>
+        public bool? AddAdditionalDocs { get => _addAdditionalDocs; set => SetField(ref _addAdditionalDocs, value); }
+
+        /// <summary>
+        /// EDisclosuresRights DeselectDocs
+        /// </summary>
+        public bool? DeselectDocs { get => _deselectDocs; set => SetField(ref _deselectDocs, value); }
+
+        /// <summary>
+        /// EDisclosuresRights MoveDocsUpDown
+        /// </summary>
+        [JsonProperty("moveDocsUp/Down")]
+        public bool? MoveDocsUpDown { get => _moveDocsUpDown; set => SetField(ref _moveDocsUpDown, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EFolderOtherRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EFolderOtherRights.cs
@@ -1,0 +1,84 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OtherRights
+    /// </summary>
+    public sealed class EFolderOtherRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _archiveDocuments;
+        private DirtyValue<bool?> _createDuplicateDocuments;
+        private EDisclosuresRights _eDisclosures;
+        private ManageAccessToDocumentsRights _manageAccessToDocuments;
+        private DirtyValue<bool?> _requestBorrowerDocuments;
+        private DirtyValue<bool?> _requestEllieMaeNetworkServices;
+        private DirtyValue<bool?> _retrieveBorrowerDocuments;
+        private DirtyValue<bool?> _retrieveEllieMaeNetworkServices;
+        private DirtyValue<bool?> _sendConsent;
+        private DirtyValue<bool?> _sendFiles;
+        private DirtyValue<bool?> _sendFilestoLender;
+        private DirtyValue<bool?> _viewAllAnnotations;
+
+        /// <summary>
+        /// OtherRights ArchiveDocuments
+        /// </summary>
+        public bool? ArchiveDocuments { get => _archiveDocuments; set => SetField(ref _archiveDocuments, value); }
+
+        /// <summary>
+        /// OtherRights CreateDuplicateDocuments
+        /// </summary>
+        [JsonProperty("create/DuplicateDocuments")]
+        public bool? CreateDuplicateDocuments { get => _createDuplicateDocuments; set => SetField(ref _createDuplicateDocuments, value); }
+
+        /// <summary>
+        /// OtherRights EDisclosures
+        /// </summary>
+        public EDisclosuresRights EDisclosures { get => GetField(ref _eDisclosures); set => SetField(ref _eDisclosures, value); }
+
+        /// <summary>
+        /// OtherRights ManageAccessToDocuments
+        /// </summary>
+        public ManageAccessToDocumentsRights ManageAccessToDocuments { get => GetField(ref _manageAccessToDocuments); set => SetField(ref _manageAccessToDocuments, value); }
+
+        /// <summary>
+        /// OtherRights RequestBorrowerDocuments
+        /// </summary>
+        public bool? RequestBorrowerDocuments { get => _requestBorrowerDocuments; set => SetField(ref _requestBorrowerDocuments, value); }
+
+        /// <summary>
+        /// OtherRights RequestEllieMaeNetworkServices
+        /// </summary>
+        public bool? RequestEllieMaeNetworkServices { get => _requestEllieMaeNetworkServices; set => SetField(ref _requestEllieMaeNetworkServices, value); }
+
+        /// <summary>
+        /// OtherRights RetrieveBorrowerDocuments
+        /// </summary>
+        public bool? RetrieveBorrowerDocuments { get => _retrieveBorrowerDocuments; set => SetField(ref _retrieveBorrowerDocuments, value); }
+
+        /// <summary>
+        /// OtherRights RetrieveEllieMaeNetworkServices
+        /// </summary>
+        public bool? RetrieveEllieMaeNetworkServices { get => _retrieveEllieMaeNetworkServices; set => SetField(ref _retrieveEllieMaeNetworkServices, value); }
+
+        /// <summary>
+        /// OtherRights SendConsent
+        /// </summary>
+        public bool? SendConsent { get => _sendConsent; set => SetField(ref _sendConsent, value); }
+
+        /// <summary>
+        /// OtherRights SendFiles
+        /// </summary>
+        public bool? SendFiles { get => _sendFiles; set => SetField(ref _sendFiles, value); }
+
+        /// <summary>
+        /// OtherRights SendFilestoLender
+        /// </summary>
+        public bool? SendFilestoLender { get => _sendFilestoLender; set => SetField(ref _sendFilestoLender, value); }
+
+        /// <summary>
+        /// OtherRights ViewAllAnnotations
+        /// </summary>
+        public bool? ViewAllAnnotations { get => _viewAllAnnotations; set => SetField(ref _viewAllAnnotations, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EFolderRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EFolderRights.cs
@@ -1,0 +1,45 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EFolderRights
+    /// </summary>
+    public sealed class EFolderRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _accessToDocumentTab;
+        private UserEFolderRights _eFolder;
+        private EFolderOtherRights _other;
+        private ProtectedDocumentsRights _protectedDocuments;
+        private UnassignedFilesRights _unassignedFiles;
+        private UnprotectedDocumentsRights _unprotectedDocuments;
+
+        /// <summary>
+        /// EFolderRights AccessToDocumentTab
+        /// </summary>
+        public bool? AccessToDocumentTab { get => _accessToDocumentTab; set => SetField(ref _accessToDocumentTab, value); }
+
+        /// <summary>
+        /// EFolderRights EFolder
+        /// </summary>
+        public UserEFolderRights EFolder { get => GetField(ref _eFolder); set => SetField(ref _eFolder, value); }
+
+        /// <summary>
+        /// EFolderRights Other
+        /// </summary>
+        public EFolderOtherRights Other { get => GetField(ref _other); set => SetField(ref _other, value); }
+
+        /// <summary>
+        /// EFolderRights ProtectedDocuments
+        /// </summary>
+        public ProtectedDocumentsRights ProtectedDocuments { get => GetField(ref _protectedDocuments); set => SetField(ref _protectedDocuments, value); }
+
+        /// <summary>
+        /// EFolderRights UnassignedFiles
+        /// </summary>
+        public UnassignedFilesRights UnassignedFiles { get => GetField(ref _unassignedFiles); set => SetField(ref _unassignedFiles, value); }
+
+        /// <summary>
+        /// EFolderRights UnprotectedDocuments
+        /// </summary>
+        public UnprotectedDocumentsRights UnprotectedDocuments { get => GetField(ref _unprotectedDocuments); set => SetField(ref _unprotectedDocuments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EFolderSetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EFolderSetupRights.cs
@@ -1,0 +1,108 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EFolderSetupRights
+    /// </summary>
+    public sealed class EFolderSetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _conditions;
+        private DirtyValue<bool?> _conditionSets;
+        private DirtyValue<bool?> _documentConversion;
+        private DirtyValue<bool?> _documentExportTemplates;
+        private DirtyValue<bool?> _documentGroups;
+        private DirtyValue<bool?> _documentIdentification;
+        private DirtyValue<bool?> _documents;
+        private DirtyValue<bool?> _documentStackingTemplates;
+        private DirtyValue<bool?> _documentTraining;
+        private DirtyValue<bool?> _hTMLEmailTemplates;
+        private DirtyValue<bool?> _postClosingConditionSets;
+        private DirtyValue<bool?> _postClosingConditions;
+        private DirtyValue<bool?> _purchaseConditionOptions;
+        private DirtyValue<bool?> _purchaseConditions;
+        private DirtyValue<bool?> _purchaseConditionSets;
+        private DirtyValue<bool?> _webCenterConfiguration;
+
+        /// <summary>
+        /// EFolderSetupRights Conditions
+        /// </summary>
+        public bool? Conditions { get => _conditions; set => SetField(ref _conditions, value); }
+
+        /// <summary>
+        /// EFolderSetupRights ConditionSets
+        /// </summary>
+        public bool? ConditionSets { get => _conditionSets; set => SetField(ref _conditionSets, value); }
+
+        /// <summary>
+        /// EFolderSetupRights DocumentConversion
+        /// </summary>
+        public bool? DocumentConversion { get => _documentConversion; set => SetField(ref _documentConversion, value); }
+
+        /// <summary>
+        /// EFolderSetupRights DocumentExportTemplates
+        /// </summary>
+        public bool? DocumentExportTemplates { get => _documentExportTemplates; set => SetField(ref _documentExportTemplates, value); }
+
+        /// <summary>
+        /// EFolderSetupRights DocumentGroups
+        /// </summary>
+        public bool? DocumentGroups { get => _documentGroups; set => SetField(ref _documentGroups, value); }
+
+        /// <summary>
+        /// EFolderSetupRights DocumentIdentification
+        /// </summary>
+        public bool? DocumentIdentification { get => _documentIdentification; set => SetField(ref _documentIdentification, value); }
+
+        /// <summary>
+        /// EFolderSetupRights Documents
+        /// </summary>
+        public bool? Documents { get => _documents; set => SetField(ref _documents, value); }
+
+        /// <summary>
+        /// EFolderSetupRights DocumentStackingTemplates
+        /// </summary>
+        public bool? DocumentStackingTemplates { get => _documentStackingTemplates; set => SetField(ref _documentStackingTemplates, value); }
+
+        /// <summary>
+        /// EFolderSetupRights DocumentTraining
+        /// </summary>
+        public bool? DocumentTraining { get => _documentTraining; set => SetField(ref _documentTraining, value); }
+
+        /// <summary>
+        /// EFolderSetupRights HTMLEmailTemplates
+        /// </summary>
+        public bool? HTMLEmailTemplates { get => _hTMLEmailTemplates; set => SetField(ref _hTMLEmailTemplates, value); }
+
+        /// <summary>
+        /// EFolderSetupRights PostClosingConditionSets
+        /// </summary>
+        [JsonProperty("post-ClosingConditionSets")]
+        public bool? PostClosingConditionSets { get => _postClosingConditionSets; set => SetField(ref _postClosingConditionSets, value); }
+
+        /// <summary>
+        /// EFolderSetupRights PostClosingConditions
+        /// </summary>
+        public bool? PostClosingConditions { get => _postClosingConditions; set => SetField(ref _postClosingConditions, value); }
+
+        /// <summary>
+        /// EFolderSetupRights PurchaseConditionOptions
+        /// </summary>
+        public bool? PurchaseConditionOptions { get => _purchaseConditionOptions; set => SetField(ref _purchaseConditionOptions, value); }
+
+        /// <summary>
+        /// EFolderSetupRights PurchaseConditions
+        /// </summary>
+        public bool? PurchaseConditions { get => _purchaseConditions; set => SetField(ref _purchaseConditions, value); }
+
+        /// <summary>
+        /// EFolderSetupRights PurchaseConditionSets
+        /// </summary>
+        public bool? PurchaseConditionSets { get => _purchaseConditionSets; set => SetField(ref _purchaseConditionSets, value); }
+
+        /// <summary>
+        /// EFolderSetupRights WebCenterConfiguration
+        /// </summary>
+        public bool? WebCenterConfiguration { get => _webCenterConfiguration; set => SetField(ref _webCenterConfiguration, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EditAttachmentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EditAttachmentsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EditAttachmentsRights
+    /// </summary>
+    public sealed class EditAttachmentsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteAttachments;
+
+        /// <summary>
+        /// EditAttachmentsRights DeleteAttachments
+        /// </summary>
+        public bool? DeleteAttachments { get => _deleteAttachments; set => SetField(ref _deleteAttachments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EditDocumentDetailsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EditDocumentDetailsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EditDocumentDetailsRights
+    /// </summary>
+    public sealed class EditDocumentDetailsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _createNewDocumentName;
+
+        /// <summary>
+        /// EditDocumentDetailsRights CreateNewDocumentName
+        /// </summary>
+        public bool? CreateNewDocumentName { get => _createNewDocumentName; set => SetField(ref _createNewDocumentName, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EditDocumentRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EditDocumentRights.cs
@@ -1,0 +1,102 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EditDocumentRights
+    /// </summary>
+    public sealed class EditDocumentRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addComment;
+        private AddNotesToFileRights _addNotesToFile;
+        private DirtyValue<bool?> _attachEncompassForms;
+        private DirtyValue<bool?> _attachUnassignedFiles;
+        private DirtyValue<bool?> _browseAndAttach;
+        private DirtyValue<bool?> _deleteComment;
+        private EditDocumentDetailsRights _editDocumentDetails;
+        private EditFileRights _editFile;
+        private DirtyValue<bool?> _markFileAsCurrentVersion;
+        private DirtyValue<bool?> _markStatusAsReviewed;
+        private DirtyValue<bool?> _mergeFiles;
+        private DirtyValue<bool?> _moveFileUpDown;
+        private DirtyValue<bool?> _removeFilefromDocument;
+        private DirtyValue<bool?> _scanAndAttach;
+        private DirtyValue<bool?> _splitFile;
+
+        /// <summary>
+        /// EditDocumentRights AddComment
+        /// </summary>
+        public bool? AddComment { get => _addComment; set => SetField(ref _addComment, value); }
+
+        /// <summary>
+        /// EditDocumentRights AddNotesToFile
+        /// </summary>
+        public AddNotesToFileRights AddNotesToFile { get => GetField(ref _addNotesToFile); set => SetField(ref _addNotesToFile, value); }
+
+        /// <summary>
+        /// EditDocumentRights AttachEncompassForms
+        /// </summary>
+        public bool? AttachEncompassForms { get => _attachEncompassForms; set => SetField(ref _attachEncompassForms, value); }
+
+        /// <summary>
+        /// EditDocumentRights AttachUnassignedFiles
+        /// </summary>
+        public bool? AttachUnassignedFiles { get => _attachUnassignedFiles; set => SetField(ref _attachUnassignedFiles, value); }
+
+        /// <summary>
+        /// EditDocumentRights BrowseAndAttach
+        /// </summary>
+        public bool? BrowseAndAttach { get => _browseAndAttach; set => SetField(ref _browseAndAttach, value); }
+
+        /// <summary>
+        /// EditDocumentRights DeleteComment
+        /// </summary>
+        public bool? DeleteComment { get => _deleteComment; set => SetField(ref _deleteComment, value); }
+
+        /// <summary>
+        /// EditDocumentRights EditDocumentDetails
+        /// </summary>
+        public EditDocumentDetailsRights EditDocumentDetails { get => GetField(ref _editDocumentDetails); set => SetField(ref _editDocumentDetails, value); }
+
+        /// <summary>
+        /// EditDocumentRights EditFile
+        /// </summary>
+        public EditFileRights EditFile { get => GetField(ref _editFile); set => SetField(ref _editFile, value); }
+
+        /// <summary>
+        /// EditDocumentRights MarkFileAsCurrentVersion
+        /// </summary>
+        public bool? MarkFileAsCurrentVersion { get => _markFileAsCurrentVersion; set => SetField(ref _markFileAsCurrentVersion, value); }
+
+        /// <summary>
+        /// EditDocumentRights MarkStatusAsReviewed
+        /// </summary>
+        public bool? MarkStatusAsReviewed { get => _markStatusAsReviewed; set => SetField(ref _markStatusAsReviewed, value); }
+
+        /// <summary>
+        /// EditDocumentRights MergeFiles
+        /// </summary>
+        public bool? MergeFiles { get => _mergeFiles; set => SetField(ref _mergeFiles, value); }
+
+        /// <summary>
+        /// EditDocumentRights MoveFileUpDown
+        /// </summary>
+        [JsonProperty("moveFileUp/Down")]
+        public bool? MoveFileUpDown { get => _moveFileUpDown; set => SetField(ref _moveFileUpDown, value); }
+
+        /// <summary>
+        /// EditDocumentRights RemoveFilefromDocument
+        /// </summary>
+        public bool? RemoveFilefromDocument { get => _removeFilefromDocument; set => SetField(ref _removeFilefromDocument, value); }
+
+        /// <summary>
+        /// EditDocumentRights ScanAndAttach
+        /// </summary>
+        public bool? ScanAndAttach { get => _scanAndAttach; set => SetField(ref _scanAndAttach, value); }
+
+        /// <summary>
+        /// EditDocumentRights SplitFile
+        /// </summary>
+        public bool? SplitFile { get => _splitFile; set => SetField(ref _splitFile, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EditFileRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EditFileRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EditFileRights
+    /// </summary>
+    public sealed class EditFileRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deletePagePermanently;
+
+        /// <summary>
+        /// EditFileRights DeletePagePermanently
+        /// </summary>
+        public bool? DeletePagePermanently { get => _deletePagePermanently; set => SetField(ref _deletePagePermanently, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EditNotesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EditNotesRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EditNotesRights
+    /// </summary>
+    public sealed class EditNotesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteNotes;
+
+        /// <summary>
+        /// EditNotesRights DeleteNotes
+        /// </summary>
+        public bool? DeleteNotes { get => _deleteNotes; set => SetField(ref _deleteNotes, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EllieMaeNetworkServiceCategoriesClassRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EllieMaeNetworkServiceCategoriesClassRights.cs
@@ -1,0 +1,123 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EllieMaeNetworkServiceCategoriesClassRights
+    /// </summary>
+    public sealed class EllieMaeNetworkServiceCategoriesClassRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _additionalServices;
+        private DirtyValue<bool?> _appraisal;
+        private DirtyValue<bool?> _aVM;
+        private DirtyValue<bool?> _creditReport;
+        private DirtyValue<bool?> _customLinks;
+        private DirtyValue<bool?> _docPreparation;
+        private DirtyValue<bool?> _floodCertification;
+        private DirtyValue<bool?> _fraudAuditServices;
+        private DirtyValue<bool?> _hMDAManagement;
+        private DirtyValue<bool?> _investors;
+        private DirtyValue<bool?> _lenders;
+        private DirtyValue<bool?> _mERS;
+        private DirtyValue<bool?> _mortgageInsurance;
+        private DirtyValue<bool?> _productandPricing;
+        private DirtyValue<bool?> _titleClosing;
+        private DirtyValue<bool?> _underwriting;
+        private DirtyValue<bool?> _verifications;
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights AdditionalServices
+        /// </summary>
+        [JsonProperty("additional Services")]
+        public bool? AdditionalServices { get => _additionalServices; set => SetField(ref _additionalServices, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights Appraisal
+        /// </summary>
+        public bool? Appraisal { get => _appraisal; set => SetField(ref _appraisal, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights AVM
+        /// </summary>
+        public bool? AVM { get => _aVM; set => SetField(ref _aVM, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights CreditReport
+        /// </summary>
+        [JsonProperty("credit Report")]
+        public bool? CreditReport { get => _creditReport; set => SetField(ref _creditReport, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights CustomLinks
+        /// </summary>
+        [JsonProperty("custom Links")]
+        public bool? CustomLinks { get => _customLinks; set => SetField(ref _customLinks, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights DocPreparation
+        /// </summary>
+        [JsonProperty("doc Preparation")]
+        public bool? DocPreparation { get => _docPreparation; set => SetField(ref _docPreparation, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights FloodCertification
+        /// </summary>
+        [JsonProperty("flood Certification")]
+        public bool? FloodCertification { get => _floodCertification; set => SetField(ref _floodCertification, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights FraudAuditServices
+        /// </summary>
+        [JsonProperty("fraud/Audit Services")]
+        public bool? FraudAuditServices { get => _fraudAuditServices; set => SetField(ref _fraudAuditServices, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights HMDAManagement
+        /// </summary>
+        [JsonProperty("hMDA Management")]
+        public bool? HMDAManagement { get => _hMDAManagement; set => SetField(ref _hMDAManagement, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights Investors
+        /// </summary>
+        public bool? Investors { get => _investors; set => SetField(ref _investors, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights Lenders
+        /// </summary>
+        public bool? Lenders { get => _lenders; set => SetField(ref _lenders, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights MERS
+        /// </summary>
+        public bool? MERS { get => _mERS; set => SetField(ref _mERS, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights MortgageInsurance
+        /// </summary>
+        [JsonProperty("mortgage Insurance")]
+        public bool? MortgageInsurance { get => _mortgageInsurance; set => SetField(ref _mortgageInsurance, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights ProductandPricing
+        /// </summary>
+        [JsonProperty("product and Pricing")]
+        public bool? ProductandPricing { get => _productandPricing; set => SetField(ref _productandPricing, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights TitleClosing
+        /// </summary>
+        [JsonProperty("title & Closing")]
+        public bool? TitleClosing { get => _titleClosing; set => SetField(ref _titleClosing, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights Underwriting
+        /// </summary>
+        public bool? Underwriting { get => _underwriting; set => SetField(ref _underwriting, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights Verifications
+        /// </summary>
+        public bool? Verifications { get => _verifications; set => SetField(ref _verifications, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/EllieMaeNetworkServiceCategoriesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EllieMaeNetworkServiceCategoriesRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// EllieMaeNetworkServiceCategoriesRights
+    /// </summary>
+    public sealed class EllieMaeNetworkServiceCategoriesRights : DirtyExtensibleObject
+    {
+        private EllieMaeNetworkServiceCategoriesClassRights _all;
+        private EllieMaeNetworkServiceCategoriesClassRights _custom;
+        private EllieMaeNetworkServiceCategoriesClassRights _none;
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesRights All
+        /// </summary>
+        public EllieMaeNetworkServiceCategoriesClassRights All { get => GetField(ref _all); set => SetField(ref _all, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesRights Custom
+        /// </summary>
+        public EllieMaeNetworkServiceCategoriesClassRights Custom { get => GetField(ref _custom); set => SetField(ref _custom, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesRights None
+        /// </summary>
+        public EllieMaeNetworkServiceCategoriesClassRights None { get => GetField(ref _none); set => SetField(ref _none, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ExternalSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ExternalSettingsRights.cs
@@ -1,0 +1,69 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ExternalSettingsRights
+    /// </summary>
+    public sealed class ExternalSettingsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _allTPOContactInformation;
+        private CompanyDetailsRights _companyDetails;
+        private DirtyValue<bool?> _tPOConnectSiteManagement;
+        private DirtyValue<bool?> _tPOCustomFields;
+        private DirtyValue<bool?> _tPODisclosureSettings;
+        private TPOFeesRights _tPOFees;
+        private DirtyValue<bool?> _tPOGlobalLenderContacts;
+        private DirtyValue<bool?> _tPOReassignment;
+        private DirtyValue<bool?> _tPOSettings;
+        private TPOWebCenterDocumentListSettingsRights _tPOWebCenterDocumentListSettings;
+
+        /// <summary>
+        /// ExternalSettingsRights AllTPOContactInformation
+        /// </summary>
+        public bool? AllTPOContactInformation { get => _allTPOContactInformation; set => SetField(ref _allTPOContactInformation, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights CompanyDetails
+        /// </summary>
+        public CompanyDetailsRights CompanyDetails { get => GetField(ref _companyDetails); set => SetField(ref _companyDetails, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOConnectSiteManagement
+        /// </summary>
+        public bool? TPOConnectSiteManagement { get => _tPOConnectSiteManagement; set => SetField(ref _tPOConnectSiteManagement, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOCustomFields
+        /// </summary>
+        public bool? TPOCustomFields { get => _tPOCustomFields; set => SetField(ref _tPOCustomFields, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPODisclosureSettings
+        /// </summary>
+        public bool? TPODisclosureSettings { get => _tPODisclosureSettings; set => SetField(ref _tPODisclosureSettings, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOFees
+        /// </summary>
+        public TPOFeesRights TPOFees { get => GetField(ref _tPOFees); set => SetField(ref _tPOFees, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOGlobalLenderContacts
+        /// </summary>
+        public bool? TPOGlobalLenderContacts { get => _tPOGlobalLenderContacts; set => SetField(ref _tPOGlobalLenderContacts, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOReassignment
+        /// </summary>
+        public bool? TPOReassignment { get => _tPOReassignment; set => SetField(ref _tPOReassignment, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOSettings
+        /// </summary>
+        public bool? TPOSettings { get => _tPOSettings; set => SetField(ref _tPOSettings, value); }
+
+        /// <summary>
+        /// ExternalSettingsRights TPOWebCenterDocumentListSettings
+        /// </summary>
+        public TPOWebCenterDocumentListSettingsRights TPOWebCenterDocumentListSettings { get => GetField(ref _tPOWebCenterDocumentListSettings); set => SetField(ref _tPOWebCenterDocumentListSettings, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/FeeAmountsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/FeeAmountsRights.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// FeeAmountsRights
+    /// </summary>
+    public sealed class FeeAmountsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _borrowerAmountOnly;
+        private DirtyValue<bool?> _brokerLenderOtherAmounts;
+        private DirtyValue<bool?> _sellerAmountSellerCreditSellerObligated;
+
+        /// <summary>
+        /// FeeAmountsRights BorrowerAmountOnly
+        /// </summary>
+        public bool? BorrowerAmountOnly { get => _borrowerAmountOnly; set => SetField(ref _borrowerAmountOnly, value); }
+
+        /// <summary>
+        /// FeeAmountsRights BrokerLenderOtherAmounts
+        /// </summary>
+        [JsonProperty("broker,Lender,OtherAmounts")]
+        public bool? BrokerLenderOtherAmounts { get => _brokerLenderOtherAmounts; set => SetField(ref _brokerLenderOtherAmounts, value); }
+
+        /// <summary>
+        /// FeeAmountsRights SellerAmountSellerCreditSellerObligated
+        /// </summary>
+        [JsonProperty("sellerAmount,SellerCredit,SellerObligated")]
+        public bool? SellerAmountSellerCreditSellerObligated { get => _sellerAmountSellerCreditSellerObligated; set => SetField(ref _sellerAmountSellerCreditSellerObligated, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/FeeOptionsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/FeeOptionsRights.cs
@@ -1,0 +1,56 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// FeeOptionsRights
+    /// </summary>
+    public sealed class FeeOptionsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _borrowerCanShopFor;
+        private DirtyValue<bool?> _borrwerDidShopFor;
+        private DirtyValue<bool?> _escrowed;
+        private DirtyValue<bool?> _impactAPR;
+        private DirtyValue<bool?> _optional13101315;
+        private DirtyValue<bool?> _propertyTaxesHomeownersInsuranceOther10071009;
+        private DirtyValue<bool?> _propertyTaxesHomeownersInsuranceOther907912;
+
+        /// <summary>
+        /// FeeOptionsRights BorrowerCanShopFor
+        /// </summary>
+        public bool? BorrowerCanShopFor { get => _borrowerCanShopFor; set => SetField(ref _borrowerCanShopFor, value); }
+
+        /// <summary>
+        /// FeeOptionsRights BorrwerDidShopFor
+        /// </summary>
+        public bool? BorrwerDidShopFor { get => _borrwerDidShopFor; set => SetField(ref _borrwerDidShopFor, value); }
+
+        /// <summary>
+        /// FeeOptionsRights Escrowed
+        /// </summary>
+        public bool? Escrowed { get => _escrowed; set => SetField(ref _escrowed, value); }
+
+        /// <summary>
+        /// FeeOptionsRights ImpactAPR
+        /// </summary>
+        public bool? ImpactAPR { get => _impactAPR; set => SetField(ref _impactAPR, value); }
+
+        /// <summary>
+        /// FeeOptionsRights Optional13101315
+        /// </summary>
+        [JsonProperty("optional(1310-1315)")]
+        public bool? Optional13101315 { get => _optional13101315; set => SetField(ref _optional13101315, value); }
+
+        /// <summary>
+        /// FeeOptionsRights PropertyTaxesHomeownersInsuranceOther10071009
+        /// </summary>
+        [JsonProperty("propertyTaxes,Homeowner'sInsurance,Other(1007-1009)")]
+        public bool? PropertyTaxesHomeownersInsuranceOther10071009 { get => _propertyTaxesHomeownersInsuranceOther10071009; set => SetField(ref _propertyTaxesHomeownersInsuranceOther10071009, value); }
+
+        /// <summary>
+        /// FeeOptionsRights PropertyTaxesHomeownersInsuranceOther907912
+        /// </summary>
+        [JsonProperty("propertyTaxes,Homeowner'sInsurance,Other(907-912)")]
+        public bool? PropertyTaxesHomeownersInsuranceOther907912 { get => _propertyTaxesHomeownersInsuranceOther907912; set => SetField(ref _propertyTaxesHomeownersInsuranceOther907912, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/FeeVarianceWorksheetRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/FeeVarianceWorksheetRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// FeeVarianceWorksheetRights
+    /// </summary>
+    public sealed class FeeVarianceWorksheetRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _cureVariance;
+
+        /// <summary>
+        /// FeeVarianceWorksheetRights CureVariance
+        /// </summary>
+        public bool? CureVariance { get => _cureVariance; set => SetField(ref _cureVariance, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/FileContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/FileContactsRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// FileContactsRights
+    /// </summary>
+    public sealed class FileContactsRights : ParentAccessRights
+    {
+        private GrantWriteAccessToLoanTeamMembersRights _grantWriteAccessToLoanTeamMembers;
+        private DirtyValue<bool?> _showInvestorContact;
+
+        /// <summary>
+        /// FileContactsRights GrantWriteAccessToLoanTeamMembers
+        /// </summary>
+        public GrantWriteAccessToLoanTeamMembersRights GrantWriteAccessToLoanTeamMembers { get => GetField(ref _grantWriteAccessToLoanTeamMembers); set => SetField(ref _grantWriteAccessToLoanTeamMembers, value); }
+
+        /// <summary>
+        /// FileContactsRights ShowInvestorContact
+        /// </summary>
+        public bool? ShowInvestorContact { get => _showInvestorContact; set => SetField(ref _showInvestorContact, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/FormsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/FormsRights.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// FormsRights
+    /// </summary>
+    public sealed class FormsRights : DirtyExtensibleObject
+    {
+        private DirtyDictionary<string, bool> _inputForms;
+
+        /// <summary>
+        /// FormsRights InputForms
+        /// </summary>
+        public IDictionary<string, bool> InputForms { get => GetField(ref _inputForms); set => SetField(ref _inputForms, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/GSEServicesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/GSEServicesRights.cs
@@ -1,0 +1,39 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// GSEServicesRights
+    /// </summary>
+    public sealed class GSEServicesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _exportFannieMaeformattedfile;
+        private DirtyValue<bool?> _exportPDDtoGinnieMae;
+        private DirtyValue<bool?> _exportUCDfile;
+        private DirtyValue<bool?> _exportULDDtoFannieMae;
+        private DirtyValue<bool?> _exportULDDtoFreddieMac;
+
+        /// <summary>
+        /// GSEServicesRights ExportFannieMaeformattedfile
+        /// </summary>
+        public bool? ExportFannieMaeformattedfile { get => _exportFannieMaeformattedfile; set => SetField(ref _exportFannieMaeformattedfile, value); }
+
+        /// <summary>
+        /// GSEServicesRights ExportPDDtoGinnieMae
+        /// </summary>
+        public bool? ExportPDDtoGinnieMae { get => _exportPDDtoGinnieMae; set => SetField(ref _exportPDDtoGinnieMae, value); }
+
+        /// <summary>
+        /// GSEServicesRights ExportUCDfile
+        /// </summary>
+        public bool? ExportUCDfile { get => _exportUCDfile; set => SetField(ref _exportUCDfile, value); }
+
+        /// <summary>
+        /// GSEServicesRights ExportULDDtoFannieMae
+        /// </summary>
+        public bool? ExportULDDtoFannieMae { get => _exportULDDtoFannieMae; set => SetField(ref _exportULDDtoFannieMae, value); }
+
+        /// <summary>
+        /// GSEServicesRights ExportULDDtoFreddieMac
+        /// </summary>
+        public bool? ExportULDDtoFreddieMac { get => _exportULDDtoFreddieMac; set => SetField(ref _exportULDDtoFreddieMac, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/GeneralRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/GeneralRights.cs
@@ -1,0 +1,33 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// GeneralRights
+    /// </summary>
+    public sealed class GeneralRights : ParentAccessRights
+    {
+        private AccessCorrespondentRights _accessCorrespondent;
+        private AccessToManageAccountPageRights _accessToManageAccountPage;
+        private DirtyValue<bool?> _accessToScenarios;
+        private AccessWholesaleRights _accessWholesale;
+
+        /// <summary>
+        /// GeneralRights AccessCorrespondent
+        /// </summary>
+        public AccessCorrespondentRights AccessCorrespondent { get => GetField(ref _accessCorrespondent); set => SetField(ref _accessCorrespondent, value); }
+
+        /// <summary>
+        /// GeneralRights AccessToManageAccountPage
+        /// </summary>
+        public AccessToManageAccountPageRights AccessToManageAccountPage { get => GetField(ref _accessToManageAccountPage); set => SetField(ref _accessToManageAccountPage, value); }
+
+        /// <summary>
+        /// GeneralRights AccessToScenarios
+        /// </summary>
+        public bool? AccessToScenarios { get => _accessToScenarios; set => SetField(ref _accessToScenarios, value); }
+
+        /// <summary>
+        /// GeneralRights AccessWholesale
+        /// </summary>
+        public AccessWholesaleRights AccessWholesale { get => GetField(ref _accessWholesale); set => SetField(ref _accessWholesale, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/GrantWriteAccessToLoanTeamMembersRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/GrantWriteAccessToLoanTeamMembersRights.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// GrantWriteAccessToLoanTeamMembersRights
+    /// </summary>
+    public sealed class GrantWriteAccessToLoanTeamMembersRights : ParentAccessRights
+    {
+        private DirtyDictionary<string, bool> _freeRoles;
+        private DirtyDictionary<string, bool> _milestones;
+
+        /// <summary>
+        /// GrantWriteAccessToLoanTeamMembersRights FreeRoles
+        /// </summary>
+        public IDictionary<string, bool> FreeRoles { get => GetField(ref _freeRoles); set => SetField(ref _freeRoles, value); }
+
+        /// <summary>
+        /// GrantWriteAccessToLoanTeamMembersRights Milestones
+        /// </summary>
+        public IDictionary<string, bool> Milestones { get => GetField(ref _milestones); set => SetField(ref _milestones, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/HMDAProfilesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/HMDAProfilesRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// HMDAProfilesRights
+    /// </summary>
+    public sealed class HMDAProfilesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addHMDAProfile;
+        private DirtyValue<bool?> _deleteHMDAProfile;
+        private DirtyValue<bool?> _editHMDAProfile;
+
+        /// <summary>
+        /// HMDAProfilesRights AddHMDAProfile
+        /// </summary>
+        public bool? AddHMDAProfile { get => _addHMDAProfile; set => SetField(ref _addHMDAProfile, value); }
+
+        /// <summary>
+        /// HMDAProfilesRights DeleteHMDAProfile
+        /// </summary>
+        public bool? DeleteHMDAProfile { get => _deleteHMDAProfile; set => SetField(ref _deleteHMDAProfile, value); }
+
+        /// <summary>
+        /// HMDAProfilesRights EditHMDAProfile
+        /// </summary>
+        public bool? EditHMDAProfile { get => _editHMDAProfile; set => SetField(ref _editHMDAProfile, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/HMDAServicesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/HMDAServicesRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// HMDAServicesRights
+    /// </summary>
+    public sealed class HMDAServicesRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _generateHMDALAR;
+        private DirtyValue<bool?> _orderHMDAServices;
+
+        /// <summary>
+        /// HMDAServicesRights GenerateHMDALAR
+        /// </summary>
+        public bool? GenerateHMDALAR { get => _generateHMDALAR; set => SetField(ref _generateHMDALAR, value); }
+
+        /// <summary>
+        /// HMDAServicesRights OrderHMDAServices
+        /// </summary>
+        public bool? OrderHMDAServices { get => _orderHMDAServices; set => SetField(ref _orderHMDAServices, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/HomeRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/HomeRights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// HomeRights
+    /// </summary>
+    public sealed class HomeRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _allowAccessToTheCompanysMyAccountModuleAndPages;
+
+        /// <summary>
+        /// HomeRights AllowAccessToTheCompanysMyAccountModuleAndPages
+        /// </summary>
+        [JsonProperty("allowAccessToTheCompany'sMyAccountModuleAndPages.")]
+        public bool? AllowAccessToTheCompanysMyAccountModuleAndPages { get => _allowAccessToTheCompanysMyAccountModuleAndPages; set => SetField(ref _allowAccessToTheCompanysMyAccountModuleAndPages, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ImportBorrowersRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ImportBorrowersRights.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ImportBorrowersRights
+    /// </summary>
+    public sealed class ImportBorrowersRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _fromaFNMA32File;
+        private DirtyValue<bool?> _fromAnotherLoan;
+        private DirtyValue<bool?> _fromContacts;
+
+        /// <summary>
+        /// ImportBorrowersRights FromaFNMA32File
+        /// </summary>
+        [JsonProperty("fromaFNMA3.2File")]
+        public bool? FromaFNMA32File { get => _fromaFNMA32File; set => SetField(ref _fromaFNMA32File, value); }
+
+        /// <summary>
+        /// ImportBorrowersRights FromAnotherLoan
+        /// </summary>
+        public bool? FromAnotherLoan { get => _fromAnotherLoan; set => SetField(ref _fromAnotherLoan, value); }
+
+        /// <summary>
+        /// ImportBorrowersRights FromContacts
+        /// </summary>
+        public bool? FromContacts { get => _fromContacts; set => SetField(ref _fromContacts, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ImportLoansRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ImportLoansRights.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ImportLoansRights
+    /// </summary>
+    public sealed class ImportLoansRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _calyxPoint;
+        private DirtyValue<bool?> _fannieMae3x;
+
+        /// <summary>
+        /// ImportLoansRights CalyxPoint
+        /// </summary>
+        [JsonProperty("calyx Point")]
+        public bool? CalyxPoint { get => _calyxPoint; set => SetField(ref _calyxPoint, value); }
+
+        /// <summary>
+        /// ImportLoansRights FannieMae3x
+        /// </summary>
+        [JsonProperty("fannie Mae 3.x")]
+        public bool? FannieMae3x { get => _fannieMae3x; set => SetField(ref _fannieMae3x, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/InterimServicingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/InterimServicingRights.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// InterimServicingRights
+    /// </summary>
+    public sealed class InterimServicingRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editDeleteTransaction;
+        private DirtyValue<bool?> _enterTransaction;
+        private StartServicingRights _startServicing;
+
+        /// <summary>
+        /// InterimServicingRights EditDeleteTransaction
+        /// </summary>
+        [JsonProperty("edit/DeleteTransaction")]
+        public bool? EditDeleteTransaction { get => _editDeleteTransaction; set => SetField(ref _editDeleteTransaction, value); }
+
+        /// <summary>
+        /// InterimServicingRights EnterTransaction
+        /// </summary>
+        public bool? EnterTransaction { get => _enterTransaction; set => SetField(ref _enterTransaction, value); }
+
+        /// <summary>
+        /// InterimServicingRights StartServicing
+        /// </summary>
+        public StartServicingRights StartServicing { get => GetField(ref _startServicing); set => SetField(ref _startServicing, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ItemizationFeeRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ItemizationFeeRights.cs
@@ -1,0 +1,39 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ItemizationFeeRights
+    /// </summary>
+    public sealed class ItemizationFeeRights : DirtyExtensibleObject
+    {
+        private FeeAmountsRights _feeAmounts;
+        private DirtyValue<bool?> _feeDescription;
+        private FeeOptionsRights _feeOptions;
+        private DirtyValue<bool?> _paidToName;
+        private DirtyValue<bool?> _paidToType;
+
+        /// <summary>
+        /// ItemizationFeeRights FeeAmounts
+        /// </summary>
+        public FeeAmountsRights FeeAmounts { get => GetField(ref _feeAmounts); set => SetField(ref _feeAmounts, value); }
+
+        /// <summary>
+        /// ItemizationFeeRights FeeDescription
+        /// </summary>
+        public bool? FeeDescription { get => _feeDescription; set => SetField(ref _feeDescription, value); }
+
+        /// <summary>
+        /// ItemizationFeeRights FeeOptions
+        /// </summary>
+        public FeeOptionsRights FeeOptions { get => GetField(ref _feeOptions); set => SetField(ref _feeOptions, value); }
+
+        /// <summary>
+        /// ItemizationFeeRights PaidToName
+        /// </summary>
+        public bool? PaidToName { get => _paidToName; set => SetField(ref _paidToName, value); }
+
+        /// <summary>
+        /// ItemizationFeeRights PaidToType
+        /// </summary>
+        public bool? PaidToType { get => _paidToType; set => SetField(ref _paidToType, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LOCompRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LOCompRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LOCompRights
+    /// </summary>
+    public sealed class LOCompRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editLOComp;
+
+        /// <summary>
+        /// LOCompRights EditLOComp
+        /// </summary>
+        public bool? EditLOComp { get => _editLOComp; set => SetField(ref _editLOComp, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LOCompToolRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LOCompToolRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LOCompToolRights
+    /// </summary>
+    public sealed class LOCompToolRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _brokerComp;
+        private DirtyValue<bool?> _loanOfficerComp;
+
+        /// <summary>
+        /// LOCompToolRights BrokerComp
+        /// </summary>
+        public bool? BrokerComp { get => _brokerComp; set => SetField(ref _brokerComp, value); }
+
+        /// <summary>
+        /// LOCompToolRights LoanOfficerComp
+        /// </summary>
+        public bool? LoanOfficerComp { get => _loanOfficerComp; set => SetField(ref _loanOfficerComp, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LenderContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LenderContactsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LenderContactsRights
+    /// </summary>
+    public sealed class LenderContactsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editLenderContacts;
+
+        /// <summary>
+        /// LenderContactsRights EditLenderContacts
+        /// </summary>
+        public bool? EditLenderContacts { get => _editLenderContacts; set => SetField(ref _editLenderContacts, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LicenseRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LicenseRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LicenseRights
+    /// </summary>
+    public sealed class LicenseRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editLicenseInformation;
+
+        /// <summary>
+        /// LicenseRights EditLicenseInformation
+        /// </summary>
+        public bool? EditLicenseInformation { get => _editLicenseInformation; set => SetField(ref _editLicenseInformation, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LoanCriteriaRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LoanCriteriaRights.cs
@@ -1,0 +1,9 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LoanCriteriaRights
+    /// </summary>
+    public sealed class LoanCriteriaRights : ParentAccessRights
+    {
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LoanOtherRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LoanOtherRights.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// UserOtherRights
+    /// </summary>
+    public sealed class LoanOtherRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _applyLoanTemplates;
+        private DirtyValue<bool?> _applyMilestoneTemplate;
+        private DirtyValue<bool?> _deleteBorrowers;
+        private ManageBorrowersRights _manageBorrowers;
+        private DirtyValue<bool?> _manageMilestoneDatesMode;
+        private DirtyValue<bool?> _manageMilestoneTemplatesMode;
+        private ManageServiceProvidersListRights _manageServiceProvidersList;
+        private DirtyValue<bool?> _manuallyBlockMultiUserEditing;
+
+        /// <summary>
+        /// UserOtherRights ApplyLoanTemplates
+        /// </summary>
+        public bool? ApplyLoanTemplates { get => _applyLoanTemplates; set => SetField(ref _applyLoanTemplates, value); }
+
+        /// <summary>
+        /// UserOtherRights ApplyMilestoneTemplate
+        /// </summary>
+        public bool? ApplyMilestoneTemplate { get => _applyMilestoneTemplate; set => SetField(ref _applyMilestoneTemplate, value); }
+
+        /// <summary>
+        /// UserOtherRights DeleteBorrowers
+        /// </summary>
+        [JsonProperty("delete Borrowers")]
+        public bool? DeleteBorrowers { get => _deleteBorrowers; set => SetField(ref _deleteBorrowers, value); }
+
+        /// <summary>
+        /// UserOtherRights ManageBorrowers
+        /// </summary>
+        public ManageBorrowersRights ManageBorrowers { get => GetField(ref _manageBorrowers); set => SetField(ref _manageBorrowers, value); }
+
+        /// <summary>
+        /// UserOtherRights ManageMilestoneDatesMode
+        /// </summary>
+        public bool? ManageMilestoneDatesMode { get => _manageMilestoneDatesMode; set => SetField(ref _manageMilestoneDatesMode, value); }
+
+        /// <summary>
+        /// UserOtherRights ManageMilestoneTemplatesMode
+        /// </summary>
+        public bool? ManageMilestoneTemplatesMode { get => _manageMilestoneTemplatesMode; set => SetField(ref _manageMilestoneTemplatesMode, value); }
+
+        /// <summary>
+        /// UserOtherRights ManageServiceProvidersList
+        /// </summary>
+        public ManageServiceProvidersListRights ManageServiceProvidersList { get => GetField(ref _manageServiceProvidersList); set => SetField(ref _manageServiceProvidersList, value); }
+
+        /// <summary>
+        /// UserOtherRights ManuallyBlockMultiUserEditing
+        /// </summary>
+        [JsonProperty("manuallyBlockMulti-UserEditing")]
+        public bool? ManuallyBlockMultiUserEditing { get => _manuallyBlockMultiUserEditing; set => SetField(ref _manuallyBlockMultiUserEditing, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LoanReportsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LoanReportsRights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LoanReportsRights
+    /// </summary>
+    public sealed class LoanReportsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _allowLoanFilesToBeOpenForData;
+
+        /// <summary>
+        /// LoanReportsRights AllowLoanFilesToBeOpenForData
+        /// </summary>
+        [JsonProperty("allowLoanFilesToBeOpenForData(slowerperformance)")]
+        public bool? AllowLoanFilesToBeOpenForData { get => _allowLoanFilesToBeOpenForData; set => SetField(ref _allowLoanFilesToBeOpenForData, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LoanRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LoanRights.cs
@@ -1,0 +1,56 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LoanRights
+    /// </summary>
+    public sealed class LoanRights : DirtyExtensibleObject
+    {
+        private ClosingDocsRights _closingDocs;
+        private ItemizationFeeRights _itemizationFee;
+        private MilestoneWorkFlowManagementRights _milestoneWorkFlowManagement;
+        private LoanOtherRights _other;
+        private DirtyValue<bool?> _otherChangeRESPATILAFormVersion;
+        private OtherDisplayMilestoneListChangeScreenRights _otherDisplayMilestoneListChangeScreen;
+        private PrintRights _print;
+
+        /// <summary>
+        /// LoanRights ClosingDocs
+        /// </summary>
+        public ClosingDocsRights ClosingDocs { get => GetField(ref _closingDocs); set => SetField(ref _closingDocs, value); }
+
+        /// <summary>
+        /// LoanRights ItemizationFee
+        /// </summary>
+        public ItemizationFeeRights ItemizationFee { get => GetField(ref _itemizationFee); set => SetField(ref _itemizationFee, value); }
+
+        /// <summary>
+        /// LoanRights MilestoneWorkFlowManagement
+        /// </summary>
+        [JsonProperty("milestone/WorkFlowManagement")]
+        public MilestoneWorkFlowManagementRights MilestoneWorkFlowManagement { get => GetField(ref _milestoneWorkFlowManagement); set => SetField(ref _milestoneWorkFlowManagement, value); }
+
+        /// <summary>
+        /// LoanRights Other
+        /// </summary>
+        public LoanOtherRights Other { get => GetField(ref _other); set => SetField(ref _other, value); }
+
+        /// <summary>
+        /// LoanRights OtherChangeRESPATILAFormVersion
+        /// </summary>
+        [JsonProperty("other_ChangeRESPA-TILAFormVersion")]
+        public bool? OtherChangeRESPATILAFormVersion { get => _otherChangeRESPATILAFormVersion; set => SetField(ref _otherChangeRESPATILAFormVersion, value); }
+
+        /// <summary>
+        /// LoanRights OtherDisplayMilestoneListChangeScreen
+        /// </summary>
+        [JsonProperty("other_DisplayMilestoneListChangeScreen")]
+        public OtherDisplayMilestoneListChangeScreenRights OtherDisplayMilestoneListChangeScreen { get => GetField(ref _otherDisplayMilestoneListChangeScreen); set => SetField(ref _otherDisplayMilestoneListChangeScreen, value); }
+
+        /// <summary>
+        /// LoanRights Print
+        /// </summary>
+        public PrintRights Print { get => GetField(ref _print); set => SetField(ref _print, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/LoanSetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/LoanSetupRights.cs
@@ -1,0 +1,156 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// LoanSetupRights
+    /// </summary>
+    public sealed class LoanSetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _n2009GFEPrint;
+        private DirtyValue<bool?> _alerts;
+        private DirtyValue<bool?> _autoLoanNumbering;
+        private DirtyValue<bool?> _autoMERSMINNumbering;
+        private DirtyValue<bool?> _changedCircumstancesSetup;
+        private DirtyValue<bool?> _channelOptions;
+        private DirtyValue<bool?> _complianceCalendar;
+        private DirtyValue<bool?> _conditionForms;
+        private DirtyValue<bool?> _defaultInputForms;
+        private DirtyValue<bool?> _disclosureTrackingSettings;
+        private HMDAProfilesRights _hMDAProfiles;
+        private DirtyValue<bool?> _loanCustomFields;
+        private DirtyValue<bool?> _loanDuplication;
+        private DirtyValue<bool?> _loanFolders;
+        private DirtyValue<bool?> _log;
+        private DirtyValue<bool?> _nMLSReportSetup;
+        private DirtyValue<bool?> _piggybackLoanSynchronization;
+        private DirtyValue<bool?> _privacyPolicy;
+        private DirtyValue<bool?> _rESPA;
+        private DirtyValue<bool?> _syncTemplates;
+        private DirtyValue<bool?> _tasks;
+        private DirtyValue<bool?> _trusteeList;
+        private DirtyValue<bool?> _verificationContactSetup;
+        private DirtyValue<bool?> _zipcodeSetup;
+
+        /// <summary>
+        /// LoanSetupRights 2009GFEPrint
+        /// </summary>
+        [JsonProperty("2009GFEPrint")]
+        public bool? n2009GFEPrint { get => _n2009GFEPrint; set => SetField(ref _n2009GFEPrint, value); }
+
+        /// <summary>
+        /// LoanSetupRights Alerts
+        /// </summary>
+        public bool? Alerts { get => _alerts; set => SetField(ref _alerts, value); }
+
+        /// <summary>
+        /// LoanSetupRights AutoLoanNumbering
+        /// </summary>
+        public bool? AutoLoanNumbering { get => _autoLoanNumbering; set => SetField(ref _autoLoanNumbering, value); }
+
+        /// <summary>
+        /// LoanSetupRights AutoMERSMINNumbering
+        /// </summary>
+        public bool? AutoMERSMINNumbering { get => _autoMERSMINNumbering; set => SetField(ref _autoMERSMINNumbering, value); }
+
+        /// <summary>
+        /// LoanSetupRights ChangedCircumstancesSetup
+        /// </summary>
+        public bool? ChangedCircumstancesSetup { get => _changedCircumstancesSetup; set => SetField(ref _changedCircumstancesSetup, value); }
+
+        /// <summary>
+        /// LoanSetupRights ChannelOptions
+        /// </summary>
+        public bool? ChannelOptions { get => _channelOptions; set => SetField(ref _channelOptions, value); }
+
+        /// <summary>
+        /// LoanSetupRights ComplianceCalendar
+        /// </summary>
+        public bool? ComplianceCalendar { get => _complianceCalendar; set => SetField(ref _complianceCalendar, value); }
+
+        /// <summary>
+        /// LoanSetupRights ConditionForms
+        /// </summary>
+        public bool? ConditionForms { get => _conditionForms; set => SetField(ref _conditionForms, value); }
+
+        /// <summary>
+        /// LoanSetupRights DefaultInputForms
+        /// </summary>
+        public bool? DefaultInputForms { get => _defaultInputForms; set => SetField(ref _defaultInputForms, value); }
+
+        /// <summary>
+        /// LoanSetupRights DisclosureTrackingSettings
+        /// </summary>
+        public bool? DisclosureTrackingSettings { get => _disclosureTrackingSettings; set => SetField(ref _disclosureTrackingSettings, value); }
+
+        /// <summary>
+        /// LoanSetupRights HMDAProfiles
+        /// </summary>
+        public HMDAProfilesRights HMDAProfiles { get => GetField(ref _hMDAProfiles); set => SetField(ref _hMDAProfiles, value); }
+
+        /// <summary>
+        /// LoanSetupRights LoanCustomFields
+        /// </summary>
+        public bool? LoanCustomFields { get => _loanCustomFields; set => SetField(ref _loanCustomFields, value); }
+
+        /// <summary>
+        /// LoanSetupRights LoanDuplication
+        /// </summary>
+        public bool? LoanDuplication { get => _loanDuplication; set => SetField(ref _loanDuplication, value); }
+
+        /// <summary>
+        /// LoanSetupRights LoanFolders
+        /// </summary>
+        public bool? LoanFolders { get => _loanFolders; set => SetField(ref _loanFolders, value); }
+
+        /// <summary>
+        /// LoanSetupRights Log
+        /// </summary>
+        public bool? Log { get => _log; set => SetField(ref _log, value); }
+
+        /// <summary>
+        /// LoanSetupRights NMLSReportSetup
+        /// </summary>
+        public bool? NMLSReportSetup { get => _nMLSReportSetup; set => SetField(ref _nMLSReportSetup, value); }
+
+        /// <summary>
+        /// LoanSetupRights PiggybackLoanSynchronization
+        /// </summary>
+        public bool? PiggybackLoanSynchronization { get => _piggybackLoanSynchronization; set => SetField(ref _piggybackLoanSynchronization, value); }
+
+        /// <summary>
+        /// LoanSetupRights PrivacyPolicy
+        /// </summary>
+        public bool? PrivacyPolicy { get => _privacyPolicy; set => SetField(ref _privacyPolicy, value); }
+
+        /// <summary>
+        /// LoanSetupRights RESPA
+        /// </summary>
+        public bool? RESPA { get => _rESPA; set => SetField(ref _rESPA, value); }
+
+        /// <summary>
+        /// LoanSetupRights SyncTemplates
+        /// </summary>
+        public bool? SyncTemplates { get => _syncTemplates; set => SetField(ref _syncTemplates, value); }
+
+        /// <summary>
+        /// LoanSetupRights Tasks
+        /// </summary>
+        public bool? Tasks { get => _tasks; set => SetField(ref _tasks, value); }
+
+        /// <summary>
+        /// LoanSetupRights TrusteeList
+        /// </summary>
+        public bool? TrusteeList { get => _trusteeList; set => SetField(ref _trusteeList, value); }
+
+        /// <summary>
+        /// LoanSetupRights VerificationContactSetup
+        /// </summary>
+        public bool? VerificationContactSetup { get => _verificationContactSetup; set => SetField(ref _verificationContactSetup, value); }
+
+        /// <summary>
+        /// LoanSetupRights ZipcodeSetup
+        /// </summary>
+        public bool? ZipcodeSetup { get => _zipcodeSetup; set => SetField(ref _zipcodeSetup, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ManageAccessToDocumentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ManageAccessToDocumentsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ManageAccessToDocumentsRights
+    /// </summary>
+    public sealed class ManageAccessToDocumentsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _removeAccessFromProtectedRoles;
+
+        /// <summary>
+        /// ManageAccessToDocumentsRights RemoveAccessFromProtectedRoles
+        /// </summary>
+        public bool? RemoveAccessFromProtectedRoles { get => _removeAccessFromProtectedRoles; set => SetField(ref _removeAccessFromProtectedRoles, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ManageBorrowersRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ManageBorrowersRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ManageBorrowersRights
+    /// </summary>
+    public sealed class ManageBorrowersRights : ParentAccessRights
+    {
+        private ImportBorrowersRights _importBorrowers;
+        private DirtyValue<bool?> _moveBorrowers;
+
+        /// <summary>
+        /// ManageBorrowersRights ImportBorrowers
+        /// </summary>
+        public ImportBorrowersRights ImportBorrowers { get => GetField(ref _importBorrowers); set => SetField(ref _importBorrowers, value); }
+
+        /// <summary>
+        /// ManageBorrowersRights MoveBorrowers
+        /// </summary>
+        public bool? MoveBorrowers { get => _moveBorrowers; set => SetField(ref _moveBorrowers, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ManagePipelineServicesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ManagePipelineServicesRights.cs
@@ -1,0 +1,9 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ManagePipelineServicesRights
+    /// </summary>
+    public sealed class ManagePipelineServicesRights : ParentAccessRights
+    {
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ManageServiceProvidersListRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ManageServiceProvidersListRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ManageServiceProvidersListRights
+    /// </summary>
+    public sealed class ManageServiceProvidersListRights : ParentAccessRights
+    {
+        private EllieMaeNetworkServiceCategoriesRights _ellieMaeNetworkServiceCategories;
+
+        /// <summary>
+        /// ManageServiceProvidersListRights EllieMaeNetworkServiceCategories
+        /// </summary>
+        public EllieMaeNetworkServiceCategoriesRights EllieMaeNetworkServiceCategories { get => GetField(ref _ellieMaeNetworkServiceCategories); set => SetField(ref _ellieMaeNetworkServiceCategories, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/MarkStatusCompletedRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/MarkStatusCompletedRights.cs
@@ -1,0 +1,45 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// MarkStatusCompletedRights
+    /// </summary>
+    public sealed class MarkStatusCompletedRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _cleared;
+        private DirtyValue<bool?> _fulfilled;
+        private DirtyValue<bool?> _received;
+        private DirtyValue<bool?> _rejected;
+        private DirtyValue<bool?> _reviewed;
+        private DirtyValue<bool?> _waived;
+
+        /// <summary>
+        /// MarkStatusCompletedRights Cleared
+        /// </summary>
+        public bool? Cleared { get => _cleared; set => SetField(ref _cleared, value); }
+
+        /// <summary>
+        /// MarkStatusCompletedRights Fulfilled
+        /// </summary>
+        public bool? Fulfilled { get => _fulfilled; set => SetField(ref _fulfilled, value); }
+
+        /// <summary>
+        /// MarkStatusCompletedRights Received
+        /// </summary>
+        public bool? Received { get => _received; set => SetField(ref _received, value); }
+
+        /// <summary>
+        /// MarkStatusCompletedRights Rejected
+        /// </summary>
+        public bool? Rejected { get => _rejected; set => SetField(ref _rejected, value); }
+
+        /// <summary>
+        /// MarkStatusCompletedRights Reviewed
+        /// </summary>
+        public bool? Reviewed { get => _reviewed; set => SetField(ref _reviewed, value); }
+
+        /// <summary>
+        /// MarkStatusCompletedRights Waived
+        /// </summary>
+        public bool? Waived { get => _waived; set => SetField(ref _waived, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/MilestoneWorkFlowManagementRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/MilestoneWorkFlowManagementRights.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// MilestoneWorkFlowManagementRights
+    /// </summary>
+    public sealed class MilestoneWorkFlowManagementRights : DirtyExtensibleObject
+    {
+        private DirtyDictionary<string, bool> _acceptFiles;
+        private AssignLoanTeamMembersRights _assignLoanTeamMembers;
+        private DirtyDictionary<string, bool> _changeExpectedDate;
+        private DirtyDictionary<string, bool> _editMilestoneComments;
+        private DirtyDictionary<string, bool> _finishMilestones;
+        private DirtyDictionary<string, bool> _returnFiles;
+
+        /// <summary>
+        /// MilestoneWorkFlowManagementRights AcceptFiles
+        /// </summary>
+        public IDictionary<string, bool> AcceptFiles { get => GetField(ref _acceptFiles); set => SetField(ref _acceptFiles, value); }
+
+        /// <summary>
+        /// MilestoneWorkFlowManagementRights AssignLoanTeamMembers
+        /// </summary>
+        public AssignLoanTeamMembersRights AssignLoanTeamMembers { get => GetField(ref _assignLoanTeamMembers); set => SetField(ref _assignLoanTeamMembers, value); }
+
+        /// <summary>
+        /// MilestoneWorkFlowManagementRights ChangeExpectedDate
+        /// </summary>
+        public IDictionary<string, bool> ChangeExpectedDate { get => GetField(ref _changeExpectedDate); set => SetField(ref _changeExpectedDate, value); }
+
+        /// <summary>
+        /// MilestoneWorkFlowManagementRights EditMilestoneComments
+        /// </summary>
+        public IDictionary<string, bool> EditMilestoneComments { get => GetField(ref _editMilestoneComments); set => SetField(ref _editMilestoneComments, value); }
+
+        /// <summary>
+        /// MilestoneWorkFlowManagementRights FinishMilestones
+        /// </summary>
+        public IDictionary<string, bool> FinishMilestones { get => GetField(ref _finishMilestones); set => SetField(ref _finishMilestones, value); }
+
+        /// <summary>
+        /// MilestoneWorkFlowManagementRights ReturnFiles
+        /// </summary>
+        public IDictionary<string, bool> ReturnFiles { get => GetField(ref _returnFiles); set => SetField(ref _returnFiles, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/MiscellaneousRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/MiscellaneousRights.cs
@@ -1,0 +1,493 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// MiscellaneousRights
+    /// </summary>
+    public sealed class MiscellaneousRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _eFolderAccess;
+        private DirtyValue<bool?> _eFolderArchive;
+        private DirtyValue<bool?> _eFolderAssignAs;
+        private DirtyValue<bool?> _eFolderAttachDoc;
+        private DirtyValue<bool?> _eFolderConditionsAddBusinessRuleUnderwriting;
+        private DirtyValue<bool?> _eFolderDeleteDoc;
+        private DirtyValue<bool?> _eFolderDownloadFaxes;
+        private DirtyValue<bool?> _eFolderRequestDoc;
+        private DirtyValue<bool?> _eFolderSendDoc;
+        private DirtyValue<bool?> _eFolderUFApprover;
+        private DirtyValue<bool?> _externalSettingsTPOWCDocs;
+        private DirtyValue<bool?> _externalSettingsTPOWCSiteManagement;
+        private DirtyValue<bool?> _globalTabNews;
+        private DirtyValue<bool?> _inputFormsShowAllFormsCheckBox;
+        private DirtyValue<bool?> _instantMessenger;
+        private DirtyValue<bool?> _loanMgmtDownload;
+        private DirtyValue<bool?> _loanMgmtDuplicateBlank;
+        private DirtyValue<bool?> _loanMgmtUpload;
+        private DirtyValue<bool?> _loanTabeFolderDTModifyProtectedDocAndFiles;
+        private DirtyValue<bool?> _loanTabeFolderDTNewEditFiles;
+        private DirtyValue<bool?> _loanTabOtherExclusiveLock;
+        private DirtyValue<bool?> _platFormAccess;
+        private DirtyValue<bool?> _settingsTabAffiliatedBusinessArrangementTemplates;
+        private DirtyValue<bool?> _settingsTabAllTPOContactInformation;
+        private DirtyValue<bool?> _settingsTabAutomatedDisclosures;
+        private DirtyValue<bool?> _settingsTabClosingCosts;
+        private DirtyValue<bool?> _settingsTabClosingPlanCodes;
+        private DirtyValue<bool?> _settingsTabClosingStackingTemplates;
+        private DirtyValue<bool?> _settingsTabCompanyDetails;
+        private DirtyValue<bool?> _settingsTabCompanyCompanySettingsObsolete;
+        private DirtyValue<bool?> _settingsTabCompanyConditionSetup;
+        private DirtyValue<bool?> _settingsTabCompanyConfigurableKeyDates;
+        private DirtyValue<bool?> _settingsTabCompanyDocumentSetup;
+        private DirtyValue<bool?> _settingsTabComplianceReviewSetup;
+        private DirtyValue<bool?> _settingsTabConditionForms;
+        private DirtyValue<bool?> _settingsTabCurrentLogins;
+        private DirtyValue<bool?> _settingsTabCustomPrintForms;
+        private DirtyValue<bool?> _settingsTabDataTemplates;
+        private DirtyValue<bool?> _settingsTabDocumentSets;
+        private DirtyValue<bool?> _settingsTabEDisclosurePlanCodes;
+        private DirtyValue<bool?> _settingsTabEDisclosureStackingTemplates;
+        private DirtyValue<bool?> _settingsTabExtCompany;
+        private DirtyValue<bool?> _settingsTabInputFormSets;
+        private DirtyValue<bool?> _settingsTabItemizationFeeManagement;
+        private DirtyValue<bool?> _settingsTabLoanCustomFields;
+        private DirtyValue<bool?> _settingsTabLoanErrorInformation;
+        private DirtyValue<bool?> _settingsTabLoanPrograms;
+        private DirtyValue<bool?> _settingsTabLoanReassignment;
+        private DirtyValue<bool?> _settingsTabLoanTemplateSets;
+        private DirtyValue<bool?> _settingsTabPrintFormGroups;
+        private DirtyValue<bool?> _settingsTabPublicBusinessContactGroups;
+        private DirtyValue<bool?> _settingsTabRebuildPipeline;
+        private DirtyValue<bool?> _settingsTabSecondaryRoot;
+        private DirtyValue<bool?> _settingsTabSettingsReport;
+        private DirtyValue<bool?> _settingsTabSettlementServiceProviders;
+        private DirtyValue<bool?> _settingsTabSystemAuditTrail;
+        private DirtyValue<bool?> _settingsTabTablesFees;
+        private DirtyValue<bool?> _settingsTabTaskSets;
+        private DirtyValue<bool?> _settingsTabTpoCustomFields;
+        private DirtyValue<bool?> _settingsTabTpoFees;
+        private DirtyValue<bool?> _settingsTabTpoReassignment;
+        private DirtyValue<bool?> _settingsTabTpoSettings;
+        private DirtyValue<bool?> _settingsTabTpoWebCenterDocs;
+        private DirtyValue<bool?> _settingsTabUnlockLoanFile;
+        private DirtyValue<bool?> _thinThickPipelineTabAccess;
+        private DirtyValue<bool?> _thinThickTradesTabAccess;
+        private DirtyValue<bool?> _tPOAdministrationTabShowAsMgrAdminInBranchesTab;
+        private DirtyValue<bool?> _tPOAdministrationTabShowAsMgrAdminInCompanyInfoTab;
+        private DirtyValue<bool?> _tPOAdministrationTabViewCmtConfirmations;
+
+        /// <summary>
+        /// MiscellaneousRights EFolderAccess
+        /// </summary>
+        [JsonProperty("eFolder_Access")]
+        public bool? EFolderAccess { get => _eFolderAccess; set => SetField(ref _eFolderAccess, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderArchive
+        /// </summary>
+        [JsonProperty("eFolder_Archive")]
+        public bool? EFolderArchive { get => _eFolderArchive; set => SetField(ref _eFolderArchive, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderAssignAs
+        /// </summary>
+        [JsonProperty("eFolder_AssignAs")]
+        public bool? EFolderAssignAs { get => _eFolderAssignAs; set => SetField(ref _eFolderAssignAs, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderAttachDoc
+        /// </summary>
+        [JsonProperty("eFolder_AttachDoc")]
+        public bool? EFolderAttachDoc { get => _eFolderAttachDoc; set => SetField(ref _eFolderAttachDoc, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderConditionsAddBusinessRuleUnderwriting
+        /// </summary>
+        [JsonProperty("eFolder_Conditions_AddBusinessRuleUnderwriting")]
+        public bool? EFolderConditionsAddBusinessRuleUnderwriting { get => _eFolderConditionsAddBusinessRuleUnderwriting; set => SetField(ref _eFolderConditionsAddBusinessRuleUnderwriting, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderDeleteDoc
+        /// </summary>
+        [JsonProperty("eFolder_DeleteDoc")]
+        public bool? EFolderDeleteDoc { get => _eFolderDeleteDoc; set => SetField(ref _eFolderDeleteDoc, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderDownloadFaxes
+        /// </summary>
+        [JsonProperty("eFolder_DownloadFaxes")]
+        public bool? EFolderDownloadFaxes { get => _eFolderDownloadFaxes; set => SetField(ref _eFolderDownloadFaxes, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderRequestDoc
+        /// </summary>
+        [JsonProperty("eFolder_RequestDoc")]
+        public bool? EFolderRequestDoc { get => _eFolderRequestDoc; set => SetField(ref _eFolderRequestDoc, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderSendDoc
+        /// </summary>
+        [JsonProperty("eFolder_SendDoc")]
+        public bool? EFolderSendDoc { get => _eFolderSendDoc; set => SetField(ref _eFolderSendDoc, value); }
+
+        /// <summary>
+        /// MiscellaneousRights EFolderUFApprover
+        /// </summary>
+        [JsonProperty("eFolder_UF_Approver")]
+        public bool? EFolderUFApprover { get => _eFolderUFApprover; set => SetField(ref _eFolderUFApprover, value); }
+
+        /// <summary>
+        /// MiscellaneousRights ExternalSettingsTPOWCDocs
+        /// </summary>
+        [JsonProperty("externalSettings_TPOWCDocs")]
+        public bool? ExternalSettingsTPOWCDocs { get => _externalSettingsTPOWCDocs; set => SetField(ref _externalSettingsTPOWCDocs, value); }
+
+        /// <summary>
+        /// MiscellaneousRights ExternalSettingsTPOWCSiteManagement
+        /// </summary>
+        [JsonProperty("externalSettings_TPOWCSiteManagement")]
+        public bool? ExternalSettingsTPOWCSiteManagement { get => _externalSettingsTPOWCSiteManagement; set => SetField(ref _externalSettingsTPOWCSiteManagement, value); }
+
+        /// <summary>
+        /// MiscellaneousRights GlobalTabNews
+        /// </summary>
+        [JsonProperty("globalTab_News")]
+        public bool? GlobalTabNews { get => _globalTabNews; set => SetField(ref _globalTabNews, value); }
+
+        /// <summary>
+        /// MiscellaneousRights InputFormsShowAllFormsCheckBox
+        /// </summary>
+        [JsonProperty("inputForms_ShowAllFormsCheckBox")]
+        public bool? InputFormsShowAllFormsCheckBox { get => _inputFormsShowAllFormsCheckBox; set => SetField(ref _inputFormsShowAllFormsCheckBox, value); }
+
+        /// <summary>
+        /// MiscellaneousRights InstantMessenger
+        /// </summary>
+        public bool? InstantMessenger { get => _instantMessenger; set => SetField(ref _instantMessenger, value); }
+
+        /// <summary>
+        /// MiscellaneousRights LoanMgmtDownload
+        /// </summary>
+        [JsonProperty("loanMgmt_Download")]
+        public bool? LoanMgmtDownload { get => _loanMgmtDownload; set => SetField(ref _loanMgmtDownload, value); }
+
+        /// <summary>
+        /// MiscellaneousRights LoanMgmtDuplicateBlank
+        /// </summary>
+        [JsonProperty("loanMgmt_Duplicate_Blank")]
+        public bool? LoanMgmtDuplicateBlank { get => _loanMgmtDuplicateBlank; set => SetField(ref _loanMgmtDuplicateBlank, value); }
+
+        /// <summary>
+        /// MiscellaneousRights LoanMgmtUpload
+        /// </summary>
+        [JsonProperty("loanMgmt_Upload")]
+        public bool? LoanMgmtUpload { get => _loanMgmtUpload; set => SetField(ref _loanMgmtUpload, value); }
+
+        /// <summary>
+        /// MiscellaneousRights LoanTabeFolderDTModifyProtectedDocAndFiles
+        /// </summary>
+        [JsonProperty("loanTab_eFolder_DT_ModifyProtectedDocAndFiles")]
+        public bool? LoanTabeFolderDTModifyProtectedDocAndFiles { get => _loanTabeFolderDTModifyProtectedDocAndFiles; set => SetField(ref _loanTabeFolderDTModifyProtectedDocAndFiles, value); }
+
+        /// <summary>
+        /// MiscellaneousRights LoanTabeFolderDTNewEditFiles
+        /// </summary>
+        [JsonProperty("loanTab_eFolder_DT_NewEditFiles")]
+        public bool? LoanTabeFolderDTNewEditFiles { get => _loanTabeFolderDTNewEditFiles; set => SetField(ref _loanTabeFolderDTNewEditFiles, value); }
+
+        /// <summary>
+        /// MiscellaneousRights LoanTabOtherExclusiveLock
+        /// </summary>
+        [JsonProperty("loanTab_Other_ExclusiveLock")]
+        public bool? LoanTabOtherExclusiveLock { get => _loanTabOtherExclusiveLock; set => SetField(ref _loanTabOtherExclusiveLock, value); }
+
+        /// <summary>
+        /// MiscellaneousRights PlatFormAccess
+        /// </summary>
+        [JsonProperty("platForm_Access")]
+        public bool? PlatFormAccess { get => _platFormAccess; set => SetField(ref _platFormAccess, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabAffiliatedBusinessArrangementTemplates
+        /// </summary>
+        [JsonProperty("settingsTab_AffiliatedBusinessArrangementTemplates")]
+        public bool? SettingsTabAffiliatedBusinessArrangementTemplates { get => _settingsTabAffiliatedBusinessArrangementTemplates; set => SetField(ref _settingsTabAffiliatedBusinessArrangementTemplates, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabAllTPOContactInformation
+        /// </summary>
+        [JsonProperty("settingsTab_AllTPOContactInformation")]
+        public bool? SettingsTabAllTPOContactInformation { get => _settingsTabAllTPOContactInformation; set => SetField(ref _settingsTabAllTPOContactInformation, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabAutomatedDisclosures
+        /// </summary>
+        [JsonProperty("settingsTab_AutomatedDisclosures")]
+        public bool? SettingsTabAutomatedDisclosures { get => _settingsTabAutomatedDisclosures; set => SetField(ref _settingsTabAutomatedDisclosures, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabClosingCosts
+        /// </summary>
+        [JsonProperty("settingsTab_ClosingCosts")]
+        public bool? SettingsTabClosingCosts { get => _settingsTabClosingCosts; set => SetField(ref _settingsTabClosingCosts, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabClosingPlanCodes
+        /// </summary>
+        [JsonProperty("settingsTab_ClosingPlanCodes")]
+        public bool? SettingsTabClosingPlanCodes { get => _settingsTabClosingPlanCodes; set => SetField(ref _settingsTabClosingPlanCodes, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabClosingStackingTemplates
+        /// </summary>
+        [JsonProperty("settingsTab_ClosingStackingTemplates")]
+        public bool? SettingsTabClosingStackingTemplates { get => _settingsTabClosingStackingTemplates; set => SetField(ref _settingsTabClosingStackingTemplates, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCompanyDetails
+        /// </summary>
+        [JsonProperty("settingsTab_CompanyDetails")]
+        public bool? SettingsTabCompanyDetails { get => _settingsTabCompanyDetails; set => SetField(ref _settingsTabCompanyDetails, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCompanyCompanySettingsObsolete
+        /// </summary>
+        [JsonProperty("settingsTab_Company_CompanySettings_Obsolete")]
+        public bool? SettingsTabCompanyCompanySettingsObsolete { get => _settingsTabCompanyCompanySettingsObsolete; set => SetField(ref _settingsTabCompanyCompanySettingsObsolete, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCompanyConditionSetup
+        /// </summary>
+        [JsonProperty("settingsTab_Company_ConditionSetup")]
+        public bool? SettingsTabCompanyConditionSetup { get => _settingsTabCompanyConditionSetup; set => SetField(ref _settingsTabCompanyConditionSetup, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCompanyConfigurableKeyDates
+        /// </summary>
+        [JsonProperty("settingsTab_Company_ConfigurableKeyDates")]
+        public bool? SettingsTabCompanyConfigurableKeyDates { get => _settingsTabCompanyConfigurableKeyDates; set => SetField(ref _settingsTabCompanyConfigurableKeyDates, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCompanyDocumentSetup
+        /// </summary>
+        [JsonProperty("settingsTab_Company_DocumentSetup")]
+        public bool? SettingsTabCompanyDocumentSetup { get => _settingsTabCompanyDocumentSetup; set => SetField(ref _settingsTabCompanyDocumentSetup, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabComplianceReviewSetup
+        /// </summary>
+        [JsonProperty("settingsTab_ComplianceReviewSetup")]
+        public bool? SettingsTabComplianceReviewSetup { get => _settingsTabComplianceReviewSetup; set => SetField(ref _settingsTabComplianceReviewSetup, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabConditionForms
+        /// </summary>
+        [JsonProperty("settingsTab_ConditionForms")]
+        public bool? SettingsTabConditionForms { get => _settingsTabConditionForms; set => SetField(ref _settingsTabConditionForms, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCurrentLogins
+        /// </summary>
+        [JsonProperty("settingsTab_CurrentLogins")]
+        public bool? SettingsTabCurrentLogins { get => _settingsTabCurrentLogins; set => SetField(ref _settingsTabCurrentLogins, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabCustomPrintForms
+        /// </summary>
+        [JsonProperty("settingsTab_CustomPrintForms")]
+        public bool? SettingsTabCustomPrintForms { get => _settingsTabCustomPrintForms; set => SetField(ref _settingsTabCustomPrintForms, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabDataTemplates
+        /// </summary>
+        [JsonProperty("settingsTab_DataTemplates")]
+        public bool? SettingsTabDataTemplates { get => _settingsTabDataTemplates; set => SetField(ref _settingsTabDataTemplates, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabDocumentSets
+        /// </summary>
+        [JsonProperty("settingsTab_DocumentSets")]
+        public bool? SettingsTabDocumentSets { get => _settingsTabDocumentSets; set => SetField(ref _settingsTabDocumentSets, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabEDisclosurePlanCodes
+        /// </summary>
+        [JsonProperty("settingsTab_EDisclosurePlanCodes")]
+        public bool? SettingsTabEDisclosurePlanCodes { get => _settingsTabEDisclosurePlanCodes; set => SetField(ref _settingsTabEDisclosurePlanCodes, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabEDisclosureStackingTemplates
+        /// </summary>
+        [JsonProperty("settingsTab_EDisclosureStackingTemplates")]
+        public bool? SettingsTabEDisclosureStackingTemplates { get => _settingsTabEDisclosureStackingTemplates; set => SetField(ref _settingsTabEDisclosureStackingTemplates, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabExtCompany
+        /// </summary>
+        [JsonProperty("settingsTab_ExtCompany")]
+        public bool? SettingsTabExtCompany { get => _settingsTabExtCompany; set => SetField(ref _settingsTabExtCompany, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabInputFormSets
+        /// </summary>
+        [JsonProperty("settingsTab_InputFormSets")]
+        public bool? SettingsTabInputFormSets { get => _settingsTabInputFormSets; set => SetField(ref _settingsTabInputFormSets, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabItemizationFeeManagement
+        /// </summary>
+        [JsonProperty("settingsTab_ItemizationFeeManagement")]
+        public bool? SettingsTabItemizationFeeManagement { get => _settingsTabItemizationFeeManagement; set => SetField(ref _settingsTabItemizationFeeManagement, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabLoanCustomFields
+        /// </summary>
+        [JsonProperty("settingsTab_LoanCustomFields")]
+        public bool? SettingsTabLoanCustomFields { get => _settingsTabLoanCustomFields; set => SetField(ref _settingsTabLoanCustomFields, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabLoanErrorInformation
+        /// </summary>
+        [JsonProperty("settingsTab_LoanErrorInformation")]
+        public bool? SettingsTabLoanErrorInformation { get => _settingsTabLoanErrorInformation; set => SetField(ref _settingsTabLoanErrorInformation, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabLoanPrograms
+        /// </summary>
+        [JsonProperty("settingsTab_LoanPrograms")]
+        public bool? SettingsTabLoanPrograms { get => _settingsTabLoanPrograms; set => SetField(ref _settingsTabLoanPrograms, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabLoanReassignment
+        /// </summary>
+        [JsonProperty("settingsTab_LoanReassignment")]
+        public bool? SettingsTabLoanReassignment { get => _settingsTabLoanReassignment; set => SetField(ref _settingsTabLoanReassignment, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabLoanTemplateSets
+        /// </summary>
+        [JsonProperty("settingsTab_LoanTemplateSets")]
+        public bool? SettingsTabLoanTemplateSets { get => _settingsTabLoanTemplateSets; set => SetField(ref _settingsTabLoanTemplateSets, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabPrintFormGroups
+        /// </summary>
+        [JsonProperty("settingsTab_PrintFormGroups")]
+        public bool? SettingsTabPrintFormGroups { get => _settingsTabPrintFormGroups; set => SetField(ref _settingsTabPrintFormGroups, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabPublicBusinessContactGroups
+        /// </summary>
+        [JsonProperty("settingsTab_PublicBusinessContactGroups")]
+        public bool? SettingsTabPublicBusinessContactGroups { get => _settingsTabPublicBusinessContactGroups; set => SetField(ref _settingsTabPublicBusinessContactGroups, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabRebuildPipeline
+        /// </summary>
+        [JsonProperty("settingsTab_RebuildPipeline")]
+        public bool? SettingsTabRebuildPipeline { get => _settingsTabRebuildPipeline; set => SetField(ref _settingsTabRebuildPipeline, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabSecondaryRoot
+        /// </summary>
+        [JsonProperty("settingsTab_SecondaryRoot")]
+        public bool? SettingsTabSecondaryRoot { get => _settingsTabSecondaryRoot; set => SetField(ref _settingsTabSecondaryRoot, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabSettingsReport
+        /// </summary>
+        [JsonProperty("settingsTab_SettingsReport")]
+        public bool? SettingsTabSettingsReport { get => _settingsTabSettingsReport; set => SetField(ref _settingsTabSettingsReport, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabSettlementServiceProviders
+        /// </summary>
+        [JsonProperty("settingsTab_SettlementServiceProviders")]
+        public bool? SettingsTabSettlementServiceProviders { get => _settingsTabSettlementServiceProviders; set => SetField(ref _settingsTabSettlementServiceProviders, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabSystemAuditTrail
+        /// </summary>
+        [JsonProperty("settingsTab_SystemAuditTrail")]
+        public bool? SettingsTabSystemAuditTrail { get => _settingsTabSystemAuditTrail; set => SetField(ref _settingsTabSystemAuditTrail, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTablesFees
+        /// </summary>
+        [JsonProperty("settingsTab_TablesFees")]
+        public bool? SettingsTabTablesFees { get => _settingsTabTablesFees; set => SetField(ref _settingsTabTablesFees, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTaskSets
+        /// </summary>
+        [JsonProperty("settingsTab_TaskSets")]
+        public bool? SettingsTabTaskSets { get => _settingsTabTaskSets; set => SetField(ref _settingsTabTaskSets, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTpoCustomFields
+        /// </summary>
+        [JsonProperty("settingsTab_TpoCustomFields")]
+        public bool? SettingsTabTpoCustomFields { get => _settingsTabTpoCustomFields; set => SetField(ref _settingsTabTpoCustomFields, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTpoFees
+        /// </summary>
+        [JsonProperty("settingsTab_TpoFees")]
+        public bool? SettingsTabTpoFees { get => _settingsTabTpoFees; set => SetField(ref _settingsTabTpoFees, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTpoReassignment
+        /// </summary>
+        [JsonProperty("settingsTab_TpoReassignment")]
+        public bool? SettingsTabTpoReassignment { get => _settingsTabTpoReassignment; set => SetField(ref _settingsTabTpoReassignment, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTpoSettings
+        /// </summary>
+        [JsonProperty("settingsTab_TpoSettings")]
+        public bool? SettingsTabTpoSettings { get => _settingsTabTpoSettings; set => SetField(ref _settingsTabTpoSettings, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabTpoWebCenterDocs
+        /// </summary>
+        [JsonProperty("settingsTab_TpoWebCenterDocs")]
+        public bool? SettingsTabTpoWebCenterDocs { get => _settingsTabTpoWebCenterDocs; set => SetField(ref _settingsTabTpoWebCenterDocs, value); }
+
+        /// <summary>
+        /// MiscellaneousRights SettingsTabUnlockLoanFile
+        /// </summary>
+        [JsonProperty("settingsTab_UnlockLoanFile")]
+        public bool? SettingsTabUnlockLoanFile { get => _settingsTabUnlockLoanFile; set => SetField(ref _settingsTabUnlockLoanFile, value); }
+
+        /// <summary>
+        /// MiscellaneousRights ThinThickPipelineTabAccess
+        /// </summary>
+        [JsonProperty("thinThick_PipelineTab_Access")]
+        public bool? ThinThickPipelineTabAccess { get => _thinThickPipelineTabAccess; set => SetField(ref _thinThickPipelineTabAccess, value); }
+
+        /// <summary>
+        /// MiscellaneousRights ThinThickTradesTabAccess
+        /// </summary>
+        [JsonProperty("thinThick_TradesTab_Access")]
+        public bool? ThinThickTradesTabAccess { get => _thinThickTradesTabAccess; set => SetField(ref _thinThickTradesTabAccess, value); }
+
+        /// <summary>
+        /// MiscellaneousRights TPOAdministrationTabShowAsMgrAdminInBranchesTab
+        /// </summary>
+        [JsonProperty("tPOAdministrationTab_ShowAsMgrAdminInBranchesTab")]
+        public bool? TPOAdministrationTabShowAsMgrAdminInBranchesTab { get => _tPOAdministrationTabShowAsMgrAdminInBranchesTab; set => SetField(ref _tPOAdministrationTabShowAsMgrAdminInBranchesTab, value); }
+
+        /// <summary>
+        /// MiscellaneousRights TPOAdministrationTabShowAsMgrAdminInCompanyInfoTab
+        /// </summary>
+        [JsonProperty("tPOAdministrationTab_ShowAsMgrAdminInCompanyInfoTab")]
+        public bool? TPOAdministrationTabShowAsMgrAdminInCompanyInfoTab { get => _tPOAdministrationTabShowAsMgrAdminInCompanyInfoTab; set => SetField(ref _tPOAdministrationTabShowAsMgrAdminInCompanyInfoTab, value); }
+
+        /// <summary>
+        /// MiscellaneousRights TPOAdministrationTabViewCmtConfirmations
+        /// </summary>
+        [JsonProperty("tPOAdministrationTab_ViewCmtConfirmations")]
+        public bool? TPOAdministrationTabViewCmtConfirmations { get => _tPOAdministrationTabViewCmtConfirmations; set => SetField(ref _tPOAdministrationTabViewCmtConfirmations, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/MobileAccessRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/MobileAccessRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// MobileAccessRights
+    /// </summary>
+    public sealed class MobileAccessRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _encompassWindowsClient;
+        private DirtyValue<bool?> _encompassWindowsClientAndMobile;
+
+        /// <summary>
+        /// MobileAccessRights EncompassWindowsClient
+        /// </summary>
+        public bool? EncompassWindowsClient { get => _encompassWindowsClient; set => SetField(ref _encompassWindowsClient, value); }
+
+        /// <summary>
+        /// MobileAccessRights EncompassWindowsClientAndMobile
+        /// </summary>
+        public bool? EncompassWindowsClientAndMobile { get => _encompassWindowsClientAndMobile; set => SetField(ref _encompassWindowsClientAndMobile, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/MoveLoansRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/MoveLoansRights.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// MoveLoansRights
+    /// </summary>
+    public sealed class MoveLoansRights : ParentAccessRights
+    {
+        private DirtyDictionary<string, bool> _moveFrom;
+        private DirtyDictionary<string, bool> _moveTo;
+
+        /// <summary>
+        /// MoveLoansRights MoveFrom
+        /// </summary>
+        public IDictionary<string, bool> MoveFrom { get => GetField(ref _moveFrom); set => SetField(ref _moveFrom, value); }
+
+        /// <summary>
+        /// MoveLoansRights MoveTo
+        /// </summary>
+        public IDictionary<string, bool> MoveTo { get => GetField(ref _moveTo); set => SetField(ref _moveTo, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/MyProfileRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/MyProfileRights.cs
@@ -1,0 +1,50 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// MyProfileRights
+    /// </summary>
+    public sealed class MyProfileRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _cell;
+        private DirtyValue<bool?> _email;
+        private DirtyValue<bool?> _fax;
+        private DirtyValue<bool?> _name;
+        private DirtyValue<bool?> _phone;
+        private DirtyValue<bool?> _publicProfile;
+
+        /// <summary>
+        /// MyProfileRights Cell
+        /// </summary>
+        [JsonProperty("cell#")]
+        public bool? Cell { get => _cell; set => SetField(ref _cell, value); }
+
+        /// <summary>
+        /// MyProfileRights Email
+        /// </summary>
+        public bool? Email { get => _email; set => SetField(ref _email, value); }
+
+        /// <summary>
+        /// MyProfileRights Fax
+        /// </summary>
+        [JsonProperty("fax#")]
+        public bool? Fax { get => _fax; set => SetField(ref _fax, value); }
+
+        /// <summary>
+        /// MyProfileRights Name
+        /// </summary>
+        public bool? Name { get => _name; set => SetField(ref _name, value); }
+
+        /// <summary>
+        /// MyProfileRights Phone
+        /// </summary>
+        [JsonProperty("phone#")]
+        public bool? Phone { get => _phone; set => SetField(ref _phone, value); }
+
+        /// <summary>
+        /// MyProfileRights PublicProfile
+        /// </summary>
+        public bool? PublicProfile { get => _publicProfile; set => SetField(ref _publicProfile, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/NewEditDeleteConditionsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/NewEditDeleteConditionsRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// NewEditDeleteConditionsRights
+    /// </summary>
+    public sealed class NewEditDeleteConditionsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _changeSignoffDates;
+        private DirtyValue<bool?> _changeSignoffNames;
+
+        /// <summary>
+        /// NewEditDeleteConditionsRights ChangeSignoffDates
+        /// </summary>
+        public bool? ChangeSignoffDates { get => _changeSignoffDates; set => SetField(ref _changeSignoffDates, value); }
+
+        /// <summary>
+        /// NewEditDeleteConditionsRights ChangeSignoffNames
+        /// </summary>
+        public bool? ChangeSignoffNames { get => _changeSignoffNames; set => SetField(ref _changeSignoffNames, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/NewLoansRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/NewLoansRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// NewLoansRights
+    /// </summary>
+    public sealed class NewLoansRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _newBlankLoan;
+        private DirtyValue<bool?> _newFromTemplate;
+
+        /// <summary>
+        /// NewLoansRights NewBlankLoan
+        /// </summary>
+        public bool? NewBlankLoan { get => _newBlankLoan; set => SetField(ref _newBlankLoan, value); }
+
+        /// <summary>
+        /// NewLoansRights NewFromTemplate
+        /// </summary>
+        public bool? NewFromTemplate { get => _newFromTemplate; set => SetField(ref _newFromTemplate, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/NotesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/NotesRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// NotesRights
+    /// </summary>
+    public sealed class NotesRights : ParentAccessRights
+    {
+        private EditNotesRights _editNotes;
+
+        /// <summary>
+        /// NotesRights EditNotes
+        /// </summary>
+        public EditNotesRights EditNotes { get => GetField(ref _editNotes); set => SetField(ref _editNotes, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/OrderClosingDocsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/OrderClosingDocsRights.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OrderClosingDocsRights
+    /// </summary>
+    public sealed class OrderClosingDocsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addAdditionalDocs;
+        private DirtyValue<bool?> _deselectDocs;
+        private DirtyValue<bool?> _moveDocsUpDown;
+        private DirtyValue<bool?> _orderDocsEvenWithComplianceReviewFailures;
+
+        /// <summary>
+        /// OrderClosingDocsRights AddAdditionalDocs
+        /// </summary>
+        public bool? AddAdditionalDocs { get => _addAdditionalDocs; set => SetField(ref _addAdditionalDocs, value); }
+
+        /// <summary>
+        /// OrderClosingDocsRights DeselectDocs
+        /// </summary>
+        public bool? DeselectDocs { get => _deselectDocs; set => SetField(ref _deselectDocs, value); }
+
+        /// <summary>
+        /// OrderClosingDocsRights MoveDocsUpDown
+        /// </summary>
+        [JsonProperty("moveDocsUp/Down")]
+        public bool? MoveDocsUpDown { get => _moveDocsUpDown; set => SetField(ref _moveDocsUpDown, value); }
+
+        /// <summary>
+        /// OrderClosingDocsRights OrderDocsEvenWithComplianceReviewFailures
+        /// </summary>
+        public bool? OrderDocsEvenWithComplianceReviewFailures { get => _orderDocsEvenWithComplianceReviewFailures; set => SetField(ref _orderDocsEvenWithComplianceReviewFailures, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/OrganizationsUserRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/OrganizationsUserRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OrganizationsUserRights
+    /// </summary>
+    public sealed class OrganizationsUserRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addLEI;
+        private DirtyValue<bool?> _editLEI;
+
+        /// <summary>
+        /// OrganizationsUserRights AddLEI
+        /// </summary>
+        public bool? AddLEI { get => _addLEI; set => SetField(ref _addLEI, value); }
+
+        /// <summary>
+        /// OrganizationsUserRights EditLEI
+        /// </summary>
+        public bool? EditLEI { get => _editLEI; set => SetField(ref _editLEI, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/OriginateLoanOrderCreditProductPricingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/OriginateLoanOrderCreditProductPricingRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OriginateLoanOrderCreditProductPricingRights
+    /// </summary>
+    public sealed class OriginateLoanOrderCreditProductPricingRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _orderCredit;
+        private OriginateLoanRights _originateLoan;
+        private DirtyValue<bool?> _productAndPricing;
+
+        /// <summary>
+        /// OriginateLoanOrderCreditProductPricingRights OrderCredit
+        /// </summary>
+        public bool? OrderCredit { get => _orderCredit; set => SetField(ref _orderCredit, value); }
+
+        /// <summary>
+        /// OriginateLoanOrderCreditProductPricingRights OriginateLoan
+        /// </summary>
+        public OriginateLoanRights OriginateLoan { get => GetField(ref _originateLoan); set => SetField(ref _originateLoan, value); }
+
+        /// <summary>
+        /// OriginateLoanOrderCreditProductPricingRights ProductAndPricing
+        /// </summary>
+        public bool? ProductAndPricing { get => _productAndPricing; set => SetField(ref _productAndPricing, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/OriginateLoanRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/OriginateLoanRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OriginateLoanRights
+    /// </summary>
+    public sealed class OriginateLoanRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _newBlankLoan;
+        private DirtyValue<bool?> _newFromTemplate;
+
+        /// <summary>
+        /// OriginateLoanRights NewBlankLoan
+        /// </summary>
+        public bool? NewBlankLoan { get => _newBlankLoan; set => SetField(ref _newBlankLoan, value); }
+
+        /// <summary>
+        /// OriginateLoanRights NewFromTemplate
+        /// </summary>
+        public bool? NewFromTemplate { get => _newFromTemplate; set => SetField(ref _newFromTemplate, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/OtherDisplayMilestoneListChangeScreenRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/OtherDisplayMilestoneListChangeScreenRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OtherDisplayMilestoneListChangeScreenRights
+    /// </summary>
+    public sealed class OtherDisplayMilestoneListChangeScreenRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _modifyWhoReceivesNotificationOfAccessLoss;
+
+        /// <summary>
+        /// OtherDisplayMilestoneListChangeScreenRights ModifyWhoReceivesNotificationOfAccessLoss
+        /// </summary>
+        public bool? ModifyWhoReceivesNotificationOfAccessLoss { get => _modifyWhoReceivesNotificationOfAccessLoss; set => SetField(ref _modifyWhoReceivesNotificationOfAccessLoss, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ParentAccessRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ParentAccessRights.cs
@@ -1,0 +1,15 @@
+﻿namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ParentAccessRights
+    /// </summary>
+    public abstract class ParentAccessRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _parentAccess;
+
+        /// <summary>
+        /// ParentAccessRights ParentAccess
+        /// </summary>
+        public bool? ParentAccess { get => _parentAccess; set => SetField(ref _parentAccess, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PersonalSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PersonalSettingsRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PersonalSettingsRights
+    /// </summary>
+    public sealed class PersonalSettingsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _defaultFileContacts;
+        private DirtyValue<bool?> _grantFileAccess;
+        private MyProfileRights _myProfile;
+
+        /// <summary>
+        /// PersonalSettingsRights DefaultFileContacts
+        /// </summary>
+        public bool? DefaultFileContacts { get => _defaultFileContacts; set => SetField(ref _defaultFileContacts, value); }
+
+        /// <summary>
+        /// PersonalSettingsRights GrantFileAccess
+        /// </summary>
+        public bool? GrantFileAccess { get => _grantFileAccess; set => SetField(ref _grantFileAccess, value); }
+
+        /// <summary>
+        /// PersonalSettingsRights MyProfile
+        /// </summary>
+        public MyProfileRights MyProfile { get => GetField(ref _myProfile); set => SetField(ref _myProfile, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PersonalTemplatesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PersonalTemplatesRights.cs
@@ -1,0 +1,75 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PersonalTemplatesRights
+    /// </summary>
+    public sealed class PersonalTemplatesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _affiliatedBusinessArrangementTemplates;
+        private DirtyValue<bool?> _closingCosts;
+        private DirtyValue<bool?> _customPrintForms;
+        private DirtyValue<bool?> _dataTemplates;
+        private DirtyValue<bool?> _documentSets;
+        private DirtyValue<bool?> _inputFormSets;
+        private DirtyValue<bool?> _loanPrograms;
+        private DirtyValue<bool?> _loanTemplateSets;
+        private DirtyValue<bool?> _printFormGroups;
+        private DirtyValue<bool?> _settlementServiceProviders;
+        private DirtyValue<bool?> _taskSets;
+
+        /// <summary>
+        /// PersonalTemplatesRights AffiliatedBusinessArrangementTemplates
+        /// </summary>
+        public bool? AffiliatedBusinessArrangementTemplates { get => _affiliatedBusinessArrangementTemplates; set => SetField(ref _affiliatedBusinessArrangementTemplates, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights ClosingCosts
+        /// </summary>
+        public bool? ClosingCosts { get => _closingCosts; set => SetField(ref _closingCosts, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights CustomPrintForms
+        /// </summary>
+        public bool? CustomPrintForms { get => _customPrintForms; set => SetField(ref _customPrintForms, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights DataTemplates
+        /// </summary>
+        public bool? DataTemplates { get => _dataTemplates; set => SetField(ref _dataTemplates, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights DocumentSets
+        /// </summary>
+        public bool? DocumentSets { get => _documentSets; set => SetField(ref _documentSets, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights InputFormSets
+        /// </summary>
+        public bool? InputFormSets { get => _inputFormSets; set => SetField(ref _inputFormSets, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights LoanPrograms
+        /// </summary>
+        public bool? LoanPrograms { get => _loanPrograms; set => SetField(ref _loanPrograms, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights LoanTemplateSets
+        /// </summary>
+        public bool? LoanTemplateSets { get => _loanTemplateSets; set => SetField(ref _loanTemplateSets, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights PrintFormGroups
+        /// </summary>
+        public bool? PrintFormGroups { get => _printFormGroups; set => SetField(ref _printFormGroups, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights SettlementServiceProviders
+        /// </summary>
+        public bool? SettlementServiceProviders { get => _settlementServiceProviders; set => SetField(ref _settlementServiceProviders, value); }
+
+        /// <summary>
+        /// PersonalTemplatesRights TaskSets
+        /// </summary>
+        public bool? TaskSets { get => _taskSets; set => SetField(ref _taskSets, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PersonasRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PersonasRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PersonasRights
+    /// </summary>
+    public sealed class PersonasRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _edit;
+
+        /// <summary>
+        /// PersonasRights Edit
+        /// </summary>
+        public bool? Edit { get => _edit; set => SetField(ref _edit, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PipelineAndLoansRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PipelineAndLoansRights.cs
@@ -1,0 +1,49 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PipelineAndLoansRights
+    /// </summary>
+    public sealed class PipelineAndLoansRights : ParentAccessRights
+    {
+        private AccessToFeesRights _accessToFees;
+        private AccessToProductPricingRights _accessToProductPricing;
+        private DirtyValue<bool?> _generateDisclosures;
+        private DirtyValue<bool?> _submitForPurchase;
+        private DirtyValue<bool?> _viewPurchaseAdvice;
+        private DirtyValue<bool?> _viewMessages;
+
+        /// <summary>
+        /// PipelineAndLoansRights AccessToFees
+        /// </summary>
+        public AccessToFeesRights AccessToFees { get => GetField(ref _accessToFees); set => SetField(ref _accessToFees, value); }
+
+        /// <summary>
+        /// PipelineAndLoansRights AccessToProductPricing
+        /// </summary>
+        [JsonProperty("accessToProduct&Pricing")]
+        public AccessToProductPricingRights AccessToProductPricing { get => GetField(ref _accessToProductPricing); set => SetField(ref _accessToProductPricing, value); }
+
+        /// <summary>
+        /// PipelineAndLoansRights GenerateDisclosures
+        /// </summary>
+        public bool? GenerateDisclosures { get => _generateDisclosures; set => SetField(ref _generateDisclosures, value); }
+
+        /// <summary>
+        /// PipelineAndLoansRights SubmitForPurchase
+        /// </summary>
+        public bool? SubmitForPurchase { get => _submitForPurchase; set => SetField(ref _submitForPurchase, value); }
+
+        /// <summary>
+        /// PipelineAndLoansRights ViewPurchaseAdvice
+        /// </summary>
+        [JsonProperty("view Purchase Advice")]
+        public bool? ViewPurchaseAdvice { get => _viewPurchaseAdvice; set => SetField(ref _viewPurchaseAdvice, value); }
+
+        /// <summary>
+        /// PipelineAndLoansRights ViewMessages
+        /// </summary>
+        public bool? ViewMessages { get => _viewMessages; set => SetField(ref _viewMessages, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PipelineRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PipelineRights.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PipelineRights
+    /// </summary>
+    public sealed class PipelineRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _accessToPipelineLoanTab;
+        private DirtyDictionary<string, bool> _notAccessibleColumns;
+        private PipelineTasksRights _pipelineTasks;
+
+        /// <summary>
+        /// PipelineRights AccessToPipelineLoanTab
+        /// </summary>
+        [JsonProperty("accessToPipeline/LoanTab")]
+        public bool? AccessToPipelineLoanTab { get => _accessToPipelineLoanTab; set => SetField(ref _accessToPipelineLoanTab, value); }
+
+        /// <summary>
+        /// PipelineRights NotAccessibleColumns
+        /// </summary>
+        public IDictionary<string, bool> NotAccessibleColumns { get => GetField(ref _notAccessibleColumns); set => SetField(ref _notAccessibleColumns, value); }
+
+        /// <summary>
+        /// PipelineRights PipelineTasks
+        /// </summary>
+        public PipelineTasksRights PipelineTasks { get => GetField(ref _pipelineTasks); set => SetField(ref _pipelineTasks, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PipelineTasksRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PipelineTasksRights.cs
@@ -1,0 +1,111 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PipelineTasksRights
+    /// </summary>
+    public sealed class PipelineTasksRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _automaticRefreshConfiguration;
+        private DirtyValue<bool?> _deleteLoans;
+        private DuplicateLoansRights _duplicateLoans;
+        private DirtyValue<bool?> _duplicateLoansforSecond;
+        private DirtyValue<bool?> _exportDatatoExcel;
+        private DirtyValue<bool?> _generateNMLSReport;
+        private GSEServicesRights _gSEServices;
+        private HMDAServicesRights _hMDAServices;
+        private ImportLoansRights _importLoans;
+        private DirtyValue<bool?> _includeArchiveFolders;
+        private DirtyValue<bool?> _investorServices;
+        private DirtyValue<bool?> _manageAlerts;
+        private ManagePipelineServicesRights _managePipelineServices;
+        private MoveLoansRights _moveLoans;
+        private NewLoansRights _newLoans;
+        private DirtyValue<bool?> _transferLoans;
+        private TrashFolderTasksRights _trashFolderTasks;
+
+        /// <summary>
+        /// PipelineTasksRights AutomaticRefreshConfiguration
+        /// </summary>
+        public bool? AutomaticRefreshConfiguration { get => _automaticRefreshConfiguration; set => SetField(ref _automaticRefreshConfiguration, value); }
+
+        /// <summary>
+        /// PipelineTasksRights DeleteLoans
+        /// </summary>
+        public bool? DeleteLoans { get => _deleteLoans; set => SetField(ref _deleteLoans, value); }
+
+        /// <summary>
+        /// PipelineTasksRights DuplicateLoans
+        /// </summary>
+        public DuplicateLoansRights DuplicateLoans { get => GetField(ref _duplicateLoans); set => SetField(ref _duplicateLoans, value); }
+
+        /// <summary>
+        /// PipelineTasksRights DuplicateLoansforSecond
+        /// </summary>
+        public bool? DuplicateLoansforSecond { get => _duplicateLoansforSecond; set => SetField(ref _duplicateLoansforSecond, value); }
+
+        /// <summary>
+        /// PipelineTasksRights ExportDatatoExcel
+        /// </summary>
+        public bool? ExportDatatoExcel { get => _exportDatatoExcel; set => SetField(ref _exportDatatoExcel, value); }
+
+        /// <summary>
+        /// PipelineTasksRights GenerateNMLSReport
+        /// </summary>
+        public bool? GenerateNMLSReport { get => _generateNMLSReport; set => SetField(ref _generateNMLSReport, value); }
+
+        /// <summary>
+        /// PipelineTasksRights GSEServices
+        /// </summary>
+        public GSEServicesRights GSEServices { get => GetField(ref _gSEServices); set => SetField(ref _gSEServices, value); }
+
+        /// <summary>
+        /// PipelineTasksRights HMDAServices
+        /// </summary>
+        public HMDAServicesRights HMDAServices { get => GetField(ref _hMDAServices); set => SetField(ref _hMDAServices, value); }
+
+        /// <summary>
+        /// PipelineTasksRights ImportLoans
+        /// </summary>
+        public ImportLoansRights ImportLoans { get => GetField(ref _importLoans); set => SetField(ref _importLoans, value); }
+
+        /// <summary>
+        /// PipelineTasksRights IncludeArchiveFolders
+        /// </summary>
+        public bool? IncludeArchiveFolders { get => _includeArchiveFolders; set => SetField(ref _includeArchiveFolders, value); }
+
+        /// <summary>
+        /// PipelineTasksRights InvestorServices
+        /// </summary>
+        public bool? InvestorServices { get => _investorServices; set => SetField(ref _investorServices, value); }
+
+        /// <summary>
+        /// PipelineTasksRights ManageAlerts
+        /// </summary>
+        public bool? ManageAlerts { get => _manageAlerts; set => SetField(ref _manageAlerts, value); }
+
+        /// <summary>
+        /// PipelineTasksRights ManagePipelineServices
+        /// </summary>
+        public ManagePipelineServicesRights ManagePipelineServices { get => GetField(ref _managePipelineServices); set => SetField(ref _managePipelineServices, value); }
+
+        /// <summary>
+        /// PipelineTasksRights MoveLoans
+        /// </summary>
+        public MoveLoansRights MoveLoans { get => GetField(ref _moveLoans); set => SetField(ref _moveLoans, value); }
+
+        /// <summary>
+        /// PipelineTasksRights NewLoans
+        /// </summary>
+        public NewLoansRights NewLoans { get => GetField(ref _newLoans); set => SetField(ref _newLoans, value); }
+
+        /// <summary>
+        /// PipelineTasksRights TransferLoans
+        /// </summary>
+        public bool? TransferLoans { get => _transferLoans; set => SetField(ref _transferLoans, value); }
+
+        /// <summary>
+        /// PipelineTasksRights TrashFolderTasks
+        /// </summary>
+        public TrashFolderTasksRights TrashFolderTasks { get => GetField(ref _trashFolderTasks); set => SetField(ref _trashFolderTasks, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PostClosingConditionsTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PostClosingConditionsTabRights.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PostClosingConditionsTabRights
+    /// </summary>
+    public sealed class PostClosingConditionsTabRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addEditDeleteConditions;
+        private DirtyValue<bool?> _addAutomatedConditions;
+
+        /// <summary>
+        /// PostClosingConditionsTabRights AddEditDeleteConditions
+        /// </summary>
+        [JsonProperty("add/Edit/DeleteConditions")]
+        public bool? AddEditDeleteConditions { get => _addEditDeleteConditions; set => SetField(ref _addEditDeleteConditions, value); }
+
+        /// <summary>
+        /// PostClosingConditionsTabRights AddAutomatedConditions
+        /// </summary>
+        public bool? AddAutomatedConditions { get => _addAutomatedConditions; set => SetField(ref _addAutomatedConditions, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PreliminaryConditionsTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PreliminaryConditionsTabRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PreliminaryConditionsTabRights
+    /// </summary>
+    public sealed class PreliminaryConditionsTabRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addAutomatedConditions;
+
+        /// <summary>
+        /// PreliminaryConditionsTabRights AddAutomatedConditions
+        /// </summary>
+        public bool? AddAutomatedConditions { get => _addAutomatedConditions; set => SetField(ref _addAutomatedConditions, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PrintRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PrintRights.cs
@@ -1,0 +1,43 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PrintRights
+    /// </summary>
+    public sealed class PrintRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _customFormsTab;
+        private DirtyValue<bool?> _preview;
+        private DirtyValue<bool?> _printButton;
+        private DirtyValue<bool?> _printToFile;
+        private DirtyValue<bool?> _standardFormsTab;
+
+        /// <summary>
+        /// PrintRights CustomFormsTab
+        /// </summary>
+        [JsonProperty("customFormsTab*")]
+        public bool? CustomFormsTab { get => _customFormsTab; set => SetField(ref _customFormsTab, value); }
+
+        /// <summary>
+        /// PrintRights Preview
+        /// </summary>
+        public bool? Preview { get => _preview; set => SetField(ref _preview, value); }
+
+        /// <summary>
+        /// PrintRights PrintButton
+        /// </summary>
+        public bool? PrintButton { get => _printButton; set => SetField(ref _printButton, value); }
+
+        /// <summary>
+        /// PrintRights PrintToFile
+        /// </summary>
+        public bool? PrintToFile { get => _printToFile; set => SetField(ref _printToFile, value); }
+
+        /// <summary>
+        /// PrintRights StandardFormsTab
+        /// </summary>
+        [JsonProperty("standardFormsTab*")]
+        public bool? StandardFormsTab { get => _standardFormsTab; set => SetField(ref _standardFormsTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ProtectedDocumentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ProtectedDocumentsRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ProtectedDocumentsRights
+    /// </summary>
+    public sealed class ProtectedDocumentsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _deleteDocument;
+        private EditDocumentRights _editDocument;
+
+        /// <summary>
+        /// ProtectedDocumentsRights DeleteDocument
+        /// </summary>
+        public bool? DeleteDocument { get => _deleteDocument; set => SetField(ref _deleteDocument, value); }
+
+        /// <summary>
+        /// ProtectedDocumentsRights EditDocument
+        /// </summary>
+        public EditDocumentRights EditDocument { get => GetField(ref _editDocument); set => SetField(ref _editDocument, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PurchaseAdviceFormRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PurchaseAdviceFormRights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PurchaseAdviceFormRights
+    /// </summary>
+    public sealed class PurchaseAdviceFormRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _createEditTemplate;
+
+        /// <summary>
+        /// PurchaseAdviceFormRights CreateEditTemplate
+        /// </summary>
+        [JsonProperty("create/EditTemplate")]
+        public bool? CreateEditTemplate { get => _createEditTemplate; set => SetField(ref _createEditTemplate, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/PurchaseConditionsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/PurchaseConditionsRights.cs
@@ -1,0 +1,55 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// PurchaseConditionsRights
+    /// </summary>
+    public sealed class PurchaseConditionsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addEditDeleteComments;
+        private DirtyValue<bool?> _addAutomatedConditions;
+        private DirtyValue<bool?> _addSupportingDocuments;
+        private DirtyValue<bool?> _changePriorTo;
+        private DirtyValue<bool?> _markStatusCompleted;
+        private NewEditDeleteConditionsRights _newEditDeleteConditions;
+        private DirtyValue<bool?> _removeSupportingDocuments;
+
+        /// <summary>
+        /// PurchaseConditionsRights AddEditDeleteComments
+        /// </summary>
+        [JsonProperty("add/Edit/DeleteComments")]
+        public bool? AddEditDeleteComments { get => _addEditDeleteComments; set => SetField(ref _addEditDeleteComments, value); }
+
+        /// <summary>
+        /// PurchaseConditionsRights AddAutomatedConditions
+        /// </summary>
+        public bool? AddAutomatedConditions { get => _addAutomatedConditions; set => SetField(ref _addAutomatedConditions, value); }
+
+        /// <summary>
+        /// PurchaseConditionsRights AddSupportingDocuments
+        /// </summary>
+        public bool? AddSupportingDocuments { get => _addSupportingDocuments; set => SetField(ref _addSupportingDocuments, value); }
+
+        /// <summary>
+        /// PurchaseConditionsRights ChangePriorTo
+        /// </summary>
+        public bool? ChangePriorTo { get => _changePriorTo; set => SetField(ref _changePriorTo, value); }
+
+        /// <summary>
+        /// PurchaseConditionsRights MarkStatusCompleted
+        /// </summary>
+        public bool? MarkStatusCompleted { get => _markStatusCompleted; set => SetField(ref _markStatusCompleted, value); }
+
+        /// <summary>
+        /// PurchaseConditionsRights NewEditDeleteConditions
+        /// </summary>
+        [JsonProperty("new/Edit/DeleteConditions")]
+        public NewEditDeleteConditionsRights NewEditDeleteConditions { get => GetField(ref _newEditDeleteConditions); set => SetField(ref _newEditDeleteConditions, value); }
+
+        /// <summary>
+        /// PurchaseConditionsRights RemoveSupportingDocuments
+        /// </summary>
+        public bool? RemoveSupportingDocuments { get => _removeSupportingDocuments; set => SetField(ref _removeSupportingDocuments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ReportsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ReportsRights.cs
@@ -1,0 +1,51 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ReportsRights
+    /// </summary>
+    public sealed class ReportsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _borrowerContactReports;
+        private DirtyValue<bool?> _businessContactReports;
+        private DirtyValue<bool?> _dynamicReporting;
+        private LoanReportsRights _loanReports;
+        private DirtyValue<bool?> _managePersonalReports;
+        private DirtyValue<bool?> _tPOSettingsReports;
+        private DirtyValue<bool?> _tradeReports;
+
+        /// <summary>
+        /// ReportsRights BorrowerContactReports
+        /// </summary>
+        public bool? BorrowerContactReports { get => _borrowerContactReports; set => SetField(ref _borrowerContactReports, value); }
+
+        /// <summary>
+        /// ReportsRights BusinessContactReports
+        /// </summary>
+        public bool? BusinessContactReports { get => _businessContactReports; set => SetField(ref _businessContactReports, value); }
+
+        /// <summary>
+        /// ReportsRights DynamicReporting
+        /// </summary>
+        public bool? DynamicReporting { get => _dynamicReporting; set => SetField(ref _dynamicReporting, value); }
+
+        /// <summary>
+        /// ReportsRights LoanReports
+        /// </summary>
+        public LoanReportsRights LoanReports { get => GetField(ref _loanReports); set => SetField(ref _loanReports, value); }
+
+        /// <summary>
+        /// ReportsRights ManagePersonalReports
+        /// </summary>
+        public bool? ManagePersonalReports { get => _managePersonalReports; set => SetField(ref _managePersonalReports, value); }
+
+        /// <summary>
+        /// ReportsRights TPOSettingsReports
+        /// </summary>
+        public bool? TPOSettingsReports { get => _tPOSettingsReports; set => SetField(ref _tPOSettingsReports, value); }
+
+        /// <summary>
+        /// ReportsRights TradeReports
+        /// </summary>
+        public bool? TradeReports { get => _tradeReports; set => SetField(ref _tradeReports, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SalesRepsAERights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SalesRepsAERights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// SalesRepsAERights
+    /// </summary>
+    public sealed class SalesRepsAERights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editSalesRepsAE;
+
+        /// <summary>
+        /// SalesRepsAERights EditSalesRepsAE
+        /// </summary>
+        [JsonProperty("editSalesReps/AE")]
+        public bool? EditSalesRepsAE { get => _editSalesRepsAE; set => SetField(ref _editSalesRepsAE, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SecondarySetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SecondarySetupRights.cs
@@ -1,0 +1,102 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// SecondarySetupRights
+    /// </summary>
+    public sealed class SecondarySetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _adjustmentTemplates;
+        private DirtyValue<bool?> _autoLock;
+        private DirtyValue<bool?> _correspondentPurchaseAdviceManagementSetup;
+        private DirtyValue<bool?> _ePPSLoanProgramTable;
+        private DirtyValue<bool?> _fundingTemplates;
+        private DirtyValue<bool?> _investorTemplates;
+        private DirtyValue<bool?> _loanPricingDecimalPlaces;
+        private DirtyValue<bool?> _lockDeskSetup;
+        private DirtyValue<bool?> _lockRequestAdditionalFields;
+        private DirtyValue<bool?> _productandPricing;
+        private DirtyValue<bool?> _purchaseAdviceForm;
+        private DirtyValue<bool?> _secondaryLockFields;
+        private DirtyValue<bool?> _servicing;
+        private DirtyValue<bool?> _sRPTemplates;
+        private DirtyValue<bool?> _tradeManagementSetup;
+
+        /// <summary>
+        /// SecondarySetupRights AdjustmentTemplates
+        /// </summary>
+        public bool? AdjustmentTemplates { get => _adjustmentTemplates; set => SetField(ref _adjustmentTemplates, value); }
+
+        /// <summary>
+        /// SecondarySetupRights AutoLock
+        /// </summary>
+        [JsonProperty("auto-Lock")]
+        public bool? AutoLock { get => _autoLock; set => SetField(ref _autoLock, value); }
+
+        /// <summary>
+        /// SecondarySetupRights CorrespondentPurchaseAdviceManagementSetup
+        /// </summary>
+        public bool? CorrespondentPurchaseAdviceManagementSetup { get => _correspondentPurchaseAdviceManagementSetup; set => SetField(ref _correspondentPurchaseAdviceManagementSetup, value); }
+
+        /// <summary>
+        /// SecondarySetupRights EPPSLoanProgramTable
+        /// </summary>
+        public bool? EPPSLoanProgramTable { get => _ePPSLoanProgramTable; set => SetField(ref _ePPSLoanProgramTable, value); }
+
+        /// <summary>
+        /// SecondarySetupRights FundingTemplates
+        /// </summary>
+        public bool? FundingTemplates { get => _fundingTemplates; set => SetField(ref _fundingTemplates, value); }
+
+        /// <summary>
+        /// SecondarySetupRights InvestorTemplates
+        /// </summary>
+        public bool? InvestorTemplates { get => _investorTemplates; set => SetField(ref _investorTemplates, value); }
+
+        /// <summary>
+        /// SecondarySetupRights LoanPricingDecimalPlaces
+        /// </summary>
+        public bool? LoanPricingDecimalPlaces { get => _loanPricingDecimalPlaces; set => SetField(ref _loanPricingDecimalPlaces, value); }
+
+        /// <summary>
+        /// SecondarySetupRights LockDeskSetup
+        /// </summary>
+        public bool? LockDeskSetup { get => _lockDeskSetup; set => SetField(ref _lockDeskSetup, value); }
+
+        /// <summary>
+        /// SecondarySetupRights LockRequestAdditionalFields
+        /// </summary>
+        public bool? LockRequestAdditionalFields { get => _lockRequestAdditionalFields; set => SetField(ref _lockRequestAdditionalFields, value); }
+
+        /// <summary>
+        /// SecondarySetupRights ProductandPricing
+        /// </summary>
+        public bool? ProductandPricing { get => _productandPricing; set => SetField(ref _productandPricing, value); }
+
+        /// <summary>
+        /// SecondarySetupRights PurchaseAdviceForm
+        /// </summary>
+        public bool? PurchaseAdviceForm { get => _purchaseAdviceForm; set => SetField(ref _purchaseAdviceForm, value); }
+
+        /// <summary>
+        /// SecondarySetupRights SecondaryLockFields
+        /// </summary>
+        public bool? SecondaryLockFields { get => _secondaryLockFields; set => SetField(ref _secondaryLockFields, value); }
+
+        /// <summary>
+        /// SecondarySetupRights Servicing
+        /// </summary>
+        public bool? Servicing { get => _servicing; set => SetField(ref _servicing, value); }
+
+        /// <summary>
+        /// SecondarySetupRights SRPTemplates
+        /// </summary>
+        public bool? SRPTemplates { get => _sRPTemplates; set => SetField(ref _sRPTemplates, value); }
+
+        /// <summary>
+        /// SecondarySetupRights TradeManagementSetup
+        /// </summary>
+        public bool? TradeManagementSetup { get => _tradeManagementSetup; set => SetField(ref _tradeManagementSetup, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SettingsOtherRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SettingsOtherRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// OtherClassRights
+    /// </summary>
+    public sealed class SettingsOtherRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _accessToInputFormBuilder;
+        private DirtyValue<bool?> _diagnosticMode;
+
+        /// <summary>
+        /// OtherClassRights AccessToInputFormBuilder
+        /// </summary>
+        public bool? AccessToInputFormBuilder { get => _accessToInputFormBuilder; set => SetField(ref _accessToInputFormBuilder, value); }
+
+        /// <summary>
+        /// OtherClassRights DiagnosticMode
+        /// </summary>
+        public bool? DiagnosticMode { get => _diagnosticMode; set => SetField(ref _diagnosticMode, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SettingsReportRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SettingsReportRights.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// SettingsReportRights
+    /// </summary>
+    public sealed class SettingsReportRights : DirtyExtensibleObject
+    {
+        private CancelSettingReportsRights _cancelSettingReports;
+        private DirtyValue<bool?> _deleteSettingsReports;
+        private DirtyValue<bool?> _generateViewSettingsReports;
+        private DirtyValue<bool?> _viewSettingsReportsSubmittedByOthers;
+
+        /// <summary>
+        /// SettingsReportRights CancelSettingReports
+        /// </summary>
+        public CancelSettingReportsRights CancelSettingReports { get => GetField(ref _cancelSettingReports); set => SetField(ref _cancelSettingReports, value); }
+
+        /// <summary>
+        /// SettingsReportRights DeleteSettingsReports
+        /// </summary>
+        public bool? DeleteSettingsReports { get => _deleteSettingsReports; set => SetField(ref _deleteSettingsReports, value); }
+
+        /// <summary>
+        /// SettingsReportRights GenerateViewSettingsReports
+        /// </summary>
+        [JsonProperty("generate&ViewSettingsReports")]
+        public bool? GenerateViewSettingsReports { get => _generateViewSettingsReports; set => SetField(ref _generateViewSettingsReports, value); }
+
+        /// <summary>
+        /// SettingsReportRights ViewSettingsReportsSubmittedByOthers
+        /// </summary>
+        public bool? ViewSettingsReportsSubmittedByOthers { get => _viewSettingsReportsSubmittedByOthers; set => SetField(ref _viewSettingsReportsSubmittedByOthers, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SettingsRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// SettingsRights
+    /// </summary>
+    public sealed class SettingsRights : DirtyExtensibleObject
+    {
+        private CompanySettingsRights _companySettings;
+        private SettingsOtherRights _other;
+        private PersonalSettingsRights _personalSettings;
+
+        /// <summary>
+        /// SettingsRights CompanySettings
+        /// </summary>
+        public CompanySettingsRights CompanySettings { get => GetField(ref _companySettings); set => SetField(ref _companySettings, value); }
+
+        /// <summary>
+        /// SettingsRights Other
+        /// </summary>
+        public SettingsOtherRights Other { get => GetField(ref _other); set => SetField(ref _other, value); }
+
+        /// <summary>
+        /// SettingsRights PersonalSettings
+        /// </summary>
+        public PersonalSettingsRights PersonalSettings { get => GetField(ref _personalSettings); set => SetField(ref _personalSettings, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SiteSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SiteSettingsRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// SiteSettingsRights
+    /// </summary>
+    public sealed class SiteSettingsRights : DirtyExtensibleObject
+    {
+        private AccessToTPOTradeManagementRights _accessToTPOTradeManagement;
+        private GeneralRights _general;
+        private PipelineAndLoansRights _pipelineAndLoans;
+
+        /// <summary>
+        /// SiteSettingsRights AccessToTPOTradeManagement
+        /// </summary>
+        public AccessToTPOTradeManagementRights AccessToTPOTradeManagement { get => GetField(ref _accessToTPOTradeManagement); set => SetField(ref _accessToTPOTradeManagement, value); }
+
+        /// <summary>
+        /// SiteSettingsRights General
+        /// </summary>
+        public GeneralRights General { get => GetField(ref _general); set => SetField(ref _general, value); }
+
+        /// <summary>
+        /// SiteSettingsRights PipelineAndLoans
+        /// </summary>
+        public PipelineAndLoansRights PipelineAndLoans { get => GetField(ref _pipelineAndLoans); set => SetField(ref _pipelineAndLoans, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/StartServicingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/StartServicingRights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// StartServicingRights
+    /// </summary>
+    public sealed class StartServicingRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _reStartServicing;
+
+        /// <summary>
+        /// StartServicingRights ReStartServicing
+        /// </summary>
+        [JsonProperty("re-StartServicing")]
+        public bool? ReStartServicing { get => _reStartServicing; set => SetField(ref _reStartServicing, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/SystemAdministrationRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/SystemAdministrationRights.cs
@@ -1,0 +1,51 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// SystemAdministrationRights
+    /// </summary>
+    public sealed class SystemAdministrationRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _allUserInformation;
+        private DirtyValue<bool?> _analysisTools;
+        private CurrentLoginsRights _currentLogins;
+        private DirtyValue<bool?> _loanReassignment;
+        private SettingsReportRights _settingsReport;
+        private DirtyValue<bool?> _systemAuditTrail;
+        private DirtyValue<bool?> _unlockLoanFile;
+
+        /// <summary>
+        /// SystemAdministrationRights AllUserInformation
+        /// </summary>
+        public bool? AllUserInformation { get => _allUserInformation; set => SetField(ref _allUserInformation, value); }
+
+        /// <summary>
+        /// SystemAdministrationRights AnalysisTools
+        /// </summary>
+        public bool? AnalysisTools { get => _analysisTools; set => SetField(ref _analysisTools, value); }
+
+        /// <summary>
+        /// SystemAdministrationRights CurrentLogins
+        /// </summary>
+        public CurrentLoginsRights CurrentLogins { get => GetField(ref _currentLogins); set => SetField(ref _currentLogins, value); }
+
+        /// <summary>
+        /// SystemAdministrationRights LoanReassignment
+        /// </summary>
+        public bool? LoanReassignment { get => _loanReassignment; set => SetField(ref _loanReassignment, value); }
+
+        /// <summary>
+        /// SystemAdministrationRights SettingsReport
+        /// </summary>
+        public SettingsReportRights SettingsReport { get => GetField(ref _settingsReport); set => SetField(ref _settingsReport, value); }
+
+        /// <summary>
+        /// SystemAdministrationRights SystemAuditTrail
+        /// </summary>
+        public bool? SystemAuditTrail { get => _systemAuditTrail; set => SetField(ref _systemAuditTrail, value); }
+
+        /// <summary>
+        /// SystemAdministrationRights UnlockLoanFile
+        /// </summary>
+        public bool? UnlockLoanFile { get => _unlockLoanFile; set => SetField(ref _unlockLoanFile, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOConnectRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOConnectRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOConnectRights
+    /// </summary>
+    public sealed class TPOConnectRights : DirtyExtensibleObject
+    {
+        private AdministrationSettingsRights _administrationSettings;
+        private SiteSettingsRights _siteSettings;
+
+        /// <summary>
+        /// TPOConnectRights AdministrationSettings
+        /// </summary>
+        public AdministrationSettingsRights AdministrationSettings { get => GetField(ref _administrationSettings); set => SetField(ref _administrationSettings, value); }
+
+        /// <summary>
+        /// TPOConnectRights SiteSettings
+        /// </summary>
+        public SiteSettingsRights SiteSettings { get => GetField(ref _siteSettings); set => SetField(ref _siteSettings, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOContactsRights.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOContactsRights
+    /// </summary>
+    public sealed class TPOContactsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _createEditContacts;
+        private DirtyValue<bool?> _deleteContacts;
+        private DirtyValue<bool?> _exportContacts;
+        private DirtyValue<bool?> _resetPassword;
+        private DirtyValue<bool?> _salesRep;
+        private DirtyValue<bool?> _sendWelcomeEmail;
+
+        /// <summary>
+        /// TPOContactsRights CreateEditContacts
+        /// </summary>
+        [JsonProperty("create/EditContacts")]
+        public bool? CreateEditContacts { get => _createEditContacts; set => SetField(ref _createEditContacts, value); }
+
+        /// <summary>
+        /// TPOContactsRights DeleteContacts
+        /// </summary>
+        public bool? DeleteContacts { get => _deleteContacts; set => SetField(ref _deleteContacts, value); }
+
+        /// <summary>
+        /// TPOContactsRights ExportContacts
+        /// </summary>
+        public bool? ExportContacts { get => _exportContacts; set => SetField(ref _exportContacts, value); }
+
+        /// <summary>
+        /// TPOContactsRights ResetPassword
+        /// </summary>
+        public bool? ResetPassword { get => _resetPassword; set => SetField(ref _resetPassword, value); }
+
+        /// <summary>
+        /// TPOContactsRights SalesRep
+        /// </summary>
+        public bool? SalesRep { get => _salesRep; set => SetField(ref _salesRep, value); }
+
+        /// <summary>
+        /// TPOContactsRights SendWelcomeEmail
+        /// </summary>
+        public bool? SendWelcomeEmail { get => _sendWelcomeEmail; set => SetField(ref _sendWelcomeEmail, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOFeesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOFeesRights.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOFeesRights
+    /// </summary>
+    public sealed class TPOFeesRights : ParentAccessRights
+    {
+        private AddEditTPOFeesRights _addEditTPOFees;
+
+        /// <summary>
+        /// TPOFeesRights AddEditTPOFees
+        /// </summary>
+        [JsonProperty("add/EditTPOFees")]
+        public AddEditTPOFeesRights AddEditTPOFees { get => GetField(ref _addEditTPOFees); set => SetField(ref _addEditTPOFees, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOInformationRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOInformationRights.cs
@@ -1,0 +1,108 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOInformationRights
+    /// </summary>
+    public sealed class TPOInformationRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _attachmentsTab;
+        private DirtyValue<bool?> _basicInfoTab;
+        private DirtyValue<bool?> _commitmentsTab;
+        private CustomFieldsTabRights _customFieldsTab;
+        private DirtyValue<bool?> _dBATab;
+        private DirtyValue<bool?> _feesTab;
+        private DirtyValue<bool?> _keyContactsTab;
+        private DirtyValue<bool?> _lenderContacts;
+        private DirtyValue<bool?> _licenseTab;
+        private DirtyValue<bool?> _loanCriteriaTab;
+        private DirtyValue<bool?> _lOCompTab;
+        private DirtyValue<bool?> _notesTab;
+        private DirtyValue<bool?> _salesRepsAETab;
+        private DirtyValue<bool?> _tPOWebCenterDocsTab;
+        private DirtyValue<bool?> _tPOWebCenterSetupTab;
+        private DirtyValue<bool?> _warehouseTab;
+
+        /// <summary>
+        /// TPOInformationRights AttachmentsTab
+        /// </summary>
+        public bool? AttachmentsTab { get => _attachmentsTab; set => SetField(ref _attachmentsTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights BasicInfoTab
+        /// </summary>
+        public bool? BasicInfoTab { get => _basicInfoTab; set => SetField(ref _basicInfoTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights CommitmentsTab
+        /// </summary>
+        public bool? CommitmentsTab { get => _commitmentsTab; set => SetField(ref _commitmentsTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights CustomFieldsTab
+        /// </summary>
+        public CustomFieldsTabRights CustomFieldsTab { get => GetField(ref _customFieldsTab); set => SetField(ref _customFieldsTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights DBATab
+        /// </summary>
+        public bool? DBATab { get => _dBATab; set => SetField(ref _dBATab, value); }
+
+        /// <summary>
+        /// TPOInformationRights FeesTab
+        /// </summary>
+        public bool? FeesTab { get => _feesTab; set => SetField(ref _feesTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights KeyContactsTab
+        /// </summary>
+        public bool? KeyContactsTab { get => _keyContactsTab; set => SetField(ref _keyContactsTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights LenderContacts
+        /// </summary>
+        public bool? LenderContacts { get => _lenderContacts; set => SetField(ref _lenderContacts, value); }
+
+        /// <summary>
+        /// TPOInformationRights LicenseTab
+        /// </summary>
+        public bool? LicenseTab { get => _licenseTab; set => SetField(ref _licenseTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights LoanCriteriaTab
+        /// </summary>
+        public bool? LoanCriteriaTab { get => _loanCriteriaTab; set => SetField(ref _loanCriteriaTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights LOCompTab
+        /// </summary>
+        public bool? LOCompTab { get => _lOCompTab; set => SetField(ref _lOCompTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights NotesTab
+        /// </summary>
+        public bool? NotesTab { get => _notesTab; set => SetField(ref _notesTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights SalesRepsAETab
+        /// </summary>
+        [JsonProperty("salesReps/AETab")]
+        public bool? SalesRepsAETab { get => _salesRepsAETab; set => SetField(ref _salesRepsAETab, value); }
+
+        /// <summary>
+        /// TPOInformationRights TPOWebCenterDocsTab
+        /// </summary>
+        public bool? TPOWebCenterDocsTab { get => _tPOWebCenterDocsTab; set => SetField(ref _tPOWebCenterDocsTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights TPOWebCenterSetupTab
+        /// </summary>
+        public bool? TPOWebCenterSetupTab { get => _tPOWebCenterSetupTab; set => SetField(ref _tPOWebCenterSetupTab, value); }
+
+        /// <summary>
+        /// TPOInformationRights WarehouseTab
+        /// </summary>
+        public bool? WarehouseTab { get => _warehouseTab; set => SetField(ref _warehouseTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOOrganizationSettingsContactsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOOrganizationSettingsContactsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOOrganizationSettingsContactsRights
+    /// </summary>
+    public sealed class TPOOrganizationSettingsContactsRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTPOContacts;
+
+        /// <summary>
+        /// TPOOrganizationSettingsContactsRights EditTPOContacts
+        /// </summary>
+        public bool? EditTPOContacts { get => _editTPOContacts; set => SetField(ref _editTPOContacts, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOOrganizationSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOOrganizationSettingsRights.cs
@@ -1,0 +1,124 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOOrganizationSettingsRights
+    /// </summary>
+    public sealed class TPOOrganizationSettingsRights : ParentAccessRights
+    {
+        private LenderContactsRights _lenderContacts;
+        private AttachmentsRights _attachments;
+        private BasicInfoRights _basicInfo;
+        private CommitmentsRights _commitments;
+        private CustomFieldsRights _customFields;
+        private DBARights _dBA;
+        private DirtyValue<bool?> _editLoanriteria;
+        private TPOFeesRights _fees;
+        private LicenseRights _license;
+        private LoanCriteriaRights _loanCriteria;
+        private LOCompRights _lOComp;
+        private NotesRights _notes;
+        private SalesRepsAERights _salesRepsAE;
+        private TPOOrganizationSettingsContactsRights _tPOContacts;
+        private TPOWebCenterDocumentsTabRights _tPOWebCenterDocumentsTab;
+        private TPOWebCenterSetupRights _tPOWebCenterSetup;
+        private DirtyValue<bool?> _tPOWebCenterSiteManagement;
+        private WarehouseTabRights _warehouseTab;
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights LenderContacts
+        /// </summary>
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Reuse)]
+        public LenderContactsRights LenderContacts { get => GetField(ref _lenderContacts); set => SetField(ref _lenderContacts, value); }
+
+        [JsonProperty(" LenderContacts", ObjectCreationHandling = ObjectCreationHandling.Reuse)]
+        private LenderContactsRights _LenderContacts { get => LenderContacts; set => LenderContacts = value; }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights Attachments
+        /// </summary>
+        public AttachmentsRights Attachments { get => GetField(ref _attachments); set => SetField(ref _attachments, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights BasicInfo
+        /// </summary>
+        public BasicInfoRights BasicInfo { get => GetField(ref _basicInfo); set => SetField(ref _basicInfo, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights Commitments
+        /// </summary>
+        public CommitmentsRights Commitments { get => GetField(ref _commitments); set => SetField(ref _commitments, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights CustomFields
+        /// </summary>
+        public CustomFieldsRights CustomFields { get => GetField(ref _customFields); set => SetField(ref _customFields, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights DBA
+        /// </summary>
+        public DBARights DBA { get => GetField(ref _dBA); set => SetField(ref _dBA, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights EditLoanriteria
+        /// </summary>
+        public bool? EditLoanriteria { get => _editLoanriteria; set => SetField(ref _editLoanriteria, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights Fees
+        /// </summary>
+        public TPOFeesRights Fees { get => GetField(ref _fees); set => SetField(ref _fees, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights License
+        /// </summary>
+        public LicenseRights License { get => GetField(ref _license); set => SetField(ref _license, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights LoanCriteria
+        /// </summary>
+        public LoanCriteriaRights LoanCriteria { get => GetField(ref _loanCriteria); set => SetField(ref _loanCriteria, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights LOComp
+        /// </summary>
+        public LOCompRights LOComp { get => GetField(ref _lOComp); set => SetField(ref _lOComp, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights Notes
+        /// </summary>
+        public NotesRights Notes { get => GetField(ref _notes); set => SetField(ref _notes, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights SalesRepsAE
+        /// </summary>
+        [JsonProperty("salesReps/AE")]
+        public SalesRepsAERights SalesRepsAE { get => GetField(ref _salesRepsAE); set => SetField(ref _salesRepsAE, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights TPOContacts
+        /// </summary>
+        public TPOOrganizationSettingsContactsRights TPOContacts { get => GetField(ref _tPOContacts); set => SetField(ref _tPOContacts, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights TPOWebCenterDocumentsTab
+        /// </summary>
+        public TPOWebCenterDocumentsTabRights TPOWebCenterDocumentsTab { get => GetField(ref _tPOWebCenterDocumentsTab); set => SetField(ref _tPOWebCenterDocumentsTab, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights TPOWebCenterSetup
+        /// </summary>
+        public TPOWebCenterSetupRights TPOWebCenterSetup { get => GetField(ref _tPOWebCenterSetup); set => SetField(ref _tPOWebCenterSetup, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights TPOWebCenterSiteManagement
+        /// </summary>
+        public bool? TPOWebCenterSiteManagement { get => _tPOWebCenterSiteManagement; set => SetField(ref _tPOWebCenterSiteManagement, value); }
+
+        /// <summary>
+        /// TPOOrganizationSettingsRights WarehouseTab
+        /// </summary>
+        public WarehouseTabRights WarehouseTab { get => GetField(ref _warehouseTab); set => SetField(ref _warehouseTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOWebCenterDocumentListSettingsEditDocumentRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOWebCenterDocumentListSettingsEditDocumentRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ExternalSettingsRightsEditDocumentRights
+    /// </summary>
+    public sealed class TPOWebCenterDocumentListSettingsEditDocumentRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _deleteDocument;
+
+        /// <summary>
+        /// ExternalSettingsRightsEditDocumentRights DeleteDocument
+        /// </summary>
+        public bool? DeleteDocument { get => _deleteDocument; set => SetField(ref _deleteDocument, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOWebCenterDocumentListSettingsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOWebCenterDocumentListSettingsRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOWebCenterDocumentListSettingsRights
+    /// </summary>
+    public sealed class TPOWebCenterDocumentListSettingsRights : ParentAccessRights
+    {
+        private TPOWebCenterDocumentListSettingsEditDocumentRights _editDocument;
+
+        /// <summary>
+        /// TPOWebCenterDocumentListSettingsRights EditDocument
+        /// </summary>
+        public TPOWebCenterDocumentListSettingsEditDocumentRights EditDocument { get => GetField(ref _editDocument); set => SetField(ref _editDocument, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOWebCenterDocumentsTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOWebCenterDocumentsTabRights.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOWebCenterDocumentsTabRights
+    /// </summary>
+    public sealed class TPOWebCenterDocumentsTabRights : ParentAccessRights
+    {
+        private AddEditTPOWebCenterAdditionalDocumentsRights _addEditTPOWebCenterAdditionalDocuments;
+        private DirtyValue<bool?> _disableTPOWebCenterGlobalDocuments;
+
+        /// <summary>
+        /// TPOWebCenterDocumentsTabRights AddEditTPOWebCenterAdditionalDocuments
+        /// </summary>
+        [JsonProperty("add/EditTPOWebCenterAdditionalDocuments")]
+        public AddEditTPOWebCenterAdditionalDocumentsRights AddEditTPOWebCenterAdditionalDocuments { get => GetField(ref _addEditTPOWebCenterAdditionalDocuments); set => SetField(ref _addEditTPOWebCenterAdditionalDocuments, value); }
+
+        /// <summary>
+        /// TPOWebCenterDocumentsTabRights DisableTPOWebCenterGlobalDocuments
+        /// </summary>
+        public bool? DisableTPOWebCenterGlobalDocuments { get => _disableTPOWebCenterGlobalDocuments; set => SetField(ref _disableTPOWebCenterGlobalDocuments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TPOWebCenterSetupRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TPOWebCenterSetupRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TPOWebCenterSetupRights
+    /// </summary>
+    public sealed class TPOWebCenterSetupRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editTPOWebCenterSetup;
+
+        /// <summary>
+        /// TPOWebCenterSetupRights EditTPOWebCenterSetup
+        /// </summary>
+        public bool? EditTPOWebCenterSetup { get => _editTPOWebCenterSetup; set => SetField(ref _editTPOWebCenterSetup, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TQLServicesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TQLServicesRights.cs
@@ -1,0 +1,42 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TQLServicesRights
+    /// </summary>
+    public sealed class TQLServicesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addComments;
+        private DirtyValue<bool?> _addComplianceReportComments;
+        private DirtyValue<bool?> _addFraudReportComments;
+        private DirtyValue<bool?> _selectInvestor;
+        private DirtyValue<bool?> _startStopPublishing;
+
+        /// <summary>
+        /// TQLServicesRights AddComments
+        /// </summary>
+        public bool? AddComments { get => _addComments; set => SetField(ref _addComments, value); }
+
+        /// <summary>
+        /// TQLServicesRights AddComplianceReportComments
+        /// </summary>
+        public bool? AddComplianceReportComments { get => _addComplianceReportComments; set => SetField(ref _addComplianceReportComments, value); }
+
+        /// <summary>
+        /// TQLServicesRights AddFraudReportComments
+        /// </summary>
+        public bool? AddFraudReportComments { get => _addFraudReportComments; set => SetField(ref _addFraudReportComments, value); }
+
+        /// <summary>
+        /// TQLServicesRights SelectInvestor
+        /// </summary>
+        public bool? SelectInvestor { get => _selectInvestor; set => SetField(ref _selectInvestor, value); }
+
+        /// <summary>
+        /// TQLServicesRights StartStopPublishing
+        /// </summary>
+        [JsonProperty("start/StopPublishing")]
+        public bool? StartStopPublishing { get => _startStopPublishing; set => SetField(ref _startStopPublishing, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TablesAndFeesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TablesAndFeesRights.cs
@@ -1,0 +1,69 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TablesAndFeesRights
+    /// </summary>
+    public sealed class TablesAndFeesRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _cityTax;
+        private DirtyValue<bool?> _escrow;
+        private DirtyValue<bool?> _fHACountyLimits;
+        private DirtyValue<bool?> _hELOCTable;
+        private DirtyValue<bool?> _itemizationFeeManagement;
+        private DirtyValue<bool?> _lOCompensation;
+        private DirtyValue<bool?> _mITables;
+        private DirtyValue<bool?> _stateTax;
+        private DirtyValue<bool?> _title;
+        private DirtyValue<bool?> _userDefinedFee;
+
+        /// <summary>
+        /// TablesAndFeesRights CityTax
+        /// </summary>
+        public bool? CityTax { get => _cityTax; set => SetField(ref _cityTax, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights Escrow
+        /// </summary>
+        public bool? Escrow { get => _escrow; set => SetField(ref _escrow, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights FHACountyLimits
+        /// </summary>
+        public bool? FHACountyLimits { get => _fHACountyLimits; set => SetField(ref _fHACountyLimits, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights HELOCTable
+        /// </summary>
+        public bool? HELOCTable { get => _hELOCTable; set => SetField(ref _hELOCTable, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights ItemizationFeeManagement
+        /// </summary>
+        public bool? ItemizationFeeManagement { get => _itemizationFeeManagement; set => SetField(ref _itemizationFeeManagement, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights LOCompensation
+        /// </summary>
+        public bool? LOCompensation { get => _lOCompensation; set => SetField(ref _lOCompensation, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights MITables
+        /// </summary>
+        public bool? MITables { get => _mITables; set => SetField(ref _mITables, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights StateTax
+        /// </summary>
+        public bool? StateTax { get => _stateTax; set => SetField(ref _stateTax, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights Title
+        /// </summary>
+        public bool? Title { get => _title; set => SetField(ref _title, value); }
+
+        /// <summary>
+        /// TablesAndFeesRights UserDefinedFee
+        /// </summary>
+        public bool? UserDefinedFee { get => _userDefinedFee; set => SetField(ref _userDefinedFee, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TasksRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TasksRights.cs
@@ -1,0 +1,27 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TasksRights
+    /// </summary>
+    public sealed class TasksRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addTasks;
+        private DirtyValue<bool?> _deleteTasks;
+        private DirtyValue<bool?> _editTasks;
+
+        /// <summary>
+        /// TasksRights AddTasks
+        /// </summary>
+        public bool? AddTasks { get => _addTasks; set => SetField(ref _addTasks, value); }
+
+        /// <summary>
+        /// TasksRights DeleteTasks
+        /// </summary>
+        public bool? DeleteTasks { get => _deleteTasks; set => SetField(ref _deleteTasks, value); }
+
+        /// <summary>
+        /// TasksRights EditTasks
+        /// </summary>
+        public bool? EditTasks { get => _editTasks; set => SetField(ref _editTasks, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ToolsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ToolsRights.cs
@@ -1,0 +1,238 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ToolsRights
+    /// </summary>
+    public sealed class ToolsRights : DirtyExtensibleObject
+    {
+        private PurchaseAdviceFormRights _PurchaseAdviceForm;
+        private DirtyValue<bool?> _ShippingDetail;
+        private DirtyValue<bool?> _amortizationSchedule;
+        private DirtyValue<bool?> _antiSteeringSafeHarborDisclosure;
+        private DirtyValue<bool?> _auditTrail;
+        private AUSTrackingRights _aUSTracking;
+        private DirtyValue<bool?> _brokerCheckCalculation;
+        private DirtyValue<bool?> _businessContacts;
+        private DirtyValue<bool?> _cashtoClose;
+        private DirtyValue<bool?> _collateralTracking;
+        private DirtyValue<bool?> _conversationLog;
+        private DirtyValue<bool?> _correspondentLoanStatus;
+        private DirtyValue<bool?> _correspondentPurchaseAdviceForm;
+        private DirtyValue<bool?> _debtConsolidation;
+        private DisclosureTrackingRights _disclosureTracking;
+        private DirtyValue<bool?> _eCSDataViewer;
+        private FeeVarianceWorksheetRights _feeVarianceWorksheet;
+        private FileContactsRights _fileContacts;
+        private DirtyValue<bool?> _fundingBalancingWorksheet;
+        private DirtyValue<bool?> _fundingWorksheet;
+        private InterimServicingRights _interimServicing;
+        private DirtyValue<bool?> _loanComparison;
+        private DirtyValue<bool?> _lockRequestForm;
+        private LOCompToolRights _lOCompTool;
+        private DirtyValue<bool?> _netTangibleBenefit;
+        private DirtyValue<bool?> _piggybackLoans;
+        private DirtyValue<bool?> _prequalification;
+        private DirtyValue<bool?> _profitManagement;
+        private DirtyValue<bool?> _rentVsOwn;
+        private DirtyValue<bool?> _secondaryRegistration;
+        private DirtyValue<bool?> _secureFormTransfer;
+        private TasksRights _tasks;
+        private TPOInformationRights _tPOInformation;
+        private TQLServicesRights _tQLServices;
+        private DirtyValue<bool?> _trustAccount;
+        private DirtyValue<bool?> _underwriterSummary;
+        private VerificationAndDocumentationTrackingRights _verificationAndDocumentationTracking;
+
+        /// <summary>
+        /// ToolsRights PurchaseAdviceForm
+        /// </summary>
+        [JsonProperty(" PurchaseAdviceForm")]
+        public PurchaseAdviceFormRights PurchaseAdviceForm { get => GetField(ref _PurchaseAdviceForm); set => SetField(ref _PurchaseAdviceForm, value); }
+
+        /// <summary>
+        /// ToolsRights ShippingDetail
+        /// </summary>
+        [JsonProperty(" ShippingDetail")]
+        public bool? ShippingDetail { get => _ShippingDetail; set => SetField(ref _ShippingDetail, value); }
+
+        /// <summary>
+        /// ToolsRights AmortizationSchedule
+        /// </summary>
+        public bool? AmortizationSchedule { get => _amortizationSchedule; set => SetField(ref _amortizationSchedule, value); }
+
+        /// <summary>
+        /// ToolsRights AntiSteeringSafeHarborDisclosure
+        /// </summary>
+        [JsonProperty("anti-SteeringSafeHarborDisclosure")]
+        public bool? AntiSteeringSafeHarborDisclosure { get => _antiSteeringSafeHarborDisclosure; set => SetField(ref _antiSteeringSafeHarborDisclosure, value); }
+
+        /// <summary>
+        /// ToolsRights AuditTrail
+        /// </summary>
+        public bool? AuditTrail { get => _auditTrail; set => SetField(ref _auditTrail, value); }
+
+        /// <summary>
+        /// ToolsRights AUSTracking
+        /// </summary>
+        public AUSTrackingRights AUSTracking { get => GetField(ref _aUSTracking); set => SetField(ref _aUSTracking, value); }
+
+        /// <summary>
+        /// ToolsRights BrokerCheckCalculation
+        /// </summary>
+        public bool? BrokerCheckCalculation { get => _brokerCheckCalculation; set => SetField(ref _brokerCheckCalculation, value); }
+
+        /// <summary>
+        /// ToolsRights BusinessContacts
+        /// </summary>
+        public bool? BusinessContacts { get => _businessContacts; set => SetField(ref _businessContacts, value); }
+
+        /// <summary>
+        /// ToolsRights CashtoClose
+        /// </summary>
+        [JsonProperty("cash-to-Close")]
+        public bool? CashtoClose { get => _cashtoClose; set => SetField(ref _cashtoClose, value); }
+
+        /// <summary>
+        /// ToolsRights CollateralTracking
+        /// </summary>
+        public bool? CollateralTracking { get => _collateralTracking; set => SetField(ref _collateralTracking, value); }
+
+        /// <summary>
+        /// ToolsRights ConversationLog
+        /// </summary>
+        public bool? ConversationLog { get => _conversationLog; set => SetField(ref _conversationLog, value); }
+
+        /// <summary>
+        /// ToolsRights CorrespondentLoanStatus
+        /// </summary>
+        public bool? CorrespondentLoanStatus { get => _correspondentLoanStatus; set => SetField(ref _correspondentLoanStatus, value); }
+
+        /// <summary>
+        /// ToolsRights CorrespondentPurchaseAdviceForm
+        /// </summary>
+        public bool? CorrespondentPurchaseAdviceForm { get => _correspondentPurchaseAdviceForm; set => SetField(ref _correspondentPurchaseAdviceForm, value); }
+
+        /// <summary>
+        /// ToolsRights DebtConsolidation
+        /// </summary>
+        public bool? DebtConsolidation { get => _debtConsolidation; set => SetField(ref _debtConsolidation, value); }
+
+        /// <summary>
+        /// ToolsRights DisclosureTracking
+        /// </summary>
+        public DisclosureTrackingRights DisclosureTracking { get => GetField(ref _disclosureTracking); set => SetField(ref _disclosureTracking, value); }
+
+        /// <summary>
+        /// ToolsRights ECSDataViewer
+        /// </summary>
+        public bool? ECSDataViewer { get => _eCSDataViewer; set => SetField(ref _eCSDataViewer, value); }
+
+        /// <summary>
+        /// ToolsRights FeeVarianceWorksheet
+        /// </summary>
+        public FeeVarianceWorksheetRights FeeVarianceWorksheet { get => GetField(ref _feeVarianceWorksheet); set => SetField(ref _feeVarianceWorksheet, value); }
+
+        /// <summary>
+        /// ToolsRights FileContacts
+        /// </summary>
+        public FileContactsRights FileContacts { get => GetField(ref _fileContacts); set => SetField(ref _fileContacts, value); }
+
+        /// <summary>
+        /// ToolsRights FundingBalancingWorksheet
+        /// </summary>
+        public bool? FundingBalancingWorksheet { get => _fundingBalancingWorksheet; set => SetField(ref _fundingBalancingWorksheet, value); }
+
+        /// <summary>
+        /// ToolsRights FundingWorksheet
+        /// </summary>
+        public bool? FundingWorksheet { get => _fundingWorksheet; set => SetField(ref _fundingWorksheet, value); }
+
+        /// <summary>
+        /// ToolsRights InterimServicing
+        /// </summary>
+        public InterimServicingRights InterimServicing { get => GetField(ref _interimServicing); set => SetField(ref _interimServicing, value); }
+
+        /// <summary>
+        /// ToolsRights LoanComparison
+        /// </summary>
+        public bool? LoanComparison { get => _loanComparison; set => SetField(ref _loanComparison, value); }
+
+        /// <summary>
+        /// ToolsRights LockRequestForm
+        /// </summary>
+        public bool? LockRequestForm { get => _lockRequestForm; set => SetField(ref _lockRequestForm, value); }
+
+        /// <summary>
+        /// ToolsRights LOCompTool
+        /// </summary>
+        public LOCompToolRights LOCompTool { get => GetField(ref _lOCompTool); set => SetField(ref _lOCompTool, value); }
+
+        /// <summary>
+        /// ToolsRights NetTangibleBenefit
+        /// </summary>
+        public bool? NetTangibleBenefit { get => _netTangibleBenefit; set => SetField(ref _netTangibleBenefit, value); }
+
+        /// <summary>
+        /// ToolsRights PiggybackLoans
+        /// </summary>
+        public bool? PiggybackLoans { get => _piggybackLoans; set => SetField(ref _piggybackLoans, value); }
+
+        /// <summary>
+        /// ToolsRights Prequalification
+        /// </summary>
+        public bool? Prequalification { get => _prequalification; set => SetField(ref _prequalification, value); }
+
+        /// <summary>
+        /// ToolsRights ProfitManagement
+        /// </summary>
+        public bool? ProfitManagement { get => _profitManagement; set => SetField(ref _profitManagement, value); }
+
+        /// <summary>
+        /// ToolsRights RentVsOwn
+        /// </summary>
+        [JsonProperty("rentVs.Own")]
+        public bool? RentVsOwn { get => _rentVsOwn; set => SetField(ref _rentVsOwn, value); }
+
+        /// <summary>
+        /// ToolsRights SecondaryRegistration
+        /// </summary>
+        public bool? SecondaryRegistration { get => _secondaryRegistration; set => SetField(ref _secondaryRegistration, value); }
+
+        /// <summary>
+        /// ToolsRights SecureFormTransfer
+        /// </summary>
+        public bool? SecureFormTransfer { get => _secureFormTransfer; set => SetField(ref _secureFormTransfer, value); }
+
+        /// <summary>
+        /// ToolsRights Tasks
+        /// </summary>
+        public TasksRights Tasks { get => GetField(ref _tasks); set => SetField(ref _tasks, value); }
+
+        /// <summary>
+        /// ToolsRights TPOInformation
+        /// </summary>
+        public TPOInformationRights TPOInformation { get => GetField(ref _tPOInformation); set => SetField(ref _tPOInformation, value); }
+
+        /// <summary>
+        /// ToolsRights TQLServices
+        /// </summary>
+        public TQLServicesRights TQLServices { get => GetField(ref _tQLServices); set => SetField(ref _tQLServices, value); }
+
+        /// <summary>
+        /// ToolsRights TrustAccount
+        /// </summary>
+        public bool? TrustAccount { get => _trustAccount; set => SetField(ref _trustAccount, value); }
+
+        /// <summary>
+        /// ToolsRights UnderwriterSummary
+        /// </summary>
+        public bool? UnderwriterSummary { get => _underwriterSummary; set => SetField(ref _underwriterSummary, value); }
+
+        /// <summary>
+        /// ToolsRights VerificationAndDocumentationTracking
+        /// </summary>
+        public VerificationAndDocumentationTrackingRights VerificationAndDocumentationTracking { get => GetField(ref _verificationAndDocumentationTracking); set => SetField(ref _verificationAndDocumentationTracking, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TradesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TradesRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TradesRights
+    /// </summary>
+    public sealed class TradesRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _accessToTradesTab;
+
+        /// <summary>
+        /// TradesRights AccessToTradesTab
+        /// </summary>
+        public bool? AccessToTradesTab { get => _accessToTradesTab; set => SetField(ref _accessToTradesTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/TrashFolderTasksRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/TrashFolderTasksRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// TrashFolderTasksRights
+    /// </summary>
+    public sealed class TrashFolderTasksRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _deleteLoansPermanently;
+        private DirtyValue<bool?> _restoreLoanstoFolder;
+
+        /// <summary>
+        /// TrashFolderTasksRights DeleteLoansPermanently
+        /// </summary>
+        public bool? DeleteLoansPermanently { get => _deleteLoansPermanently; set => SetField(ref _deleteLoansPermanently, value); }
+
+        /// <summary>
+        /// TrashFolderTasksRights RestoreLoanstoFolder
+        /// </summary>
+        public bool? RestoreLoanstoFolder { get => _restoreLoanstoFolder; set => SetField(ref _restoreLoanstoFolder, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UnassignedFilesRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UnassignedFilesRights.cs
@@ -1,0 +1,69 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// UnassignedFilesRights
+    /// </summary>
+    public sealed class UnassignedFilesRights : DirtyExtensibleObject
+    {
+        private AddNotesToFileRights _addNotesToFile;
+        private DirtyValue<bool?> _attachEncompassForms;
+        private DirtyValue<bool?> _autoAssign;
+        private DirtyValue<bool?> _browseAndAttach;
+        private DeleteNotesRights _deleteNotes;
+        private EditFileRights _editFile;
+        private DirtyValue<bool?> _mergeFiles;
+        private DirtyValue<bool?> _scanAndAttach;
+        private DirtyValue<bool?> _splitFile;
+        private DirtyValue<bool?> _suggestor;
+
+        /// <summary>
+        /// UnassignedFilesRights AddNotesToFile
+        /// </summary>
+        public AddNotesToFileRights AddNotesToFile { get => GetField(ref _addNotesToFile); set => SetField(ref _addNotesToFile, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights AttachEncompassForms
+        /// </summary>
+        public bool? AttachEncompassForms { get => _attachEncompassForms; set => SetField(ref _attachEncompassForms, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights AutoAssign
+        /// </summary>
+        public bool? AutoAssign { get => _autoAssign; set => SetField(ref _autoAssign, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights BrowseAndAttach
+        /// </summary>
+        public bool? BrowseAndAttach { get => _browseAndAttach; set => SetField(ref _browseAndAttach, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights DeleteNotes
+        /// </summary>
+        public DeleteNotesRights DeleteNotes { get => GetField(ref _deleteNotes); set => SetField(ref _deleteNotes, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights EditFile
+        /// </summary>
+        public EditFileRights EditFile { get => GetField(ref _editFile); set => SetField(ref _editFile, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights MergeFiles
+        /// </summary>
+        public bool? MergeFiles { get => _mergeFiles; set => SetField(ref _mergeFiles, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights ScanAndAttach
+        /// </summary>
+        public bool? ScanAndAttach { get => _scanAndAttach; set => SetField(ref _scanAndAttach, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights SplitFile
+        /// </summary>
+        public bool? SplitFile { get => _splitFile; set => SetField(ref _splitFile, value); }
+
+        /// <summary>
+        /// UnassignedFilesRights Suggestor
+        /// </summary>
+        public bool? Suggestor { get => _suggestor; set => SetField(ref _suggestor, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UnderwritingConditionsTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UnderwritingConditionsTabRights.cs
@@ -1,0 +1,49 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// UnderwritingConditionsTabRights
+    /// </summary>
+    public sealed class UnderwritingConditionsTabRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _addEditDeleteComments;
+        private DirtyValue<bool?> _addSupportingDocuments;
+        private DirtyValue<bool?> _changePriorTo;
+        private MarkStatusCompletedRights _markStatusCompleted;
+        private NewEditDeleteConditionsRights _newEditDeleteConditions;
+        private DirtyValue<bool?> _removeSupportingDocuments;
+
+        /// <summary>
+        /// UnderwritingConditionsTabRights AddEditDeleteComments
+        /// </summary>
+        [JsonProperty("add/Edit/DeleteComments")]
+        public bool? AddEditDeleteComments { get => _addEditDeleteComments; set => SetField(ref _addEditDeleteComments, value); }
+
+        /// <summary>
+        /// UnderwritingConditionsTabRights AddSupportingDocuments
+        /// </summary>
+        public bool? AddSupportingDocuments { get => _addSupportingDocuments; set => SetField(ref _addSupportingDocuments, value); }
+
+        /// <summary>
+        /// UnderwritingConditionsTabRights ChangePriorTo
+        /// </summary>
+        public bool? ChangePriorTo { get => _changePriorTo; set => SetField(ref _changePriorTo, value); }
+
+        /// <summary>
+        /// UnderwritingConditionsTabRights MarkStatusCompleted
+        /// </summary>
+        public MarkStatusCompletedRights MarkStatusCompleted { get => GetField(ref _markStatusCompleted); set => SetField(ref _markStatusCompleted, value); }
+
+        /// <summary>
+        /// UnderwritingConditionsTabRights NewEditDeleteConditions
+        /// </summary>
+        [JsonProperty("new/Edit/DeleteConditions")]
+        public NewEditDeleteConditionsRights NewEditDeleteConditions { get => GetField(ref _newEditDeleteConditions); set => SetField(ref _newEditDeleteConditions, value); }
+
+        /// <summary>
+        /// UnderwritingConditionsTabRights RemoveSupportingDocuments
+        /// </summary>
+        public bool? RemoveSupportingDocuments { get => _removeSupportingDocuments; set => SetField(ref _removeSupportingDocuments, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UnprotectedDocumentsRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UnprotectedDocumentsRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// UnprotectedDocumentsRights
+    /// </summary>
+    public sealed class UnprotectedDocumentsRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _deleteDocument;
+        private EditDocumentRights _editDocument;
+
+        /// <summary>
+        /// UnprotectedDocumentsRights DeleteDocument
+        /// </summary>
+        public bool? DeleteDocument { get => _deleteDocument; set => SetField(ref _deleteDocument, value); }
+
+        /// <summary>
+        /// UnprotectedDocumentsRights EditDocument
+        /// </summary>
+        public EditDocumentRights EditDocument { get => GetField(ref _editDocument); set => SetField(ref _editDocument, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UserEFolderRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UserEFolderRights.cs
@@ -1,0 +1,42 @@
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// UserEFolderRights
+    /// </summary>
+    public sealed class UserEFolderRights : DirtyExtensibleObject
+    {
+        private DirtyValue<bool?> _historyTab;
+        private PostClosingConditionsTabRights _postClosingConditionsTab;
+        private PreliminaryConditionsTabRights _preliminaryConditionsTab;
+        private PurchaseConditionsRights _purchaseConditions;
+        private UnderwritingConditionsTabRights _underwritingConditionsTab;
+
+        /// <summary>
+        /// UserEFolderRights HistoryTab
+        /// </summary>
+        public bool? HistoryTab { get => _historyTab; set => SetField(ref _historyTab, value); }
+
+        /// <summary>
+        /// UserEFolderRights PostClosingConditionsTab
+        /// </summary>
+        [JsonProperty("post-ClosingConditionsTab")]
+        public PostClosingConditionsTabRights PostClosingConditionsTab { get => GetField(ref _postClosingConditionsTab); set => SetField(ref _postClosingConditionsTab, value); }
+
+        /// <summary>
+        /// UserEFolderRights PreliminaryConditionsTab
+        /// </summary>
+        public PreliminaryConditionsTabRights PreliminaryConditionsTab { get => GetField(ref _preliminaryConditionsTab); set => SetField(ref _preliminaryConditionsTab, value); }
+
+        /// <summary>
+        /// UserEFolderRights PurchaseConditions
+        /// </summary>
+        public PurchaseConditionsRights PurchaseConditions { get => GetField(ref _purchaseConditions); set => SetField(ref _purchaseConditions, value); }
+
+        /// <summary>
+        /// UserEFolderRights UnderwritingConditionsTab
+        /// </summary>
+        public UnderwritingConditionsTabRights UnderwritingConditionsTab { get => GetField(ref _underwritingConditionsTab); set => SetField(ref _underwritingConditionsTab, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UserRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UserRights.cs
@@ -1,0 +1,105 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// UserRights
+    /// </summary>
+    public sealed class UserRights : DirtyExtensibleObject
+    {
+        private AccessRights _access;
+        private ConsumerConnectRights _consumerConnect;
+        private ContactsRights _contacts;
+        private DashboardRights _dashboard;
+        private EFolderRights _eFolder;
+        private ExternalSettingsRights _externalSettings;
+        private FormsRights _forms;
+        private HomeRights _home;
+        private LoanRights _loan;
+        private MiscellaneousRights _miscellaneous;
+        private PipelineRights _pipeline;
+        private ReportsRights _reports;
+        private SettingsRights _settings;
+        private ToolsRights _tools;
+        private TPOConnectRights _tPOConnect;
+        private TradesRights _trades;
+
+        /// <summary>
+        /// UserRights Access
+        /// </summary>
+        public AccessRights Access { get => GetField(ref _access); set => SetField(ref _access, value); }
+
+        /// <summary>
+        /// UserRights ConsumerConnect
+        /// </summary>
+        public ConsumerConnectRights ConsumerConnect { get => GetField(ref _consumerConnect); set => SetField(ref _consumerConnect, value); }
+
+        /// <summary>
+        /// UserRights Contacts
+        /// </summary>
+        public ContactsRights Contacts { get => GetField(ref _contacts); set => SetField(ref _contacts, value); }
+
+        /// <summary>
+        /// UserRights Dashboard
+        /// </summary>
+        public DashboardRights Dashboard { get => GetField(ref _dashboard); set => SetField(ref _dashboard, value); }
+
+        /// <summary>
+        /// UserRights EFolder
+        /// </summary>
+        public EFolderRights EFolder { get => GetField(ref _eFolder); set => SetField(ref _eFolder, value); }
+
+        /// <summary>
+        /// UserRights ExternalSettings
+        /// </summary>
+        public ExternalSettingsRights ExternalSettings { get => GetField(ref _externalSettings); set => SetField(ref _externalSettings, value); }
+
+        /// <summary>
+        /// UserRights Forms
+        /// </summary>
+        public FormsRights Forms { get => GetField(ref _forms); set => SetField(ref _forms, value); }
+
+        /// <summary>
+        /// UserRights Home
+        /// </summary>
+        public HomeRights Home { get => GetField(ref _home); set => SetField(ref _home, value); }
+
+        /// <summary>
+        /// UserRights Loan
+        /// </summary>
+        public LoanRights Loan { get => GetField(ref _loan); set => SetField(ref _loan, value); }
+
+        /// <summary>
+        /// UserRights Miscellaneous
+        /// </summary>
+        public MiscellaneousRights Miscellaneous { get => GetField(ref _miscellaneous); set => SetField(ref _miscellaneous, value); }
+
+        /// <summary>
+        /// UserRights Pipeline
+        /// </summary>
+        public PipelineRights Pipeline { get => GetField(ref _pipeline); set => SetField(ref _pipeline, value); }
+
+        /// <summary>
+        /// UserRights Reports
+        /// </summary>
+        public ReportsRights Reports { get => GetField(ref _reports); set => SetField(ref _reports, value); }
+
+        /// <summary>
+        /// UserRights Settings
+        /// </summary>
+        public SettingsRights Settings { get => GetField(ref _settings); set => SetField(ref _settings, value); }
+
+        /// <summary>
+        /// UserRights Tools
+        /// </summary>
+        public ToolsRights Tools { get => GetField(ref _tools); set => SetField(ref _tools, value); }
+
+        /// <summary>
+        /// UserRights TPOConnect
+        /// </summary>
+        public TPOConnectRights TPOConnect { get => GetField(ref _tPOConnect); set => SetField(ref _tPOConnect, value); }
+
+        /// <summary>
+        /// UserRights Trades
+        /// </summary>
+        public TradesRights Trades { get => GetField(ref _trades); set => SetField(ref _trades, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UserRightsCategory.cs
+++ b/src/EncompassRest/Company/Users/Rights/UserRightsCategory.cs
@@ -1,0 +1,90 @@
+﻿using System.Runtime.Serialization;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// User Rights Category
+    /// </summary>
+    public enum UserRightsCategory
+    {
+        /// <summary>
+        /// Pipeline
+        /// </summary>
+        [EnumMember(Value = "pipeline")]
+        Pipeline = 0,
+        /// <summary>
+        /// Loan
+        /// </summary>
+        [EnumMember(Value = "loan")]
+        Loan = 1,
+        /// <summary>
+        /// eFolder
+        /// </summary>
+        eFolder = 2,
+        /// <summary>
+        /// Access
+        /// </summary>
+        [EnumMember(Value = "access")]
+        Access = 3,
+        /// <summary>
+        /// Miscellaneous
+        /// </summary>
+        [EnumMember(Value = "miscellaneous")]
+        Miscellaneous = 4,
+        /// <summary>
+        /// Home
+        /// </summary>
+        [EnumMember(Value = "home")]
+        Home = 5,
+        /// <summary>
+        /// Contacts
+        /// </summary>
+        [EnumMember(Value = "contacts")]
+        Contacts = 6,
+        /// <summary>
+        /// Dashboard
+        /// </summary>
+        [EnumMember(Value = "dashboard")]
+        Dashboard = 7,
+        /// <summary>
+        /// Trades
+        /// </summary>
+        [EnumMember(Value = "trades")]
+        Trades = 8,
+        /// <summary>
+        /// Reports
+        /// </summary>
+        [EnumMember(Value = "reports")]
+        Reports = 9,
+        /// <summary>
+        /// Tools
+        /// </summary>
+        [EnumMember(Value = "tools")]
+        Tools = 10,
+        /// <summary>
+        /// Settings
+        /// </summary>
+        [EnumMember(Value = "settings")]
+        Settings = 11,
+        /// <summary>
+        /// ExternalSettings
+        /// </summary>
+        [EnumMember(Value = "externalSettings")]
+        ExternalSettings = 12,
+        /// <summary>
+        /// TPOConnect
+        /// </summary>
+        [EnumMember(Value = "tpoConnect")]
+        TPOConnect = 13,
+        /// <summary>
+        /// ConsumerConnect
+        /// </summary>
+        [EnumMember(Value = "consumerConnect")]
+        ConsumerConnect = 14,
+        /// <summary>
+        /// Forms
+        /// </summary>
+        [EnumMember(Value = "forms")]
+        Forms = 15
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UserRightsType.cs
+++ b/src/EncompassRest/Company/Users/Rights/UserRightsType.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.Serialization;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// User Rights Type
+    /// </summary>
+    public enum UserRightsType
+    {
+        /// <summary>
+        /// Assigned
+        /// </summary>
+        [EnumMember(Value = "assignedRights")]
+        Assigned = 0,
+        /// <summary>
+        /// Effective
+        /// </summary>
+        [EnumMember(Value = "effectiveRights")]
+        Effective = 1
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/UsersRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UsersRights.cs
@@ -1,0 +1,70 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EncompassRest.Utilities;
+using EnumsNET;
+
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// User Rights Apis
+    /// </summary>
+    public sealed class UsersRights : UserApiObject
+    {
+        internal UsersRights(EncompassRestClient client, string userId)
+            : base(client, userId, null)
+        {
+        }
+
+        /// <summary>
+        /// Gets the users rights for the specified rights <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<UserRights> GetRightsAsync(UserRightsType type, CancellationToken cancellationToken = default) => GetRightsAsync(type, null, cancellationToken);
+
+        /// <summary>
+        /// Gets the users rights for the specified rights <paramref name="type"/> and filtered to include only the specified <paramref name="category"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="category">The user rights category.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<UserRights> GetRightsAsync(UserRightsType type, UserRightsCategory category, CancellationToken cancellationToken = default) => GetRightsAsync(type, category.Validate(nameof(category)).GetValue(), cancellationToken);
+
+        /// <summary>
+        /// Gets the users rights for the specified rights <paramref name="type"/> and optionally filtered to include only the specified <paramref name="category"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="category">The optional user rights category.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<UserRights> GetRightsAsync(UserRightsType type, string category, CancellationToken cancellationToken = default)
+        {
+            type.Validate(nameof(type));
+
+            var queryParameters = new QueryParameters();
+            if (!string.IsNullOrEmpty(category))
+            {
+                queryParameters.Add("category", category);
+            }
+            var path = type.GetValue();
+            return GetDirtyAsync<UserRights>(path, queryParameters.ToString(), nameof(GetRightsAsync), path, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the users rights as raw json for the specified rights <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> GetRightsRawAsync(UserRightsType type, string queryString = null, CancellationToken cancellationToken = default)
+        {
+            type.Validate(nameof(type));
+
+            var path = type.GetValue();
+            return GetRawAsync(path, queryString, nameof(GetRightsRawAsync), path, cancellationToken);
+        }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/VerificationAndDocumentationTrackingRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/VerificationAndDocumentationTrackingRights.cs
@@ -1,0 +1,21 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// VerificationAndDocumentationTrackingRights
+    /// </summary>
+    public sealed class VerificationAndDocumentationTrackingRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _createNewEntry;
+        private DirtyValue<bool?> _editEntry;
+
+        /// <summary>
+        /// VerificationAndDocumentationTrackingRights CreateNewEntry
+        /// </summary>
+        public bool? CreateNewEntry { get => _createNewEntry; set => SetField(ref _createNewEntry, value); }
+
+        /// <summary>
+        /// VerificationAndDocumentationTrackingRights EditEntry
+        /// </summary>
+        public bool? EditEntry { get => _editEntry; set => SetField(ref _editEntry, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/ViewClosingDocumentDataRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/ViewClosingDocumentDataRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// ViewClosingDocumentDataRights
+    /// </summary>
+    public sealed class ViewClosingDocumentDataRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _overrideClosingDocumentDataFields;
+
+        /// <summary>
+        /// ViewClosingDocumentDataRights OverrideClosingDocumentDataFields
+        /// </summary>
+        public bool? OverrideClosingDocumentDataFields { get => _overrideClosingDocumentDataFields; set => SetField(ref _overrideClosingDocumentDataFields, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/Rights/WarehouseTabRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/WarehouseTabRights.cs
@@ -1,0 +1,15 @@
+namespace EncompassRest.Company.Users.Rights
+{
+    /// <summary>
+    /// WarehouseTabRights
+    /// </summary>
+    public sealed class WarehouseTabRights : ParentAccessRights
+    {
+        private DirtyValue<bool?> _editWarehouseBanks;
+
+        /// <summary>
+        /// WarehouseTabRights EditWarehouseBanks
+        /// </summary>
+        public bool? EditWarehouseBanks { get => _editWarehouseBanks; set => SetField(ref _editWarehouseBanks, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/SubordinateLoanAccess.cs
+++ b/src/EncompassRest/Company/Users/SubordinateLoanAccess.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.Serialization;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// SubordinateLoanAccess
+    /// </summary>
+    public enum SubordinateLoanAccess
+    {
+        /// <summary>
+        /// ReadOnly
+        /// </summary>
+        [EnumMember(Value = "readOnly")]
+        ReadOnly = 0,
+        /// <summary>
+        /// ReadWrite
+        /// </summary>
+        [EnumMember(Value = "readWrite")]
+        ReadWrite = 1
+    }
+}

--- a/src/EncompassRest/Company/Users/User.cs
+++ b/src/EncompassRest/Company/Users/User.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using EncompassRest.Utilities;
+using Newtonsoft.Json;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// User
+    /// </summary>
+    public sealed class User : DirtyExtensibleObject, IIdentifiable
+    {
+        private DirtyValue<string> _id;
+        private DirtyValue<string> _lastName;
+        private DirtyValue<string> _firstName;
+        private NeverSerializeValue<string> _fullName;
+        private DirtyValue<string> _email;
+        private DirtyValue<string> _phone;
+        private DirtyValue<string> _cellPhone;
+        private DirtyValue<string> _fax;
+        private DirtyValue<string> _employeeId;
+        private DirtyValue<bool?> _apiUser;
+        private DirtyValue<string> _oAuthClientId;
+        private DirtyValue<string> _workingFolder;
+        private EntityReference _organization;
+        private DirtyValue<StringEnumValue<SubordinateLoanAccess>> _subordinateLoanAccess;
+        private DirtyList<string> _userIndicators;
+        private DirtyValue<StringEnumValue<PeerLoanAccess>> _peerLoanAccess;
+        private NeverSerializeValue<DateTime?> _lastLogin;
+        private DirtyValue<string> _encompassVersion;
+        private DirtyValue<string> _chumId;
+        private DirtyValue<string> _nmlsOriginatorId;
+        private DirtyValue<DateTime?> _nmlsExpirationDate;
+        private DirtyValue<string> _emailSignature;
+        private NeverSerializeValue<bool?> _personalStatusOnline;
+        private DirtyValue<string> _comments;
+        private DirtyList<EntityReference> _personas;
+        private ConsumerConnectSite _ccSite;
+        private UserApis _userApis;
+
+        /// <summary>
+        /// User Id
+        /// </summary>
+        public string Id { get => _id; set => SetField(ref _id, value); }
+
+        /// <summary>
+        /// User LastName
+        /// </summary>
+        public string LastName { get => _lastName; set => SetField(ref _lastName, value); }
+
+        /// <summary>
+        /// User FirstName
+        /// </summary>
+        public string FirstName { get => _firstName; set => SetField(ref _firstName, value); }
+
+        /// <summary>
+        /// User FullName
+        /// </summary>
+        public string FullName { get => _fullName; set => SetField(ref _fullName, value); }
+
+        /// <summary>
+        /// User Email
+        /// </summary>
+        public string Email { get => _email; set => SetField(ref _email, value); }
+
+        /// <summary>
+        /// User Phone
+        /// </summary>
+        public string Phone { get => _phone; set => SetField(ref _phone, value); }
+
+        /// <summary>
+        /// User CellPhone
+        /// </summary>
+        public string CellPhone { get => _cellPhone; set => SetField(ref _cellPhone, value); }
+
+        /// <summary>
+        /// User Fax
+        /// </summary>
+        public string Fax { get => _fax; set => SetField(ref _fax, value); }
+
+        /// <summary>
+        /// User EmployeeId
+        /// </summary>
+        public string EmployeeId { get => _employeeId; set => SetField(ref _employeeId, value); }
+
+        /// <summary>
+        /// User ApiUser
+        /// </summary>
+        public bool? ApiUser { get => _apiUser; set => SetField(ref _apiUser, value); }
+
+        /// <summary>
+        /// User OAuthClientId
+        /// </summary>
+        public string OAuthClientId { get => _oAuthClientId; set => SetField(ref _oAuthClientId, value); }
+
+        /// <summary>
+        /// User WorkingFolder
+        /// </summary>
+        public string WorkingFolder { get => _workingFolder; set => SetField(ref _workingFolder, value); }
+
+        /// <summary>
+        /// User Organization
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public EntityReference Organization { get => _organization; set => SetField(ref _organization, value); }
+
+        /// <summary>
+        /// User SubordinateLoanAccess
+        /// </summary>
+        public StringEnumValue<SubordinateLoanAccess> SubordinateLoanAccess { get => _subordinateLoanAccess; set => SetField(ref _subordinateLoanAccess, value); }
+
+        /// <summary>
+        /// User UserIndicators
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> UserIndicators { get => GetField(ref _userIndicators); set => SetField(ref _userIndicators, value); }
+
+        /// <summary>
+        /// User PeerLoanAccess
+        /// </summary>
+        public StringEnumValue<PeerLoanAccess> PeerLoanAccess { get => _peerLoanAccess; set => SetField(ref _peerLoanAccess, value); }
+
+        /// <summary>
+        /// User LastLogin
+        /// </summary>
+        public DateTime? LastLogin { get => _lastLogin; set => SetField(ref _lastLogin, value); }
+
+        /// <summary>
+        /// User EncompassVersion
+        /// </summary>
+        public string EncompassVersion { get => _encompassVersion; set => SetField(ref _encompassVersion, value); }
+
+        /// <summary>
+        /// User ChumId
+        /// </summary>
+        public string ChumId { get => _chumId; set => SetField(ref _chumId, value); }
+
+        /// <summary>
+        /// User NmlsOriginatorId
+        /// </summary>
+        public string NmlsOriginatorId { get => _nmlsOriginatorId; set => SetField(ref _nmlsOriginatorId, value); }
+
+        /// <summary>
+        /// User NmlsExpirationDate
+        /// </summary>
+        public DateTime? NmlsExpirationDate { get => _nmlsExpirationDate; set => SetField(ref _nmlsExpirationDate, value); }
+
+        /// <summary>
+        /// User EmailSignature
+        /// </summary>
+        public string EmailSignature { get => _emailSignature; set => SetField(ref _emailSignature, value); }
+
+        /// <summary>
+        /// User PersonalStatusOnline
+        /// </summary>
+        public bool? PersonalStatusOnline { get => _personalStatusOnline; set => SetField(ref _personalStatusOnline, value); }
+
+        /// <summary>
+        /// User Comments
+        /// </summary>
+        public string Comments { get => _comments; set => SetField(ref _comments, value); }
+
+        /// <summary>
+        /// User Personas
+        /// </summary>
+        public IList<EntityReference> Personas { get => GetField(ref _personas); set => SetField(ref _personas, value); }
+
+        /// <summary>
+        /// User CcSite
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public ConsumerConnectSite CcSite { get => _ccSite; set => SetField(ref _ccSite, value); }
+
+        /// <summary>
+        /// User UserApis
+        /// </summary>
+        [JsonIgnore]
+        public UserApis UserApis => _userApis ?? throw new InvalidOperationException("User object must be initialized to use UserApis");
+
+        /// <summary>
+        /// User Client
+        /// </summary>
+        [JsonIgnore]
+        public EncompassRestClient Client { get; internal set; }
+
+        /// <summary>
+        /// User update constructor.
+        /// </summary>
+        /// <param name="client">The client to initialize the object.</param>
+        /// <param name="userId">The user's id.</param>
+        public User(EncompassRestClient client, string userId)
+        {
+            Initialize(client, userId);
+        }
+
+        /// <summary>
+        /// User creation constructor.
+        /// </summary>
+        [JsonConstructor]
+        public User()
+        {
+        }
+
+        /// <summary>
+        /// Initializes the user object with a client and user id so that you can use <see cref="UserApis"/>.
+        /// </summary>
+        /// <param name="client">The client to initialize the object.</param>
+        /// <param name="userId">The user's id.</param>
+        public void Initialize(EncompassRestClient client, string userId)
+        {
+            Preconditions.NotNull(client, nameof(client));
+            Preconditions.NotNullOrEmpty(userId, nameof(userId));
+
+            if (!string.IsNullOrEmpty(Id) && !string.Equals(Id, userId, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Cannot initialize with different userId");
+            }
+
+            if (!ReferenceEquals(Client, client) || _userApis == null)
+            {
+                Client = client;
+                Id = userId;
+                _id.Dirty = false;
+                _userApis = new UserApis(client, userId);
+            }
+        }
+    }
+}

--- a/src/EncompassRest/Company/Users/UserApiObject.cs
+++ b/src/EncompassRest/Company/Users/UserApiObject.cs
@@ -1,0 +1,23 @@
+﻿using EncompassRest.Utilities;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// Base class for User Apis
+    /// </summary>
+    public abstract class UserApiObject : ApiObject
+    {
+        /// <summary>
+        /// User's Id
+        /// </summary>
+        public string UserId { get; }
+
+        internal UserApiObject(EncompassRestClient client, string userId, string baseApiPath)
+            : base(client, $"encompass/v1/company/users/{userId}{baseApiPath?.PrecedeWith("/")}")
+        {
+            UserId = userId;
+        }
+
+        internal override string CreateErrorMessage(string methodName, string resourceId = null) => base.CreateErrorMessage(methodName, $"{UserId}{resourceId?.PrecedeWith("/")}");
+    }
+}

--- a/src/EncompassRest/Company/Users/UserApis.cs
+++ b/src/EncompassRest/Company/Users/UserApis.cs
@@ -1,0 +1,82 @@
+﻿using System.Threading;
+using EncompassRest.Company.Users.Rights;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// User Apis
+    /// </summary>
+    public sealed class UserApis : UserApiObject
+    {
+        private UserCustomDataObjects _customDataObjects;
+        private UserGroups _groups;
+        private UserCompensationPlans _compensation;
+        private UserLicenseDetails _licenses;
+        private UsersRights _rights;
+
+        /// <summary>
+        /// User Custom Data Objects Apis
+        /// </summary>
+        public UserCustomDataObjects CustomDataObjects
+        {
+            get
+            {
+                var customDataObjects = _customDataObjects;
+                return customDataObjects ?? Interlocked.CompareExchange(ref _customDataObjects, (customDataObjects = new UserCustomDataObjects(Client, UserId)), null) ?? customDataObjects;
+            }
+        }
+
+        /// <summary>
+        /// User Groups Apis
+        /// </summary>
+        public UserGroups Groups
+        {
+            get
+            {
+                var groups = _groups;
+                return groups ?? Interlocked.CompareExchange(ref _groups, (groups = new UserGroups(Client, UserId)), null) ?? groups;
+            }
+        }
+
+        /// <summary>
+        /// User Compensation Apis
+        /// </summary>
+        public UserCompensationPlans Compensation
+        {
+            get
+            {
+                var compensation = _compensation;
+                return compensation ?? Interlocked.CompareExchange(ref _compensation, (compensation = new UserCompensationPlans(Client, UserId)), null) ?? compensation;
+            }
+        }
+
+        /// <summary>
+        /// User Licenses Apis
+        /// </summary>
+        public UserLicenseDetails Licenses
+        {
+            get
+            {
+                var licenses = _licenses;
+                return licenses ?? Interlocked.CompareExchange(ref _licenses, (licenses = new UserLicenseDetails(Client, UserId)), null) ?? licenses;
+            }
+        }
+
+        /// <summary>
+        /// User Rights Apis
+        /// </summary>
+        public UsersRights Rights
+        {
+            get
+            {
+                var rights = _rights;
+                return rights ?? Interlocked.CompareExchange(ref _rights, (rights = new UsersRights(Client, UserId)), null) ?? rights;
+            }
+        }
+
+        internal UserApis(EncompassRestClient client, string userId)
+            : base(client, userId, null)
+        {
+        }
+    }
+}

--- a/src/EncompassRest/Company/Users/UserCompensation.cs
+++ b/src/EncompassRest/Company/Users/UserCompensation.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// UserCompensation
+    /// </summary>
+    public sealed class UserCompensation : DirtyExtensibleObject
+    {
+        private DirtyValue<bool> _useParentInformation;
+        private DirtyList<UserCompensationPlan> _plans;
+
+        /// <summary>
+        /// UserCompensation UseParentInformation
+        /// </summary>
+        public bool UseParentInformation { get => _useParentInformation; set => SetField(ref _useParentInformation, value); }
+
+        /// <summary>
+        /// UserCompensation Plans
+        /// </summary>
+        public IList<UserCompensationPlan> Plans { get => GetField(ref _plans); set => SetField(ref _plans, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/UserCompensationPlan.cs
+++ b/src/EncompassRest/Company/Users/UserCompensationPlan.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// UserCompensationPlan
+    /// </summary>
+    public sealed class UserCompensationPlan : DirtyExtensibleObject
+    {
+        private DirtyValue<DateTime> _startDate;
+        private EntityReference _plan;
+
+        /// <summary>
+        /// UserCompensationPlan StartDate
+        /// </summary>
+        public DateTime StartDate { get => _startDate; set => SetField(ref _startDate, value); }
+
+        /// <summary>
+        /// UserCompensationPlan Plan
+        /// </summary>
+        public EntityReference Plan { get => GetField(ref _plan); set => SetField(ref _plan, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/UserCompensationPlans.cs
+++ b/src/EncompassRest/Company/Users/UserCompensationPlans.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// User Compensation Apis
+    /// </summary>
+    public sealed class UserCompensationPlans : UserApiObject
+    {
+        internal UserCompensationPlans(EncompassRestClient client, string userId)
+            : base(client, userId, "compensation")
+        {
+        }
+
+        /// <summary>
+        /// Gets the user's compensation plans.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<UserCompensation> GetCompensationPlansAsync(CancellationToken cancellationToken = default) => GetDirtyAsync<UserCompensation>(null, null, nameof(GetCompensationPlansAsync), null, cancellationToken);
+
+        /// <summary>
+        /// Gets the user's compensation plans as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> GetCompensationPlansRawAsync(string queryString = null, CancellationToken cancellationToken = default) => GetRawAsync(null, queryString, nameof(GetCompensationPlansRawAsync), null, cancellationToken);
+    }
+}

--- a/src/EncompassRest/Company/Users/UserCustomDataObjects.cs
+++ b/src/EncompassRest/Company/Users/UserCustomDataObjects.cs
@@ -1,0 +1,23 @@
+﻿using EncompassRest.Utilities;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// User Custom Data Objects Apis
+    /// </summary>
+    public sealed class UserCustomDataObjects : CustomDataObjects.CustomDataObjects
+    {
+        /// <summary>
+        /// User's Id
+        /// </summary>
+        public string UserId { get; }
+
+        internal UserCustomDataObjects(EncompassRestClient client, string userId)
+            : base(client, $"encompass/v1/users/{userId}/customObjects")
+        {
+            UserId = userId;
+        }
+
+        internal override string CreateErrorMessage(string methodName, string resourceId = null) => base.CreateErrorMessage(methodName, $"{UserId}{resourceId?.PrecedeWith("/")}");
+    }
+}

--- a/src/EncompassRest/Company/Users/UserGroups.cs
+++ b/src/EncompassRest/Company/Users/UserGroups.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// User Groups Apis
+    /// </summary>
+    public sealed class UserGroups : UserApiObject
+    {
+        internal UserGroups(EncompassRestClient client, string userId)
+            : base(client, userId, "groups")
+        {
+        }
+
+        /// <summary>
+        /// Gets the user's groups.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<List<EntityReference>> GetGroupsAsync(CancellationToken cancellationToken = default) => GetDirtyListAsync<EntityReference>(null, null, nameof(GetGroupsAsync), null, cancellationToken);
+
+        /// <summary>
+        /// Gets the user's groups as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> GetGroupsRawAsync(string queryString = null, CancellationToken cancellationToken = default) => GetRawAsync(null, queryString, nameof(GetGroupsRawAsync), null, cancellationToken);
+    }
+}

--- a/src/EncompassRest/Company/Users/UserLicenseDetail.cs
+++ b/src/EncompassRest/Company/Users/UserLicenseDetail.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using EncompassRest.Loans.Enums;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// UserLicenseDetail
+    /// </summary>
+    public sealed class UserLicenseDetail : DirtyExtensibleObject
+    {
+        private DirtyValue<StringEnumValue<State>> _state;
+        private DirtyValue<bool> _enabled;
+        private DirtyValue<string> _license;
+        private DirtyValue<DateTime?> _expirationDate;
+
+        /// <summary>
+        /// UserLicenseDetail State
+        /// </summary>
+        public StringEnumValue<State> State { get => _state; set => SetField(ref _state, value); }
+
+        /// <summary>
+        /// UserLicenseDetail Enabled
+        /// </summary>
+        public bool Enabled { get => _enabled; set => SetField(ref _enabled, value); }
+
+        /// <summary>
+        /// UserLicenseDetail License
+        /// </summary>
+        public string License { get => _license; set => SetField(ref _license, value); }
+
+        /// <summary>
+        /// UserLicenseDetail ExpirationDate
+        /// </summary>
+        public DateTime? ExpirationDate { get => _expirationDate; set => SetField(ref _expirationDate, value); }
+    }
+}

--- a/src/EncompassRest/Company/Users/UserLicenseDetails.cs
+++ b/src/EncompassRest/Company/Users/UserLicenseDetails.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EncompassRest.Loans.Enums;
+using EncompassRest.Utilities;
+using EnumsNET;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// User Licenses Apis
+    /// </summary>
+    public sealed class UserLicenseDetails : UserApiObject
+    {
+        internal UserLicenseDetails(EncompassRestClient client, string userId)
+            : base(client, userId, "licenses")
+        {
+        }
+
+        /// <summary>
+        /// Gets the user's licenses.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<List<UserLicenseDetail>> GetLicenseDetailsAsync(CancellationToken cancellationToken = default) => GetLicenseDetailsAsync(null, cancellationToken);
+
+        /// <summary>
+        /// Gets the user's licenses for a particular state.
+        /// </summary>
+        /// <param name="state">The requested license's state.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<List<UserLicenseDetail>> GetLicenseDetailsAsync(State state, CancellationToken cancellationToken = default) => GetLicenseDetailsAsync(state.Validate(nameof(state)).GetValue(), cancellationToken);
+
+        /// <summary>
+        /// Gets the user's licenses and for a particular state if specified.
+        /// </summary>
+        /// <param name="state">The requested license's state if specified.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<List<UserLicenseDetail>> GetLicenseDetailsAsync(string state, CancellationToken cancellationToken = default)
+        {
+            var queryParameters = new QueryParameters();
+            if (!string.IsNullOrEmpty(state))
+            {
+                queryParameters.Add("state", state);
+            }
+            return GetDirtyListAsync<UserLicenseDetail>(null, queryParameters.ToString(), nameof(GetLicenseDetailsAsync), null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the user's licenses as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> GetLicenseDetailsRawAsync(string queryString = null, CancellationToken cancellationToken = default) => GetRawAsync(null, queryString, nameof(GetLicenseDetailsRawAsync), null, cancellationToken);
+    }
+}

--- a/src/EncompassRest/Company/Users/Users.cs
+++ b/src/EncompassRest/Company/Users/Users.cs
@@ -1,0 +1,133 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EncompassRest.Utilities;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// Users Apis
+    /// </summary>
+    public sealed class Users : ApiObject
+    {
+        private UserApis _currentUserApis;
+
+        /// <summary>
+        /// Gets the Current User's Apis. Custom Data Objects are not currently supported through this property.
+        /// </summary>
+        public UserApis CurrentUserApis
+        {
+            get
+            {
+                var currentUserApis = _currentUserApis;
+                return currentUserApis ?? Interlocked.CompareExchange(ref _currentUserApis, (currentUserApis = new UserApis(Client, "me")), null) ?? currentUserApis;
+            }
+        }
+
+        internal Users(EncompassRestClient client)
+            : base(client, "encompass/v1/company/users")
+        {
+        }
+
+        /// <summary>
+        /// Gets the User Apis for the specified <paramref name="userId"/>.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <returns></returns>
+        public UserApis GetUserApis(string userId)
+        {
+            Preconditions.NotNullOrEmpty(userId, nameof(userId));
+
+            return new UserApis(Client, userId);
+        }
+
+        /// <summary>
+        /// Gets all users.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<List<User>> GetUsersAsync(CancellationToken cancellationToken = default) => GetUsersAsync(null, cancellationToken);
+
+        /// <summary>
+        /// Gets users using the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="options">The users retrieval options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public async Task<List<User>> GetUsersAsync(UsersRetrievalOptions options, CancellationToken cancellationToken = default)
+        {
+            var users = await GetDirtyListAsync<User>(null, options?.ToQueryParameters().ToString(), nameof(GetUsersAsync), null, cancellationToken).ConfigureAwait(false);
+            foreach (var user in users)
+            {
+                user.Initialize(Client, user.Id);
+            }
+            return users;
+        }
+
+        /// <summary>
+        /// Gets users as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> GetUsersRawAsync(string queryString = null, CancellationToken cancellationToken = default) => GetRawAsync(null, queryString, nameof(GetUsersRawAsync), null, cancellationToken);
+
+        /// <summary>
+        /// Gets the current user.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<User> GetCurrentUserAsync(CancellationToken cancellationToken = default) => GetUserAsync("me", null, cancellationToken);
+
+        /// <summary>
+        /// Gets the current user and optionally includes the email signature in the response object.
+        /// </summary>
+        /// <param name="viewEmailSignature">Optionally include the email signature in the response object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<User> GetCurrentUserAsync(bool? viewEmailSignature, CancellationToken cancellationToken = default) => GetUserAsync("me", viewEmailSignature, cancellationToken);
+
+        /// <summary>
+        /// Gets the user with the specified <paramref name="userId"/>.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<User> GetUserAsync(string userId, CancellationToken cancellationToken = default) => GetUserAsync(userId, null, cancellationToken);
+
+        /// <summary>
+        /// Gets the user with the specified <paramref name="userId"/> and optionally includes the email signature in the response object.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <param name="viewEmailSignature">Optionally include the email signature in the response object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public async Task<User> GetUserAsync(string userId, bool? viewEmailSignature, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(userId, nameof(userId));
+
+            var queryParameters = new QueryParameters();
+            if (viewEmailSignature.HasValue)
+            {
+                queryParameters.Add("viewEmailSignature", viewEmailSignature.ToString().ToLower());
+            }
+            var user = await GetDirtyAsync<User>(userId, queryParameters.ToString(), nameof(GetUserAsync), userId, cancellationToken).ConfigureAwait(false);
+            user.Initialize(Client, user.Id);
+            return user;
+        }
+
+        /// <summary>
+        /// Gets user as raw json.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> GetUserRawAsync(string userId, string queryString = null, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(userId, nameof(userId));
+
+            return GetRawAsync(userId, queryString, nameof(GetUserRawAsync), userId, cancellationToken);
+        }
+    }
+}

--- a/src/EncompassRest/Company/Users/UsersRetrievalOptions.cs
+++ b/src/EncompassRest/Company/Users/UsersRetrievalOptions.cs
@@ -1,0 +1,88 @@
+﻿using EncompassRest.Utilities;
+
+namespace EncompassRest.Company.Users
+{
+    /// <summary>
+    /// Users retrieval options.
+    /// </summary>
+    public sealed class UsersRetrievalOptions
+    {
+        /// <summary>
+        /// Optionally include the email signature in the response object.
+        /// </summary>
+        public bool? ViewEmailSignature { get; set; }
+
+        /// <summary>
+        /// Optionally filters results on group id.
+        /// </summary>
+        public string GroupId { get; set; }
+
+        /// <summary>
+        /// Optionally filters results on role id.
+        /// </summary>
+        public string RoleId { get; set; }
+
+        /// <summary>
+        /// Optionally filters results on persona id.
+        /// </summary>
+        public string PersonaId { get; set; }
+
+        /// <summary>
+        /// Optionally filters results on organization id.
+        /// </summary>
+        public string OrganizationId { get; set; }
+
+        /// <summary>
+        /// Optionally filters results on users' names containing this value.
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Optional start index.
+        /// </summary>
+        public int? Start { get; set; }
+
+        /// <summary>
+        /// Optional limit of number of users to return.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        internal QueryParameters ToQueryParameters()
+        {
+            var queryParameters = new QueryParameters();
+            if (ViewEmailSignature.HasValue)
+            {
+                queryParameters.Add("viewEmailSignature", ViewEmailSignature.ToString().ToLower());
+            }
+            if (!string.IsNullOrEmpty(GroupId))
+            {
+                queryParameters.Add("groupId", GroupId);
+            }
+            if (!string.IsNullOrEmpty(RoleId))
+            {
+                queryParameters.Add("roleId", RoleId);
+            }
+            if (!string.IsNullOrEmpty(PersonaId))
+            {
+                queryParameters.Add("personaId", PersonaId);
+            }
+            if (!string.IsNullOrEmpty(OrganizationId))
+            {
+                queryParameters.Add("organizationId", OrganizationId);
+            }
+            if (!string.IsNullOrEmpty(UserName))
+            {
+                queryParameters.Add("userName", UserName);
+            }
+            if (Start.HasValue)
+            {
+                queryParameters.Add("start", Start.ToString());
+            }
+            if (Limit.HasValue)
+            {
+                queryParameters.Add("limit", Limit.ToString());
+            }
+            return queryParameters;
+        }
+    }
+}

--- a/src/EncompassRest/DirtyExtensibleObject.cs
+++ b/src/EncompassRest/DirtyExtensibleObject.cs
@@ -65,11 +65,11 @@ namespace EncompassRest
             }
         }
 
-        internal void SetField(ref DirtyDictionary<string, string> field, IDictionary<string, string> value, [CallerMemberName] string propertyName = null)
+        internal void SetField<T>(ref DirtyDictionary<string, T> field, IDictionary<string, T> value, [CallerMemberName] string propertyName = null)
         {
             if (!ReferenceEquals(field, value))
             {
-                field = value != null ? new DirtyDictionary<string, string>(value, StringComparer.OrdinalIgnoreCase) : null;
+                field = value != null ? new DirtyDictionary<string, T>(value, StringComparer.OrdinalIgnoreCase) : null;
                 OnPropertyChanged(propertyName);
             }
         }
@@ -80,7 +80,7 @@ namespace EncompassRest
 
         internal IList<T> GetField<T>(ref List<T> field) => field ?? (field = new List<T>());
 
-        internal IDictionary<string, string> GetField(ref DirtyDictionary<string, string> field) => field ?? (field = new DirtyDictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+        internal IDictionary<string, T> GetField<T>(ref DirtyDictionary<string, T> field) => field ?? (field = new DirtyDictionary<string, T>(StringComparer.OrdinalIgnoreCase));
 
         private bool _gettingDirty;
         private bool _settingDirty;

--- a/src/EncompassRest/DirtyList.cs
+++ b/src/EncompassRest/DirtyList.cs
@@ -305,7 +305,17 @@ namespace EncompassRest
 
     internal sealed class DirtyListConverter<T> : JsonConverter
     {
-        private static readonly bool s_serializeWholeList = TypeData<T>.TypeInfo.GetCustomAttribute<EntityAttribute>(false)?.SerializeWholeListWhenDirty == true;
+        private static readonly bool s_serializeWholeList = (!TypeData<T>.TypeInfo.IsSubclassOf(TypeData<DirtyExtensibleObject>.Type)) || TypeData<T>.TypeInfo.GetCustomAttribute<EntityAttribute>(false)?.SerializeWholeListWhenDirty == true;
+        private readonly bool _serializeWholeList;
+
+        public DirtyListConverter()
+        {
+        }
+
+        public DirtyListConverter(bool serializeWholeList)
+        {
+            _serializeWholeList = serializeWholeList;
+        }
 
         public override bool CanConvert(Type objectType) => objectType == TypeData<DirtyList<T>>.Type;
 
@@ -313,6 +323,6 @@ namespace EncompassRest
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) => throw new NotSupportedException();
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => serializer.Serialize(writer, (s_serializeWholeList ? ((DirtyList<T>)value)._list : ((DirtyList<T>)value)._list.Where(item => item.Dirty)).Select(item => (T)item));
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => serializer.Serialize(writer, (_serializeWholeList || s_serializeWholeList ? ((DirtyList<T>)value)._list : ((DirtyList<T>)value)._list.Where(item => item.Dirty)).Select(item => (T)item));
     }
 }

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -118,6 +118,7 @@ namespace EncompassRest
         private LoanFolders.LoanFolders _loanFolders;
         private Settings.Settings _settings;
         private Services.Services _services;
+        private Company.Company _company;
         private BaseApiClient _baseApiClient;
 
         #region Properties
@@ -240,6 +241,7 @@ namespace EncompassRest
             }
         }
 
+        [Obsolete("Use EncompassRestClient.Company.GlobalCustomDataObjects instead.")]
         public GlobalCustomDataObjects GlobalCustomDataObjects
         {
             get
@@ -249,6 +251,7 @@ namespace EncompassRest
             }
         }
 
+        [Obsolete("Use EncompassRestClient.Company.Users.GetUserApis(userId).CustomDataObjects instead.")]
         public Users.Users Users
         {
             get
@@ -282,6 +285,18 @@ namespace EncompassRest
             {
                 var services = _services;
                 return services ?? Interlocked.CompareExchange(ref _services, (services = new Services.Services(this)), null) ?? services;
+            }
+        }
+
+        /// <summary>
+        /// Company Apis
+        /// </summary>
+        public Company.Company Company
+        {
+            get
+            {
+                var company = _company;
+                return company ?? Interlocked.CompareExchange(ref _company, (company = new Company.Company(this)), null) ?? company;
             }
         }
 

--- a/src/EncompassRest/EntityReference.cs
+++ b/src/EncompassRest/EntityReference.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace EncompassRest
 {
-    [Entity(PropertiesToAlwaysSerialize = nameof(EntityType))]
+    [Entity(SerializeWholeListWhenDirty = true, PropertiesToAlwaysSerialize = nameof(EntityType))]
     public class EntityReference : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _entityId;

--- a/src/EncompassRest/EntityType.cs
+++ b/src/EncompassRest/EntityType.cs
@@ -1,12 +1,21 @@
-﻿using System.Runtime.Serialization;
-
-namespace EncompassRest
+﻿namespace EncompassRest
 {
     public enum EntityType
     {
-        [EnumMember(Value = "attachment")]
         Attachment = 0,
-        [EnumMember(Value = "loan")]
-        Loan = 1
+        Loan = 1,
+        Document = 2,
+        Borrower = 3,
+        Business = 4,
+        Folder = 5,
+        File = 6,
+        Application = 7,
+        User = 8,
+        Snapshot = 9,
+        Role = 10,
+        Organization = 11,
+        Persona = 12,
+        UserGroup = 13,
+        CompensationPlan = 14
     }
 }

--- a/src/EncompassRest/Loans/LoanCustomizations.cs
+++ b/src/EncompassRest/Loans/LoanCustomizations.cs
@@ -19,15 +19,15 @@ namespace EncompassRest.Loans
         public EncompassRestClient Client { get; internal set; }
 
         [JsonIgnore]
-        [Obsolete("Use LoanApis.Documents instead.")]
+        [Obsolete("Use Loan.LoanApis.Documents instead.")]
         public LoanDocuments Documents => LoanApis.Documents;
 
         [JsonIgnore]
-        [Obsolete("Use LoanApis.Attachments instead.")]
+        [Obsolete("Use Loan.LoanApis.Attachments instead.")]
         public LoanAttachments Attachments => LoanApis.Attachments;
 
         [JsonIgnore]
-        [Obsolete("Use LoanApis.CustomDataObjects instead.")]
+        [Obsolete("Use Loan.LoanApis.CustomDataObjects instead.")]
         public LoanCustomDataObjects CustomDataObjects => LoanApis.CustomDataObjects;
 
         [JsonIgnore]

--- a/src/EncompassRest/Loans/LoanField.cs
+++ b/src/EncompassRest/Loans/LoanField.cs
@@ -27,25 +27,25 @@ namespace EncompassRest.Loans
         /// </summary>
         public string AttributePath => _modelPath.ToString(name => JsonHelper.CamelCaseNamingStrategy.GetPropertyName(name, false), true).Replace("/currentApplication", "/applications/*");
 
-        [Obsolete("Use Descriptor.MultiInstance instead.")]
+        [Obsolete("Use LoanField.Descriptor.MultiInstance instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool MultiInstance => Descriptor.MultiInstance;
 
-        [Obsolete("Use Descriptor.InstanceSpecifier instead.")]
+        [Obsolete("Use LoanField.Descriptor.InstanceSpecifier instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string InstanceSpecifier => Descriptor.InstanceSpecifier;
 
-        [Obsolete("Use Descriptor.IsBorrowerPairSpecific instead.")]
+        [Obsolete("Use LoanField.Descriptor.IsBorrowerPairSpecific instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsBorrowerPairSpecific => Descriptor.IsBorrowerPairSpecific;
 
         public int? BorrowerPairIndex { get; }
 
-        [Obsolete("Use Descriptor.ValueType instead.")]
+        [Obsolete("Use LoanField.Descriptor.ValueType instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public LoanFieldValueType ValueType => Descriptor.ValueType;
 
-        [Obsolete("Use Descriptor.Type instead.")]
+        [Obsolete("Use LoanField.Descriptor.Type instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public LoanFieldType Type => Descriptor.Type;
 
@@ -53,7 +53,7 @@ namespace EncompassRest.Loans
 
         public bool ReadOnly => Descriptor.ReadOnly;
 
-        [Obsolete("Use Descriptor.Description instead.")]
+        [Obsolete("Use LoanField.Descriptor.Description instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Description => Descriptor.Description;
 
@@ -209,7 +209,7 @@ namespace EncompassRest.Loans
             }
         }
 
-        [Obsolete("Use Descriptor.Options instead.")]
+        [Obsolete("Use LoanField.Descriptor.Options instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ReadOnlyCollection<FieldOption> Options => Descriptor.Options;
 


### PR DESCRIPTION
Added support for user apis.

Moved EncompassRestClient.GlobalCustomDataObjects to EncompassRestClient.Company.GlobalCustomDataObjects to better follow api path.

Deprecated EncompassRestClient.Users and moved UserCustomDataObjects to EncompassRestClient.Company.Users.

When I say moved I really mean duplicated the classes in the new location and deprecated the existing locations.

Unified testing for extension data.