### PR TITLE
Added ToString overload for dirty serialization.

### DIFF
--- a/src/EncompassRest.Tests/BatchUpdateTests.cs
+++ b/src/EncompassRest.Tests/BatchUpdateTests.cs
@@ -15,7 +15,7 @@ namespace EncompassRest.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var batchUpdateParameters = new BatchUpdateParameters(new StringFieldFilter(CanonicalLoanField.LoanFolder, StringFieldMatchType.Exact, "Active Loans"), new Loan { Tltv = 85.00M });
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(@"{""filter"":{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""},""loanData"":{""tltv"":85.00}}", batchUpdateParameters.ToJson());
+            Assert.AreEqual(@"{""filter"":{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""},""loanData"":{""tltv"":85.00}}", batchUpdateParameters.ToString(SerializationOptions.Dirty));
         }
     }
 }

--- a/src/EncompassRest.Tests/BorrowerPairsTests.cs
+++ b/src/EncompassRest.Tests/BorrowerPairsTests.cs
@@ -33,17 +33,17 @@ namespace EncompassRest.Tests
                 var borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
                 Assert.AreSame(loan.Applications, borrowerPairs);
                 Assert.IsTrue(loan.Applications.Count > 0);
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 var oldCount = loan.Applications.Count;
                 var application = new Application();
                 var applicationId = await loan.LoanApis.BorrowerPairs.CreateBorrowerPairAsync(application);
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(oldCount + 1, loan.Applications.Count);
                 Assert.AreSame(application, loan.Applications.First(a => a.Id == applicationId));
                 application.ApplicationSignedDate = DateTime.Now.AddDays(-5);
                 var newApplication = new Application { Id = applicationId, ApplicationSignedDate = DateTime.Now.AddDays(2), Borrower = new Borrower { FirstName = "Bob", LastName = "Smith" }, Coborrower = new Borrower { FirstName = "Jane", LastName = "Doe" } };
                 await loan.LoanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(newApplication.ApplicationSignedDate, loan.Applications.First(a => a.Id == applicationId).ApplicationSignedDate);
 
                 borrowerPairs = await loan.LoanApis.BorrowerPairs.GetBorrowerPairsAsync();
@@ -67,7 +67,7 @@ namespace EncompassRest.Tests
 
                 oldCount = loan.Applications.Count;
                 Assert.IsTrue(await loan.LoanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(oldCount - 1, loan.Applications.Count);
                 Assert.IsNull(loan.Applications.FirstOrDefault(a => a.Id == applicationId));
             }
@@ -108,18 +108,18 @@ namespace EncompassRest.Tests
             try
             {
                 var borrowerPairs = await loanApis.BorrowerPairs.GetBorrowerPairsAsync();
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(0, loan.Applications.Count);
                 var application = new Application();
                 var applicationId = await loanApis.BorrowerPairs.CreateBorrowerPairAsync(application);
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(0, loan.Applications.Count);
                 var newApplication = new Application { Id = applicationId, ApplicationSignedDate = DateTime.Now.AddDays(2) };
                 await loanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(0, loan.Applications.Count);
                 Assert.IsTrue(await loanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
-                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToJson());
+                Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(0, loan.Applications.Count);
             }
             finally

