### PR TITLE
Refactored transient loan update to use new loan calculation API

### DIFF
--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -1529,8 +1529,10 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(250000M, retrievedLoan.BorrowerRequestedLoanAmount);
                 Assert.AreEqual(250000M, retrievedLoan.BaseLoanAmount);
                 loan.BorrowerRequestedLoanAmount = 200000M;
-                await client.Loans.UpdateLoanAsync(loan, new UpdateLoanOptions { Populate = true, Persistent = false });
-                Assert.IsFalse(loan.Dirty);
+                var loanAsJson = loan.ToString(SerializationOptions.Dirty);
+                await client.Calculators.CalculateLoanAsync(loan);
+                Assert.IsTrue(loan.Dirty);
+                Assert.AreEqual(loanAsJson, loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(200000M, loan.BorrowerRequestedLoanAmount);
                 Assert.AreEqual(200000M, loan.BaseLoanAmount);
                 retrievedLoan = await client.Loans.GetLoanAsync(loanId, new[] { LoanEntity.Loan });
@@ -1652,9 +1654,9 @@ namespace EncompassRest.Tests
                 Assert.AreSame(residences, application.Residences);
                 Assert.AreEqual(2, residences.Count);
                 Assert.AreSame(currentResidence, residences[0]);
-                Assert.AreEqual(ResidencyType.Current.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name), currentResidence.ResidencyType.Value);
+                Assert.AreEqual(ResidencyType.Current.GetValue(), currentResidence.ResidencyType.Value);
                 Assert.AreSame(priorResidence, residences[1]);
