### PR TITLE
Updated conditions to always serialize Application or ForAllApplications

### DIFF
--- a/src/EncompassRest/Comment.cs
+++ b/src/EncompassRest/Comment.cs
@@ -10,7 +10,7 @@ namespace EncompassRest
         private DirtyValue<string> _commentId;
         private DirtyValue<string> _comments;
         private DirtyValue<int?> _forRoleId;
-        private EntityReference _forRole;
+        private DirtyValue<EntityReference> _forRole;
         private DirtyValue<DateTime?> _dateCreated;
         private DirtyValue<string> _createdBy;
         private DirtyValue<string> _createdByName;
@@ -35,7 +35,7 @@ namespace EncompassRest
         /// <summary>
         /// Information about the Encompass role ID that has access to this comment.
         /// </summary>
-        public EntityReference ForRole { get => GetField(ref _forRole); set => SetField(ref _forRole, value); }
+        public EntityReference ForRole { get => _forRole; set => SetField(ref _forRole, value); }
 
         /// <summary>
         /// Date the comment was created.

--- a/src/EncompassRest/Company/CompensationPlan.cs
+++ b/src/EncompassRest/Company/CompensationPlan.cs
@@ -9,7 +9,7 @@ namespace EncompassRest.Company
     {
         private DirtyValue<DateTime?> _startDate;
         private DirtyValue<DateTime?> _endDate;
-        private EntityReference _plan;
+        private DirtyValue<EntityReference> _plan;
 
         /// <summary>
         /// The start date for the entity's compensation plan. The date that the plan will go into effect for the entity.
@@ -24,6 +24,6 @@ namespace EncompassRest.Company
         /// <summary>
         /// Details about each compensation plan.
         /// </summary>
-        public EntityReference Plan { get => GetField(ref _plan); set => SetField(ref _plan, value); }
+        public EntityReference Plan { get => _plan; set => SetField(ref _plan, value); }
     }
 }

--- a/src/EncompassRest/Company/Users/User.cs
+++ b/src/EncompassRest/Company/Users/User.cs
@@ -22,7 +22,7 @@ namespace EncompassRest.Company.Users
         private DirtyValue<bool?> _apiUser;
         private DirtyValue<string> _oAuthClientId;
         private DirtyValue<string> _workingFolder;
-        private EntityReference _organization;
+        private DirtyValue<EntityReference> _organization;
         private DirtyValue<StringEnumValue<SubordinateLoanAccess>> _subordinateLoanAccess;
         private DirtyList<string> _userIndicators;
         private DirtyValue<StringEnumValue<PeerLoanAccess>> _peerLoanAccess;

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -27,7 +27,7 @@ namespace EncompassRest.Loans.Attachments
         private DirtyValue<int?> _rotation;
         private DirtyValue<string> _title;
         private DirtyValue<string> _fileWithExtension;
-        private EntityReference _document;
+        private DirtyValue<EntityReference> _document;
         private NeverSerializeValue<string> _mediaUrl;
 
         /// <summary>

--- a/src/EncompassRest/Loans/Conditions/LoanCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/LoanCondition.cs
@@ -6,6 +6,7 @@ namespace EncompassRest.Loans.Conditions
     /// <summary>
     /// LoanCondition
     /// </summary>
+    [Entity(PropertiesToAlwaysSerialize = nameof(ForAllApplications) + "," + nameof(Application))]
     public abstract class LoanCondition : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _id;
@@ -14,7 +15,7 @@ namespace EncompassRest.Loans.Conditions
         private DirtyValue<bool?> _isRemoved;
         private DirtyValue<string> _title;
         private DirtyValue<string> _description;
-        private EntityReference _application;
+        private DirtyValue<EntityReference> _application;
         private DirtyValue<bool?> _forAllApplications;
         private DirtyValue<StringEnumValue<ConditionSource>> _source;
         private DirtyValue<DateTime?> _expectedDate;
@@ -23,16 +24,16 @@ namespace EncompassRest.Loans.Conditions
         private DirtyValue<int?> _daysToReceive;
         private DirtyValue<string> _requestedFrom;
         private DirtyValue<DateTime?> _createdDate;
-        private EntityReference _createdBy;
+        private DirtyValue<EntityReference> _createdBy;
         private DirtyValue<bool?> _isRequested;
         private DirtyValue<DateTime?> _requestedDate;
-        private EntityReference _requestedBy;
+        private DirtyValue<EntityReference> _requestedBy;
         private DirtyValue<bool?> _isRerequested;
         private DirtyValue<DateTime?> _rerequestedDate;
-        private EntityReference _rerequestedBy;
+        private DirtyValue<EntityReference> _rerequestedBy;
         private DirtyValue<bool?> _isReceived;
         private DirtyValue<DateTime?> _receivedDate;