--- a/src/EncompassRest.Tests/ContactNoteTests.cs
+++ b/src/EncompassRest.Tests/ContactNoteTests.cs
@@ -13,9 +13,9 @@ namespace EncompassRest.Tests
         {
             var contactNote = new ContactNote("5");
             Assert.AreEqual(contactNote.NoteIdInt, 5);
-            Assert.AreEqual(@"{""noteId"":5}", contactNote.ToJson());
+            Assert.AreEqual(@"{""noteId"":5}", contactNote.ToString(SerializationOptions.Dirty));
             contactNote.Dirty = false;
-            Assert.AreEqual(@"{""noteId"":5}", contactNote.ToJson());
+            Assert.AreEqual(@"{""noteId"":5}", contactNote.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/ContactsTests.cs
+++ b/src/EncompassRest.Tests/ContactsTests.cs
@@ -17,9 +17,9 @@ namespace EncompassRest.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var borrowerContact = new BorrowerContact { AccessLevel = ContactAccessLevel.Private };
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(@"{""accessLevel"":0}", borrowerContact.ToJson());
+            Assert.AreEqual(@"{""accessLevel"":0}", borrowerContact.ToString(SerializationOptions.Dirty));
             borrowerContact.Dirty = false;
-            Assert.AreEqual("{}", borrowerContact.ToJson());
+            Assert.AreEqual("{}", borrowerContact.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -28,9 +28,9 @@ namespace EncompassRest.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var businessContact = new BusinessContact { AccessLevel = ContactAccessLevel.Private };
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(@"{""accessLevel"":0}", businessContact.ToJson());
+            Assert.AreEqual(@"{""accessLevel"":0}", businessContact.ToString(SerializationOptions.Dirty));
             businessContact.Dirty = false;
-            Assert.AreEqual("{}", businessContact.ToJson());
+            Assert.AreEqual("{}", businessContact.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/FilterTests.cs
+++ b/src/EncompassRest.Tests/FilterTests.cs
@@ -11,7 +11,7 @@ namespace EncompassRest.Tests
         public void Filter_Simple_Serialization()
         {
             var filter = new StringFieldFilter(CanonicalLoanField.LoanFolder, StringFieldMatchType.Exact, "Active Loans");
-            Assert.AreEqual(@"{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""}", filter.ToJson());
+            Assert.AreEqual(@"{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""}", filter.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -19,7 +19,7 @@ namespace EncompassRest.Tests
         {
             var filter = new StringFieldFilter(CanonicalLoanField.LoanFolder, StringFieldMatchType.Exact, "Active Loans")
                 .And(new NumericFieldFilter(CanonicalLoanField.LoanAmount, OrdinalFieldMatchType.GreaterThanOrEquals, 80000M));
-            Assert.AreEqual(@"{""operator"":""and"",""terms"":[{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""},{""matchType"":""greaterThanOrEquals"",""value"":80000.0,""canonicalName"":""Loan.LoanAmount""}]}", filter.ToJson());
+            Assert.AreEqual(@"{""operator"":""and"",""terms"":[{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""},{""matchType"":""greaterThanOrEquals"",""value"":80000.0,""canonicalName"":""Loan.LoanAmount""}]}", filter.ToString(SerializationOptions.Dirty));
         }
     }
 }

--- a/src/EncompassRest.Tests/LoanAttachmentTests.cs
+++ b/src/EncompassRest.Tests/LoanAttachmentTests.cs
@@ -17,7 +17,7 @@ namespace EncompassRest.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var loanAttachment = new LoanAttachment { AttachmentType = AttachmentType.Image };
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(@"{""attachmentType"":1}", loanAttachment.ToJson());
+            Assert.AreEqual(@"{""attachmentType"":1}", loanAttachment.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/LoanDocumentTests.cs
+++ b/src/EncompassRest.Tests/LoanDocumentTests.cs
@@ -16,21 +16,21 @@ namespace EncompassRest.Tests
         public void LoanDocument_Serialization()
         {
             var document = new LoanDocument("Mortgage Insurance", "All");
-            Assert.AreEqual(@"{""title"":""Mortgage Insurance"",""applicationId"":""All""}", document.ToJson());
+            Assert.AreEqual(@"{""title"":""Mortgage Insurance"",""applicationId"":""All""}", document.ToString(SerializationOptions.Dirty));
             document.Dirty = false;
-            Assert.AreEqual("{}", document.ToJson());
+            Assert.AreEqual("{}", document.ToString(SerializationOptions.Dirty));
             document.Status = "expected";
             Assert.IsNotNull(document.Status.EnumValue);
             Assert.AreEqual(DocumentStatus.Expected, document.Status.EnumValue.GetValueOrDefault());
-            Assert.AreEqual(@"{""status"":""expected""}", document.ToJson());
+            Assert.AreEqual(@"{""status"":""expected""}", document.ToString(SerializationOptions.Dirty));
             document.Status = "ready to ship";
             Assert.IsNull(document.Status.EnumValue);
-            Assert.AreEqual(@"{""status"":""ready to ship""}", document.ToJson());
+            Assert.AreEqual(@"{""status"":""ready to ship""}", document.ToString(SerializationOptions.Dirty));
             document.Dirty = false;
-            Assert.AreEqual("{}", document.ToJson());
+            Assert.AreEqual("{}", document.ToString(SerializationOptions.Dirty));
             document.Status = DocumentStatus.Added;
             Assert.AreEqual("added", document.Status.Value);
-            Assert.AreEqual(@"{""status"":""added""}", document.ToJson());
+            Assert.AreEqual(@"{""status"":""added""}", document.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -36,12 +36,12 @@ namespace EncompassRest.Tests
             var serializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
             Assert.AreEqual("{}", JsonConvert.SerializeObject(loan, serializerSettings));
             loan.ExtensionData.Add("dog", true);
-            Assert.AreEqual(@"{""dog"":true}", loan.ToJson());
+            Assert.AreEqual(@"{""dog"":true}", loan.ToString(SerializationOptions.Dirty));
             Assert.AreEqual(@"{
   ""dog"": true
 }", JsonConvert.SerializeObject(loan, serializerSettings));
             loan.Dirty = false;
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             Assert.AreEqual(@"{
   ""dog"": true
 }", JsonConvert.SerializeObject(loan, serializerSettings));
@@ -106,13 +106,13 @@ namespace EncompassRest.Tests
             Assert.AreEqual(@"{""baseLoanAmount"":123456.78}", loan.ToString());
             Assert.AreEqual(@"{
   ""baseLoanAmount"": 123456.78
-}", loan.ToString(indent: true));
+}", loan.ToString(SerializationOptions.Indent));
             loan.BaseLoanAmount = null;
             Assert.AreEqual("{}", loan.ToString());
             loan.ExtensionData.Add("dog", true);
             Assert.AreEqual(@"{
   ""dog"": true
-}", loan.ToString(indent: true));
+}", loan.ToString(SerializationOptions.Indent));
             loan.CustomFields.Add(new CustomField { FieldName = "CX.TEMP", StringValue = "TempValue" });
             Assert.AreEqual(@"{
   ""customFields"": [
@@ -122,7 +122,7 @@ namespace EncompassRest.Tests
     }
   ],
   ""dog"": true
-}", loan.ToString(indent: true));
+}", loan.ToString(SerializationOptions.Indent));
         }
 
         [TestMethod]
@@ -136,8 +136,8 @@ namespace EncompassRest.Tests
                 var loan = await client.Loans.GetLoanAsync(loanId);
                 loan.Fees.First(f => f.FeeType == "TitleExamination").NewHUDBorPaidAmount = 0.0M; // Required due to issue with number of decimals serialized
                 var clonedLoan = loan.Clone();
-                var loanAsJson = loan.ToString(true);
-                var clonedLoanAsJson = clonedLoan.ToString(true);
+                var loanAsJson = loan.ToString(SerializationOptions.Indent);
+                var clonedLoanAsJson = clonedLoan.ToString(SerializationOptions.Indent);
                 Assert.AreEqual(loanAsJson, clonedLoanAsJson);
             }
             finally
@@ -203,7 +203,7 @@ namespace EncompassRest.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var loan = new Loan();
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace EncompassRest.Tests
                 Tltv = 85.00M
             };
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(@"{""tltv"":85.00}", loan.ToJson());
+            Assert.AreEqual(@"{""tltv"":85.00}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -227,7 +227,7 @@ namespace EncompassRest.Tests
                 Tltv = null
             };
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(@"{""tltv"":null}", loan.ToJson());
+            Assert.AreEqual(@"{""tltv"":null}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -239,11 +239,11 @@ namespace EncompassRest.Tests
             var customField = new CustomField { FieldName = "CUST91FV", StringValue = "Initial Value" };
             loan.CustomFields.Add(customField);
             loan.CustomFields.Add(new CustomField { FieldName = "CUST92FV", NumericValue = 10.0M });
-            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""Initial Value""},{""fieldName"":""CUST92FV"",""numericValue"":10.0}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""Initial Value""},{""fieldName"":""CUST92FV"",""numericValue"":10.0}]}", loan.ToString(SerializationOptions.Dirty));
             loan.Dirty = false;
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             customField.StringValue = "New Value";
-            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""New Value""}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CUST91FV"",""stringValue"":""New Value""}]}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -252,15 +252,15 @@ namespace EncompassRest.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var loan = new Loan();
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             const string boolPropertyName = "boolProperty";
             loan.ExtensionData[boolPropertyName] = true;
             Assert.AreEqual(1, loan.ExtensionData.Count);
             Assert.IsTrue(loan.ExtensionData.ContainsKey(boolPropertyName));
             Assert.AreEqual(true, (bool)loan.ExtensionData[boolPropertyName]);