-                Assert.AreEqual(ResidencyType.Prior.AsString(EnumFormat.EnumMemberValue, EnumFormat.Name), priorResidence.ResidencyType.Value);
+                Assert.AreEqual(ResidencyType.Prior.GetValue(), priorResidence.ResidencyType.Value);
             }
             finally
             {

--- a/src/EncompassRest/Calculators/Calculators.cs
+++ b/src/EncompassRest/Calculators/Calculators.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using EncompassRest.Loans;
+using EncompassRest.Utilities;
+using EnumsNET;
+using Newtonsoft.Json;
+
+namespace EncompassRest.Calculators
+{
+    /// <summary>
+    /// The Calculators Apis.
+    /// </summary>
+    public sealed class Calculators : ApiObject
+    {
+        internal Calculators(EncompassRestClient client)
+            : base(client, "encompass/v1/calculators")
+        {
+        }
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task CalculateLoanAsync(Loan loan, CancellationToken cancellationToken = default) => CalculateLoanAsync(loan, (IEnumerable<string>)null, null, cancellationToken);
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task CalculateLoanAsync(Loan loan, IEnumerable<string> entities, CancellationToken cancellationToken = default) => CalculateLoanAsync(loan, entities, null, cancellationToken);
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task CalculateLoanAsync(Loan loan, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default) => CalculateLoanAsync(loan, entities, null, cancellationToken);
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="calcAllOnly">Indicates whether calculations will be executed for all fields. The default is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task CalculateLoanAsync(Loan loan, bool? calcAllOnly, CancellationToken cancellationToken = default) => CalculateLoanAsync(loan, (IEnumerable<string>)null, calcAllOnly, cancellationToken);
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="calcAllOnly">Indicates whether calculations will be executed for all fields. The default is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task CalculateLoanAsync(Loan loan, IEnumerable<LoanEntity> entities, bool? calcAllOnly, CancellationToken cancellationToken = default) => CalculateLoanAsync(loan, entities?.Select(e => e.Validate(nameof(entities)).GetValue()), calcAllOnly, cancellationToken);
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="calcAllOnly">Indicates whether calculations will be executed for all fields. The default is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public async Task CalculateLoanAsync(Loan loan, IEnumerable<string> entities, bool? calcAllOnly, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNull(loan, nameof(loan));
+            Preconditions.NotNullOrEmpty(loan.EncompassId, $"{nameof(loan)}.{nameof(loan.EncompassId)}");
+
+            var queryParameters = new QueryParameters();
+            if (calcAllOnly.HasValue)
+            {
+                queryParameters.Add(nameof(calcAllOnly), calcAllOnly.ToString().ToLower());
+            }
+            var body = new CalculateLoanBody { LoanData = loan, Entities = entities };
+            await PostAsync("loan", queryParameters.ToString(), JsonStreamContent.Create(body), nameof(CalculateLoanAsync), loan.EncompassId, cancellationToken, async (HttpResponseMessage response) =>
+            {
+                var loanAsJson = loan.ToString(SerializationOptions.Dirty);
+                await response.Content.PopulateAsync(loan).ConfigureAwait(false);
+                loan.Dirty = false;
+                // Repopulate with original dirty loan to maintain loan dirtiness.
+                // This may overwrite calculated values but they shouldn't have been dirty to begin with if they're calculated values.
+                JsonHelper.PopulateFromJson(loanAsJson, loan);
+                return string.Empty;
+            }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="body">The request body as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>The loan with calculations performed as raw json.</returns>
+        public Task<string> CalculateLoanRawAsync(string body, string queryString = null, CancellationToken cancellationToken = default) => PostRawAsync("loan", queryString, new JsonStringContent(body), nameof(CalculateLoanRawAsync), null, cancellationToken);
+
+        private sealed class CalculateLoanBody
+        {
+            public string LoanId => LoanData.EncompassId;
+
+            public Loan LoanData { get; set; }
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public IEnumerable<string> Entities { get; set; }
+        }
+    }
+}

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -162,6 +162,7 @@ namespace EncompassRest
         private Services.Services _services;
         private Company.Company _company;
         private Organizations.Organizations _organizations;
+        private Calculators.Calculators _calculators;
         private BaseApiClient _baseApiClient;
 
         #region Properties
@@ -402,7 +403,7 @@ namespace EncompassRest
         }
 
         /// <summary>
-        /// Organizations Apis
+        /// The Organizations Apis.
         /// </summary>
         public Organizations.Organizations Organizations
         {
@@ -410,6 +411,18 @@ namespace EncompassRest
             {
                 var organizations = _organizations;
                 return organizations ?? Interlocked.CompareExchange(ref _organizations, (organizations = new Organizations.Organizations(this)), null) ?? organizations;
+            }
+        }
+
+        /// <summary>
+        /// The Calculators Apis.
+        /// </summary>
+        public Calculators.Calculators Calculators
+        {
+            get
+            {
+                var calculators = _calculators;
+                return calculators ?? Interlocked.CompareExchange(ref _calculators, (calculators = new Calculators.Calculators(this)), null) ?? calculators;
             }
         }
 

--- a/src/EncompassRest/Loans/CreateLoanOptions.cs
+++ b/src/EncompassRest/Loans/CreateLoanOptions.cs
@@ -12,7 +12,7 @@ namespace EncompassRest.Loans
         /// </summary>
         public string LoanFolder { get; set; }
 
-        internal override QueryParameters ToQueryParameters(bool forPersistingTransientUpdates = false)
+        internal override QueryParameters ToQueryParameters()
         {
             var queryParameters = base.ToQueryParameters();
             if (!string.IsNullOrEmpty(LoanFolder))

--- a/src/EncompassRest/Loans/LoanCustomizations.cs
+++ b/src/EncompassRest/Loans/LoanCustomizations.cs
@@ -13,7 +13,6 @@ namespace EncompassRest.Loans
     {
         private LoanFields _fields;
         private LoanObjectBoundApis _loanApis;
-        internal List<TransientLoanUpdate> TransientLoanUpdates;
 
         /// <summary>
         /// The <see cref="EncompassRestClient"/> associated with this object.
@@ -145,13 +144,6 @@ namespace EncompassRest.Loans
                     _currentApplication = null;
                     break;
             }
-        }
-
-        internal sealed class TransientLoanUpdate
-        {
-            public string Body { get; set; }
-
-            public string QueryString { get; set; }
         }
     }
 }

--- a/src/EncompassRest/Loans/LoanOptions.cs
+++ b/src/EncompassRest/Loans/LoanOptions.cs
@@ -21,10 +21,10 @@ namespace EncompassRest.Loans
         {
         }
 