-        private EntityReference _receivedBy;
+        private DirtyValue<EntityReference> _receivedBy;
         private DirtyValue<bool?> _isAddedToConditionSet;
         private DirtyList<Comment> _comments;
         private DirtyList<EntityReference> _documents;
@@ -70,7 +71,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Loan application to which to apply the condition. Required if applying condition to a specific application. If you want to apply the condition to all applications of the loan, set <see cref="ForAllApplications"/> to <c>true</c>.
         /// </summary>
-        public EntityReference Application { get => GetField(ref _application); set => SetField(ref _application, value); }
+        public EntityReference Application { get => _application; set => SetField(ref _application, value); }
 
         /// <summary>
         /// A value of <c>true</c> indicates the condition will be linked to all applications or only for a specified application. If linked to a specified application, the application ID must be provided.
@@ -115,7 +116,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who created the condition.
         /// </summary>
-        public EntityReference CreatedBy { get => GetField(ref _createdBy); set => SetField(ref _createdBy, value); }
+        public EntityReference CreatedBy { get => _createdBy; set => SetField(ref _createdBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Requested.
@@ -130,7 +131,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who requested the condition.
         /// </summary>
-        public EntityReference RequestedBy { get => GetField(ref _requestedBy); set => SetField(ref _requestedBy, value); }
+        public EntityReference RequestedBy { get => _requestedBy; set => SetField(ref _requestedBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Re-requested.
@@ -145,7 +146,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who re-requested the condition.
         /// </summary>
-        public EntityReference RerequestedBy { get => GetField(ref _rerequestedBy); set => SetField(ref _rerequestedBy, value); }
+        public EntityReference RerequestedBy { get => _rerequestedBy; set => SetField(ref _rerequestedBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Received.
@@ -160,7 +161,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who received the condition.
         /// </summary>
-        public EntityReference ReceivedBy { get => GetField(ref _receivedBy); set => SetField(ref _receivedBy, value); }
+        public EntityReference ReceivedBy { get => _receivedBy; set => SetField(ref _receivedBy, value); }
 
         /// <summary>
         /// Whether the condition belongs to a condition set.

--- a/src/EncompassRest/Loans/Conditions/PostClosingCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/PostClosingCondition.cs
@@ -10,10 +10,10 @@ namespace EncompassRest.Loans.Conditions
         private DirtyValue<string> _recipient;
         private DirtyValue<bool?> _isSent;
         private DirtyValue<DateTime?> _sentDate;
-        private EntityReference _sentBy;
+        private DirtyValue<EntityReference> _sentBy;
         private DirtyValue<bool?> _isCleared;
         private DirtyValue<DateTime?> _clearedDate;
-        private EntityReference _clearedBy;
+        private DirtyValue<EntityReference> _clearedBy;
 
         /// <summary>
         /// Recipient of the condition.
@@ -33,7 +33,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// User that sent the condition.
         /// </summary>
-        public EntityReference SentBy { get => GetField(ref _sentBy); set => SetField(ref _sentBy, value); }
+        public EntityReference SentBy { get => _sentBy; set => SetField(ref _sentBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Cleared.
@@ -48,6 +48,6 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who cleared the condition.
         /// </summary>
-        public EntityReference ClearedBy { get => GetField(ref _clearedBy); set => SetField(ref _clearedBy, value); }
+        public EntityReference ClearedBy { get => _clearedBy; set => SetField(ref _clearedBy, value); }
     }
 }

--- a/src/EncompassRest/Loans/Conditions/PreliminaryCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/PreliminaryCondition.cs
@@ -12,7 +12,7 @@ namespace EncompassRest.Loans.Conditions
         private DirtyValue<StringEnumValue<ConditionCategory>> _category;
         private DirtyValue<bool?> _isFulfilled;
         private DirtyValue<DateTime?> _fulfilledDate;
-        private EntityReference _fulfilledBy;
+        private DirtyValue<EntityReference> _fulfilledBy;
 
         /// <summary>
         /// A value of <c>true</c> indicates that underwriting has access to this condition.
@@ -42,6 +42,6 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who fulfilled the condition.
         /// </summary>
-        public EntityReference FulfilledBy { get => GetField(ref _fulfilledBy); set => SetField(ref _fulfilledBy, value); }
+        public EntityReference FulfilledBy { get => _fulfilledBy; set => SetField(ref _fulfilledBy, value); }
     }
 }

--- a/src/EncompassRest/Loans/Conditions/UnderwritingCondition.cs
+++ b/src/EncompassRest/Loans/Conditions/UnderwritingCondition.cs
@@ -16,19 +16,19 @@ namespace EncompassRest.Loans.Conditions
         private DirtyValue<DateTime?> _expirationDate;
         private DirtyValue<bool?> _isFulfilled;
         private DirtyValue<DateTime?> _fulfilledDate;
-        private EntityReference _fulfilledBy;
+        private DirtyValue<EntityReference> _fulfilledBy;
         private DirtyValue<bool?> _isReviewed;
         private DirtyValue<DateTime?> _reviewedDate;
-        private EntityReference _reviewedBy;
+        private DirtyValue<EntityReference> _reviewedBy;
         private DirtyValue<bool?> _isRejected;
         private DirtyValue<DateTime?> _rejectedDate;
-        private EntityReference _rejectedBy;
+        private DirtyValue<EntityReference> _rejectedBy;
         private DirtyValue<bool?> _isCleared;
         private DirtyValue<DateTime?> _clearedDate;
-        private EntityReference _clearedBy;
+        private DirtyValue<EntityReference> _clearedBy;
         private DirtyValue<bool?> _isWaived;
         private DirtyValue<DateTime?> _waivedDate;
-        private EntityReference _waivedBy;
+        private DirtyValue<EntityReference> _waivedBy;
 
         /// <summary>
         /// The milestones to describe when the condition must be satisfied.
@@ -78,7 +78,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who fulfilled the condition.
         /// </summary>
-        public EntityReference FulfilledBy { get => GetField(ref _fulfilledBy); set => SetField(ref _fulfilledBy, value); }
+        public EntityReference FulfilledBy { get => _fulfilledBy; set => SetField(ref _fulfilledBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Reviewed.
@@ -93,7 +93,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who reviewed the condition.
         /// </summary>
-        public EntityReference ReviewedBy { get => GetField(ref _reviewedBy); set => SetField(ref _reviewedBy, value); }
+        public EntityReference ReviewedBy { get => _reviewedBy; set => SetField(ref _reviewedBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Rejected.
@@ -108,7 +108,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who rejected the condition.
         /// </summary>
-        public EntityReference RejectedBy { get => GetField(ref _rejectedBy); set => SetField(ref _rejectedBy, value); }
+        public EntityReference RejectedBy { get => _rejectedBy; set => SetField(ref _rejectedBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Cleared.
@@ -123,7 +123,7 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who cleared the condition.
         /// </summary>
-        public EntityReference ClearedBy { get => GetField(ref _clearedBy); set => SetField(ref _clearedBy, value); }
+        public EntityReference ClearedBy { get => _clearedBy; set => SetField(ref _clearedBy, value); }
 
         /// <summary>
         /// Whether the condition's status is Waived.
@@ -138,6 +138,6 @@ namespace EncompassRest.Loans.Conditions
         /// <summary>
         /// Information about the Encompass user who waived the condition.
         /// </summary>
-        public EntityReference WaivedBy { get => GetField(ref _waivedBy); set => SetField(ref _waivedBy, value); }
+        public EntityReference WaivedBy { get => _waivedBy; set => SetField(ref _waivedBy, value); }
     }
 }

--- a/src/EncompassRest/Organizations/LegalEntityIdentifierInformation.cs
+++ b/src/EncompassRest/Organizations/LegalEntityIdentifierInformation.cs
@@ -7,13 +7,13 @@ namespace EncompassRest.Organizations
     /// </summary>
     public sealed class LegalEntityIdentifierInformation : ParentInformation
     {
-        private EntityReference _hmdaProfile;
+        private DirtyValue<EntityReference> _hmdaProfile;
         private DirtyValue<string> _lei;
 
         /// <summary>
         /// The LEI associated with the organization.
         /// </summary>
-        public EntityReference HmdaProfile { get => GetField(ref _hmdaProfile); set => SetField(ref _hmdaProfile, value); }
+        public EntityReference HmdaProfile { get => _hmdaProfile; set => SetField(ref _hmdaProfile, value); }
 
         /// <summary>
         /// The LEI code that is associated with the organization's HMDA profile.

--- a/src/EncompassRest/ResourceLocks/ResourceLock.cs
+++ b/src/EncompassRest/ResourceLocks/ResourceLock.cs
@@ -8,7 +8,7 @@ namespace EncompassRest.ResourceLocks
     public sealed class ResourceLock : DirtyExtensibleObject, IIdentifiable
     {
         private DirtyValue<string> _id;
-        private EntityReference _resource;
+        private DirtyValue<EntityReference> _resource;
         private DirtyValue<string> _userId;
         private DirtyValue<StringEnumValue<ResourceLockType>> _lockType;
         private DirtyValue<DateTime?> _lockTime;
@@ -21,7 +21,7 @@ namespace EncompassRest.ResourceLocks
         /// <summary>
         /// References the entity ID and entity type.
         /// </summary>
-        public EntityReference Resource { get => GetField(ref _resource); set => SetField(ref _resource, value); }
+        public EntityReference Resource { get => _resource; set => SetField(ref _resource, value); }
 
         /// <summary>
         /// The Encompass user ID of the user holding the lock.


### PR DESCRIPTION
Updated conditions to always serialize `Application` or `ForAllApplications`.

Made all `EntityReference` properties not create the object upon gets.

Fixes #238