-            Assert.AreEqual($@"{{""{boolPropertyName}"":true}}", loan.ToJson());
+            Assert.AreEqual($@"{{""{boolPropertyName}"":true}}", loan.ToString(SerializationOptions.Dirty));
             loan.Dirty = false;
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             const string decimalPropertyName = "decimalProperty";
             loan.ExtensionData[decimalPropertyName] = 10.5M;
             Assert.AreEqual(2, loan.ExtensionData.Count);
@@ -268,7 +268,7 @@ namespace EncompassRest.Tests
             Assert.IsTrue(loan.ExtensionData.ContainsKey(decimalPropertyName));
             Assert.AreEqual(true, (bool)loan.ExtensionData[boolPropertyName]);
             Assert.AreEqual(10.5M, (decimal)loan.ExtensionData[decimalPropertyName]);
-            Assert.AreEqual($@"{{""{decimalPropertyName}"":10.5}}", loan.ToJson());
+            Assert.AreEqual($@"{{""{decimalPropertyName}"":10.5}}", loan.ToString(SerializationOptions.Dirty));
             const string stringPropertyName = "stringProperty";
             const string stringPropertyValue = "Hello";
             loan.ExtensionData[stringPropertyName] = stringPropertyValue;
@@ -282,7 +282,7 @@ namespace EncompassRest.Tests
             CollectionAssert.AreEqual(new[] { boolPropertyName, decimalPropertyName, stringPropertyName }, loan.ExtensionData.Keys.ToList());
             CollectionAssert.AreEqual(new object[] { true, 10.5M, stringPropertyValue }, loan.ExtensionData.Values.ToList());
             CollectionAssert.AreEqual(new[] { new KeyValuePair<string, object>(boolPropertyName, true), new KeyValuePair<string, object>(decimalPropertyName, 10.5M), new KeyValuePair<string, object>(stringPropertyName, stringPropertyValue) }, loan.ExtensionData.ToList());
-            Assert.AreEqual($@"{{""{decimalPropertyName}"":10.5,""{stringPropertyName}"":""{stringPropertyValue}""}}", loan.ToJson());
+            Assert.AreEqual($@"{{""{decimalPropertyName}"":10.5,""{stringPropertyName}"":""{stringPropertyValue}""}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -489,13 +489,13 @@ namespace EncompassRest.Tests
                             Assert.IsFalse(field.IsEmpty);
                             if (fieldId != "GUID")
                             {
-                                Assert.AreNotEqual("{}", loan.ToJson());
+                                Assert.AreNotEqual("{}", loan.ToString(SerializationOptions.Dirty));
                             }
 
                             loan.Dirty = false;
                             if (fieldId != "GUID")
                             {
-                                Assert.AreEqual("{}", loan.ToJson());
+                                Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
                             }
 
                             field.Value = null;
@@ -503,7 +503,7 @@ namespace EncompassRest.Tests
                             Assert.IsTrue(field.IsEmpty);
                             if (fieldId != "GUID")
                             {
-                                Assert.AreNotEqual("{}", loan.ToJson());
+                                Assert.AreNotEqual("{}", loan.ToString(SerializationOptions.Dirty));
                             }
                             break;
                         case LoanFieldType.Virtual:
@@ -515,14 +515,14 @@ namespace EncompassRest.Tests
                             Assert.IsFalse(field.IsEmpty);
                             Assert.AreEqual(value, (string)field.Value);
                             Assert.AreEqual(value, field.ToString());
-                            Assert.AreEqual($@"{{""virtualFields"":{{""{field.FieldId}"":""{value}""}}}}", loan.ToJson());
+                            Assert.AreEqual($@"{{""virtualFields"":{{""{field.FieldId}"":""{value}""}}}}", loan.ToString(SerializationOptions.Dirty));
 
                             Assert.ThrowsException<InvalidOperationException>(() => field.Value = null);
 
                             loan.VirtualFields[field.FieldId] = null;
                             Assert.IsTrue(field.IsEmpty);
                             Assert.IsNull(field.Value);
-                            Assert.AreEqual($@"{{""virtualFields"":{{""{field.FieldId}"":null}}}}", loan.ToJson());
+                            Assert.AreEqual($@"{{""virtualFields"":{{""{field.FieldId}"":null}}}}", loan.ToString(SerializationOptions.Dirty));
                             break;
                         default:
                             Assert.Fail($"Invalid LoanFieldType of {field.Descriptor.Type}");
@@ -545,12 +545,12 @@ namespace EncompassRest.Tests
             Assert.AreEqual(loanNumber, (string)field.Value);
             Assert.AreEqual(loanNumber, field.ToString());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""loanNumber"":""{loanNumber}""}}", loan.ToJson());
+            Assert.AreEqual($@"{{""loanNumber"":""{loanNumber}""}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToString());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""loanNumber"":null}", loan.ToJson());
+            Assert.AreEqual(@"{""loanNumber"":null}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -566,12 +566,12 @@ namespace EncompassRest.Tests
             Assert.AreEqual(now, (DateTime?)field.Value);
             Assert.AreEqual(now, field.ToDateTime());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""closingCost"":{{""closingDisclosure1"":{{""cdDateIssued"":{now.ToJson()}}}}}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""closingCost"":{{""closingDisclosure1"":{{""cdDateIssued"":{now.ToJson()}}}}}}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToDateTime());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""closingCost"":{""closingDisclosure1"":{""cdDateIssued"":null}}}", loan.ToJson());
+            Assert.AreEqual(@"{""closingCost"":{""closingDisclosure1"":{""cdDateIssued"":null}}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -588,13 +588,13 @@ namespace EncompassRest.Tests
             Assert.AreEqual(borrowerRequestedLoanAmount, field.ToDecimal());
             Assert.AreEqual(borrowerRequestedLoanAmount, field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""borrowerRequestedLoanAmount"":{borrowerRequestedLoanAmount}.0}}", loan.ToJson());
