### PR TITLE
Features/add http logging interface

### DIFF
--- a/src/EncompassRest.Tests/App.config
+++ b/src/EncompassRest.Tests/App.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings></appSettings>
+</configuration>

--- a/src/EncompassRest.Tests/EncompassRest.Tests.csproj
+++ b/src/EncompassRest.Tests/EncompassRest.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EncompassRest.Tests/HttpLoggingInterfaceTests.cs
+++ b/src/EncompassRest.Tests/HttpLoggingInterfaceTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System;
+
+namespace EncompassRest.Tests
+{
+    public class HttpLoggingInterfaceImplementation : IHttpRequestLogger
+    {
+        public Task<string> LogHttpRequestMessageAsync(HttpRequestMessage httpRequestMessage)
+        {
+            return Task.FromResult("Called LogHttpRequestMessageAsync");
+        }
+
+        public Task<string> LogHttpResponseMessageAsync(HttpResponseMessage httpResponseMessage, string httpRequestMessageLog)
+        {
+            return Task.FromResult("Called LogHttpResponseMessageAsync");
+        }
+    }
+
+    [TestClass]
+    public class HttpLoggingInterfaceTests
+    {
+#if NETCOREAPP1_1
+#else
+        private Type apiObjectType;
+        private MethodInfo apiObjectGetHttpRequestLoggerMethod;
+        private FieldInfo isUsingCustomHttpLogger;
+
+        public HttpLoggingInterfaceTests()
+        {
+            apiObjectType = Type.GetType("EncompassRest.ApiObject, EncompassRest", true, false);
+
+            apiObjectGetHttpRequestLoggerMethod = apiObjectType.GetMethod("GetHttpRequestLogger", BindingFlags.Static | BindingFlags.NonPublic);
+
+            isUsingCustomHttpLogger = apiObjectType.GetField("IsUsingCustomHttpLogger", BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        private void HttpLoggingInterface_ModifyAppSettings(string key, string value)
+        {
+            var config = System.Configuration.ConfigurationManager.OpenExeConfiguration(Assembly.GetCallingAssembly().Location);
+            var appSettingsSection = (System.Configuration.AppSettingsSection)config.GetSection("appSettings");
+            appSettingsSection.Settings.Clear();
+            appSettingsSection.Settings.Add(key, value);
+            config.Save();
+            System.Configuration.ConfigurationManager.RefreshSection("appSettings");
+        }
+
+        [TestMethod]
+        public void HttpLoggingInterface_GetHttpRequestLoggerWithInterface()
+        {
+            isUsingCustomHttpLogger.SetValue(null, true);
+            HttpLoggingInterface_ModifyAppSettings("HttpLoggingAssembly", "EncompassRest.Tests.dll");
+            Assert.IsInstanceOfType(apiObjectGetHttpRequestLoggerMethod.Invoke(null, null), typeof(IHttpRequestLogger));
+        }
+
+        [TestMethod]
+        public void HttpLoggingInterface_GetHttpRequestLoggerWithOutInterface()
+        {
+            isUsingCustomHttpLogger.SetValue(null, false);
+            HttpLoggingInterface_ModifyAppSettings("HttpLoggingAssembly", "");
+            Assert.IsNull(apiObjectGetHttpRequestLoggerMethod.Invoke(null, null));
+        }
+#endif
+    }
+}

--- a/src/EncompassRest/ApiObject.cs
+++ b/src/EncompassRest/ApiObject.cs
@@ -43,7 +43,7 @@ namespace EncompassRest
         private static IHttpRequestLogger HttpRequestLoggerHolder { get; set; }
 
 #if NETSTANDARD1_1
-        private IHttpRequestLogger HttpRequestLogger => null;
+        private IHttpRequestLogger HttpRequestLogger => GetHttpRequestLogger();
 #else
         /// <summary>
         /// The Http Logging interface for netstandard2.0, net45, net46
@@ -204,6 +204,11 @@ namespace EncompassRest
             };
         }
 
+#if NETSTANDARD1_1
+        private static IHttpRequestLogger GetHttpRequestLogger(){
+            return null;
+        }
+#else
         private static IHttpRequestLogger GetHttpRequestLogger()
         {
             if (IsUsingCustomHttpLogger == false)
@@ -216,7 +221,7 @@ namespace EncompassRest
                 return HttpRequestLoggerHolder;
             }
 
-            var loggingAssembly = System.Configuration.ConfigurationManager.AppSettings["LoggingAssembly"];
+            var loggingAssembly = System.Configuration.ConfigurationManager.AppSettings["HttpLoggingAssembly"];
 
             if (string.IsNullOrEmpty(loggingAssembly))
             {
@@ -242,6 +247,6 @@ namespace EncompassRest
             }
             throw new EntryPointNotFoundException($"Failed to load implemenation class for interface IHttpRequestLogging from assembly: {assemblyPath}");
         }
-
+#endif
     }
 }

--- a/src/EncompassRest/EncompassRest.csproj
+++ b/src/EncompassRest/EncompassRest.csproj
@@ -31,6 +31,13 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager">
+      <Version>4.5.0</Version>
+    </PackageReference>
   </ItemGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/EncompassRest/IHttpRequestLogger.cs
+++ b/src/EncompassRest/IHttpRequestLogger.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+namespace EncompassRest
+{
+    /// <summary>
+    /// Interace for Implementing HTTP Logging. 
+    /// Supported in netstandard2.0, net45, net46
+    /// </summary>
+    public interface IHttpRequestLogger
+    {
+        /// <summary>
+        /// Logs the HTTP request message
+        /// </summary>
+        /// <param name="httpRequestMessage"></param>
+        /// <returns>
+        /// Returns the Id of the Http Request Log
+        /// </returns>
+        Task<string> LogHttpRequestMessageAsync(HttpRequestMessage httpRequestMessage);
+
+        /// <summary>
+        /// Logs the HTTP response message
+        /// </summary>
+        /// <param name="httpResponseMessage"></param>
+        /// <param name="httpRequestMessageLog">Value returned from LogHttpRequestMessage</param>
+        /// <returns>Returns the Id of the Http Response Log</returns>
+        Task<string> LogHttpResponseMessageAsync(HttpResponseMessage httpResponseMessage, string httpRequestMessageLog);
+    }
+}


### PR DESCRIPTION
The objective for this pull request is to add a simple HttpRequestMessage / HttpResponseMessage logging interface to EncompassRest with as few edits as possible, so that we know what data is going to and from Encompass with each request.  I determined that modifying the ApiObject class was probably the simplest way to capture all the requests made by EncompassRest without many changes.

The return type of the interface is Task<string> as I hit a wall when trying to use generics and ended up having to modify more of the project than I was comfortable with. To me, string makes sense as people using correlation id's and Guid's can use the interface normally, and those using defined objects or ints can serialize/deserialize or cast to get whatever object they require. 

Reflection is used to load the assembly implementing the interface based on an entry in App.config called "HttpLoggingAssembly", this must be the name of the assembly and it's extension (e.g. MyInterfaces.dll). To achieve this functionality, I added the NuGet package System.Configuration.ConfigurationManager for .NET Standard 2.0 and a reference to System.Configuration if using .NET 4.5 / .NET 4.6.  

Additionally, an App.config file was added to EncompassRests.Tests to support the Unit test which tests if a user has added their own logging implementation or not.
 
