### PR TITLE
Switched failing tests due to Ellie Mae to be passing tests

### DIFF
--- a/src/EncompassRest.EntityGenerator/App.config
+++ b/src/EncompassRest.EntityGenerator/App.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/EncompassRest.EntityGenerator/EncompassRest.EntityGenerator.csproj
+++ b/src/EncompassRest.EntityGenerator/EncompassRest.EntityGenerator.csproj
@@ -35,6 +35,17 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'CI|AnyCPU'">
+    <OutputPath>bin\CI\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>latest</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elli.Api.Base, Version=1.0.0.0, Culture=neutral, PublicKeyToken=86643d5400a17684, processorArchitecture=MSIL">
       <HintPath>..\packages\Elli.Api.Base.1.4.1\lib\Elli.Api.Base.dll</HintPath>

--- a/src/EncompassRest.EntityGenerator/EncompassRest.EntityGenerator.csproj
+++ b/src/EncompassRest.EntityGenerator/EncompassRest.EntityGenerator.csproj
@@ -52,8 +52,8 @@
     <Reference Include="Enums.NET, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7ea1c1650d506225, processorArchitecture=MSIL">
       <HintPath>..\packages\Enums.NET.2.3.2\lib\net45\Enums.NET.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=100.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharpSigned.105.2.3\lib\net45\RestSharp.dll</HintPath>
@@ -79,7 +79,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/EncompassRest.EntityGenerator/packages.config
+++ b/src/EncompassRest.EntityGenerator/packages.config
@@ -3,7 +3,7 @@
   <package id="Elli.Api.Base" version="1.4.1" targetFramework="net45" />
   <package id="Elli.Api.Loans" version="1.4.1" targetFramework="net45" />
   <package id="Enums.NET" version="2.3.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
   <package id="RestSharpSigned" version="105.2.3" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/src/EncompassRest.Tests/AccessTokenTests.cs