+            Assert.AreEqual($@"{{""borrowerRequestedLoanAmount"":{borrowerRequestedLoanAmount}.0}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToDecimal());
             Assert.IsNull(field.ToInt32());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual($@"{{""borrowerRequestedLoanAmount"":null}}", loan.ToJson());
+            Assert.AreEqual($@"{{""borrowerRequestedLoanAmount"":null}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -611,13 +611,13 @@ namespace EncompassRest.Tests
             Assert.AreEqual(bltv, field.ToInt32());
             Assert.AreEqual(bltv, field.ToDecimal());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""bltv"":{bltv}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""bltv"":{bltv}}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToInt32());
             Assert.IsNull(field.ToDecimal());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual($@"{{""bltv"":null}}", loan.ToJson());
+            Assert.AreEqual($@"{{""bltv"":null}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -633,18 +633,18 @@ namespace EncompassRest.Tests
             Assert.AreEqual(borrowerCoBorrowerMarriedIndicator, (bool?)field.Value);
             Assert.AreEqual(borrowerCoBorrowerMarriedIndicator, field.ToBoolean());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""borrowerCoBorrowerMarriedIndicator"":{borrowerCoBorrowerMarriedIndicator.ToString().ToLower()}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""borrowerCoBorrowerMarriedIndicator"":{borrowerCoBorrowerMarriedIndicator.ToString().ToLower()}}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToBoolean());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual($@"{{""borrowerCoBorrowerMarriedIndicator"":null}}", loan.ToJson());
+            Assert.AreEqual($@"{{""borrowerCoBorrowerMarriedIndicator"":null}}", loan.ToString(SerializationOptions.Dirty));
 
             field.Value = "Y";
             Assert.AreEqual(true, (bool?)field.Value);
             Assert.AreEqual(true, field.ToBoolean());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""borrowerCoBorrowerMarriedIndicator"":true}}", loan.ToJson());
+            Assert.AreEqual($@"{{""borrowerCoBorrowerMarriedIndicator"":true}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -660,12 +660,12 @@ namespace EncompassRest.Tests
             Assert.AreEqual(applicationTakenMethodType, (string)field.Value);
             Assert.AreEqual(applicationTakenMethodType, field.ToString());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual(@"{""applicationTakenMethodType"":""Internet""}", loan.ToJson());
+            Assert.AreEqual(@"{""applicationTakenMethodType"":""Internet""}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToString());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""applicationTakenMethodType"":null}", loan.ToJson());
+            Assert.AreEqual(@"{""applicationTakenMethodType"":null}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -683,7 +683,7 @@ namespace EncompassRest.Tests
             Assert.AreEqual(income, field.ToDecimal());
             Assert.AreEqual(income, field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""hmda"":{{""income"":""{income}""}}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""hmda"":{{""income"":""{income}""}}}}", loan.ToString(SerializationOptions.Dirty));
             income = 5500;
             field.Value = income.ToString();
             Assert.AreEqual(income.ToString(), (string)field.Value);
@@ -691,21 +691,21 @@ namespace EncompassRest.Tests
             Assert.AreEqual(income, field.ToDecimal());
             Assert.AreEqual(income, field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""hmda"":{{""income"":""{income}""}}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""hmda"":{{""income"":""{income}""}}}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = "NA";
             Assert.AreEqual("NA", (string)field.Value);
             Assert.AreEqual("NA", field.ToString());
             Assert.IsNull(field.ToDecimal());
             Assert.IsNull(field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual(@"{""hmda"":{""income"":""NA""}}", loan.ToJson());
+            Assert.AreEqual(@"{""hmda"":{""income"":""NA""}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToString());
             Assert.IsNull(field.ToDecimal());
             Assert.IsNull(field.ToInt32());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""hmda"":{""income"":null}}", loan.ToJson());
+            Assert.AreEqual(@"{""hmda"":{""income"":null}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -721,12 +721,12 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CX.NAME"",""stringValue"":""{value}""}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CX.NAME"",""stringValue"":""{value}""}}]}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToString());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CX.NAME"",""stringValue"":null}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CX.NAME"",""stringValue"":null}]}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -742,17 +742,17 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, (DateTime?)field.Value);
             Assert.AreEqual(value, field.ToDateTime());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""customFields"":[{{""dateValue"":{value.ToJson()},""fieldName"":""CX.NOW""}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""customFields"":[{{""dateValue"":{value.ToJson()},""fieldName"":""CX.NOW""}}]}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToDateTime());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""customFields"":[{""dateValue"":null,""fieldName"":""CX.NOW""}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""dateValue"":null,""fieldName"":""CX.NOW""}]}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToDateTime());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""customFields"":[{""dateValue"":null,""fieldName"":""CX.NOW""}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""dateValue"":null,""fieldName"":""CX.NOW""}]}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -769,26 +769,26 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, field.ToDecimal());
             Assert.AreEqual(1235, field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CX.NUMBER"",""numericValue"":{value}}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CX.NUMBER"",""numericValue"":{value}}}]}}", loan.ToString(SerializationOptions.Dirty));
             var integerValue = 98765;
             field.Value = integerValue;
             Assert.AreEqual(integerValue, (decimal?)field.Value);
             Assert.AreEqual(integerValue, field.ToDecimal());
             Assert.AreEqual(integerValue, field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CX.NUMBER"",""numericValue"":{integerValue}.0}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CX.NUMBER"",""numericValue"":{integerValue}.0}}]}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToDecimal());
             Assert.IsNull(field.ToInt32());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CX.NUMBER"",""numericValue"":null}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CX.NUMBER"",""numericValue"":null}]}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToDecimal());
             Assert.IsNull(field.ToInt32());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CX.NUMBER"",""numericValue"":null}]}", loan.ToJson());
