### PR TITLE
Added anonymous type support to BaseApiClient

### DIFF
--- a/src/EncompassRest.Tests/BaseApiClientTests.cs
+++ b/src/EncompassRest.Tests/BaseApiClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using EncompassRest.CustomDataObjects;
@@ -15,13 +16,8 @@ namespace EncompassRest.Tests
         public async Task BaseApiClient_GetLoanFolders()
         {
             var client = await GetTestClientAsync();
-            var loanFolders = await client.BaseApiClient.GetAsync<List<LoanFolder>>("https://api.elliemae.com/encompass/v1/loanFolders");
+            var loanFolders = await client.BaseApiClient.GetAnonymousTypeAsync("https://api.elliemae.com/encompass/v1/loanFolders", new[] { new { Name = string.Empty } }.ToList());
             Assert.IsTrue(loanFolders.Count > 0);
-        }
-
-        private class LoanFolder
-        {
-            public string Name { get; set; }
         }
 
         [TestMethod]

--- a/src/EncompassRest/BaseApiClient.cs
+++ b/src/EncompassRest/BaseApiClient.cs
@@ -31,6 +31,19 @@ namespace EncompassRest
         /// <returns></returns>
         public Task<TResponse> GetAsync<TResponse>(string uri, CancellationToken cancellationToken = default) => GetAsync<TResponse>(uri, null, nameof(GetAsync), null, cancellationToken);
 
+
+        /// <summary>
+        /// Sends an HTTP GET request to the specified <paramref name="uri"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+#pragma warning disable IDE0060 // Remove unused parameter
+        public Task<TResponse> GetAnonymousTypeAsync<TResponse>(string uri, TResponse anonymousTypeObject, CancellationToken cancellationToken = default) => GetAsync<TResponse>(uri, null, nameof(GetAnonymousTypeAsync), null, cancellationToken);
+#pragma warning restore IDE0060 // Remove unused parameter
+
         /// <summary>
         /// Sends an HTTP GET request to the specified <paramref name="uri"/> and returns the response body as raw json.
         /// </summary>
@@ -57,6 +70,19 @@ namespace EncompassRest
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         public Task<TResponse> PostAsync<TResponse>(string uri, object content, CancellationToken cancellationToken = default) => PostAsync<TResponse>(uri, null, JsonStreamContent.Create(content), nameof(PostAsync), null, cancellationToken);
+
+        /// <summary>
+        /// Sends an HTTP POST request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+#pragma warning disable IDE0060 // Remove unused parameter
+        public Task<TResponse> PostAnonymousTypeAsync<TResponse>(string uri, object content, TResponse anonymousTypeObject, CancellationToken cancellationToken = default) => PostAsync<TResponse>(uri, null, JsonStreamContent.Create(content), nameof(PostAnonymousTypeAsync), null, cancellationToken);
+#pragma warning restore IDE0060 // Remove unused parameter
 
         /// <summary>
         /// Sends an HTTP POST request to the specified <paramref name="uri"/> with the raw json <paramref name="content"/> and returns the response body as raw json.
@@ -87,6 +113,19 @@ namespace EncompassRest
         public Task<TResponse> PatchAsync<TResponse>(string uri, object content, CancellationToken cancellationToken = default) => PatchAsync(uri, null, JsonStreamContent.Create(content), nameof(PatchAsync), null, cancellationToken, FuncCache<TResponse>.ReadAsFunc);
 
         /// <summary>
+        /// Sends an HTTP PATCH request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+#pragma warning disable IDE0060 // Remove unused parameter
+        public Task<TResponse> PatchAnonymousTypeAsync<TResponse>(string uri, object content, TResponse anonymousTypeObject, CancellationToken cancellationToken = default) => PatchAsync(uri, null, JsonStreamContent.Create(content), nameof(PatchAnonymousTypeAsync), null, cancellationToken, FuncCache<TResponse>.ReadAsFunc);
+#pragma warning restore IDE0060 // Remove unused parameter
+
+        /// <summary>
         /// Sends an HTTP PATCH request to the specified <paramref name="uri"/> with the raw json <paramref name="content"/> and returns the response body as raw json.
         /// </summary>
         /// <param name="uri">The request uri including any query parameters.</param>
@@ -113,6 +152,19 @@ namespace EncompassRest
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         public Task<TResponse> PutAsync<TResponse>(string uri, object content, CancellationToken cancellationToken = default) => PutAsync(uri, null, JsonStreamContent.Create(content), nameof(PutAsync), null, cancellationToken, FuncCache<TResponse>.ReadAsFunc);
+
+        /// <summary>
+        /// Sends an HTTP PUT request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+#pragma warning disable IDE0060 // Remove unused parameter
+        public Task<TResponse> PutAnonymousTypeAsync<TResponse>(string uri, object content, TResponse anonymousTypeObject, CancellationToken cancellationToken = default) => PutAsync(uri, null, JsonStreamContent.Create(content), nameof(PutAnonymousTypeAsync), null, cancellationToken, FuncCache<TResponse>.ReadAsFunc);
+#pragma warning restore IDE0060 // Remove unused parameter
 
         /// <summary>
         /// Sends an HTTP PUT request to the specified <paramref name="uri"/> with the raw json <paramref name="content"/> and returns the response body as raw json.


### PR DESCRIPTION
Added support to the `BaseApiClient` to return anonymous types so as not to require explicitly creating a new type for simple or temporary uses.