### PR TITLE
Revert making [1395] a StringEnumValue<State> property

### DIFF
--- a/src/EncompassRest.EntityGenerator/EntityGenerator.cs
+++ b/src/EncompassRest.EntityGenerator/EntityGenerator.cs
@@ -183,7 +183,6 @@ namespace EncompassRest
             { "AdditionalStateDisclosure.StateCode", nameof(State) },
             { "LoanAssociate.EnableWriteAccess", nameof(YOrN) },
             { "FreddieMac.CondoClass", nameof(CondoClass) },
-            { "Hmda.StateCode", nameof(State) },
             { "MilestoneTaskContact.State", nameof(State) },
             { "Miscellaneous.State", nameof(State) }
         };

--- a/src/EncompassRest/Loans/Hmda.cs
+++ b/src/EncompassRest/Loans/Hmda.cs
@@ -107,7 +107,7 @@ namespace EncompassRest.Loans
         private DirtyValue<StringEnumValue<TypeOfPurchaser>> _repurchasedTypeOfPurchaser;
         private DirtyValue<string> _respondentID;
         private DirtyValue<StringEnumValue<ReverseMortgage>> _reverseMortgage;
-        private DirtyValue<StringEnumValue<State>> _stateCode;
+        private DirtyValue<string> _stateCode;
         private DirtyValue<StringEnumValue<SubmissionOfApplication>> _submissionOfApplication;
         private DirtyValue<string> _totalLoanCosts;
         private DirtyValue<string> _totalPointsAndFees;
@@ -641,7 +641,7 @@ namespace EncompassRest.Loans
         /// <summary>
         /// Subject Property State Code [1395]
         /// </summary>
-        public StringEnumValue<State> StateCode { get => _stateCode; set => SetField(ref _stateCode, value); }
+        public string StateCode { get => _stateCode; set => SetField(ref _stateCode, value); }
 
         /// <summary>
         /// Submission of Application [HMDA.X42]


### PR DESCRIPTION
Revert making [1395] a `StringEnumValue<State>` property. The state code should be a 2 digit numeric value stored as a string, not a state abbreviation.