+            Assert.AreEqual(@"{""customFields"":[{""fieldName"":""CX.NUMBER"",""numericValue"":null}]}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -805,7 +805,7 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, field.ToDecimal());
             Assert.AreEqual(988, field.ToInt32());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CUST100FV"",""numericValue"":{value}}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""customFields"":[{{""fieldName"":""CUST100FV"",""numericValue"":{value}}}]}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -833,12 +833,12 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""applications"":[{{""applicationIndex"":1,""borrower"":{{""firstName"":""{value}""}}}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""applications"":[{{""applicationIndex"":1,""borrower"":{{""firstName"":""{value}""}}}}]}}", loan.ToString(SerializationOptions.Dirty));
             field.Value = null;
             Assert.IsNull(field.Value);
             Assert.IsNull(field.ToString());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual($@"{{""applications"":[{{""applicationIndex"":1,""borrower"":{{""firstName"":null}}}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""applications"":[{{""applicationIndex"":1,""borrower"":{{""firstName"":null}}}}]}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -863,12 +863,12 @@ namespace EncompassRest.Tests
             Assert.IsTrue(field.Locked);
             Assert.AreEqual(field.ModelPath, loan.FieldLockData[0].ModelPath);
             Assert.AreEqual(false, loan.FieldLockData[0].LockRemoved);
-            Assert.AreEqual($@"{{""fieldLockData"":[{{""lockRemoved"":false,""modelPath"":""{field.ModelPath}""}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""fieldLockData"":[{{""lockRemoved"":false,""modelPath"":""{field.ModelPath}""}}]}}", loan.ToString(SerializationOptions.Dirty));
             field.Locked = false;
             Assert.IsFalse(field.Locked);
             Assert.AreEqual(field.ModelPath, loan.FieldLockData[0].ModelPath);
             Assert.AreEqual(true, loan.FieldLockData[0].LockRemoved);
-            Assert.AreEqual($@"{{""fieldLockData"":[{{""lockRemoved"":true,""modelPath"":""{field.ModelPath}""}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""fieldLockData"":[{{""lockRemoved"":true,""modelPath"":""{field.ModelPath}""}}]}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -1085,15 +1085,15 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""contacts"":[{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM"",""state"":""{value}""}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""contacts"":[{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM"",""state"":""{value}""}}]}}", loan.ToString(SerializationOptions.Dirty));
             loan.Dirty = false;
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             value = "NY";
             field.Value = value;
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual($@"{{""contacts"":[{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM"",""state"":""{value}""}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""contacts"":[{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM""}},{{""contactType"":""CUSTOM"",""state"":""{value}""}}]}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -1111,13 +1111,13 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, (bool?)field.Value);
             Assert.AreEqual(value, field.ToBoolean());
             Assert.IsFalse(field.IsEmpty);
-            Assert.AreEqual(@"{""milestoneTemplateLogs"":[{""isTemplateLocked"":true}]}", loan.ToJson());
+            Assert.AreEqual(@"{""milestoneTemplateLogs"":[{""isTemplateLocked"":true}]}", loan.ToString(SerializationOptions.Dirty));
 
             field.Value = null;
             Assert.AreEqual(null, (bool?)field.Value);
             Assert.AreEqual(null, field.ToBoolean());
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual(@"{""milestoneTemplateLogs"":[{""isTemplateLocked"":null}]}", loan.ToJson());
+            Assert.AreEqual(@"{""milestoneTemplateLogs"":[{""isTemplateLocked"":null}]}", loan.ToString(SerializationOptions.Dirty));
 
             Assert.IsFalse(field.Locked);
             field.Locked = true;
@@ -1133,18 +1133,18 @@ namespace EncompassRest.Tests
 #pragma warning restore CS0618 // Type or member is obsolete
             var field = loan.Fields["NEWFIELD"];
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             var intValue = 4;
             field.Value = intValue;
             Assert.IsFalse(field.IsEmpty);
             Assert.AreEqual(intValue, (int?)field.Value);
             Assert.AreEqual(intValue, field.ToInt32());
-            Assert.AreEqual($@"{{""newEntity"":[{{}},{{""borrower"":{{""borrowerId"":{intValue}}}}}]}}", loan.ToJson());
+            Assert.AreEqual($@"{{""newEntity"":[{{}},{{""borrower"":{{""borrowerId"":{intValue}}}}}]}}", loan.ToString(SerializationOptions.Dirty));
 
             field.Value = null;
             Assert.IsTrue(field.IsEmpty);
             Assert.IsNull(field.Value);
-            Assert.AreEqual(@"{""newEntity"":[{},{""borrower"":{""borrowerId"":null}}]}", loan.ToJson());
+            Assert.AreEqual(@"{""newEntity"":[{},{""borrower"":{""borrowerId"":null}}]}", loan.ToString(SerializationOptions.Dirty));
 
 #pragma warning disable CS0618 // Type or member is obsolete
             loan = new Loan();
@@ -1153,7 +1153,7 @@ namespace EncompassRest.Tests
             Assert.IsFalse(field.Locked);
             field.Locked = true;
             Assert.IsTrue(field.Locked);
-            Assert.AreEqual(@"{""fieldLockData"":[{""lockRemoved"":false,""modelPath"":""Loan.NewEntity[2].Borrower.BorrowerId""}]}", loan.ToJson());
+            Assert.AreEqual(@"{""fieldLockData"":[{""lockRemoved"":false,""modelPath"":""Loan.NewEntity[2].Borrower.BorrowerId""}]}", loan.ToString(SerializationOptions.Dirty));
 
             Assert.IsTrue(LoanFieldDescriptors.FieldMappings.TryRemove("NEWFIELD", out _));
         }
@@ -1167,7 +1167,7 @@ namespace EncompassRest.Tests
             var field = loan.Fields["Log.MS.CurrentMilestone"];
             Assert.AreEqual(LoanFieldType.Virtual, field.Descriptor.Type);
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             var value = "Processing";
 
             Assert.ThrowsException<InvalidOperationException>(() => field.Value = value);
@@ -1176,14 +1176,14 @@ namespace EncompassRest.Tests
             Assert.IsFalse(field.IsEmpty);
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
-            Assert.AreEqual($@"{{""virtualFields"":{{""Log.MS.CurrentMilestone"":""{value}""}}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""virtualFields"":{{""Log.MS.CurrentMilestone"":""{value}""}}}}", loan.ToString(SerializationOptions.Dirty));
 
             Assert.ThrowsException<InvalidOperationException>(() => field.Value = null);
 
             loan.VirtualFields["Log.MS.CurrentMilestone"] = null;
             Assert.IsTrue(field.IsEmpty);
             Assert.IsNull(field.Value);
-            Assert.AreEqual(@"{""virtualFields"":{""Log.MS.CurrentMilestone"":null}}", loan.ToJson());
+            Assert.AreEqual(@"{""virtualFields"":{""Log.MS.CurrentMilestone"":null}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -1196,7 +1196,7 @@ namespace EncompassRest.Tests
             var field = loan.Fields["NEW.VIRTUAL.FIELD"];
             Assert.AreEqual(LoanFieldType.Virtual, field.Descriptor.Type);
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             var value = "Processing";
 
             Assert.ThrowsException<InvalidOperationException>(() => field.Value = value);
@@ -1205,14 +1205,14 @@ namespace EncompassRest.Tests
             Assert.IsFalse(field.IsEmpty);
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
-            Assert.AreEqual($@"{{""virtualFields"":{{""NEW.VIRTUAL.FIELD"":""{value}""}}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""virtualFields"":{{""NEW.VIRTUAL.FIELD"":""{value}""}}}}", loan.ToString(SerializationOptions.Dirty));
 
             Assert.ThrowsException<InvalidOperationException>(() => field.Value = null);
 
             loan.VirtualFields["NEW.VIRTUAL.FIELD"] = null;
             Assert.IsTrue(field.IsEmpty);
             Assert.IsNull(field.Value);
-            Assert.AreEqual(@"{""virtualFields"":{""NEW.VIRTUAL.FIELD"":null}}", loan.ToJson());
+            Assert.AreEqual(@"{""virtualFields"":{""NEW.VIRTUAL.FIELD"":null}}", loan.ToString(SerializationOptions.Dirty));
 
             Assert.IsTrue(LoanFieldDescriptors.FieldMappings.TryRemove("NEW.VIRTUAL.FIELD", out _));
         }
@@ -1226,7 +1226,7 @@ namespace EncompassRest.Tests
             var field = loan.Fields["Log.MS.Date.Clear to Close"];
             Assert.AreEqual(LoanFieldType.Virtual, field.Descriptor.Type);
             Assert.IsTrue(field.IsEmpty);
-            Assert.AreEqual("{}", loan.ToJson());
+            Assert.AreEqual("{}", loan.ToString(SerializationOptions.Dirty));
             var now = DateTime.Now;
             var value = JsonConvert.ToString(now);
             value = value.Substring(1, value.Length - 2);
@@ -1238,14 +1238,14 @@ namespace EncompassRest.Tests
             Assert.AreEqual(value, (string)field.Value);
             Assert.AreEqual(value, field.ToString());
             Assert.AreEqual(now, field.ToDateTime());
-            Assert.AreEqual($@"{{""virtualFields"":{{""Log.MS.Date.Clear to Close"":""{value}""}}}}", loan.ToJson());
+            Assert.AreEqual($@"{{""virtualFields"":{{""Log.MS.Date.Clear to Close"":""{value}""}}}}", loan.ToString(SerializationOptions.Dirty));
 
             Assert.ThrowsException<InvalidOperationException>(() => field.Value = null);
 
             loan.VirtualFields["Log.MS.Date.Clear to Close"] = null;
             Assert.IsTrue(field.IsEmpty);
             Assert.IsNull(field.Value);
-            Assert.AreEqual(@"{""virtualFields"":{""Log.MS.Date.Clear to Close"":null}}", loan.ToJson());
+            Assert.AreEqual(@"{""virtualFields"":{""Log.MS.Date.Clear to Close"":null}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -1759,9 +1759,9 @@ namespace EncompassRest.Tests
 #pragma warning restore CS0618 // Type or member is obsolete
             Assert.IsNull(loan.ReferralSourceContact);
             loan.ReferralSourceContact = null;
-            Assert.AreEqual(@"{""referralSourceContact"":null}", loan.ToJson());
+            Assert.AreEqual(@"{""referralSourceContact"":null}", loan.ToString(SerializationOptions.Dirty));
             loan.ReferralSourceContact = new EntityReference("123", "BorrowerContact");
-            Assert.AreEqual(@"{""referralSourceContact"":{""entityId"":""123"",""entityType"":""BorrowerContact""}}", loan.ToJson());
+            Assert.AreEqual(@"{""referralSourceContact"":{""entityId"":""123"",""entityType"":""BorrowerContact""}}", loan.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/PipelineTests.cs
+++ b/src/EncompassRest.Tests/PipelineTests.cs
@@ -24,7 +24,7 @@ namespace EncompassRest.Tests
         public void ViewPipelineParameters_Serialization()
         {
             var parameters = new PipelineParameters(new StringFieldFilter(CanonicalLoanField.LoanFolder, StringFieldMatchType.Exact, "Active Loans"), new[] { "Fields.364", "Fields.4002" }, new[] { new FieldSort("Fields.4002", SortOrder.Ascending) });
-            Assert.AreEqual(@"{""filter"":{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""},""fields"":[""Fields.364"",""Fields.4002""],""sortOrder"":[{""canonicalName"":""Fields.4002"",""order"":""asc""}]}", parameters.ToJson());
+            Assert.AreEqual(@"{""filter"":{""matchType"":""exact"",""value"":""Active Loans"",""canonicalName"":""Loan.LoanFolder""},""fields"":[""Fields.364"",""Fields.4002""],""sortOrder"":[{""canonicalName"":""Fields.4002"",""order"":""asc""}]}", parameters.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest.Tests/ServicesTests.cs
+++ b/src/EncompassRest.Tests/ServicesTests.cs
@@ -39,7 +39,7 @@ namespace EncompassRest.Tests
                     }
                 });
 
-            Assert.AreEqual($@"{{""product"":{{""options"":{{""digiCert"":true,""requestType"":""NewRequest"",""reportOn"":""Individual"",""reportType"":""Merge"",""creditReportIdentifier"":""abc"",""creditBureauEquifax"":true}},""preferences"":{{""importLiabilities"":true}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""CREDITIQ"",""credentials"":{{""userName"":""Joe"",""password"":""password1""}}}}}}", parameters.ToJson());
+            Assert.AreEqual($@"{{""product"":{{""options"":{{""digiCert"":true,""requestType"":""NewRequest"",""reportOn"":""Individual"",""reportType"":""Merge"",""creditReportIdentifier"":""abc"",""creditBureauEquifax"":true}},""preferences"":{{""importLiabilities"":true}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""CREDITIQ"",""credentials"":{{""userName"":""Joe"",""password"":""password1""}}}}}}", parameters.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace EncompassRest.Tests
                     }
                 });
 