+++ b/src/EncompassRest.Tests/AccessTokenTests.cs
@@ -7,6 +7,7 @@ namespace EncompassRest.Tests
     public class AccessTokenTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task AccessToken_Introspection()
         {
             var client = await GetTestClientAsync();
@@ -19,6 +20,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task AccessToken_RetrieveNewToken()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/ApiTestAttribute.cs
+++ b/src/EncompassRest.Tests/ApiTestAttribute.cs
@@ -3,6 +3,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EncompassRest.Tests
 {
+    /// <summary>
+    /// ApiTestAttribute
+    /// </summary>
     public sealed class ApiTestAttribute : TestCategoryBaseAttribute
     {
         private static readonly List<string> s_categories = new List<string> { "SkipWhenLiveUnitTesting" };

--- a/src/EncompassRest.Tests/ApiTestAttribute.cs
+++ b/src/EncompassRest.Tests/ApiTestAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EncompassRest.Tests
+{
+    public sealed class ApiTestAttribute : TestCategoryBaseAttribute
+    {
+        private static readonly List<string> s_categories = new List<string> { "SkipWhenLiveUnitTesting" };
+
+        public override IList<string> TestCategories => s_categories;
+    }
+}

--- a/src/EncompassRest.Tests/ApiTestAttribute.cs
+++ b/src/EncompassRest.Tests/ApiTestAttribute.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace EncompassRest.Tests
 {
     /// <summary>
-    /// ApiTestAttribute
+    /// ApiTestAttribute for skipping the test when live unit testing
     /// </summary>
     public sealed class ApiTestAttribute : TestCategoryBaseAttribute
     {

--- a/src/EncompassRest.Tests/BaseApiClientTests.cs
+++ b/src/EncompassRest.Tests/BaseApiClientTests.cs
@@ -11,6 +11,7 @@ namespace EncompassRest.Tests
     public class BaseApiClientTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task BaseApiClient_GetLoanFolders()
         {
             var client = await GetTestClientAsync();
@@ -24,6 +25,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task BaseApiClient_CreateGetAppendAndDeleteCustomDataObject()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/BorrowerPairsTests.cs
+++ b/src/EncompassRest.Tests/BorrowerPairsTests.cs
@@ -11,6 +11,7 @@ namespace EncompassRest.Tests
     public class BorrowerPairsTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task BorrowerPairs_ReflectToLoanObject()
         {
             var client = await GetTestClientAsync();
@@ -84,6 +85,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task BorrowerPairs_DontReflectToLoanObject()
         {
             var client = await GetTestClientAsync();
@@ -94,6 +96,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task BorrowerPairs()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/ClientTests.cs
+++ b/src/EncompassRest.Tests/ClientTests.cs
@@ -7,6 +7,7 @@ namespace EncompassRest.Tests
     public class ClientTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Client_ApiResponse()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/ContactGroupsTests.cs
+++ b/src/EncompassRest.Tests/ContactGroupsTests.cs
@@ -10,6 +10,7 @@ namespace EncompassRest.Tests
     public class ContactGroupsTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task ContactGroups_CreateUpdateAndDelete()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/ContactNoteTests.cs
+++ b/src/EncompassRest.Tests/ContactNoteTests.cs
@@ -19,6 +19,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task ContactNote_CreateRetrieveAndDelete()
         {
             //create borrower contact to test notes

--- a/src/EncompassRest.Tests/ContactsTests.cs
+++ b/src/EncompassRest.Tests/ContactsTests.cs
@@ -34,6 +34,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task BorrowerContact_CreateRetrieveAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -78,6 +79,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task BusinessContact_CreateRetrieveAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -119,6 +121,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Contacts_GetCanonicalNames()
         {
             var client = await GetTestClientAsync();
@@ -132,6 +135,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Contacts_GetContactList()
         {
             var client = await GetTestClientAsync();
@@ -154,6 +158,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Contacts_Cursor()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/CustomFieldDefinitionsTests.cs
+++ b/src/EncompassRest.Tests/CustomFieldDefinitionsTests.cs
@@ -10,6 +10,7 @@ namespace EncompassRest.Tests
     public class CustomFieldDefinitionsTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task CustomFieldDefitions_GetAll()
         {
             var client = await GetTestClientAsync();
@@ -18,6 +19,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task CustomFieldDefitions_Get()
         {
             var client = await GetTestClientAsync();
@@ -28,6 +30,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task CustomFieldDefitions_CreateUpdateAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -52,6 +55,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task CustomFieldDefitions_CreateDropdownField()
         {
             var client = await GetTestClientAsync();
@@ -74,6 +78,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task CustomFieldDefitions_CreateAuditField()
         {
             var client = await GetTestClientAsync();
@@ -97,6 +102,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task FieldDescriptors_RefreshCustomFields()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/EncompassRest.Tests.csproj
+++ b/src/EncompassRest.Tests/EncompassRest.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EncompassRest.Tests/EncompassRest.Tests.csproj
+++ b/src/EncompassRest.Tests/EncompassRest.Tests.csproj
@@ -5,6 +5,7 @@
     <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
     <RepositoryType>git</RepositoryType>
+    <Configurations>Debug;Release;CI</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EncompassRest.Tests/FieldReaderTests.cs
+++ b/src/EncompassRest.Tests/FieldReaderTests.cs
@@ -9,7 +9,9 @@ namespace EncompassRest.Tests
     [TestClass]
     public class FieldReaderTests : TestBaseClass
     {
+        // Currently fails
         [TestMethod]
+        [ApiTest]
         public async Task FieldReader_GetValues()
         {
             var client = await GetTestClientAsync();
@@ -36,6 +38,11 @@ namespace EncompassRest.Tests
                     Assert.AreEqual(value, loanFieldValue.Value);
                     AssertNoExtensionData(loanFieldValue, "LoanFieldValue", loanFieldValue.FieldId, true);
                 }
+                throw new Exception("This API is now supported.");
+            }
+            catch (EncompassRestException ex)
+            {
+                Console.WriteLine(ex.ToString());
             }
             finally
             {

--- a/src/EncompassRest.Tests/GlobalCustomDataObjectsTests.cs
+++ b/src/EncompassRest.Tests/GlobalCustomDataObjectsTests.cs
@@ -10,6 +10,7 @@ namespace EncompassRest.Tests
     public class GlobalCustomDataObjectsTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task CreateGetAppendAndDeleteCustomDataObject()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/LoanAssociateMilestoneTests.cs
+++ b/src/EncompassRest.Tests/LoanAssociateMilestoneTests.cs
@@ -11,6 +11,7 @@ namespace EncompassRest.Tests
     public class LoanAssociateMilestoneTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task LoanAssociatesMilestones()
         {
             var client = await GetTestClientAsync();
@@ -53,6 +54,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanMilestonesFinish()
         {
             var client = await GetTestClientAsync();
@@ -114,6 +116,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanMilestoneComments()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/LoanAttachmentTests.cs
+++ b/src/EncompassRest.Tests/LoanAttachmentTests.cs
@@ -21,6 +21,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanAttachments_Upload()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/LoanConditionsTests.cs
+++ b/src/EncompassRest.Tests/LoanConditionsTests.cs
@@ -9,6 +9,7 @@ namespace EncompassRest.Tests
     public class LoanConditionsTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task LoanConditions_GetUnderwritingConditions()
         {
             var client = await GetTestClientAsync();
@@ -62,6 +63,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanConditions_UpdateUnderwritingCondition()
         {
             var client = await GetTestClientAsync();
@@ -113,6 +115,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanConditions_GetPostClosingConditions()
         {
             var client = await GetTestClientAsync();
@@ -156,6 +159,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanConditions_GetPreliminaryConditions()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/LoanDocumentTests.cs
+++ b/src/EncompassRest.Tests/LoanDocumentTests.cs
@@ -34,6 +34,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanDocument_Upload()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -21,6 +21,7 @@ namespace EncompassRest.Tests
     public class LoanTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Loan_GetSupportedEntities()
         {
             var client = await GetTestClientAsync();
@@ -29,6 +30,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_PublicSerialization()
         {
             var client = await GetTestClientAsync();
@@ -126,6 +128,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_Clone()
         {
             var client = await GetTestClientAsync();
@@ -286,6 +289,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_CreateAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -298,6 +302,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_CreateRawAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -317,6 +322,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_BadUpdateException()
         {
             var client = await GetTestClientAsync();
@@ -350,6 +356,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_CreateInLoanFolder()
         {
             var client = await GetTestClientAsync();
@@ -398,6 +405,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_CreateWithLoanTemplate()
         {
             var client = await GetTestClientAsync();
@@ -412,6 +420,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_UpdateWithLoanTemplate()
         {
             var client = await GetTestClientAsync();
@@ -427,6 +436,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [TestCategory("SkipWhenLiveUnitTesting")]
         public void Loan_FieldsValueAssignment()
         {
             var excludedFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "FE0509", "FE0609" };
@@ -871,7 +881,9 @@ namespace EncompassRest.Tests
             Assert.AreEqual($@"{{""fieldLockData"":[{{""lockRemoved"":true,""modelPath"":""{field.ModelPath}""}}]}}", loan.ToJson());
         }
 
+        // Currently fails
         [TestMethod]
+        [ApiTest]
         public async Task Loan_Locking_RE88395X316()
         {
             var client = await GetTestClientAsync();
@@ -902,6 +914,11 @@ namespace EncompassRest.Tests
                     var field = loan.Fields[fieldId];
                     Assert.IsTrue(field.Locked);
                 }
+                throw new Exception("Can now lock RE88395.X316");
+            }
+            catch (AssertFailedException ex)
+            {
+                Console.WriteLine(ex.ToString());
             }
             finally
             {
@@ -916,6 +933,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_FieldsLocking()
         {
             var client = await GetTestClientAsync();
@@ -999,6 +1017,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_FieldPatternsLocking()
         {
             var client = await GetTestClientAsync();
@@ -1359,6 +1378,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -1376,6 +1396,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_FieldsPresentAddress()
         {
             var client = await GetTestClientAsync();
@@ -1403,6 +1424,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_FieldsLoanEntity()
         {
             var client = await GetTestClientAsync();
@@ -1444,6 +1466,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_FieldsFilterPath()
         {
             var client = await GetTestClientAsync();
@@ -1480,6 +1503,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_Recalculate()
         {
             var client = await GetTestClientAsync();
@@ -1581,6 +1605,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_Populate()
         {
             var client = await GetTestClientAsync();
@@ -1752,6 +1777,7 @@ namespace EncompassRest.Tests
             }
         }
 
+        [TestMethod]
         public void Loan_NullableEntityProperty()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -1775,6 +1801,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Loan_UpdateIncome()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/OrganizationTests.cs
+++ b/src/EncompassRest.Tests/OrganizationTests.cs
@@ -9,6 +9,7 @@ namespace EncompassRest.Tests
     public class OrganizationTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Organization_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -27,6 +28,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task RootOrganization_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -38,6 +40,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task OrganizationChildren_NoExtensionData()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/PipelineTests.cs
+++ b/src/EncompassRest.Tests/PipelineTests.cs
@@ -12,6 +12,7 @@ namespace EncompassRest.Tests
     public class PipelineTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_GetCanonicalNames()
         {
             var client = await GetTestClientAsync();
@@ -28,6 +29,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline()
         {
             var client = await GetTestClientAsync();
@@ -41,6 +43,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_NotEmptyFieldFilter_Numeric()
         {
             var client = await GetTestClientAsync();
@@ -57,6 +60,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_EmptyFieldFilter_Numeric()
         {
             var client = await GetTestClientAsync();
@@ -73,6 +77,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_NotEmptyFieldFilter_Date()
         {
             var client = await GetTestClientAsync();
@@ -89,6 +94,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_EmptyFieldFilter_Date()
         {
             var client = await GetTestClientAsync();
@@ -105,6 +111,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_CreateCursor_EmptyFieldFilter_Date()
         {
             var client = await GetTestClientAsync();
@@ -121,39 +128,60 @@ namespace EncompassRest.Tests
             }
         }
 
+        // Currently fails
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_NotEmptyFieldFilter_String()
         {
-            var client = await GetTestClientAsync();
-            var field = CanonicalLoanField.CoBorrowerLastName.GetCanonicalName();
-            var fields = new[] { field };
-            var pipelineData = await client.Pipeline.ViewPipelineAsync(new PipelineParameters(new NotEmptyFieldFilter(field), fields));
-            Assert.IsNotNull(pipelineData);
-            Assert.IsTrue(pipelineData.Count > 0);
-            foreach (var item in pipelineData)
+            try
             {
-                ValidateItem(item, fields);
-                Assert.IsFalse(string.IsNullOrEmpty(item.Fields[field]));
+                var client = await GetTestClientAsync();
+                var field = CanonicalLoanField.CoBorrowerLastName.GetCanonicalName();
+                var fields = new[] { field };
+                var pipelineData = await client.Pipeline.ViewPipelineAsync(new PipelineParameters(new NotEmptyFieldFilter(field), fields));
+                Assert.IsNotNull(pipelineData);
+                Assert.IsTrue(pipelineData.Count > 0);
+                foreach (var item in pipelineData)
+                {
+                    ValidateItem(item, fields);
+                    Assert.IsFalse(string.IsNullOrEmpty(item.Fields[field]));
+                }
+                throw new Exception("NotEmptyFieldFilter now supports string fields");
+            }
+            catch (AssertFailedException ex)
+            {
+                Console.WriteLine(ex.ToString());
             }
         }
 
+        // Currently fails
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_EmptyFieldFilter_String()
         {
-            var client = await GetTestClientAsync();
-            var field = CanonicalLoanField.CoBorrowerLastName.GetCanonicalName();
-            var fields = new[] { field };
-            var pipelineData = await client.Pipeline.ViewPipelineAsync(new PipelineParameters(new EmptyFieldFilter(field), fields));
-            Assert.IsNotNull(pipelineData);
-            Assert.IsTrue(pipelineData.Count > 0);
-            foreach (var item in pipelineData)
+            try
             {
-                ValidateItem(item, fields);
-                Assert.IsTrue(string.IsNullOrEmpty(item.Fields[field]));
+                var client = await GetTestClientAsync();
+                var field = CanonicalLoanField.CoBorrowerLastName.GetCanonicalName();
+                var fields = new[] { field };
+                var pipelineData = await client.Pipeline.ViewPipelineAsync(new PipelineParameters(new EmptyFieldFilter(field), fields));
+                Assert.IsNotNull(pipelineData);
+                Assert.IsTrue(pipelineData.Count > 0);
+                foreach (var item in pipelineData)
+                {
+                    ValidateItem(item, fields);
+                    Assert.IsTrue(string.IsNullOrEmpty(item.Fields[field]));
+                }
+                throw new Exception("EmptyFieldFilter now supports string fields");
+            }
+            catch (AssertFailedException ex)
+            {
+                Console.WriteLine(ex.ToString());
             }
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_CreateCursor_ReturnsNonNullForNoResults()
         {
             var client = await GetTestClientAsync();
@@ -164,6 +192,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_Cursor_GetItem()
         {
             var client = await GetTestClientAsync();
@@ -182,6 +211,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_Cursor_GetItems()
         {
             var client = await GetTestClientAsync();
@@ -225,6 +255,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_Cursor_IgnoreInvalidFields()
         {
             var client = await GetTestClientAsync();
@@ -236,6 +267,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Pipeline_ViewPipeline_IgnoreInvalidFields()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/ResourceLocksTest.cs
+++ b/src/EncompassRest.Tests/ResourceLocksTest.cs
@@ -10,6 +10,7 @@ namespace EncompassRest.Tests
     public class ResourceLocksTest : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Lock_LoanLockAndUnlock()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/SchemaTests.cs
+++ b/src/EncompassRest.Tests/SchemaTests.cs
@@ -12,6 +12,7 @@ namespace EncompassRest.Tests
     public class SchemaTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Schema_GetLoanSchema()
         {
             var client = await GetTestClientAsync();
@@ -28,6 +29,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Schema_GenerateContract()
         {
             var client = await GetTestClientAsync();
@@ -46,6 +48,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Schema_GeneratePaths()
         {
             var client = await GetTestClientAsync();
@@ -68,6 +71,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanFieldDescriptors_RefreshStandardFields_NoUpdates()
         {
             var client = await GetTestClientAsync();
@@ -82,6 +86,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task LoanFieldDescriptors_RefreshStandardFields_DoesNotAffectUserAddedFields()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/TemplatesTests.cs
+++ b/src/EncompassRest.Tests/TemplatesTests.cs
@@ -9,6 +9,7 @@ namespace EncompassRest.Tests
     public class TemplatesTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task LoanTemplateSet_GetTemplateFoldersAndFiles()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/UserTests.cs
+++ b/src/EncompassRest.Tests/UserTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using EncompassRest.Company.Users.Rights;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +9,7 @@ namespace EncompassRest.Tests
     public class UserTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task User_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -26,6 +24,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task UserRights_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -45,6 +44,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task UserGroups_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -61,6 +61,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task UserCompensation_NoExtensionData()
         {
             var client = await GetTestClientAsync();
@@ -77,6 +78,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task UserLicenses_NoExtensionData()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.Tests/WebhookTests.cs
+++ b/src/EncompassRest.Tests/WebhookTests.cs
@@ -12,6 +12,7 @@ namespace EncompassRest.Tests
     public class WebhookTests : TestBaseClass
     {
         [TestMethod]
+        [ApiTest]
         public async Task Webhook_GetResources()
         {
             var client = await GetTestClientAsync();
@@ -24,6 +25,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Webhook_GetResource()
         {
             var client = await GetTestClientAsync();
@@ -44,6 +46,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Webhook_CreateAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -73,6 +76,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Webhook_CreateRawAndDelete()
         {
             var client = await GetTestClientAsync();
@@ -89,6 +93,7 @@ namespace EncompassRest.Tests
         }
 
         [TestMethod]
+        [ApiTest]
         public async Task Webhook_FilterAttributes()
         {
             var client = await GetTestClientAsync();

--- a/src/EncompassRest.sln
+++ b/src/EncompassRest.sln
@@ -18,18 +18,24 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EncompassRest.Tests", "Enco
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		CI|Any CPU = CI|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1BC65F57-9279-4E7E-A43F-0DE40DE559E4}.CI|Any CPU.ActiveCfg = CI|Any CPU
+		{1BC65F57-9279-4E7E-A43F-0DE40DE559E4}.CI|Any CPU.Build.0 = CI|Any CPU
 		{1BC65F57-9279-4E7E-A43F-0DE40DE559E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1BC65F57-9279-4E7E-A43F-0DE40DE559E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1BC65F57-9279-4E7E-A43F-0DE40DE559E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1BC65F57-9279-4E7E-A43F-0DE40DE559E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E9302C6-748E-478C-A6A2-5B9C5D4A13E2}.CI|Any CPU.ActiveCfg = CI|Any CPU
 		{7E9302C6-748E-478C-A6A2-5B9C5D4A13E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E9302C6-748E-478C-A6A2-5B9C5D4A13E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E9302C6-748E-478C-A6A2-5B9C5D4A13E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E9302C6-748E-478C-A6A2-5B9C5D4A13E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3292C30A-1F1D-40A4-886C-3FE0477B6D56}.CI|Any CPU.ActiveCfg = CI|Any CPU
+		{3292C30A-1F1D-40A4-886C-3FE0477B6D56}.CI|Any CPU.Build.0 = CI|Any CPU
 		{3292C30A-1F1D-40A4-886C-3FE0477B6D56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3292C30A-1F1D-40A4-886C-3FE0477B6D56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3292C30A-1F1D-40A4-886C-3FE0477B6D56}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/EncompassRest/EncompassRest.csproj
+++ b/src/EncompassRest/EncompassRest.csproj
@@ -15,6 +15,7 @@
     <AssemblyVersion>0.6.0.0</AssemblyVersion>
     <FileVersion>0.6.0.0</FileVersion>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Configurations>Debug;Release;CI</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Switched failing tests due to Ellie Mae to be passing tests and will then fail when they are supported by Ellie Mae.

Added `ApiTestAttribute` to exclude selected tests from live unit testing.