-        internal virtual QueryParameters ToQueryParameters(bool forPersistingTransientUpdates = false)
+        internal virtual QueryParameters ToQueryParameters()
         {
             var queryParameters = new QueryParameters();
-            if (Populate && !forPersistingTransientUpdates)
+            if (Populate)
             {
                 queryParameters.Add("view", "entity");
             }

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -184,50 +184,13 @@ namespace EncompassRest.Loans
         /// <param name="updateLoanOptions">The loan update options.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public async Task UpdateLoanAsync(Loan loan, UpdateLoanOptions updateLoanOptions, CancellationToken cancellationToken = default)
+        public Task UpdateLoanAsync(Loan loan, UpdateLoanOptions updateLoanOptions, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNull(loan, nameof(loan));
             Preconditions.NotNullOrEmpty(loan.EncompassId, $"{nameof(loan)}.{nameof(loan.EncompassId)}");
 
             loan.Initialize(Client, loan.EncompassId);
-            HttpContent content;
-            if (updateLoanOptions?.Persistent == false)
-            {
-                var body = loan.ToJson();
-                content = new JsonStringContent(body);
-            }
-            else
-            {
-                var transientLoanUpdates = loan.TransientLoanUpdates;
-                if (transientLoanUpdates?.Count > 0)
-                {
-                    foreach (var transientLoanUpdate in transientLoanUpdates)
-                    {
-                        await PatchAsync(loan.EncompassId, transientLoanUpdate.QueryString, new JsonStringContent(transientLoanUpdate.Body), nameof(UpdateLoanAsync), loan.EncompassId, cancellationToken).ConfigureAwait(false);
-                    }
-                    transientLoanUpdates.Clear();
-                }
-                content = JsonStreamContent.Create(loan);
-            }
-            await PatchAsync(loan.EncompassId, updateLoanOptions?.ToQueryParameters().ToString(), content, nameof(UpdateLoanAsync), loan.EncompassId, cancellationToken, async (HttpResponseMessage response) =>
-            {
-                if (updateLoanOptions?.Populate == true)
-                {
-                    await response.Content.PopulateAsync(loan).ConfigureAwait(false);
-                }
-                loan.Dirty = false;
-                if (updateLoanOptions?.Persistent == false)
-                {
-                    var transientLoanUpdates = loan.TransientLoanUpdates;
-                    if (transientLoanUpdates == null)
-                    {
-                        transientLoanUpdates = new List<Loan.TransientLoanUpdate>();
-                        loan.TransientLoanUpdates = transientLoanUpdates;
-                    }
-                    transientLoanUpdates.Add(new Loan.TransientLoanUpdate { Body = ((JsonStringContent)content).Json, QueryString = updateLoanOptions.ToQueryParameters(true).ToString() });
-                }
-                return string.Empty;
-            }).ConfigureAwait(false);
+            return PatchPopulateDirtyAsync(loan.EncompassId, updateLoanOptions?.ToQueryParameters().ToString(), JsonStreamContent.Create(loan), nameof(UpdateLoanAsync), loan.EncompassId, loan, updateLoanOptions?.Populate == true, cancellationToken);
         }
 
         /// <summary>

--- a/src/EncompassRest/Loans/UpdateLoanOptions.cs
+++ b/src/EncompassRest/Loans/UpdateLoanOptions.cs
@@ -12,22 +12,12 @@ namespace EncompassRest.Loans
         /// </summary>
         public bool AppendData { get; set; } = false;
 
-        /// <summary>
-        /// If set to <c>false</c> in combination with <see cref="LoanOptions.Populate"/> having a <c>true</c> value allows you
-        /// to recalculate changes to your local <see cref="Loan"/> object without persisting those changes to the server.
-        /// </summary>
-        public bool? Persistent { get; set; }
-
-        internal override QueryParameters ToQueryParameters(bool forPersistingTransientUpdates = false)
+        internal override QueryParameters ToQueryParameters()
         {
             var queryParameters = base.ToQueryParameters();
             if (!string.IsNullOrEmpty(LoanTemplate))
             {
                 queryParameters.Add("appendData", AppendData.ToString().ToLower());
-            }
-            if (Persistent.HasValue && !forPersistingTransientUpdates)
-            {
-                queryParameters.Add("persistent", Persistent.ToString().ToLower());
             }
             return queryParameters;
         }


### PR DESCRIPTION
Refactored transient loan update to use new loan calculation API.

This is a hard-break, i.e. no obsolete warnings for any that are currently using the `UpdateLoanOptions.Transient` property.

Closes #245