-            Assert.AreEqual($@"{{""product"":{{""options"":{{""digiCert"":true,""requestType"":""newRequest"",""product_1040"":""1"",""transcriptType_1040"":""Account Transcript""}},""preferences"":{{""importLiabilities"":true}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""VERIF"",""credentials"":{{""userName"":""Joe"",""password"":""password1""}}}}}}", parameters.ToJson());
+            Assert.AreEqual($@"{{""product"":{{""options"":{{""digiCert"":true,""requestType"":""newRequest"",""product_1040"":""1"",""transcriptType_1040"":""Account Transcript""}},""preferences"":{{""importLiabilities"":true}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""VERIF"",""credentials"":{{""userName"":""Joe"",""password"":""password1""}}}}}}", parameters.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace EncompassRest.Tests
                     }
                 });
 
-            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""OrderVerification"",""reportOn"":""Co-Borrower"",""employment"":""EmploymentOnly"",""digiCert"":true}},""preferences"":{{""importLiabilities"":true}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""VERIF"",""credentials"":{{""userName"":""Joe"",""password"":""password1""}}}}}}", parameters.ToJson());
+            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""OrderVerification"",""reportOn"":""Co-Borrower"",""employment"":""EmploymentOnly"",""digiCert"":true}},""preferences"":{{""importLiabilities"":true}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""VERIF"",""credentials"":{{""userName"":""Joe"",""password"":""password1""}}}}}}", parameters.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -126,7 +126,7 @@ namespace EncompassRest.Tests
                     }
                 });
 
-            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""newOrder"",""ausReportIdentifier"":""123"",""orderCreditDetails"":[{{""applicationId"":""abc""}}]}},""preferences"":{{""conditionType"":""underwriting""}},""credentials"":{{""lpPassword"":""password2"",""userName"":""Joe"",""password"":""password1""}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""AUS""}}}}", parameters.ToJson());
+            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""newOrder"",""ausReportIdentifier"":""123"",""orderCreditDetails"":[{{""applicationId"":""abc""}}]}},""preferences"":{{""conditionType"":""underwriting""}},""credentials"":{{""lpPassword"":""password2"",""userName"":""Joe"",""password"":""password1""}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""AUS""}}}}", parameters.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -162,7 +162,7 @@ namespace EncompassRest.Tests
                     }
                 });
 
-            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""newOrder"",""loanPurpose"":""Purchase"",""loanType"":""VA"",""propertyType"":""Single Family"",""contacts"":{{""contact"":{{""borrower"":{{""state"":""MO"",""name"":""George""}}}},""appointmentContact"":""borrower""}}}},""credentials"":{{""accountId"":""ace"",""userName"":""Joe"",""password"":""password1""}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""APPRAISAL""}}}}", parameters.ToJson());
+            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""newOrder"",""loanPurpose"":""Purchase"",""loanType"":""VA"",""propertyType"":""Single Family"",""contacts"":{{""contact"":{{""borrower"":{{""state"":""MO"",""name"":""George""}}}},""appointmentContact"":""borrower""}}}},""credentials"":{{""accountId"":""ace"",""userName"":""Joe"",""password"":""password1""}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""APPRAISAL""}}}}", parameters.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]
@@ -187,7 +187,7 @@ namespace EncompassRest.Tests
                     }
                 });
 
-            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""newRequest"",""productDetails"":{{""name"":""Life of Loan Determination"",""id"":""26""}}}},""credentials"":{{""accountId"":""ace"",""userName"":""Joe"",""password"":""password1""}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""FLOOD""}}}}", parameters.ToJson());
+            Assert.AreEqual($@"{{""product"":{{""options"":{{""requestType"":""newRequest"",""productDetails"":{{""name"":""Life of Loan Determination"",""id"":""26""}}}},""credentials"":{{""accountId"":""ace"",""userName"":""Joe"",""password"":""password1""}},""entityRef"":{{""entityId"":""{parameters.Product.EntityRef.EntityId}"",""entityType"":""{parameters.Product.EntityRef.EntityType}""}},""name"":""FLOOD""}}}}", parameters.ToString(SerializationOptions.Dirty));
         }
     }
 }

--- a/src/EncompassRest.Tests/WebhookTests.cs
+++ b/src/EncompassRest.Tests/WebhookTests.cs
@@ -40,7 +40,7 @@ namespace EncompassRest.Tests
         public void WebhookSubscription_Serialization()
         {
             var subscription = new WebhookSubscription("https://google.com", WebhookResourceType.Loan, new[] { WebhookResourceEvent.Create, WebhookResourceEvent.Update }) { ClientId = "1234567890" };
-            Assert.AreEqual(@"{""events"":[""create"",""update""],""endpoint"":""https://google.com"",""resource"":""Loan""}", subscription.ToJson());
+            Assert.AreEqual(@"{""events"":[""create"",""update""],""endpoint"":""https://google.com"",""resource"":""Loan""}", subscription.ToString(SerializationOptions.Dirty));
         }
 
         [TestMethod]

--- a/src/EncompassRest/SerializableObject.cs
+++ b/src/EncompassRest/SerializableObject.cs
@@ -38,7 +38,7 @@ namespace EncompassRest
         /// Serializes object to it's json representation using the specified <paramref name="options"/>.
         /// </summary>
         /// <param name="options">The serialization options.</param>
-        /// <returns></returns>
+        /// <returns>Json representation of the object.</returns>
         public string ToString(SerializationOptions options)
         {
             options.Validate(nameof(options));

--- a/src/EncompassRest/SerializableObject.cs
+++ b/src/EncompassRest/SerializableObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -30,6 +31,7 @@ namespace EncompassRest
         /// <param name="indent">Specifies if the json should be indented.</param>
         /// <returns>Json representation of the object.</returns>
         [Obsolete("Use SerializationOptions overload instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ToString(bool indent) => ToString(SerializationOptions.Indent);
 
         /// <summary>

--- a/src/EncompassRest/SerializableObject.cs
+++ b/src/EncompassRest/SerializableObject.cs
@@ -1,5 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
 using EncompassRest.Utilities;
+using EnumsNET;
 using Newtonsoft.Json;
 
 namespace EncompassRest
@@ -18,17 +22,36 @@ namespace EncompassRest
         /// Serializes object to it's json representation without indenting.
         /// </summary>
         /// <returns>Json representation of the object.</returns>
-        public override string ToString() => ToString(false);
+        public override string ToString() => ToString(SerializationOptions.None);
 
         /// <summary>
         /// Serializes object to it's json representation with indenting if <paramref name="indent"/> is <c>true</c>.
         /// </summary>
         /// <param name="indent">Specifies if the json should be indented.</param>
         /// <returns>Json representation of the object.</returns>
-        public string ToString(bool indent)
+        [Obsolete("Use SerializationOptions overload instead.")]
+        public string ToString(bool indent) => ToString(SerializationOptions.Indent);
+
+        /// <summary>
+        /// Serializes object to it's json representation using the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="options">The serialization options.</param>
+        /// <returns></returns>
+        public string ToString(SerializationOptions options)
         {
-            var serializer = indent ? JsonHelper.DefaultIndentedPublicSerializer : JsonHelper.DefaultPublicSerializer;
-            using (var writer = new StringWriter())
+            options.Validate(nameof(options));
+
+            JsonSerializer serializer;
+            var indented = options.HasAnyFlags(SerializationOptions.Indent);
+            if (options.HasAnyFlags(SerializationOptions.Dirty))
+            {
+                serializer = indented ? JsonHelper.DefaultIndentedDirtySerializer : JsonHelper.DefaultDirtySerializer;
+            }
+            else
+            {
+                serializer = indented ? JsonHelper.DefaultIndentedPublicSerializer : JsonHelper.DefaultPublicSerializer;
+            }
+            using (var writer = new StringWriter(new StringBuilder(256), CultureInfo.InvariantCulture))
             {
                 serializer.Serialize(writer, this);
                 return writer.ToString();

--- a/src/EncompassRest/SerializationOptions.cs
+++ b/src/EncompassRest/SerializationOptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace EncompassRest
+{
+    /// <summary>
+    /// SerializationOptions
+    /// </summary>
+    [Flags]
+    public enum SerializationOptions
+    {
+        /// <summary>
+        /// None
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Indent the output
+        /// </summary>
+        Indent = 1,
+        /// <summary>
+        /// Serialize only the dirty elements
+        /// </summary>
+        Dirty = 2,
+        /// <summary>
+        /// Indent and serialize only the dirty elements
+        /// </summary>
+        IndentAndDirty = 3
+    }
+}

--- a/src/EncompassRest/Utilities/JsonHelper.cs
+++ b/src/EncompassRest/Utilities/JsonHelper.cs
@@ -22,6 +22,8 @@ namespace EncompassRest.Utilities
         internal static readonly CustomContractResolver InternalPrivateContractResolver = new PrivateContractResolver();
         internal static readonly JsonSerializer DefaultPublicSerializer = new JsonSerializer { ContractResolver = s_publicContractResolver, NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.None };
         internal static readonly JsonSerializer DefaultIndentedPublicSerializer = new JsonSerializer { ContractResolver = s_publicContractResolver, NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
+        internal static readonly JsonSerializer DefaultDirtySerializer = new JsonSerializer { ContractResolver = InternalPrivateContractResolver, ObjectCreationHandling = ObjectCreationHandling.Replace, Formatting = Formatting.None };
+        internal static readonly JsonSerializer DefaultIndentedDirtySerializer = new JsonSerializer { ContractResolver = InternalPrivateContractResolver, Formatting = Formatting.Indented };
         internal static readonly Encoding Utf8NoBOM = new UTF8Encoding(false);
 
         public static JsonSerializer CreatePublicSerializer(JsonSerializer existingSerializer)
@@ -63,13 +65,6 @@ namespace EncompassRest.Utilities
             return publicSerializer;
         }
 
-        private static readonly JsonSerializer s_serializer = JsonSerializer.Create(new JsonSerializerSettings
-        {
-            Formatting = Formatting.None,
-            ObjectCreationHandling = ObjectCreationHandling.Replace,
-            ContractResolver = InternalPrivateContractResolver
-        });
-
         public static T FromJson<T>(string json) => (T)FromJson(json, TypeData<T>.Type);
 
         public static object FromJson(string json) => FromJson(json, null);
@@ -86,7 +81,7 @@ namespace EncompassRest.Utilities
 
         public static object FromJson(TextReader reader) => FromJson(reader, null);
 
-        public static object FromJson(TextReader reader, Type type) => s_serializer.Deserialize(reader, type);
+        public static object FromJson(TextReader reader, Type type) => DefaultDirtySerializer.Deserialize(reader, type);
 
         public static void PopulateFromJson(string json, object target)
         {
@@ -103,8 +98,8 @@ namespace EncompassRest.Utilities
             var type = target.GetType();
             using (var jReader = new JsonTextReader(reader))
             {
-                var jToken = s_serializer.Deserialize<JToken>(jReader);
-                var source = jToken.ToObject(type, s_serializer);
+                var jToken = DefaultDirtySerializer.Deserialize<JToken>(jReader);
+                var source = jToken.ToObject(type, DefaultDirtySerializer);
 
                 var contract = InternalPrivateContractResolver.ResolveContract(type);
                 switch (contract)
@@ -325,7 +320,7 @@ namespace EncompassRest.Utilities
 
         public static void ToJson(object value, TextWriter writer) => ToJson(value, null, writer);
 
-        public static void ToJson(object value, Type type, TextWriter writer) => s_serializer.Serialize(writer, value, type);
+        public static void ToJson(object value, Type type, TextWriter writer) => DefaultDirtySerializer.Serialize(writer, value, type);
 
         public static T Clone<T>(this JsonSerializer jsonSerializer, T value)
         {


### PR DESCRIPTION
Added `ToString` overload to `SerializableObject` with `SerializationOptions` for the option to serialize only dirty elements.