### PR TITLE
Added interfaces to ApiObjects throughout to support mocking

### DIFF
--- a/src/EncompassRest.Tests/EncompassRest.Tests.csproj
+++ b/src/EncompassRest.Tests/EncompassRest.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EncompassRest.Tests/EncompassRest.Tests.csproj
+++ b/src/EncompassRest.Tests/EncompassRest.Tests.csproj
@@ -9,6 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>encompassrest.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EncompassRest.Tests/FieldReaderTests.cs
+++ b/src/EncompassRest.Tests/FieldReaderTests.cs
@@ -19,7 +19,7 @@ namespace EncompassRest.Tests
             {
                 { "1109", "250000.00" },
                 { "4002", "Smith" },
-                { "748", "1/1/2019 12:00:00 AM" },
+                { "748", "1/1/2019" },
                 { "CUST01FV", "" }
             };
             foreach (var pair in fieldValues)

--- a/src/EncompassRest.Tests/MockingTests.cs
+++ b/src/EncompassRest.Tests/MockingTests.cs
@@ -12,7 +12,9 @@ namespace EncompassRest.Tests
         public async Task MockTest()
         {
             var loanId = "abc";
+#pragma warning disable CS0618 // Type or member is obsolete
             var client = Mock.Of<IEncompassRestClient>(c => c.Loans.GetLoanAsync(loanId, default) == Task.FromResult(new Loan() { Id = loanId }));
+#pragma warning restore CS0618 // Type or member is obsolete
             var loan = await client.Loans.GetLoanAsync(loanId);
             Assert.AreEqual(loanId, loan.Id);
         }

--- a/src/EncompassRest.Tests/MockingTests.cs
+++ b/src/EncompassRest.Tests/MockingTests.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using EncompassRest.Loans;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace EncompassRest.Tests
+{
+    [TestClass]
+    public class MockingTests : TestBaseClass
+    {
+        [TestMethod]
+        public async Task MockTest()
+        {
+            var loanId = "abc";
+            var client = Mock.Of<IEncompassRestClient>(c => c.Loans.GetLoanAsync(loanId, default) == Task.FromResult(new Loan() { Id = loanId }));
+            var loan = await client.Loans.GetLoanAsync(loanId);
+            Assert.AreEqual(loanId, loan.Id);
+        }
+    }
+}

--- a/src/EncompassRest/ApiObject.cs
+++ b/src/EncompassRest/ApiObject.cs
@@ -9,9 +9,20 @@ using EncompassRest.Utilities;
 namespace EncompassRest
 {
     /// <summary>
+    /// Base Api Interface.
+    /// </summary>
+    public interface IApiObject
+    {
+        /// <summary>
+        /// The <see cref="IEncompassRestClient"/> associated with the Api object.
+        /// </summary>
+        IEncompassRestClient Client { get; }
+    }
+
+    /// <summary>
     /// Base Api Class.
     /// </summary>
-    public abstract class ApiObject
+    public abstract class ApiObject : IApiObject
     {
         internal static readonly HttpMethod PatchMethod = new HttpMethod("PATCH");
 
@@ -37,6 +48,8 @@ namespace EncompassRest
         /// The <see cref="EncompassRestClient"/> associated with the Api object.
         /// </summary>
         public EncompassRestClient Client { get; }
+
+        IEncompassRestClient IApiObject.Client => Client;
 
         internal ApiObject(EncompassRestClient client, string baseApiPath)
         {

--- a/src/EncompassRest/BaseApiClient.cs
+++ b/src/EncompassRest/BaseApiClient.cs
@@ -8,7 +8,155 @@ namespace EncompassRest
     /// <summary>
     /// A base Api client for use when Apis aren't supported directly.
     /// </summary>
-    public sealed class BaseApiClient : ApiObject
+    public interface IBaseApiClient : IApiObject
+    {
+        /// <summary>
+        /// The internal <see cref="System.Net.Http.HttpClient"/> used by the client.
+        /// </summary>
+        HttpClient HttpClient { get; }
+
+        /// <summary>
+        /// Sends an HTTP DELETE request to the specified <paramref name="uri"/> and returns whether the response had a success status code.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteAsync(string uri, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP GET request to the specified <paramref name="uri"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> GetAnonymousTypeAsync<TResponse>(string uri, TResponse anonymousTypeObject, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP GET request to the specified <paramref name="uri"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> GetAsync<TResponse>(string uri, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP GET request to the specified <paramref name="uri"/> and returns the response body as raw json.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetRawAsync(string uri, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PATCH request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> PatchAnonymousTypeAsync<TResponse>(string uri, object content, TResponse anonymousTypeObject, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PATCH request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/>.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task PatchAsync(string uri, object content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PATCH request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> PatchAsync<TResponse>(string uri, object content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PATCH request to the specified <paramref name="uri"/> with the raw json <paramref name="content"/> and returns the response body as raw json.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The content as raw json to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> PatchRawAsync(string uri, string content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP POST request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> PostAnonymousTypeAsync<TResponse>(string uri, object content, TResponse anonymousTypeObject, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP POST request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/>.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task PostAsync(string uri, object content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP POST request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> PostAsync<TResponse>(string uri, object content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP POST request to the specified <paramref name="uri"/> with the raw json <paramref name="content"/> and returns the response body as raw json.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The content as raw json to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> PostRawAsync(string uri, string content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PUT request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The anonymous type to return. This can't be specified traditionally and must be inferred from the anonymous type passed as a parameter.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="anonymousTypeObject">The anonymous type object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> PutAnonymousTypeAsync<TResponse>(string uri, object content, TResponse anonymousTypeObject, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PUT request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/>.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task PutAsync(string uri, object content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PUT request to the specified <paramref name="uri"/> with the specified json serializable <paramref name="content"/> and returns the response body as a <typeparamref name="TResponse"/>.
+        /// </summary>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The json serializable content to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TResponse> PutAsync<TResponse>(string uri, object content, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Sends an HTTP PUT request to the specified <paramref name="uri"/> with the raw json <paramref name="content"/> and returns the response body as raw json.
+        /// </summary>
+        /// <param name="uri">The request uri including any query parameters.</param>
+        /// <param name="content">The content as raw json to send.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> PutRawAsync(string uri, string content, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// A base Api client for use when Apis aren't supported directly.
+    /// </summary>
+    public sealed class BaseApiClient : ApiObject, IBaseApiClient
     {
         internal override string BaseAddress => null;
 

--- a/src/EncompassRest/Calculators/Calculators.cs
+++ b/src/EncompassRest/Calculators/Calculators.cs
@@ -13,7 +13,71 @@ namespace EncompassRest.Calculators
     /// <summary>
     /// The Calculators Apis.
     /// </summary>
-    public sealed class Calculators : ApiObject
+    public interface ICalculators : IApiObject
+    {
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CalculateLoanAsync(Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="calcAllOnly">Indicates whether calculations will be executed for all fields. The default is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CalculateLoanAsync(Loan loan, bool? calcAllOnly, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CalculateLoanAsync(Loan loan, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="calcAllOnly">Indicates whether calculations will be executed for all fields. The default is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CalculateLoanAsync(Loan loan, IEnumerable<LoanEntity> entities, bool? calcAllOnly, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CalculateLoanAsync(Loan loan, IEnumerable<string> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="loan">The loan to recalculate.</param>
+        /// <param name="entities">The list of loan entities to populate for the loan.</param>
+        /// <param name="calcAllOnly">Indicates whether calculations will be executed for all fields. The default is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CalculateLoanAsync(Loan loan, IEnumerable<string> entities, bool? calcAllOnly, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Preview calculations for a loan. This API calculates fields similar to the calculations performed in Update Loan, however, the transient calculations provide a preview and do not save to the loan file.
+        /// </summary>
+        /// <param name="body">The request body as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>The loan with calculations performed as raw json.</returns>
+        Task<string> CalculateLoanRawAsync(string body, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Calculators Apis.
+    /// </summary>
+    public sealed class Calculators : ApiObject, ICalculators
     {
         internal Calculators(EncompassRestClient client)
             : base(client, "encompass/v1/calculators")

--- a/src/EncompassRest/Company/Company.cs
+++ b/src/EncompassRest/Company/Company.cs
@@ -5,7 +5,22 @@ namespace EncompassRest.Company
     /// <summary>
     /// Company Apis
     /// </summary>
-    public sealed class Company : ApiObject
+    public interface ICompany : IApiObject
+    {
+        /// <summary>
+        /// Global Custom Data Objects Apis
+        /// </summary>
+        IGlobalCustomDataObjects GlobalCustomDataObjects { get; }
+        /// <summary>
+        /// Users Apis
+        /// </summary>
+        Users.IUsers Users { get; }
+    }
+
+    /// <summary>
+    /// Company Apis
+    /// </summary>
+    public sealed class Company : ApiObject, ICompany
     {
         private Users.Users _users;
         private GlobalCustomDataObjects _globalCustomDataObjects;
@@ -22,6 +37,8 @@ namespace EncompassRest.Company
             }
         }
 
+        Users.IUsers ICompany.Users => Users;
+
         /// <summary>
         /// Global Custom Data Objects Apis
         /// </summary>
@@ -33,6 +50,8 @@ namespace EncompassRest.Company
                 return globalCustomDataObjects ?? Interlocked.CompareExchange(ref _globalCustomDataObjects, (globalCustomDataObjects = new GlobalCustomDataObjects(Client)), null) ?? globalCustomDataObjects;
             }
         }
+
+        IGlobalCustomDataObjects ICompany.GlobalCustomDataObjects => GlobalCustomDataObjects;
 
         internal Company(EncompassRestClient client)
             : base(client, "encompass/v1/company")

--- a/src/EncompassRest/Company/GlobalCustomDataObjects.cs
+++ b/src/EncompassRest/Company/GlobalCustomDataObjects.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// Global Custom Data Objects Apis
     /// </summary>
-    public sealed class GlobalCustomDataObjects : CustomDataObjects.CustomDataObjects
+    public interface IGlobalCustomDataObjects : CustomDataObjects.ICustomDataObjects
+    {
+    }
+
+    /// <summary>
+    /// Global Custom Data Objects Apis
+    /// </summary>
+    public sealed class GlobalCustomDataObjects : CustomDataObjects.CustomDataObjects, IGlobalCustomDataObjects
     {
         internal GlobalCustomDataObjects(EncompassRestClient client)
             : base(client, "encompass/v1/company/customObjects")

--- a/src/EncompassRest/Company/Users/Rights/EllieMaeNetworkServiceCategoriesClassRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/EllieMaeNetworkServiceCategoriesClassRights.cs
@@ -24,6 +24,7 @@ namespace EncompassRest.Company.Users.Rights
         private DirtyValue<bool?> _titleClosing;
         private DirtyValue<bool?> _underwriting;
         private DirtyValue<bool?> _verifications;
+        private DirtyValue<bool?> _warehouseLenders;
 
         /// <summary>
         /// EllieMaeNetworkServiceCategoriesClassRights AdditionalServices
@@ -119,5 +120,11 @@ namespace EncompassRest.Company.Users.Rights
         /// EllieMaeNetworkServiceCategoriesClassRights Verifications
         /// </summary>
         public bool? Verifications { get => _verifications; set => SetField(ref _verifications, value); }
+
+        /// <summary>
+        /// EllieMaeNetworkServiceCategoriesClassRights WarehouseLenders
+        /// </summary>
+        [JsonProperty("warehouse Lenders")]
+        public bool? WarehouseLenders { get => _warehouseLenders; set => SetField(ref _warehouseLenders, value); }
     }
 }

--- a/src/EncompassRest/Company/Users/Rights/UsersRights.cs
+++ b/src/EncompassRest/Company/Users/Rights/UsersRights.cs
@@ -8,7 +8,45 @@ namespace EncompassRest.Company.Users.Rights
     /// <summary>
     /// User Rights Apis
     /// </summary>
-    public sealed class UsersRights : UserApiObject
+    public interface IUsersRights : IUserApiObject
+    {
+        /// <summary>
+        /// Gets the users rights for the specified rights <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<UserRights> GetRightsAsync(UserRightsType type, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the users rights for the specified rights <paramref name="type"/> and optionally filtered to include only the specified <paramref name="category"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="category">User settings category. You can filter the access rights by their tabs in Encompass.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<UserRights> GetRightsAsync(UserRightsType type, string category, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the users rights for the specified rights <paramref name="type"/> and filtered to include only the specified <paramref name="category"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="category">User settings category. You can filter the access rights by their tabs in Encompass.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<UserRights> GetRightsAsync(UserRightsType type, UserRightsCategory category, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the users rights as raw json for the specified rights <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The user rights type.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetRightsRawAsync(UserRightsType type, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// User Rights Apis
+    /// </summary>
+    public sealed class UsersRights : UserApiObject, IUsersRights
     {
         internal UsersRights(EncompassRestClient client, string userId)
             : base(client, userId, null)

--- a/src/EncompassRest/Company/Users/UserApiObject.cs
+++ b/src/EncompassRest/Company/Users/UserApiObject.cs
@@ -3,9 +3,20 @@
 namespace EncompassRest.Company.Users
 {
     /// <summary>
+    /// Base interface for User Apis
+    /// </summary>
+    public interface IUserApiObject : IApiObject
+    {
+        /// <summary>
+        /// User's Id
+        /// </summary>
+        string UserId { get; }
+    }
+
+    /// <summary>
     /// Base class for User Apis
     /// </summary>
-    public abstract class UserApiObject : ApiObject
+    public abstract class UserApiObject : ApiObject, IUserApiObject
     {
         /// <summary>
         /// User's Id

--- a/src/EncompassRest/Company/Users/UserApis.cs
+++ b/src/EncompassRest/Company/Users/UserApis.cs
@@ -6,7 +6,34 @@ namespace EncompassRest.Company.Users
     /// <summary>
     /// User Apis
     /// </summary>
-    public sealed class UserApis : UserApiObject
+    public interface IUserApis : IUserApiObject
+    {
+        /// <summary>
+        /// User Compensation Apis
+        /// </summary>
+        IUserCompensationPlans Compensation { get; }
+        /// <summary>
+        /// User Custom Data Objects Apis
+        /// </summary>
+        IUserCustomDataObjects CustomDataObjects { get; }
+        /// <summary>
+        /// User Groups Apis
+        /// </summary>
+        IUserGroups Groups { get; }
+        /// <summary>
+        /// User Licenses Apis
+        /// </summary>
+        IUserLicenseDetails Licenses { get; }
+        /// <summary>
+        /// User Rights Apis
+        /// </summary>
+        IUsersRights Rights { get; }
+    }
+
+    /// <summary>
+    /// User Apis
+    /// </summary>
+    public sealed class UserApis : UserApiObject, IUserApis
     {
         private UserCustomDataObjects _customDataObjects;
         private UserGroups _groups;
@@ -26,6 +53,8 @@ namespace EncompassRest.Company.Users
             }
         }
 
+        IUserCustomDataObjects IUserApis.CustomDataObjects => CustomDataObjects;
+
         /// <summary>
         /// User Groups Apis
         /// </summary>
@@ -37,6 +66,8 @@ namespace EncompassRest.Company.Users
                 return groups ?? Interlocked.CompareExchange(ref _groups, (groups = new UserGroups(Client, UserId)), null) ?? groups;
             }
         }
+
+        IUserGroups IUserApis.Groups => Groups;
 
         /// <summary>
         /// User Compensation Apis
@@ -50,6 +81,8 @@ namespace EncompassRest.Company.Users
             }
         }
 
+        IUserCompensationPlans IUserApis.Compensation => Compensation;
+
         /// <summary>
         /// User Licenses Apis
         /// </summary>
@@ -62,6 +95,8 @@ namespace EncompassRest.Company.Users
             }
         }
 
+        IUserLicenseDetails IUserApis.Licenses => Licenses;
+
         /// <summary>
         /// User Rights Apis
         /// </summary>
@@ -73,6 +108,8 @@ namespace EncompassRest.Company.Users
                 return rights ?? Interlocked.CompareExchange(ref _rights, (rights = new UsersRights(Client, UserId)), null) ?? rights;
             }
         }
+
+        IUsersRights IUserApis.Rights => Rights;
 
         internal UserApis(EncompassRestClient client, string userId)
             : base(client, userId, null)

--- a/src/EncompassRest/Company/Users/UserCompensationPlans.cs
+++ b/src/EncompassRest/Company/Users/UserCompensationPlans.cs
@@ -6,7 +6,27 @@ namespace EncompassRest.Company.Users
     /// <summary>
     /// User Compensation Apis
     /// </summary>
-    public sealed class UserCompensationPlans : UserApiObject
+    public interface IUserCompensationPlans : IUserApiObject
+    {
+        /// <summary>
+        /// Gets the user's compensation plans.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<CompensationPlans> GetCompensationPlansAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the user's compensation plans as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCompensationPlansRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// User Compensation Apis
+    /// </summary>
+    public sealed class UserCompensationPlans : UserApiObject, IUserCompensationPlans
     {
         internal UserCompensationPlans(EncompassRestClient client, string userId)
             : base(client, userId, "compensation")

--- a/src/EncompassRest/Company/Users/UserCustomDataObjects.cs
+++ b/src/EncompassRest/Company/Users/UserCustomDataObjects.cs
@@ -5,7 +5,14 @@ namespace EncompassRest.Company.Users
     /// <summary>
     /// User Custom Data Objects Apis
     /// </summary>
-    public sealed class UserCustomDataObjects : CustomDataObjects.CustomDataObjects
+    public interface IUserCustomDataObjects : CustomDataObjects.ICustomDataObjects, IUserApiObject
+    {
+    }
+
+    /// <summary>
+    /// User Custom Data Objects Apis
+    /// </summary>
+    public sealed class UserCustomDataObjects : CustomDataObjects.CustomDataObjects, IUserCustomDataObjects
     {
         /// <summary>
         /// User's Id

--- a/src/EncompassRest/Company/Users/UserGroups.cs
+++ b/src/EncompassRest/Company/Users/UserGroups.cs
@@ -7,7 +7,27 @@ namespace EncompassRest.Company.Users
     /// <summary>
     /// User Groups Apis
     /// </summary>
-    public sealed class UserGroups : UserApiObject
+    public interface IUserGroups : IUserApiObject
+    {
+        /// <summary>
+        /// Gets the user's groups.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<EntityReference>> GetGroupsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the user's groups as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetGroupsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// User Groups Apis
+    /// </summary>
+    public sealed class UserGroups : UserApiObject, IUserGroups
     {
         internal UserGroups(EncompassRestClient client, string userId)
             : base(client, userId, "groups")

--- a/src/EncompassRest/Company/Users/UserLicenseDetails.cs
+++ b/src/EncompassRest/Company/Users/UserLicenseDetails.cs
@@ -9,7 +9,41 @@ namespace EncompassRest.Company.Users
     /// <summary>
     /// User Licenses Apis
     /// </summary>
-    public sealed class UserLicenseDetails : UserApiObject
+    public interface IUserLicenseDetails : IUserApiObject
+    {
+        /// <summary>
+        /// Gets the user's licenses.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<UserLicenseDetail>> GetLicenseDetailsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the user's licenses for a particular state.
+        /// </summary>
+        /// <param name="state">The state code for which to return license information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<UserLicenseDetail>> GetLicenseDetailsAsync(State state, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the user's licenses and for a particular state if specified.
+        /// </summary>
+        /// <param name="state">The state code for which to return license information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<UserLicenseDetail>> GetLicenseDetailsAsync(string state, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the user's licenses as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetLicenseDetailsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// User Licenses Apis
+    /// </summary>
+    public sealed class UserLicenseDetails : UserApiObject, IUserLicenseDetails
     {
         internal UserLicenseDetails(EncompassRestClient client, string userId)
             : base(client, userId, "licenses")

--- a/src/EncompassRest/Company/Users/Users.cs
+++ b/src/EncompassRest/Company/Users/Users.cs
@@ -8,7 +8,81 @@ namespace EncompassRest.Company.Users
     /// <summary>
     /// Users Apis
     /// </summary>
-    public sealed class Users : ApiObject
+    public interface IUsers : IApiObject
+    {
+        /// <summary>
+        /// Gets the Current User's Apis. Custom Data Objects are not currently supported through this property.
+        /// </summary>
+        IUserApis CurrentUserApis { get; }
+
+        /// <summary>
+        /// Gets the current user.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<User> GetCurrentUserAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the current user and optionally includes the email signature in the response object.
+        /// </summary>
+        /// <param name="viewEmailSignature">Indicates whether the email signature should be returned as part of the response.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<User> GetCurrentUserAsync(bool? viewEmailSignature, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the User Apis for the specified <paramref name="userId"/>.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <returns></returns>
+        IUserApis GetUserApis(string userId);
+        /// <summary>
+        /// Gets the user with the specified <paramref name="userId"/>.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<User> GetUserAsync(string userId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the user with the specified <paramref name="userId"/> and optionally includes the email signature in the response object.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <param name="viewEmailSignature">Indicates whether the email signature should be returned as part of the response.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<User> GetUserAsync(string userId, bool? viewEmailSignature, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets user as raw json.
+        /// </summary>
+        /// <param name="userId">The user's id.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetUserRawAsync(string userId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets all users.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<User>> GetUsersAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets users using the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="options">The users retrieval options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<User>> GetUsersAsync(UsersRetrievalOptions options, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets users as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetUsersRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Users Apis
+    /// </summary>
+    public sealed class Users : ApiObject, IUsers
     {
         private UserApis _currentUserApis;
 
@@ -23,6 +97,8 @@ namespace EncompassRest.Company.Users
                 return currentUserApis ?? Interlocked.CompareExchange(ref _currentUserApis, (currentUserApis = new UserApis(Client, "me")), null) ?? currentUserApis;
             }
         }
+
+        IUserApis IUsers.CurrentUserApis => CurrentUserApis;
 
         internal Users(EncompassRestClient client)
             : base(client, "encompass/v1/company/users")
@@ -40,6 +116,8 @@ namespace EncompassRest.Company.Users
 
             return new UserApis(Client, userId);
         }
+
+        IUserApis IUsers.GetUserApis(string userId) => GetUserApis(userId);
 
         /// <summary>
         /// Gets all users.

--- a/src/EncompassRest/Contacts/BorrowerContactSelector.cs
+++ b/src/EncompassRest/Contacts/BorrowerContactSelector.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Borrower Contact Selector Apis.
     /// </summary>
-    public sealed class BorrowerContactSelector : ContactSelector
+    public interface IBorrowerContactSelector : IContactSelector
+    {
+    }
+
+    /// <summary>
+    /// The Borrower Contact Selector Apis.
+    /// </summary>
+    public sealed class BorrowerContactSelector : ContactSelector, IBorrowerContactSelector
     {
         internal BorrowerContactSelector(EncompassRestClient client)
             : base(client, "encompass/v1/borrowerContactSelector")

--- a/src/EncompassRest/Contacts/BorrowerContacts.cs
+++ b/src/EncompassRest/Contacts/BorrowerContacts.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Borrower Contacts Apis.
     /// </summary>
-    public sealed class BorrowerContacts : Contacts<BorrowerContact>
+    public interface IBorrowerContacts : IContacts<BorrowerContact>
+    {
+    }
+
+    /// <summary>
+    /// The Borrower Contacts Apis.
+    /// </summary>
+    public sealed class BorrowerContacts : Contacts<BorrowerContact>, IBorrowerContacts
     {
         internal BorrowerContacts(EncompassRestClient client)
             : base(client, "encompass/v1/borrowerContacts")

--- a/src/EncompassRest/Contacts/BusinessContactSelector.cs
+++ b/src/EncompassRest/Contacts/BusinessContactSelector.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Business Contact Selector Apis.
     /// </summary>
-    public sealed class BusinessContactSelector : ContactSelector
+    public interface IBusinessContactSelector : IContactSelector
+    {
+    }
+
+    /// <summary>
+    /// The Business Contact Selector Apis.
+    /// </summary>
+    public sealed class BusinessContactSelector : ContactSelector, IBusinessContactSelector
     {
         internal BusinessContactSelector(EncompassRestClient client)
             : base(client, "encompass/v1/businessContactSelector")

--- a/src/EncompassRest/Contacts/BusinessContacts.cs
+++ b/src/EncompassRest/Contacts/BusinessContacts.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Business Contacts Apis.
     /// </summary>
-    public sealed class BusinessContacts : Contacts<BusinessContact>
+    public interface IBusinessContacts : IContacts<BusinessContact>
+    {
+    }
+
+    /// <summary>
+    /// The Business Contacts Apis.
+    /// </summary>
+    public sealed class BusinessContacts : Contacts<BusinessContact>, IBusinessContacts
     {
         internal BusinessContacts(EncompassRestClient client)
             : base(client, "encompass/v1/businessContacts")

--- a/src/EncompassRest/Contacts/ContactApiObject.cs
+++ b/src/EncompassRest/Contacts/ContactApiObject.cs
@@ -3,9 +3,20 @@
 namespace EncompassRest.Contacts
 {
     /// <summary>
+    /// Base Contact Api Interface.
+    /// </summary>
+    public interface IContactApiObject : IApiObject
+    {
+        /// <summary>
+        /// The contact id associated with the Api.
+        /// </summary>
+        string ContactId { get; }
+    }
+
+    /// <summary>
     /// Base Contact Api Class.
     /// </summary>
-    public abstract class ContactApiObject : ApiObject
+    public abstract class ContactApiObject : ApiObject, IContactApiObject
     {
         /// <summary>
         /// The contact id associated with the Api.

--- a/src/EncompassRest/Contacts/ContactCursor.cs
+++ b/src/EncompassRest/Contacts/ContactCursor.cs
@@ -5,7 +5,14 @@ namespace EncompassRest.Contacts
     /// <summary>
     /// Contact cursor.
     /// </summary>
-    public sealed class ContactCursor : Cursor<ContactData>
+    public interface IContactCursor : ICursor<ContactData>
+    {
+    }
+
+    /// <summary>
+    /// Contact cursor.
+    /// </summary>
+    public sealed class ContactCursor : Cursor<ContactData>, IContactCursor
     {
         internal ContactCursor(ApiObject apiObject, EncompassRestClient client, string cursorId, int count, IEnumerable<string> fields)
             : base(apiObject, client, cursorId, count, fields)

--- a/src/EncompassRest/Contacts/ContactGroups.cs
+++ b/src/EncompassRest/Contacts/ContactGroups.cs
@@ -9,7 +9,150 @@ namespace EncompassRest.Contacts
     /// <summary>
     /// The Contact Groups Apis.
     /// </summary>
-    public sealed class ContactGroups : ApiObject
+    public interface IContactGroups : IApiObject
+    {
+        /// <summary>
+        /// Adds or removes contacts in a contact group.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to update.</param>
+        /// <param name="action">Whether to add or remove the contact.</param>
+        /// <param name="contacts">The contacts to add or remove.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignGroupContactsAsync(string groupId, AssignmentAction action, IEnumerable<EntityReference> contacts, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Adds or removes contacts in a contact group.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to update.</param>
+        /// <param name="action">Whether to add or remove the contact.</param>
+        /// <param name="contacts">The contacts to add or remove.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignGroupContactsAsync(string groupId, string action, IEnumerable<EntityReference> contacts, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Adds or removes contacts in a contact group from raw json.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to update.</param>
+        /// <param name="contacts">The contacts to add or remove as raw json.</param>
+        /// <param name="queryString">The query string to include in the request. This should include an action parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignGroupContactsRawAsync(string groupId, string contacts, string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new borrower or business contact group and returns the contact group's id.
+        /// </summary>
+        /// <param name="group">The contact group to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateGroupAsync(ContactGroup group, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new borrower or business contact group and returns the contact group's id and optionally populates the contact group object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="group">The contact group to create.</param>
+        /// <param name="populate">Indicates if the contact group object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateGroupAsync(ContactGroup group, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new borrower or business contact group from raw json and returns the response's body if not empty else the contact group's id.
+        /// </summary>
+        /// <param name="group">The contact group to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateGroupRawAsync(string group, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently removes the specified contact group from the Encompass contacts database.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves information about the specified contact group.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ContactGroup> GetGroupAsync(string groupId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns all contacts associated with a specified group Id.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group.</param>
+        /// <param name="start">Starting index or record number from which to retrieve the contacts. The default is 1.</param>
+        /// <param name="limit">The maximum number of items to return in a page. Response size is limited to 6 MB; however, the limit is recalculated if the response size exceeds 6 MB. The default value is 1000 and max value for this parameter is limited to 10000.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<EntityReference>> GetGroupContactsAsync(string groupId, int? start = null, int? limit = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns all contacts associated with a specified group Id as raw json.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetGroupContactsRawAsync(string groupId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves information about the specified contact group.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetGroupRawAsync(string groupId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all contact groups for a given contact type and group type.
+        /// </summary>
+        /// <param name="contactType">The contact type.</param>
+        /// <param name="groupType">The contact group type.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<ContactGroup>> GetGroupsAsync(ContactType contactType, ContactGroupType? groupType = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all contact groups for a given contact type and group type.
+        /// </summary>
+        /// <param name="contactType">The contact type.</param>
+        /// <param name="groupType">The contact group type.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<ContactGroup>> GetGroupsAsync(string contactType, string groupType = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all contact groups for a given contact type and group type as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request. This should include a contactType parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetGroupsRawAsync(string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the details of the specified contact group.
+        /// </summary>
+        /// <param name="group">The contact group to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateGroupAsync(ContactGroup group, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the details of the specified contact group and optionally populates the contact group object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="group">The contact group to update.</param>
+        /// <param name="populate">Indicates if the contact group object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateGroupAsync(ContactGroup group, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the details of the specified contact group from raw json.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to update.</param>
+        /// <param name="group">The contact group to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateGroupRawAsync(string groupId, string group, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Contact Groups Apis.
+    /// </summary>
+    public sealed class ContactGroups : ApiObject, IContactGroups
     {
         internal ContactGroups(EncompassRestClient client)
             : base(client, "encompass/v1/contactGroups")
@@ -159,7 +302,7 @@ namespace EncompassRest.Contacts
         public Task<string> CreateGroupRawAsync(string group, string queryString = null, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(group, nameof(group));
-            
+
             return PostAsync(null, queryString, new JsonStringContent(group), nameof(CreateGroupRawAsync), null, cancellationToken, ReadAsStringElseLocationFunc);
         }
 
@@ -204,7 +347,7 @@ namespace EncompassRest.Contacts
             Preconditions.NotNullOrEmpty(groupId, nameof(groupId));
             Preconditions.NotNullOrEmpty(contacts, nameof(contacts));
             Preconditions.NotNullOrEmpty(queryString, nameof(queryString));
-            
+
             return PatchAsync($"{groupId}/contacts", queryString, new JsonStringContent(contacts), nameof(AssignGroupContactsRawAsync), groupId, cancellationToken);
         }
 

--- a/src/EncompassRest/Contacts/ContactNotes.cs
+++ b/src/EncompassRest/Contacts/ContactNotes.cs
@@ -8,7 +8,80 @@ namespace EncompassRest.Contacts
     /// <summary>
     /// The Contact Notes Apis.
     /// </summary>
-    public sealed class ContactNotes : ContactApiObject
+    public interface IContactNotes : IContactApiObject
+    {
+        /// <summary>
+        /// Adds a note to the contact and returns the note ID.
+        /// </summary>
+        /// <param name="note">The note to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateNoteAsync(ContactNote note, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Adds a note to the contact from raw json and returns the response body if not empty else the note ID.
+        /// </summary>
+        /// <param name="note">The note to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateNoteRawAsync(string note, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently deletes the specified note from the contact.
+        /// </summary>
+        /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteNoteAsync(string noteId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the specified note from the contact.
+        /// </summary>
+        /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ContactNote> GetNoteAsync(string noteId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the specified note from the contact as raw json.
+        /// </summary>
+        /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetNoteRawAsync(string noteId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieve all notes from the contact.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<ContactNote>> GetNotesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieve all notes from the contact as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetNotesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified note with the values provided.
+        /// </summary>
+        /// <param name="note">The note to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateNoteAsync(ContactNote note, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified note with the values provided from raw json.
+        /// </summary>
+        /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
+        /// <param name="note">The note to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateNoteRawAsync(string noteId, string note, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Contact Notes Apis.
+    /// </summary>
+    public sealed class ContactNotes : ContactApiObject, IContactNotes
     {
         internal ContactNotes(EncompassRestClient client, string contactId, string baseApiPath)
             : base(client, contactId, $"{baseApiPath}/{contactId}/notes")

--- a/src/EncompassRest/Contacts/ContactSelector.cs
+++ b/src/EncompassRest/Contacts/ContactSelector.cs
@@ -9,7 +9,38 @@ namespace EncompassRest.Contacts
     /// <summary>
     /// The Base Contact Selector Apis.
     /// </summary>
-    public abstract class ContactSelector : ApiObject
+    public interface IContactSelector : IApiObject
+    {
+        /// <summary>
+        /// Creates a cursor to paginate large data sets.
+        /// </summary>
+        /// <param name="parameters">The contact list parameters used to specify the contacts and fields to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<IContactCursor> CreateCursorAsync(ContactListParameters parameters, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the contact IDs and specified fields for the contacts specified.
+        /// </summary>
+        /// <param name="parameters">The contact list parameters used to specify the contacts and fields to include.</param>
+        /// <param name="start">Starting index or record number from which to retrieve the contacts. The default is 1.</param>
+        /// <param name="limit">The maximum number of records to return in a page. Response size is limited to 6 MB and is recalculated if the response exceeds 6 MB. The default value is 1000. The maximum value is limited to 10000.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<ContactData>> GetContactListAsync(ContactListParameters parameters, int? start = null, int? limit = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the contact IDs and specified fields for the contacts specified as raw json.
+        /// </summary>
+        /// <param name="parameters">The contact list parameters used to specify the contacts and fields to include as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetContactListRawAsync(string parameters, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Base Contact Selector Apis.
+    /// </summary>
+    public abstract class ContactSelector : ApiObject, IContactSelector
     {
         internal ContactSelector(EncompassRestClient client, string baseApiPath)
             : base(client, baseApiPath)
@@ -56,6 +87,8 @@ namespace EncompassRest.Contacts
                 return new ContactCursor(this, Client, cursorId, count, parameters.Fields);
             });
         }
+
+        async Task<IContactCursor> IContactSelector.CreateCursorAsync(ContactListParameters parameters, CancellationToken cancellationToken) => await CreateCursorAsync(parameters, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Retrieves the contact IDs and specified fields for the contacts specified.

--- a/src/EncompassRest/Contacts/Contacts.cs
+++ b/src/EncompassRest/Contacts/Contacts.cs
@@ -7,8 +7,83 @@ namespace EncompassRest.Contacts
     /// <summary>
     /// The Base Contacts Apis.
     /// </summary>
-    /// <typeparam name="TContact"></typeparam>
-    public abstract class Contacts<TContact> : ApiObject
+    public interface IContacts : IApiObject
+    {
+        /// <summary>
+        /// Creates a new contact from raw json and returns the responses body if not empty else its contact id.
+        /// </summary>
+        /// <param name="contact">The contact to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateContactRawAsync(string contact, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently deletes the specified contact.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteContactAsync(string contactId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the Contact Notes Apis for the contact with the specified <paramref name="contactId"/>.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <returns></returns>
+        IContactNotes GetContactNotes(string contactId);
+        /// <summary>
+        /// Retrieves contact information for the specified contact ID as raw json.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetContactRawAsync(string contactId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates contact information for the specified contact ID from raw json.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <param name="contact">The contact to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateContactRawAsync(string contactId, string contact, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Base Contacts Apis.
+    /// </summary>
+    /// <typeparam name="TContact">The contact type.</typeparam>
+    public interface IContacts<TContact> : IContacts
+        where TContact : Contact
+    {
+        /// <summary>
+        /// Creates a new contact and returns its contact id.
+        /// </summary>
+        /// <param name="contact">The contact to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateContactAsync(TContact contact, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves contact information for the specified contact ID.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TContact> GetContactAsync(string contactId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates contact information for the specified contact ID.
+        /// </summary>
+        /// <param name="contact">The contact to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateContactAsync(TContact contact, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Base Contacts Apis.
+    /// </summary>
+    /// <typeparam name="TContact">The contact type.</typeparam>
+    public abstract class Contacts<TContact> : ApiObject, IContacts<TContact>
         where TContact : Contact
     {
         private readonly string _apiPath;
@@ -30,6 +105,8 @@ namespace EncompassRest.Contacts
 
             return new ContactNotes(Client, contactId, _apiPath);
         }
+
+        IContactNotes IContacts.GetContactNotes(string contactId) => GetContactNotes(contactId);
 
         /// <summary>
         /// Retrieves contact information for the specified contact ID.

--- a/src/EncompassRest/Cursor.cs
+++ b/src/EncompassRest/Cursor.cs
@@ -8,8 +8,108 @@ namespace EncompassRest
     /// <summary>
     /// Cursor for retrieving items.
     /// </summary>
+    public interface ICursor : IApiObject
+    {
+        /// <summary>
+        /// The cursor items count.
+        /// </summary>
+        int Count { get; }
+        /// <summary>
+        /// The cursor id.
+        /// </summary>
+        string CursorId { get; }
+        /// <summary>
+        /// The cursor's available fields.
+        /// </summary>
+        IEnumerable<string> Fields { get; }
+
+        /// <summary>
+        /// Gets the items as raw json starting at the zero-based <paramref name="start"/> index with an optional <paramref name="limit"/> of items to return.
+        /// </summary>
+        /// <param name="start">Zero-based starting index.</param>
+        /// <param name="limit">The maximum number of items to return.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetItemsRawAsync(int start, int? limit, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the items as raw json starting at the zero-based <paramref name="start"/> index with the specified <paramref name="fields"/> with an optional <paramref name="limit"/> of items to return.
+        /// </summary>
+        /// <param name="start">Zero-based starting index.</param>
+        /// <param name="limit">The maximum number of items to return.</param>
+        /// <param name="fields">The fields to include in the items.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetItemsRawAsync(int start, int? limit, IEnumerable<string> fields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the items as raw json starting at the zero-based <paramref name="start"/> index with the specified <paramref name="fields"/> with an optional <paramref name="limit"/> of items to return.
+        /// </summary>
+        /// <param name="start">Zero-based starting index.</param>
+        /// <param name="limit">The maximum number of items to return.</param>
+        /// <param name="fields">The fields to include in the items.</param>
+        /// <returns></returns>
+        Task<string> GetItemsRawAsync(int start, int? limit, params string[] fields);
+    }
+
+    /// <summary>
+    /// Cursor for retrieving items.
+    /// </summary>
     /// <typeparam name="TItem">Cursor's item type.</typeparam>
-    public abstract class Cursor<TItem>
+    public interface ICursor<TItem> : ICursor
+    {
+        /// <summary>
+        /// Gets an item from the cursor at the zero-based <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">Zero-based index.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TItem> GetItemAsync(int index, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets an item from the cursor at the zero-based <paramref name="index"/> with the specified <paramref name="fields"/>.
+        /// </summary>
+        /// <param name="index">Zero-based index.</param>
+        /// <param name="fields">The fields to include in the item.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TItem> GetItemAsync(int index, IEnumerable<string> fields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets an item from the cursor at the zero-based <paramref name="index"/> with the specified <paramref name="fields"/>.
+        /// </summary>
+        /// <param name="index">Zero-based index.</param>
+        /// <param name="fields">The fields to include in the item.</param>
+        /// <returns></returns>
+        Task<TItem> GetItemAsync(int index, params string[] fields);
+        /// <summary>
+        /// Gets the items starting at the zero-based <paramref name="start"/> index with an optional <paramref name="limit"/> of items to return.
+        /// </summary>
+        /// <param name="start">Zero-based starting index.</param>
+        /// <param name="limit">The maximum number of items to return.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<TItem>> GetItemsAsync(int start, int? limit, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the items starting at the zero-based <paramref name="start"/> index with the specified <paramref name="fields"/> with an optional <paramref name="limit"/> of items to return.
+        /// </summary>
+        /// <param name="start">Zero-based starting index.</param>
+        /// <param name="limit">The maximum number of items to return.</param>
+        /// <param name="fields">The fields to include in the items.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<TItem>> GetItemsAsync(int start, int? limit, IEnumerable<string> fields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the items starting at the zero-based <paramref name="start"/> index with the specified <paramref name="fields"/> with an optional <paramref name="limit"/> of items to return.
+        /// </summary>
+        /// <param name="start">Zero-based starting index.</param>
+        /// <param name="limit">The maximum number of items to return.</param>
+        /// <param name="fields">The fields to include in the items.</param>
+        /// <returns></returns>
+        Task<List<TItem>> GetItemsAsync(int start, int? limit, params string[] fields);
+    }
+
+    /// <summary>
+    /// Cursor for retrieving items.
+    /// </summary>
+    /// <typeparam name="TItem">Cursor's item type.</typeparam>
+    public abstract class Cursor<TItem> : ICursor<TItem>
     {
         private readonly ApiObject _apiObject;
 
@@ -17,6 +117,8 @@ namespace EncompassRest
         /// The <see cref="EncompassRestClient"/> associated with the cursor.
         /// </summary>
         public EncompassRestClient Client { get; }
+
+        IEncompassRestClient IApiObject.Client => Client;
 
         /// <summary>
         /// The cursor id.

--- a/src/EncompassRest/CustomDataObjects/CustomDataObjects.cs
+++ b/src/EncompassRest/CustomDataObjects/CustomDataObjects.cs
@@ -8,7 +8,89 @@ namespace EncompassRest.CustomDataObjects
     /// <summary>
     /// Base Custom Data Objects Apis.
     /// </summary>
-    public abstract class CustomDataObjects : ApiObject
+    public interface ICustomDataObjects : IApiObject
+    {
+        /// <summary>
+        /// Updates the specified custom data object. This call adds the data provided in the body to the end of the dataObject.
+        /// </summary>
+        /// <param name="cdo">The custom data object to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AppendToCustomDataObjectAsync(CustomDataObject cdo, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified custom data object. This call adds the data provided in the body to the end of the dataObject. Optionally populates the custom data object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="cdo">The custom data object to update.</param>
+        /// <param name="populate">Indicates if the custom data object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AppendToCustomDataObjectAsync(CustomDataObject cdo, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified custom data object from raw json. This call adds the data provided in the body to the end of the dataObject.
+        /// </summary>
+        /// <param name="objectName">Name of the custom data object to update.</param>
+        /// <param name="cdo">The custom data object to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> AppendToCustomDataObjectRawAsync(string objectName, string cdo, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates or replaces a custom data object.
+        /// </summary>
+        /// <param name="cdo">The custom data object to create or replace.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CreateOrReplaceCustomDataObjectAsync(CustomDataObject cdo, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates or replaces a custom data object from raw json.
+        /// </summary>
+        /// <param name="objectName">Name to assign to the custom data object. Or, the name of an existing custom data object to replace.</param>
+        /// <param name="cdo">The custom data object to create or replace as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateOrReplaceCustomDataObjectRawAsync(string objectName, string cdo, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Removes a custom data object.
+        /// </summary>
+        /// <param name="objectName">Name of the custom data object to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the contents of a custom data object. Contents are retrieved as a Base64 string.
+        /// </summary>
+        /// <param name="objectName">The name of the custom data object to retrieve.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<CustomDataObject> GetCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the contents of a custom data object as raw json. Contents are retrieved as a Base64 string.
+        /// </summary>
+        /// <param name="objectName">The name of the custom data object to retrieve.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCustomDataObjectRawAsync(string objectName, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Provides a list of names of custom data objects.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<string>> GetCustomDataObjectsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Provides a list of names of custom data objects as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCustomDataObjectsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Base Custom Data Objects Apis.
+    /// </summary>
+    public abstract class CustomDataObjects : ApiObject, ICustomDataObjects
     {
         internal CustomDataObjects(EncompassRestClient client, string baseApiPath)
             : base(client, baseApiPath)

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -17,7 +17,111 @@ namespace EncompassRest
     /// <summary>
     /// The client object to make calls to the Encompass Apis. Use the static factory Create* methods to create a client object.
     /// </summary>
-    public sealed class EncompassRestClient : IDisposable
+    public interface IEncompassRestClient : IDisposable
+    {
+        /// <summary>
+        /// The access token and related Apis.
+        /// </summary>
+        IAccessToken AccessToken { get; }
+        /// <summary>
+        /// A base Api client for use when Apis aren't supported directly.
+        /// </summary>
+        IBaseApiClient BaseApiClient { get; }
+        /// <summary>
+        /// The Loan Batch Update Apis.
+        /// </summary>
+        IBatchUpdate BatchUpdate { get; }
+        /// <summary>
+        /// The Borrower Contacts Apis.
+        /// </summary>
+        IBorrowerContacts BorrowerContacts { get; }
+        /// <summary>
+        /// The Borrower Contact Selector Apis.
+        /// </summary>
+        IBorrowerContactSelector BorrowerContactSelector { get; }
+        /// <summary>
+        /// The Business Contacts Apis.
+        /// </summary>
+        IBusinessContacts BusinessContacts { get; }
+        /// <summary>
+        /// The Business Contact Selector Apis.
+        /// </summary>
+        IBusinessContactSelector BusinessContactSelector { get; }
+        /// <summary>
+        /// The Calculators Apis.
+        /// </summary>
+        Calculators.ICalculators Calculators { get; }
+        /// <summary>
+        /// The Company Apis.
+        /// </summary>
+        Company.ICompany Company { get; }
+        /// <summary>
+        /// The Contact Groups Apis.
+        /// </summary>
+        IContactGroups ContactGroups { get; }
+        /// <summary>
+        /// The Loan Folders Apis.
+        /// </summary>
+        LoanFolders.ILoanFolders LoanFolders { get; }
+        /// <summary>
+        /// The Loans Apis.
+        /// </summary>
+        Loans.ILoans Loans { get; }
+        /// <summary>
+        /// The Organizations Apis.
+        /// </summary>
+        Organizations.IOrganizations Organizations { get; }
+        /// <summary>
+        /// The Loan Pipeline Apis.
+        /// </summary>
+        IPipeline Pipeline { get; }
+        /// <summary>
+        /// The Schema Apis.
+        /// </summary>
+        Schema.ISchema Schema { get; }
+        /// <summary>
+        /// The Services Apis.
+        /// </summary>
+        Services.IServices Services { get; }
+        /// <summary>
+        /// The Settings Apis.
+        /// </summary>
+        Settings.ISettings Settings { get; }
+        /// <summary>
+        /// The time span before Api requests are considered timed-out. Default is 100 seconds.
+        /// </summary>
+        TimeSpan Timeout { get; }
+        /// <summary>
+        /// The number of times to retry requests when there's a gateway timeout. Default is 0.
+        /// </summary>
+        int TimeoutRetryCount { get; set; }
+        /// <summary>
+        /// Indicates how an expired token is handled by the client.
+        /// </summary>
+        TokenExpirationHandling TokenExpirationHandling { get; }
+        /// <summary>
+        /// Specifies how the client should handle undefined custom fields.
+        /// </summary>
+        UndefinedCustomFieldHandling UndefinedCustomFieldHandling { get; set; }
+        /// <summary>
+        /// The Webhook Apis.
+        /// </summary>
+        Webhook.IWebhook Webhook { get; }
+
+        /// <summary>
+        /// An event that occurs when an Api response is received.
+        /// </summary>
+        event EventHandler<ApiResponseEventArgs> ApiResponse;
+        /// <summary>
+        /// An event that occurs before attempting to retry a request when there's a gateway timeout.
+        /// </summary>
+        event EventHandler<TimeoutRetryEventArgs> TimeoutRetry;
+    }
+
+    /// <summary>
+    /// The client object to make calls to the Encompass Apis. Use the static factory Create* methods to create a client object.
+    /// </summary>
+    public sealed class EncompassRestClient : IEncompassRestClient
     {
 #if NET45
         static EncompassRestClient()
@@ -171,6 +275,8 @@ namespace EncompassRest
         /// </summary>
         public AccessToken AccessToken { get; }
 
+        IAccessToken IEncompassRestClient.AccessToken => AccessToken;
+
         /// <summary>
         /// Indicates how an expired token is handled by the client.
         /// </summary>
@@ -218,6 +324,8 @@ namespace EncompassRest
             }
         }
 
+        Loans.ILoans IEncompassRestClient.Loans => Loans;
+
         /// <summary>
         /// The Schema Apis.
         /// </summary>
@@ -229,6 +337,8 @@ namespace EncompassRest
                 return schema ?? Interlocked.CompareExchange(ref _schema, (schema = new Schema.Schema(this)), null) ?? schema;
             }
         }
+
+        Schema.ISchema IEncompassRestClient.Schema => Schema;
 
         /// <summary>
         /// The Webhook Apis.
@@ -242,6 +352,8 @@ namespace EncompassRest
             }
         }
 
+        Webhook.IWebhook IEncompassRestClient.Webhook => Webhook;
+
         /// <summary>
         /// The Loan Pipeline Apis.
         /// </summary>
@@ -253,6 +365,8 @@ namespace EncompassRest
                 return pipeline ?? Interlocked.CompareExchange(ref _pipeline, (pipeline = new Pipeline(this)), null) ?? pipeline;
             }
         }
+
+        IPipeline IEncompassRestClient.Pipeline => Pipeline;
 
         /// <summary>
         /// The Loan Batch Update Apis.
@@ -266,6 +380,8 @@ namespace EncompassRest
             }
         }
 
+        IBatchUpdate IEncompassRestClient.BatchUpdate => BatchUpdate;
+
         /// <summary>
         /// The Borrower Contacts Apis.
         /// </summary>
@@ -277,6 +393,8 @@ namespace EncompassRest
                 return borrowerContacts ?? Interlocked.CompareExchange(ref _borrowerContacts, (borrowerContacts = new BorrowerContacts(this)), null) ?? borrowerContacts;
             }
         }
+
+        IBorrowerContacts IEncompassRestClient.BorrowerContacts => BorrowerContacts;
 
         /// <summary>
         /// The Business Contacts Apis.
@@ -290,6 +408,8 @@ namespace EncompassRest
             }
         }
 
+        IBusinessContacts IEncompassRestClient.BusinessContacts => BusinessContacts;
+
         /// <summary>
         /// The Borrower Contact Selector Apis.
         /// </summary>
@@ -301,6 +421,8 @@ namespace EncompassRest
                 return borrowerContactSelector ?? Interlocked.CompareExchange(ref _borrowerContactSelector, (borrowerContactSelector = new BorrowerContactSelector(this)), null) ?? borrowerContactSelector;
             }
         }
+
+        IBorrowerContactSelector IEncompassRestClient.BorrowerContactSelector => BorrowerContactSelector;
 
         /// <summary>
         /// The Business Contact Selector Apis.
@@ -314,6 +436,8 @@ namespace EncompassRest
             }
         }
 
+        IBusinessContactSelector IEncompassRestClient.BusinessContactSelector => BusinessContactSelector;
+
         /// <summary>
         /// The Contact Groups Apis.
         /// </summary>
@@ -325,6 +449,8 @@ namespace EncompassRest
                 return contactGroups ?? Interlocked.CompareExchange(ref _contactGroups, (contactGroups = new ContactGroups(this)), null) ?? contactGroups;
             }
         }
+
+        IContactGroups IEncompassRestClient.ContactGroups => ContactGroups;
 
         internal ResourceLocks.ResourceLocks ResourceLocks
         {
@@ -371,6 +497,8 @@ namespace EncompassRest
             }
         }
 
+        LoanFolders.ILoanFolders IEncompassRestClient.LoanFolders => LoanFolders;
+
         /// <summary>
         /// The Settings Apis.
         /// </summary>
@@ -382,6 +510,8 @@ namespace EncompassRest
                 return settings ?? Interlocked.CompareExchange(ref _settings, (settings = new Settings.Settings(this)), null) ?? settings;
             }
         }
+
+        Settings.ISettings IEncompassRestClient.Settings => Settings;
 
         /// <summary>
         /// The Services Apis.
@@ -395,6 +525,8 @@ namespace EncompassRest
             }
         }
 
+        Services.IServices IEncompassRestClient.Services => Services;
+
         /// <summary>
         /// The Company Apis.
         /// </summary>
@@ -406,6 +538,8 @@ namespace EncompassRest
                 return company ?? Interlocked.CompareExchange(ref _company, (company = new Company.Company(this)), null) ?? company;
             }
         }
+
+        Company.ICompany IEncompassRestClient.Company => Company;
 
         /// <summary>
         /// The Organizations Apis.
@@ -419,6 +553,8 @@ namespace EncompassRest
             }
         }
 
+        Organizations.IOrganizations IEncompassRestClient.Organizations => Organizations;
+
         /// <summary>
         /// The Calculators Apis.
         /// </summary>
@@ -430,6 +566,8 @@ namespace EncompassRest
                 return calculators ?? Interlocked.CompareExchange(ref _calculators, (calculators = new Calculators.Calculators(this)), null) ?? calculators;
             }
         }
+
+        Calculators.ICalculators IEncompassRestClient.Calculators => Calculators;
 
         /// <summary>
         /// Property for sharing common cache between multiple clients such as custom field descriptors.
@@ -465,6 +603,8 @@ namespace EncompassRest
                 return baseApiClient ?? Interlocked.CompareExchange(ref _baseApiClient, (baseApiClient = new BaseApiClient(this)), null) ?? baseApiClient;
             }
         }
+
+        IBaseApiClient IEncompassRestClient.BaseApiClient => BaseApiClient;
         #endregion
 
         /// <summary>

--- a/src/EncompassRest/LoanBatch/BatchUpdate.cs
+++ b/src/EncompassRest/LoanBatch/BatchUpdate.cs
@@ -7,7 +7,44 @@ namespace EncompassRest.LoanBatch
     /// <summary>
     /// The Loan Batch Update Apis.
     /// </summary>
-    public sealed class BatchUpdate : ApiObject
+    public interface IBatchUpdate : IApiObject
+    {
+        /// <summary>
+        /// Retrieves the status for the loan batch update with <paramref name="requestId"/>.
+        /// </summary>
+        /// <param name="requestId">The loan batch update request id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<BatchUpdateStatus> GetStatusAsync(string requestId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the status for the loan batch update with <paramref name="requestId"/> as raw json.
+        /// </summary>
+        /// <param name="requestId">The loan batch update request id.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetStatusRawAsync(string requestId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Submits a batch request to the server to update multiple loans and returns the batch update request id.
+        /// </summary>
+        /// <param name="parameters">The batch update parameters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateLoansAsync(BatchUpdateParameters parameters, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Submits a batch request to the server to update multiple loans from raw json and returns the batch update request id.
+        /// </summary>
+        /// <param name="parameters">The batch update parameters as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateLoansRawAsync(string parameters, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Batch Update Apis.
+    /// </summary>
+    public sealed class BatchUpdate : ApiObject, IBatchUpdate
     {
         internal BatchUpdate(EncompassRestClient client)
             : base(client, "encompass/v1/loanBatch/updateRequests")

--- a/src/EncompassRest/LoanFolders/LoanFolders.cs
+++ b/src/EncompassRest/LoanFolders/LoanFolders.cs
@@ -8,7 +8,22 @@ namespace EncompassRest.LoanFolders
     /// <summary>
     /// The Loan Folders Apis.
     /// </summary>
-    public sealed class LoanFolders : ApiObject
+    public interface ILoanFolders : IApiObject
+    {
+        /// <summary>
+        /// Move a loan from one folder to another folder.
+        /// </summary>
+        /// <param name="loanId">The id of the loan to move.</param>
+        /// <param name="loanFolder">The name of the target folder in which to move the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task MoveLoanToFolderAsync(string loanId, string loanFolder, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Folders Apis.
+    /// </summary>
+    public sealed class LoanFolders : ApiObject, ILoanFolders
     {
         internal LoanFolders(EncompassRestClient client)
             : base(client, "encompass/v1/loanfolders")

--- a/src/EncompassRest/LoanPipeline/LoanPipelineCursor.cs
+++ b/src/EncompassRest/LoanPipeline/LoanPipelineCursor.cs
@@ -5,7 +5,14 @@ namespace EncompassRest.LoanPipeline
     /// <summary>
     /// Loan pipeline cursor.
     /// </summary>
-    public sealed class LoanPipelineCursor : Cursor<LoanPipelineData>
+    public interface ILoanPipelineCursor : ICursor<LoanPipelineData>
+    {
+    }
+
+    /// <summary>
+    /// Loan pipeline cursor.
+    /// </summary>
+    public sealed class LoanPipelineCursor : Cursor<LoanPipelineData>, ILoanPipelineCursor
     {
         internal LoanPipelineCursor(EncompassRestClient client, string cursorId, int count, IEnumerable<string> fields)
             : base(client.Pipeline, client, cursorId, count, fields)

--- a/src/EncompassRest/LoanPipeline/Pipeline.cs
+++ b/src/EncompassRest/LoanPipeline/Pipeline.cs
@@ -9,7 +9,82 @@ namespace EncompassRest.LoanPipeline
     /// <summary>
     /// The Loan Pipeline Apis.
     /// </summary>
-    public sealed class Pipeline : ApiObject
+    public interface IPipeline : IApiObject
+    {
+        /// <summary>
+        /// Creates a cursor to paginate large data sets.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ILoanPipelineCursor> CreateCursorAsync(PipelineParameters parameters, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a cursor to paginate large data sets.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include.</param>
+        /// <param name="ignoreInvalidFields">Ignores the invalid fields specified in the request body if set to <c>true</c>, else will return an error with list of invalid fields.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ILoanPipelineCursor> CreateCursorAsync(PipelineParameters parameters, bool? ignoreInvalidFields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of descriptive field definitions for all canonical field names represented in the Encompass Pipeline. Canonical field names are used to view the Pipeline and perform batch loan updates.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<PipelineCanonicalNames> GetCanonicalNamesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of descriptive field definitions for all canonical field names represented in the Encompass Pipeline as raw json. Canonical field names are used to view the Pipeline and perform batch loan updates.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCanonicalNamesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves loan IDs (GUIDs) and specified fields from loans on the Pipeline.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanPipelineData>> ViewPipelineAsync(PipelineParameters parameters, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves loan IDs (GUIDs) and specified fields from loans on the Pipeline.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include.</param>
+        /// <param name="ignoreInvalidFields">Ignores the invalid fields specified in the request body if set to <c>true</c>, else will return an error with list of invalid fields.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanPipelineData>> ViewPipelineAsync(PipelineParameters parameters, bool? ignoreInvalidFields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves loan IDs (GUIDs) and specified fields from loans on the Pipeline.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include.</param>
+        /// <param name="limit">The maximum number of items to return. If not specified, the default limit is set to 1000. The maximum limit is 25k.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanPipelineData>> ViewPipelineAsync(PipelineParameters parameters, int? limit, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves loan IDs (GUIDs) and specified fields from loans on the Pipeline.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include.</param>
+        /// <param name="limit">The maximum number of items to return. If not specified, the default limit is set to 1000. The maximum limit is 25k.</param>
+        /// <param name="ignoreInvalidFields">Ignores the invalid fields specified in the request body if set to <c>true</c>, else will return an error with list of invalid fields.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanPipelineData>> ViewPipelineAsync(PipelineParameters parameters, int? limit, bool? ignoreInvalidFields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves loan IDs (GUIDs) and specified fields from loans on the Pipeline as raw json.
+        /// </summary>
+        /// <param name="parameters">The pipeline parameters used to specify the loans and fields to include as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> ViewPipelineRawAsync(string parameters, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Pipeline Apis.
+    /// </summary>
+    public sealed class Pipeline : ApiObject, IPipeline
     {
         internal Pipeline(EncompassRestClient client)
             : base(client, "encompass/v1/loanPipeline")
@@ -85,6 +160,10 @@ namespace EncompassRest.LoanPipeline
                 return new LoanPipelineCursor(Client, cursorId, count, parameters.Fields);
             });
         }
+
+        Task<ILoanPipelineCursor> IPipeline.CreateCursorAsync(PipelineParameters parameters, CancellationToken cancellationToken) => ((IPipeline)this).CreateCursorAsync(parameters, null, cancellationToken);
+
+        async Task<ILoanPipelineCursor> IPipeline.CreateCursorAsync(PipelineParameters parameters, bool? ignoreInvalidFields, CancellationToken cancellationToken) => await CreateCursorAsync(parameters, ignoreInvalidFields, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Retrieves loan IDs (GUIDs) and specified fields from loans on the Pipeline.

--- a/src/EncompassRest/Loans/Apis/BorrowerPairs.cs
+++ b/src/EncompassRest/Loans/Apis/BorrowerPairs.cs
@@ -10,7 +10,95 @@ namespace EncompassRest.Loans.Apis
     /// <summary>
     /// The Loan Borrower Pairs Apis.
     /// </summary>
-    public sealed class BorrowerPairs : LoanApiObject<Application>
+    public interface IBorrowerPairs : ILoanApiObject
+    {
+        /// <summary>
+        /// Creates a new borrower pair for the loan and returns the application id.
+        /// </summary>
+        /// <param name="application">The borrower pair to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateBorrowerPairAsync(Application application, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new borrower pair for the loan from raw json and returns the response body if not empty or else the application id.
+        /// </summary>
+        /// <param name="application">The borrower pair to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateBorrowerPairRawAsync(string application, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently deletes the borrower pair with the specified <paramref name="applicationId"/> from the loan.
+        /// </summary>
+        /// <param name="applicationId">The application id of the borrower pair to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the loan's borrower pair with the specified <paramref name="applicationId"/>.
+        /// </summary>
+        /// <param name="applicationId">The application id of the borrower pair to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Application> GetBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the loan's borrower pair with the specified <paramref name="applicationId"/>.
+        /// </summary>
+        /// <param name="applicationId">The application id of the borrower pair to get.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetBorrowerPairRawAsync(string applicationId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all borrower pairs for the loan.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<IList<Application>> GetBorrowerPairsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all borrower pairs for the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetBorrowerPairsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Swaps the position of borrower pairs in the loan. Note that the <see cref="Borrower.AltId"/> of the borrower and co-borrower do not change on the applications.
+        /// </summary>
+        /// <param name="applications">The applications to swap.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task MoveBorrowerPairsAsync(IList<Application> applications, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Swaps the position of borrower pairs in the loan from raw json. Note that the altIds of the borrower and co-borrower do not change on the applications.
+        /// </summary>
+        /// <param name="applications">The applications to swap as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task MoveBorrowerPairsRawAsync(string applications, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates an existing borrower pair for the loan.
+        /// </summary>
+        /// <param name="application">The borrower pair to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateBorrowerPairAsync(Application application, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates an existing borrower pair for the loan from raw json.
+        /// </summary>
+        /// <param name="applicationId">The application id of the borrower pair to update.</param>
+        /// <param name="application">The borrower pair to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateBorrowerPairRawAsync(string applicationId, string application, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Borrower Pairs Apis.
+    /// </summary>
+    public sealed class BorrowerPairs : LoanApiObject<Application>, IBorrowerPairs
     {
         internal BorrowerPairs(EncompassRestClient client, LoanObjectBoundApis loanObjectBoundApis, string loanId)
             : base(client, loanObjectBoundApis, loanId, "applications")

--- a/src/EncompassRest/Loans/Associates/LoanAssociates.cs
+++ b/src/EncompassRest/Loans/Associates/LoanAssociates.cs
@@ -9,7 +9,74 @@ namespace EncompassRest.Loans.Associates
     /// <summary>
     /// The Loan Associates Apis.
     /// </summary>
-    public sealed class LoanAssociates : LoanApiObject
+    public interface ILoanAssociates : ILoanApiObject
+    {
+        /// <summary>
+        /// Assigns a loan associate to a milestone based on the specified milestone or milestone-free ID and log ID.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="associate">The loan associate to assign.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignAssociateAsync(string logId, LoanAssociate associate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Assigns a loan associate to a milestone based on the specified milestone or milestone-free ID and log ID from raw json.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="associate">The loan associate to assign as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignAssociateRawAsync(string logId, string associate, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves information about a loan associate based on the milestone or milestone-free role ID. The response includes the associate's role and contact information.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanAssociate> GetAssociateAsync(string logId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves information about a loan associate based on the milestone or milestone-free role ID as raw json.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetAssociateRawAsync(string logId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of loan associates involved with the loan. The response includes role and contact information for each loan associate.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanAssociate>> GetAssociatesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of loan associates involved with the loan. The response includes role and contact information for each loan associate.
+        /// </summary>
+        /// <param name="userId">When provided, returns information about the Encompass user associated with the loan.</param>
+        /// <param name="roleId">When provided, returns information about all Encompass users associated with the specified role ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanAssociate>> GetAssociatesAsync(string userId, string roleId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of loan associates involved with the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetAssociatesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Unassigns a loan associate from a milestone based on the specified milestone or milestone-free ID.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> UnassignAssociateAsync(string logId, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Associates Apis.
+    /// </summary>
+    public sealed class LoanAssociates : LoanApiObject, ILoanAssociates
     {
         internal LoanAssociates(EncompassRestClient client, string loanId)
             : base(client, loanId, "associates")

--- a/src/EncompassRest/Loans/Attachments/LoanAttachments.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachments.cs
@@ -11,7 +11,235 @@ namespace EncompassRest.Loans.Attachments
     /// <summary>
     /// The Loan Attachments Apis.
     /// </summary>
-    public sealed class LoanAttachments : LoanApiObject
+    public interface ILoanAttachments : ILoanApiObject
+    {
+        /// <summary>
+        /// Downloads the attachment's file contents as a byte array by first getting the download url and then getting the file contents.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<byte[]> DownloadAttachmentAsync(string attachmentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Downloads the attachment page's contents as a byte array by first getting the download url and then getting the page's contents.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<byte[]> DownloadAttachmentPageAsync(string attachmentId, string pageId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Downloads the attachment page's contents as a stream by first getting the download url and then getting the page's contents.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Stream> DownloadAttachmentPageStreamAsync(string attachmentId, string pageId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Downloads the attachment page's thumbnail image as a byte array by first getting the download url and then getting the thumbnail's contents.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<byte[]> DownloadAttachmentPageThumbnailAsync(string attachmentId, string pageId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Downloads the attachment page's thumbnail image as a stream by first getting the download url and then getting the thumbnail's contents.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Stream> DownloadAttachmentPageThumbnailStreamAsync(string attachmentId, string pageId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Downloads the attachment's file contents as a stream by first getting the download url and then getting the file contents.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Stream> DownloadAttachmentStreamAsync(string attachmentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves properties for the file attachment with the specified <paramref name="attachmentId"/>.
+        /// </summary>
+        /// <param name="attachmentId">The unique identifier assigned to the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanAttachment> GetAttachmentAsync(string attachmentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves properties for the file attachment with the specified <paramref name="attachmentId"/> and optionally generates the <see cref="LoanAttachment.MediaUrl"/> for use in downloading the attachment.
+        /// </summary>
+        /// <param name="attachmentId">The unique identifier assigned to the attachment.</param>
+        /// <param name="generateUrl">When set to <c>true</c>, returns the mediaURL of the attachment in the response.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanAttachment> GetAttachmentAsync(string attachmentId, bool? generateUrl, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves properties for the file attachment with the specified <paramref name="attachmentId"/> as raw json.
+        /// </summary>
+        /// <param name="attachmentId">The unique identifier assigned to the attachment.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetAttachmentRawAsync(string attachmentId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of files attached to the loan. The response includes all properties for all assigned and unassigned file attachments.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanAttachment>> GetAttachmentsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of files attached to the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetAttachmentsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL of a thumbnail image for a specified page within an attachment.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<MediaUrlObject> GetDownloadAttachmentPageThumbnailUrlAsync(string attachmentId, string pageId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL of a thumbnail image for a specified page within an attachment as raw json.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetDownloadAttachmentPageThumbnailUrlRawAsync(string attachmentId, string pageId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL of a page within an attachment. This can be used for attachments with ids that are in GUID format.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<MediaUrlObject> GetDownloadAttachmentPageUrlAsync(string attachmentId, string pageId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL of a page within an attachment as raw json. This can be used for attachments with ids that are in GUID format.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment post Conversion. Accepted attachmentId is in the form of "99505941-3024-4b6f-972b-dad936fddbd0". Native attachmentID will not be accepted for this API.</param>
+        /// <param name="pageId">Unique identifier assigned to the page within the attachment.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetDownloadAttachmentPageUrlRawAsync(string attachmentId, string pageId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL for native attachment for a file in the eFolder. The attachment URL is the full URL where the attachment is located in the eFolder. Getting the attachment URL is the first step in retrieving an attachment from the eFolder. This API supports attachment ids that are in the native format. E.g. Attachment-97f0f34d-7194-4e45-941f-e680dcea91c1.txt.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<MediaUrlObject> GetDownloadAttachmentUrlAsync(string attachmentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL for native attachment for a file in the eFolder as raw json. The attachment URL is the full URL where the attachment is located in the eFolder. Getting the attachment URL is the first step in retrieving an attachment from the eFolder. This API supports attachment ids that are in the native format. E.g. Attachment-97f0f34d-7194-4e45-941f-e680dcea91c1.txt.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetDownloadAttachmentUrlRawAsync(string attachmentId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL for uploading an attachment. This URL is time sensitive. It must be invoked as a PUT with the attachment converted to a byteStream within the request body.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<MediaUrlObject> GetUploadAttachmentUrlAsync(LoanAttachment attachment, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the URL for uploading an attachment as raw json. This URL is time sensitive. It must be invoked as a PUT with the attachment converted to a byteStream within the request body.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload as json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetUploadAttachmentUrlRawAsync(string attachment, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates properties for a specified file attachment.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateAttachmentAsync(LoanAttachment attachment, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates properties for a specified file attachment and optionally populates the attachment object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to update.</param>
+        /// <param name="populate">Indicates if the attachment object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateAttachmentAsync(LoanAttachment attachment, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates properties for a specified file attachment from raw json.
+        /// </summary>
+        /// <param name="attachmentId">Unique identifier assigned to the attachment.</param>
+        /// <param name="attachment">The attachment properties to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateAttachmentRawAsync(string attachmentId, string attachment, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Uploads the attachment and it's data to the loan and returns the uploaded attachment's id.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload.</param>
+        /// <param name="attachmentData">The attachment data to upload.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UploadAttachmentAsync(LoanAttachment attachment, byte[] attachmentData, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Uploads the attachment and it's data to the loan and returns the uploaded attachment's id and optionally populates the attachment object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload.</param>
+        /// <param name="attachmentData">The attachment data to upload.</param>
+        /// <param name="populate">Indicates if the loan object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UploadAttachmentAsync(LoanAttachment attachment, byte[] attachmentData, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Uploads the attachment and it's data to the loan and returns the uploaded attachment's id.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload.</param>
+        /// <param name="attachmentData">The attachment data to upload.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        Task<string> UploadAttachmentAsync(LoanAttachment attachment, Stream attachmentData, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Uploads the attachment and it's data to the loan and returns the uploaded attachment's id and optionally populates the attachment object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload.</param>
+        /// <param name="attachmentData">The attachment data to upload.</param>
+        /// <param name="populate">Indicates if the loan object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UploadAttachmentAsync(LoanAttachment attachment, Stream attachmentData, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Uploads the attachment and it's data to the loan from raw json and returns the response body if not empty else the uploaded attachment's id.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload as raw json.</param>
+        /// <param name="attachmentData">The attachment data to upload.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UploadAttachmentRawAsync(string attachment, byte[] attachmentData, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Uploads the attachment and it's data to the loan from raw json and returns the response body if not empty else the uploaded attachment's id.
+        /// </summary>
+        /// <param name="attachment">The attachment properties to upload as raw json.</param>
+        /// <param name="attachmentData">The attachment data to upload.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UploadAttachmentRawAsync(string attachment, Stream attachmentData, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Attachments Apis.
+    /// </summary>
+    public sealed class LoanAttachments : LoanApiObject, ILoanAttachments
     {
         internal LoanAttachments(EncompassRestClient client, string loanId)
             : base(client, loanId, "attachments")

--- a/src/EncompassRest/Loans/Conditions/LoanConditions.cs
+++ b/src/EncompassRest/Loans/Conditions/LoanConditions.cs
@@ -10,7 +10,26 @@ namespace EncompassRest.Loans.Conditions
     /// <summary>
     /// The Loan Conditions Apis.
     /// </summary>
-    public sealed class LoanConditions : LoanApiObject
+    public interface ILoanConditions : ILoanApiObject
+    {
+        /// <summary>
+        /// The Loan PostClosing Conditions Apis.
+        /// </summary>
+        ILoanPostClosingConditions PostClosing { get; }
+        /// <summary>
+        /// The Loan Preliminary Conditions Apis.
+        /// </summary>
+        ILoanPreliminaryConditions Preliminary { get; }
+        /// <summary>
+        /// The Loan Underwriting Conditions Apis.
+        /// </summary>
+        ILoanUnderwritingConditions Underwriting { get; }
+    }
+
+    /// <summary>
+    /// The Loan Conditions Apis.
+    /// </summary>
+    public sealed class LoanConditions : LoanApiObject, ILoanConditions
     {
         private LoanUnderwritingConditions _underwriting;
         private LoanPreliminaryConditions _preliminary;
@@ -21,15 +40,21 @@ namespace EncompassRest.Loans.Conditions
         /// </summary>
         public LoanUnderwritingConditions Underwriting => _underwriting ?? (_underwriting = new LoanUnderwritingConditions(Client, LoanId));
 
+        ILoanUnderwritingConditions ILoanConditions.Underwriting => Underwriting;
+
         /// <summary>
         /// The Loan Preliminary Conditions Apis.
         /// </summary>
         public LoanPreliminaryConditions Preliminary => _preliminary ?? (_preliminary = new LoanPreliminaryConditions(Client, LoanId));
 
+        ILoanPreliminaryConditions ILoanConditions.Preliminary => Preliminary;
+
         /// <summary>
         /// The Loan PostClosing Conditions Apis.
         /// </summary>
         public LoanPostClosingConditions PostClosing => _postClosing ?? (_postClosing = new LoanPostClosingConditions(Client, LoanId));
+
+        ILoanPostClosingConditions ILoanConditions.PostClosing => PostClosing;
 
         internal LoanConditions(EncompassRestClient client, string loanId)
             : base(client, loanId, "conditions")
@@ -38,10 +63,177 @@ namespace EncompassRest.Loans.Conditions
     }
 
     /// <summary>
+    /// The Base Loan Conditions Apis Interface.
+    /// </summary>
+    /// <typeparam name="TCondition"></typeparam>
+    public interface ILoanConditions<TCondition> : ILoanApiObject
+        where TCondition : LoanCondition
+    {
+        /// <summary>
+        /// Assigns or unassigns documents from the specified condition.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to assign or unassign documents.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <param name="documents">The documents to assign or unassign.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignConditionDocumentsAsync(string conditionId, AssignmentAction action, IEnumerable<EntityReference> documents, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Assigns or unassigns documents from the specified condition.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to assign or unassign documents.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <param name="documents">The documents to assign or unassign.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignConditionDocumentsAsync(string conditionId, string action, IEnumerable<EntityReference> documents, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a condition for the loan and returns the id of the condition created.
+        /// </summary>
+        /// <param name="condition">The condition to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateConditionAsync(TCondition condition, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a condion for the loan and returns the id of the condition created and optionally populates the condition object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="condition">The condition to create.</param>
+        /// <param name="populate">Indicates if the condition object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateConditionAsync(TCondition condition, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates multiple comments for the loan condition.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to add comments.</param>
+        /// <param name="comments">The condition comments to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CreateConditionCommentsAsync(string conditionId, IEnumerable<Comment> comments, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates multiple comments for the loan condition and optionally populates the comment objects with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to add comments.</param>
+        /// <param name="comments">The condition comments to create.</param>
+        /// <param name="populate">Indicates if the comment objects should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CreateConditionCommentsAsync(string conditionId, IEnumerable<Comment> comments, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a condition for the loan from raw json and returns the response's body if not empty else the id of the condition created.
+        /// </summary>
+        /// <param name="condition">The condition to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateConditionRawAsync(string condition, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates multiple conditions for the loan.
+        /// </summary>
+        /// <param name="conditions">The conditions to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CreateConditionsAsync(IEnumerable<TCondition> conditions, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates multiple conditions for the loan and optionally populates the condition objects with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="conditions">The conditions to create.</param>
+        /// <param name="populate">Indicates if the condition objects should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task CreateConditionsAsync(IEnumerable<TCondition> conditions, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Deletes multiple condition comments from the loan.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to remove comments.</param>
+        /// <param name="commentIds">The ids of the condition comments to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteConditionCommentsAsync(string conditionId, IEnumerable<string> commentIds, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Deletes multiple conditions from the loan.
+        /// </summary>
+        /// <param name="conditionIds">The ids of the conditions to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteConditionsAsync(IEnumerable<string> conditionIds, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the condition with the specified <paramref name="conditionId"/> for the loan.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TCondition> GetConditionAsync(string conditionId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the condition with the specified <paramref name="conditionId"/> for the loan as raw json.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetConditionRawAsync(string conditionId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets conditions for the loan.
+        /// </summary>
+        /// <param name="queryParameters">The condition query parameters to sent in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<TCondition>> GetConditionsAsync(ConditionQueryParameters queryParameters = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets conditions for the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetConditionsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Manages multiple condition comments from raw json.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to add or remove comments.</param>
+        /// <param name="content">The content as raw json to send.</param>
+        /// <param name="queryString">The query string to include in the request. Must include an action parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> ManageConditionCommentsRawAsync(string conditionId, string content, string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Manages multiple condition documents from raw json.
+        /// </summary>
+        /// <param name="conditionId">The unique identifier assigned to the condition for which to assign or unassign documents.</param>
+        /// <param name="documents">The documents to assign or unassign.</param>
+        /// <param name="queryString">The query string to include in the request. Must include an action parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> ManageConditionDocumentsRawAsync(string conditionId, string documents, string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Manages multiple conditions from raw json.
+        /// </summary>
+        /// <param name="content">The content as raw json to send.</param>
+        /// <param name="queryString">The query string to include in the request. Must include an action parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> ManageConditionsRawAsync(string content, string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates multiple conditions for the loan.
+        /// </summary>
+        /// <param name="conditions">The conditions to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateConditionsAsync(IEnumerable<TCondition> conditions, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates multiple conditions for the loan and optionally populates the condition objects with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="conditions">The conditions to update.</param>
+        /// <param name="populate">Indicates if the condition objects should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateConditionsAsync(IEnumerable<TCondition> conditions, bool populate, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
     /// The Base Loan Conditions Apis Class.
     /// </summary>
     /// <typeparam name="TCondition"></typeparam>
-    public abstract class LoanConditions<TCondition> : LoanApiObject
+    public abstract class LoanConditions<TCondition> : LoanApiObject, ILoanConditions<TCondition>
         where TCondition : LoanCondition
     {
         internal LoanConditions(EncompassRestClient client, string loanId, string baseApiPath)

--- a/src/EncompassRest/Loans/Conditions/LoanPostClosingConditions.cs
+++ b/src/EncompassRest/Loans/Conditions/LoanPostClosingConditions.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Loan PostClosing Conditions Apis.
     /// </summary>
-    public sealed class LoanPostClosingConditions : LoanConditions<PostClosingCondition>
+    public interface ILoanPostClosingConditions : ILoanConditions<PostClosingCondition>
+    {
+    }
+
+    /// <summary>
+    /// The Loan PostClosing Conditions Apis.
+    /// </summary>
+    public sealed class LoanPostClosingConditions : LoanConditions<PostClosingCondition>, ILoanPostClosingConditions
     {
         internal LoanPostClosingConditions(EncompassRestClient client, string loanId)
             : base(client, loanId, "postclosing")

--- a/src/EncompassRest/Loans/Conditions/LoanPreliminaryConditions.cs
+++ b/src/EncompassRest/Loans/Conditions/LoanPreliminaryConditions.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Loan Preliminary Conditions Apis.
     /// </summary>
-    public sealed class LoanPreliminaryConditions : LoanConditions<PreliminaryCondition>
+    public interface ILoanPreliminaryConditions : ILoanConditions<PreliminaryCondition>
+    {
+    }
+
+    /// <summary>
+    /// The Loan Preliminary Conditions Apis.
+    /// </summary>
+    public sealed class LoanPreliminaryConditions : LoanConditions<PreliminaryCondition>, ILoanPreliminaryConditions
     {
         internal LoanPreliminaryConditions(EncompassRestClient client, string loanId)
             : base(client, loanId, "preliminary")

--- a/src/EncompassRest/Loans/Conditions/LoanUnderwritingConditions.cs
+++ b/src/EncompassRest/Loans/Conditions/LoanUnderwritingConditions.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Loan Underwriting Conditions Apis.
     /// </summary>
-    public sealed class LoanUnderwritingConditions : LoanConditions<UnderwritingCondition>
+    public interface ILoanUnderwritingConditions : ILoanConditions<UnderwritingCondition>
+    {
+    }
+
+    /// <summary>
+    /// The Loan Underwriting Conditions Apis.
+    /// </summary>
+    public sealed class LoanUnderwritingConditions : LoanConditions<UnderwritingCondition>, ILoanUnderwritingConditions
     {
         internal LoanUnderwritingConditions(EncompassRestClient client, string loanId)
             : base(client, loanId, "underwriting")

--- a/src/EncompassRest/Loans/Documents/LoanDocuments.cs
+++ b/src/EncompassRest/Loans/Documents/LoanDocuments.cs
@@ -9,7 +9,131 @@ namespace EncompassRest.Loans.Documents
     /// <summary>
     /// The Loan Documents Apis.
     /// </summary>
-    public sealed class LoanDocuments : LoanApiObject
+    public interface ILoanDocuments : ILoanApiObject
+    {
+        /// <summary>
+        /// Assigns or unassigns attachments.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="action">The action to perform, assign or unassign.</param>
+        /// <param name="attachmentEntities">The attachment entity references to assign or unassign.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignDocumentAttachmentsAsync(string documentId, AssignmentAction action, IEnumerable<EntityReference> attachmentEntities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Assigns or unassigns attachments.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="action">The action to perform, assign or unassign.</param>
+        /// <param name="attachmentEntities">The attachment entity references to assign or unassign.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignDocumentAttachmentsAsync(string documentId, string action, IEnumerable<EntityReference> attachmentEntities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Assigns or unassigns attachments from raw json.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="attachmentEntities">The attachment entity references to assign or unassign as raw json.</param>
+        /// <param name="queryString">The query string to include in the request. This should include an action parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task AssignDocumentAttachmentsRawAsync(string documentId, string attachmentEntities, string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new document for the loan and returns the document ID.
+        /// </summary>
+        /// <param name="document">The document to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateDocumentAsync(LoanDocument document, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new document for the loan and returns the document ID and optionally populates the document object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="document">The document to create.</param>
+        /// <param name="populate">Indicates if the document object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateDocumentAsync(LoanDocument document, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new document for the loan from raw json and returns the response body if not empty else the document ID.
+        /// </summary>
+        /// <param name="document">The document to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateDocumentRawAsync(string document, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves properties for the specified eFolder document. The response includes roles that have access to the document, any comments applied to the document, and file attachment information.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanDocument> GetDocumentAsync(string documentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of file attachments for the document with the specified <paramref name="documentId"/>.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<EntityReference>> GetDocumentAttachmentsAsync(string documentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of file attachments for the document with the specified <paramref name="documentId"/> as raw json.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetDocumentAttachmentsRawAsync(string documentId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves properties for the specified eFolder document as raw json.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetDocumentRawAsync(string documentId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns all eFolder documents for the loan. The response includes a list of eFolder documents for the loan, roles that have access to the documents, and any comments applied to the documents.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanDocument>> GetDocumentsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns all eFolder documents for the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetDocumentsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates properties of the specified <paramref name="document"/>.
+        /// </summary>
+        /// <param name="document">The document to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateDocumentAsync(LoanDocument document, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates properties of the specified <paramref name="document"/> and optionally populates the document object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="document">The document to update.</param>
+        /// <param name="populate">Indicates if the document object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateDocumentAsync(LoanDocument document, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates properties of the document with the specified <paramref name="documentId"/> from raw json.
+        /// </summary>
+        /// <param name="documentId">The unique identifier assigned to the document.</param>
+        /// <param name="document">The document to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateDocumentRawAsync(string documentId, string document, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Documents Apis.
+    /// </summary>
+    public sealed class LoanDocuments : LoanApiObject, ILoanDocuments
     {
         internal LoanDocuments(EncompassRestClient client, string loanId)
             : base(client, loanId, "documents")

--- a/src/EncompassRest/Loans/FieldReader/LoanFieldReader.cs
+++ b/src/EncompassRest/Loans/FieldReader/LoanFieldReader.cs
@@ -8,7 +8,35 @@ namespace EncompassRest.Loans.FieldReader
     /// <summary>
     /// The Loan Field Reader Apis.
     /// </summary>
-    public sealed class LoanFieldReader : LoanApiObject
+    public interface ILoanFieldReader : ILoanApiObject
+    {
+        /// <summary>
+        /// Retrieve values for specific fields in a loan.
+        /// </summary>
+        /// <param name="fieldIds">Field IDs of the values you want to retrieve from the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanFieldValue>> GetLoanFieldValuesAsync(IEnumerable<string> fieldIds, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieve values for specific fields in a loan.
+        /// </summary>
+        /// <param name="fieldIds">Field IDs of the values you want to retrieve from the loan.</param>
+        /// <returns></returns>
+        Task<List<LoanFieldValue>> GetLoanFieldValuesAsync(params string[] fieldIds);
+        /// <summary>
+        /// Retrieve values for specific fields in a loan as raw json.
+        /// </summary>
+        /// <param name="fieldIds">Field IDs of the values you want to retrieve from the loan as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetLoanFieldValuesRawAsync(string fieldIds, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Field Reader Apis.
+    /// </summary>
+    public sealed class LoanFieldReader : LoanApiObject, ILoanFieldReader
     {
         internal LoanFieldReader(EncompassRestClient client, string loanId)
             : base(client, loanId, "fieldReader")

--- a/src/EncompassRest/Loans/LoanApiObject.cs
+++ b/src/EncompassRest/Loans/LoanApiObject.cs
@@ -6,9 +6,20 @@ using EncompassRest.Utilities;
 namespace EncompassRest.Loans
 {
     /// <summary>
+    /// Base Loan Api Interface.
+    /// </summary>
+    public interface ILoanApiObject : IApiObject
+    {
+        /// <summary>
+        /// The loan id associated with the Api.
+        /// </summary>
+        string LoanId { get; }
+    }
+
+    /// <summary>
     /// Base Loan Api Class.
     /// </summary>
-    public abstract class LoanApiObject : ApiObject
+    public abstract class LoanApiObject : ApiObject, ILoanApiObject
     {
         /// <summary>
         /// The loan id associated with the Api.

--- a/src/EncompassRest/Loans/LoanApis.cs
+++ b/src/EncompassRest/Loans/LoanApis.cs
@@ -17,7 +17,122 @@ namespace EncompassRest.Loans
     /// <summary>
     /// The Loan Apis.
     /// </summary>
-    public class LoanApis : LoanApiObject
+    public interface ILoanApis : ILoanApiObject
+    {
+        /// <summary>
+        /// The Loan Associates Apis.
+        /// </summary>
+        ILoanAssociates Associates { get; }
+        /// <summary>
+        /// The Loan Attachments Apis.
+        /// </summary>
+        ILoanAttachments Attachments { get; }
+        /// <summary>
+        /// The Loan Borrower Pairs Apis.
+        /// </summary>
+        IBorrowerPairs BorrowerPairs { get; }
+        /// <summary>
+        /// The Loan Conditions Apis.
+        /// </summary>
+        ILoanConditions Conditions { get; }
+        /// <summary>
+        /// The Loan Custom Data Objects Apis.
+        /// </summary>
+        ILoanCustomDataObjects CustomDataObjects { get; }
+        /// <summary>
+        /// The Loan Documents Apis.
+        /// </summary>
+        ILoanDocuments Documents { get; }
+        /// <summary>
+        /// The Loan Field Reader Apis.
+        /// </summary>
+        ILoanFieldReader FieldReader { get; }
+        /// <summary>
+        /// The Loan Milestone Free Roles Apis.
+        /// </summary>
+        ILoanMilestoneFreeRoles MilestoneFreeRoles { get; }
+        /// <summary>
+        /// The Loan Milestone Apis.
+        /// </summary>
+        ILoanMilestones Milestones { get; }
+
+        /// <summary>
+        /// Retrieves the loan lock information with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id of the lock to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ResourceLock> GetLockAsync(string lockId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of loan lock information from Encompass.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<ResourceLock>> GetLocksAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves metadata from the loan.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanMetadata> GetMetadataAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves metadata from the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetMetadataRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Locks the loan in Encompass and returns the lock id.
+        /// </summary>
+        /// <param name="lockType">Type of Lock.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> LockAsync(ResourceLockType lockType, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Locks the loan in Encompass and returns the lock id.
+        /// </summary>
+        /// <param name="lockType">Type of Lock.</param>
+        /// <param name="force">Forcefully locks a loan. This parameter allows an administrator to lock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> LockAsync(ResourceLockType lockType, bool force, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Locks the loan in Encompass and returns the lock id.
+        /// </summary>
+        /// <param name="lockType">Type of Lock.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> LockAsync(string lockType, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Locks the loan in Encompass and returns the lock id.
+        /// </summary>
+        /// <param name="lockType">Type of Lock.</param>
+        /// <param name="force">Forcefully locks a loan. This parameter allows an administrator to lock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> LockAsync(string lockType, bool force, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id to unlock.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> UnlockAsync(string lockId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id to unlock.</param>
+        /// <param name="force">Forcefully unlocks a loan. This parameter allows an administrator to unlock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Apis.
+    /// </summary>
+    public class LoanApis : LoanApiObject, ILoanApis
     {
         private LoanDocuments _documents;
         private LoanAttachments _attachments;
@@ -34,45 +149,63 @@ namespace EncompassRest.Loans
         /// </summary>
         public LoanDocuments Documents => _documents ?? (_documents = new LoanDocuments(Client, LoanId));
 
+        ILoanDocuments ILoanApis.Documents => Documents;
+
         /// <summary>
         /// The Loan Attachments Apis.
         /// </summary>
         public LoanAttachments Attachments => _attachments ?? (_attachments = new LoanAttachments(Client, LoanId));
+
+        ILoanAttachments ILoanApis.Attachments => Attachments;
 
         /// <summary>
         /// The Loan Custom Data Objects Apis.
         /// </summary>
         public LoanCustomDataObjects CustomDataObjects => _customDataObjects ?? (_customDataObjects = new LoanCustomDataObjects(Client, LoanId));
 
+        ILoanCustomDataObjects ILoanApis.CustomDataObjects => CustomDataObjects;
+
         /// <summary>
         /// The Loan Associates Apis.
         /// </summary>
         public LoanAssociates Associates => _associates ?? (_associates = new LoanAssociates(Client, LoanId));
+
+        ILoanAssociates ILoanApis.Associates => Associates;
 
         /// <summary>
         /// The Loan Milestone Apis.
         /// </summary>
         public LoanMilestones Milestones => _milestones ?? (_milestones = new LoanMilestones(Client, LoanId));
 
+        ILoanMilestones ILoanApis.Milestones => Milestones;
+
         /// <summary>
         /// The Loan Milestone Free Roles Apis.
         /// </summary>
         public LoanMilestoneFreeRoles MilestoneFreeRoles => _milestoneFreeRoles ?? (_milestoneFreeRoles = new LoanMilestoneFreeRoles(Client, LoanId));
+
+        ILoanMilestoneFreeRoles ILoanApis.MilestoneFreeRoles => MilestoneFreeRoles;
 
         /// <summary>
         /// The Loan Field Reader Apis.
         /// </summary>
         public LoanFieldReader FieldReader => _fieldReader ?? (_fieldReader = new LoanFieldReader(Client, LoanId));
 
+        ILoanFieldReader ILoanApis.FieldReader => FieldReader;
+
         /// <summary>
         /// The Loan Conditions Apis.
         /// </summary>
         public LoanConditions Conditions => _conditions ?? (_conditions = new LoanConditions(Client, LoanId));
 
+        ILoanConditions ILoanApis.Conditions => Conditions;
+
         /// <summary>
         /// The Loan Borrower Pairs Apis.
         /// </summary>
         public BorrowerPairs BorrowerPairs => _borrowerPairs ?? (_borrowerPairs = new BorrowerPairs(Client, this as LoanObjectBoundApis, LoanId));
+
+        IBorrowerPairs ILoanApis.BorrowerPairs => BorrowerPairs;
 
         internal LoanApis(EncompassRestClient client, string loanId)
             : base(client, loanId, null)

--- a/src/EncompassRest/Loans/LoanCustomDataObjects.cs
+++ b/src/EncompassRest/Loans/LoanCustomDataObjects.cs
@@ -5,7 +5,14 @@ namespace EncompassRest.Loans
     /// <summary>
     /// The Loan Custom Data Objects Apis.
     /// </summary>
-    public sealed class LoanCustomDataObjects : CustomDataObjects.CustomDataObjects
+    public interface ILoanCustomDataObjects : CustomDataObjects.ICustomDataObjects, ILoanApiObject
+    {
+    }
+
+    /// <summary>
+    /// The Loan Custom Data Objects Apis.
+    /// </summary>
+    public sealed class LoanCustomDataObjects : CustomDataObjects.CustomDataObjects, ILoanCustomDataObjects
     {
         /// <summary>
         /// The loan id associated with the Api.

--- a/src/EncompassRest/Loans/LoanCustomizations.cs
+++ b/src/EncompassRest/Loans/LoanCustomizations.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using EncompassRest.Loans.Attachments;

--- a/src/EncompassRest/Loans/LoanEntity.cs
+++ b/src/EncompassRest/Loans/LoanEntity.cs
@@ -858,9 +858,9 @@ namespace EncompassRest.Loans
         /// </summary>
         RateLockBuydown = 214,
         /// <summary>
-        /// TradeTargetLog
+        /// TargetTradeLog
         /// </summary>
-        TradeTargetLog = 215,
+        TargetTradeLog = 215,
         /// <summary>
         /// PriceAdjustmentLogRecord
         /// </summary>

--- a/src/EncompassRest/Loans/LoanFieldDescriptors.cs
+++ b/src/EncompassRest/Loans/LoanFieldDescriptors.cs
@@ -17,7 +17,35 @@ namespace EncompassRest.Loans
     /// <summary>
     /// LoanFieldDescriptors
     /// </summary>
-    public sealed class LoanFieldDescriptors : ApiObject
+    public interface ILoanFieldDescriptors : IApiObject
+    {
+        /// <summary>
+        /// Retrieves the field descriptor for the specified field id.
+        /// </summary>
+        /// <param name="fieldId">The field id of the field descriptor to get.</param>
+        /// <returns></returns>
+        FieldDescriptor this[string fieldId] { get; }
+
+        /// <summary>
+        /// The custom fields cache. To retrieve the Standard and Virtual fields use the static properties <see cref="LoanFieldDescriptors.StandardFields"/> and <see cref="LoanFieldDescriptors.VirtualFields"/> respectively.
+        /// </summary>
+        ReadOnlyDictionary<string, FieldDescriptor> CustomFields { get; }
+        /// <summary>
+        /// The utc date and time custom fields were last refreshed.
+        /// </summary>
+        DateTime? CustomFieldsLastRefreshedUtc { get; }
+        /// <summary>
+        /// Refreshes the custom fields cache.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task RefreshCustomFieldsAsync(CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// LoanFieldDescriptors
+    /// </summary>
+    public sealed class LoanFieldDescriptors : ApiObject, ILoanFieldDescriptors
     {
         private static readonly ModelPathContext s_modelPathContext = new ModelPathContext(new[]
         {
@@ -68,7 +96,7 @@ namespace EncompassRest.Loans
                             using (var jr = new JsonTextReader(sr))
                             {
                                 var loanFields = JsonHelper.DefaultPublicSerializer.Deserialize<List<StandardFieldInfo>>(jr);
-                                
+
                                 foreach (var loanField in loanFields)
                                 {
                                     var modelPathString = loanField.ModelPath;

--- a/src/EncompassRest/Loans/LoanFieldDescriptors.cs
+++ b/src/EncompassRest/Loans/LoanFieldDescriptors.cs
@@ -201,10 +201,11 @@ namespace EncompassRest.Loans
                 if (fields.TryGetValue(fieldId, out var fieldInfo))
                 {
                     fields.Remove(fieldId);
-                    if (!string.Equals(currentDescriptor.ModelPath, fieldInfo.ModelPath, StringComparison.OrdinalIgnoreCase) || (!string.IsNullOrEmpty(fieldInfo.Description) && currentDescriptor.Description != fieldInfo.Description) || currentDescriptor.ReadOnly != (fieldInfo.ReadOnly == true))
+                    if ((!string.IsNullOrEmpty(fieldInfo.Description) && currentDescriptor.Description != fieldInfo.Description) || currentDescriptor.ReadOnly != (fieldInfo.ReadOnly == true) || (!string.Equals(currentDescriptor.ModelPath, fieldInfo.ModelPath, StringComparison.OrdinalIgnoreCase) && !string.Equals(currentDescriptor.ModelPath, CreateModelPath(fieldInfo.ModelPath).ToString(), StringComparison.OrdinalIgnoreCase)))
                     {
-                        var modelPath = string.Equals(currentDescriptor.ModelPath, fieldInfo.ModelPath, StringComparison.OrdinalIgnoreCase) ? currentDescriptor.ModelPath : fieldInfo.ModelPath;
-                        var descriptor = new NonStandardFieldDescriptor(fieldInfo.FieldId, CreateModelPath(modelPath), modelPath, fieldInfo.Description, fieldInfo.Format, fieldInfo.Options, fieldInfo.ReadOnly == true);
+                        var modelPath = CreateModelPath(string.Equals(currentDescriptor.ModelPath, fieldInfo.ModelPath, StringComparison.OrdinalIgnoreCase) ? currentDescriptor.ModelPath : fieldInfo.ModelPath);
+                        var modelPathString = modelPath.ToString();
+                        var descriptor = new NonStandardFieldDescriptor(fieldInfo.FieldId, modelPath, modelPathString, fieldInfo.Description, fieldInfo.Format, fieldInfo.Options, fieldInfo.ReadOnly == true);
                         FieldMappings._standardFields[fieldId] = descriptor;
                     }
                 }
@@ -217,8 +218,9 @@ namespace EncompassRest.Loans
             foreach (var pair in fields)
             {
                 var fieldInfo = pair.Value;
-                var modelPath = fieldInfo.ModelPath;
-                var descriptor = new NonStandardFieldDescriptor(fieldInfo.FieldId, CreateModelPath(modelPath), modelPath, fieldInfo.Description, fieldInfo.Format, fieldInfo.Options, fieldInfo.ReadOnly == true);
+                var modelPath = CreateModelPath(fieldInfo.ModelPath);
+                var modelPathString = modelPath.ToString();
+                var descriptor = new NonStandardFieldDescriptor(fieldInfo.FieldId, modelPath, modelPathString, fieldInfo.Description, fieldInfo.Format, fieldInfo.Options, fieldInfo.ReadOnly == true);
                 FieldMappings.AddField(descriptor);
             }
 

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using EncompassRest.Utilities;
@@ -11,7 +10,139 @@ namespace EncompassRest.Loans
     /// <summary>
     /// The Loans Apis.
     /// </summary>
-    public sealed class Loans : ApiObject
+    public interface ILoans : IApiObject
+    {
+        /// <summary>
+        /// The loan field descriptors.
+        /// </summary>
+        ILoanFieldDescriptors FieldDescriptors { get; }
+
+        /// <summary>
+        /// Creates a new loan in Encompass and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="loan">The loan to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanAsync(Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass and returns the loan id of the loan created and optionally populates the loan object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="loan">The loan to create.</param>
+        /// <param name="populate">Indicates if the loan object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanAsync(Loan loan, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass with the optionally specified <paramref name="createLoanOptions"/> and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="loan">The loan to create.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanAsync(Loan loan, CreateLoanOptions createLoanOptions, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using raw json and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="loan">The loan to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanRawAsync(string loan, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Deletes a specified loan by moving it to the Recycle Bin or Trash folder.
+        /// </summary>
+        /// <param name="loanId">The unique identifier assigned to the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteLoanAsync(string loanId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the Loan Apis for the loan with the specified <paramref name="loanId"/>.
+        /// </summary>
+        /// <param name="loanId">The loan id.</param>
+        /// <returns></returns>
+        ILoanApis GetLoanApis(string loanId);
+        /// <summary>
+        /// Returns the entire loan.
+        /// </summary>
+        /// <param name="loanId">The unique identifier assigned to the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Loan> GetLoanAsync(string loanId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specific entities of a loan.
+        /// </summary>
+        /// <param name="loanId">The unique identifier assigned to the loan.</param>
+        /// <param name="entities">The list of loan entities to retrieve from the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Loan> GetLoanAsync(string loanId, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specific entities of a loan.
+        /// </summary>
+        /// <param name="loanId">The unique identifier assigned to the loan.</param>
+        /// <param name="entities">The list of loan entities to retrieve from the loan.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Loan> GetLoanAsync(string loanId, IEnumerable<string> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the entire loan or specific entities of a loan as raw json.
+        /// </summary>
+        /// <param name="loanId">The unique identifier assigned to the loan.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetLoanRawAsync(string loanId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the list of loan entities that can be retrieved from a loan.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<StringEnumValue<LoanEntity>>> GetSupportedEntitiesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the list of loan entities that can be retrieved from a loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetSupportedEntitiesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates an existing loan by modifying the values of the loan data elements passed.
+        /// </summary>
+        /// <param name="loan">The loan to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateLoanAsync(Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates an existing loan by modifying the values of the loan data elements passed and optionally populates the loan object with the response's body through the use of the entity view query parameter.
+        /// </summary>
+        /// <param name="loan">The loan to update.</param>
+        /// <param name="populate">Indicates if the loan object should be populated with the response's body through the use of the entity view query parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateLoanAsync(Loan loan, bool populate, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates an existing loan by modifying the values of the loan data elements passed with the optionally specified <paramref name="updateLoanOptions"/>.
+        /// </summary>
+        /// <param name="loan">The loan to update.</param>
+        /// <param name="updateLoanOptions">The loan update options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateLoanAsync(Loan loan, UpdateLoanOptions updateLoanOptions, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates an existing loan by modifying the values of the loan data elements passed or by applying a loan template using raw json.
+        /// </summary>
+        /// <param name="loanId">The loan id of the loan to update.</param>
+        /// <param name="loan">The loan to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateLoanRawAsync(string loanId, string loan, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loans Apis.
+    /// </summary>
+    public sealed class Loans : ApiObject, ILoans
     {
         private LoanFieldDescriptors _fieldDescriptors;
 
@@ -26,6 +157,8 @@ namespace EncompassRest.Loans
                 return fieldDescriptors ?? Interlocked.CompareExchange(ref _fieldDescriptors, (fieldDescriptors = new LoanFieldDescriptors(Client)), null) ?? fieldDescriptors;
             }
         }
+
+        ILoanFieldDescriptors ILoans.FieldDescriptors => FieldDescriptors;
 
         internal Loans(EncompassRestClient client)
             : base(client, "encompass/v1/loans")
@@ -43,6 +176,8 @@ namespace EncompassRest.Loans
 
             return new LoanApis(Client, loanId);
         }
+
+        ILoanApis ILoans.GetLoanApis(string loanId) => GetLoanApis(loanId);
 
         /// <summary>
         /// Returns the entire loan.

--- a/src/EncompassRest/Loans/Loans.cs
+++ b/src/EncompassRest/Loans/Loans.cs
@@ -45,6 +45,100 @@ namespace EncompassRest.Loans
         /// <returns></returns>
         Task<string> CreateLoanAsync(Loan loan, CreateLoanOptions createLoanOptions, CancellationToken cancellationToken = default);
         /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, Stream importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, Stream importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, string importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, string importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(string importFileType, Stream importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(string importFileType, Stream importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(string importFileType, string importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileAsync(string importFileType, string importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the response content or else the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileRawAsync(string importFileType, Stream importFile, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the response content or else the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateLoanFromImportFileRawAsync(string importFileType, string importFile, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
         /// Creates a new loan in Encompass using raw json and returns the loan id of the loan created.
         /// </summary>
         /// <param name="loan">The loan to create as raw json.</param>
@@ -361,6 +455,14 @@ namespace EncompassRest.Loans
             return DeleteAsync($"loans/{loanId}", null, cancellationToken);
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
         public Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, string importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default)
         {
             if (createLoanOptions?.Populate == true)
@@ -371,6 +473,15 @@ namespace EncompassRest.Loans
             return CreateLoanFromImportFileAsync(importFileType, importFile, createLoanOptions, out _, cancellationToken);
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
         public Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, string importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default)
         {
             importFileType.Validate(nameof(importFileType));
@@ -383,6 +494,14 @@ namespace EncompassRest.Loans
             return CreateLoanFromImportFileInternalAsync(content, loan, populate, createLoanOptions, cancellationToken);
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
         public Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, Stream importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default)
         {
             if (createLoanOptions?.Populate == true)
@@ -393,6 +512,15 @@ namespace EncompassRest.Loans
             return CreateLoanFromImportFileAsync(importFileType, importFile, createLoanOptions, out _, cancellationToken);
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
         public Task<string> CreateLoanFromImportFileAsync(ImportFileType importFileType, Stream importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default)
         {
             importFileType.Validate(nameof(importFileType));
@@ -405,6 +533,84 @@ namespace EncompassRest.Loans
             return CreateLoanFromImportFileInternalAsync(content, loan, populate, createLoanOptions, cancellationToken);
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> CreateLoanFromImportFileAsync(string importFileType, string importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default)
+        {
+            if (createLoanOptions?.Populate == true)
+            {
+                throw new InvalidOperationException("Use other CreateLoanFromImportFileAsync overload to populate a loan object.");
+            }
+
+            return CreateLoanFromImportFileAsync(importFileType, importFile, createLoanOptions, out _, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> CreateLoanFromImportFileAsync(string importFileType, string importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(importFileType, nameof(importFileType));
+            Preconditions.NotNullOrEmpty(importFile, nameof(importFile));
+
+            var populate = createLoanOptions?.Populate == true;
+            loan = populate ? new Loan(Client) : null;
+            var content = new StringContent(importFile);
+            content.Headers.ContentType = new MediaTypeHeaderValue(importFileType);
+            return CreateLoanFromImportFileInternalAsync(content, loan, populate, createLoanOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> CreateLoanFromImportFileAsync(string importFileType, Stream importFile, CreateLoanOptions createLoanOptions = null, CancellationToken cancellationToken = default)
+        {
+            if (createLoanOptions?.Populate == true)
+            {
+                throw new InvalidOperationException("Use other CreateLoanFromImportFileAsync overload to populate a loan object.");
+            }
+
+            return CreateLoanFromImportFileAsync(importFileType, importFile, createLoanOptions, out _, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="createLoanOptions">The loan creation options.</param>
+        /// <param name="loan">Returns a loan object if <paramref name="createLoanOptions"/>.Populate is <c>true</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task<string> CreateLoanFromImportFileAsync(string importFileType, Stream importFile, CreateLoanOptions createLoanOptions, out Loan loan, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(importFileType, nameof(importFileType));
+            Preconditions.NotNull(importFile, nameof(importFile));
+
+            var populate = createLoanOptions?.Populate == true;
+            loan = populate ? new Loan(Client) : null;
+            var content = new StreamContent(importFile);
+            content.Headers.ContentType = new MediaTypeHeaderValue(importFileType);
+            return CreateLoanFromImportFileInternalAsync(content, loan, populate, createLoanOptions, cancellationToken);
+        }
+
         private async Task<string> CreateLoanFromImportFileInternalAsync(HttpContent content, Loan loan, bool populate, CreateLoanOptions createLoanOptions, CancellationToken cancellationToken)
         {
             var loanId = await PostPopulateDirtyAsync("importers/loan", createLoanOptions?.ToQueryParameters().ToString(), content, nameof(CreateLoanFromImportFileAsync), loan, populate, cancellationToken).ConfigureAwait(false);
@@ -412,6 +618,14 @@ namespace EncompassRest.Loans
             return loanId;
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the response content or else the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
         public Task<string> CreateLoanFromImportFileRawAsync(string importFileType, string importFile, string queryString = null, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(importFileType, nameof(importFileType));
@@ -422,6 +636,14 @@ namespace EncompassRest.Loans
             return CreateLoanFromImportFileRawInternalAsync(queryString, content, cancellationToken);
         }
 
+        /// <summary>
+        /// Creates a new loan in Encompass using loan data imported from a Fannie Mae 3.x loan file and returns the response content or else the loan id of the loan created.
+        /// </summary>
+        /// <param name="importFileType">The format of the file being sent in the request body.</param>
+        /// <param name="importFile">The Fannie Mae loan file to import.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
         public Task<string> CreateLoanFromImportFileRawAsync(string importFileType, Stream importFile, string queryString = null, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(importFileType, nameof(importFileType));

--- a/src/EncompassRest/Loans/MilestoneFreeRoles/LoanMilestoneFreeRoles.cs
+++ b/src/EncompassRest/Loans/MilestoneFreeRoles/LoanMilestoneFreeRoles.cs
@@ -8,7 +8,58 @@ namespace EncompassRest.Loans.MilestoneFreeRoles
     /// <summary>
     /// The Loan Milestone Free Roles Apis.
     /// </summary>
-    public sealed class LoanMilestoneFreeRoles : LoanApiObject
+    public interface ILoanMilestoneFreeRoles : ILoanApiObject
+    {
+        /// <summary>
+        /// Retrieves the milestone-free log with the specified <paramref name="logId"/>.
+        /// </summary>
+        /// <param name="logId">The milestone-free log ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanMilestoneFreeRole> GetMilestoneFreeRoleAsync(string logId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the milestone-free log with the specified <paramref name="logId"/> as raw json.
+        /// </summary>
+        /// <param name="logId">The milestone-free log ID.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetMilestoneFreeRoleRawAsync(string logId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all milestone-free logs for the loan.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanMilestoneFreeRole>> GetMilestoneFreeRolesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all milestone-free logs for the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetMilestoneFreeRolesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified milestone-free role for the loan.
+        /// </summary>
+        /// <param name="milestoneFreeRole">The milestone-free role to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateMilestoneFreeRoleAsync(LoanMilestoneFreeRole milestoneFreeRole, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the milestone-free role with the specified <paramref name="logId"/> for the loan from raw json.
+        /// </summary>
+        /// <param name="logId">The milestone-free log ID.</param>
+        /// <param name="milestoneFreeRole">The milestone-free role to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateMilestoneFreeRoleRawAsync(string logId, string milestoneFreeRole, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Milestone Free Roles Apis.
+    /// </summary>
+    public sealed class LoanMilestoneFreeRoles : LoanApiObject, ILoanMilestoneFreeRoles
     {
         internal LoanMilestoneFreeRoles(EncompassRestClient client, string loanId)
             : base(client, loanId, "milestoneFreeRoles")

--- a/src/EncompassRest/Loans/Milestones/LoanMilestones.cs
+++ b/src/EncompassRest/Loans/Milestones/LoanMilestones.cs
@@ -9,7 +9,74 @@ namespace EncompassRest.Loans.Milestones
     /// <summary>
     /// The Loan Milestones Apis.
     /// </summary>
-    public sealed class LoanMilestones : LoanApiObject
+    public interface ILoanMilestones : ILoanApiObject
+    {
+        /// <summary>
+        /// Retrieves the milestone with the specified <paramref name="logId"/> for the loan.
+        /// </summary>
+        /// <param name="logId">The milestone log ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanMilestone> GetMilestoneAsync(string logId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves the milestone with the specified <paramref name="logId"/> for the loan as raw json.
+        /// </summary>
+        /// <param name="logId">The milestone log ID.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetMilestoneRawAsync(string logId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all milestones for the loan.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<LoanMilestone>> GetMilestonesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves all milestones for the loan as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetMilestonesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified <paramref name="milestone"/> for the loan.
+        /// </summary>
+        /// <param name="milestone">The milestone to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateMilestoneAsync(LoanMilestone milestone, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified <paramref name="milestone"/> for the loan.
+        /// </summary>
+        /// <param name="milestone">The milestone to update.</param>
+        /// <param name="action">Specify the action to perform on the milestone such as finish or unfinish.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateMilestoneAsync(LoanMilestone milestone, MilestoneAction action, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified <paramref name="milestone"/> for the loan.
+        /// </summary>
+        /// <param name="milestone">The milestone to update.</param>
+        /// <param name="action">Specify the action to perform on the milestone such as finish or unfinish.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateMilestoneAsync(LoanMilestone milestone, string action, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the milestone with the specified <paramref name="logId"/> for the loan from raw json.
+        /// </summary>
+        /// <param name="logId">The milestone log ID.</param>
+        /// <param name="milestone">The milestone to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateMilestoneRawAsync(string logId, string milestone, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Milestones Apis.
+    /// </summary>
+    public sealed class LoanMilestones : LoanApiObject, ILoanMilestones
     {
         internal LoanMilestones(EncompassRestClient client, string loanId)
             : base(client, loanId, "milestones")
@@ -72,7 +139,6 @@ namespace EncompassRest.Loans.Milestones
         /// <param name="milestone">The milestone to update.</param>
         /// <param name="action">Specify the action to perform on the milestone such as finish or unfinish.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
-        /// <returns></returns>
         /// <returns></returns>
         public Task UpdateMilestoneAsync(LoanMilestone milestone, MilestoneAction action, CancellationToken cancellationToken = default) => UpdateMilestoneAsync(milestone, action.Validate(nameof(action)).GetValue(), cancellationToken);
 

--- a/src/EncompassRest/Organizations/Organizations.cs
+++ b/src/EncompassRest/Organizations/Organizations.cs
@@ -9,7 +9,115 @@ namespace EncompassRest.Organizations
     /// <summary>
     /// Organizations Apis
     /// </summary>
-    public sealed class Organizations : ApiObject
+    public interface IOrganizations : IApiObject
+    {
+        /// <summary>
+        /// Gets a summary view of the organization with the specified <paramref name="orgId"/>.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Organization> GetOrganizationAsync(string orgId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the organization with the specified <paramref name="orgId"/> using the specified <paramref name="view"/>.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="view">The view of the organization to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Organization> GetOrganizationAsync(string orgId, OrganizationView view, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the organization with the specified <paramref name="orgId"/> using the specified <paramref name="view"/>.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="view">The view of the organization to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Organization> GetOrganizationAsync(string orgId, string view, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the children of the organization with the specified <paramref name="orgId"/>.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<OrganizationReference>> GetOrganizationChildrenAsync(string orgId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the children of the organization with the specified <paramref name="orgId"/> using the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="options">The organization children retrieval options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<OrganizationReference>> GetOrganizationChildrenAsync(string orgId, OrganizationChildrenRetrievalOptions options, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the children of the organization with the specified <paramref name="orgId"/> as raw json.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetOrganizationChildrenRawAsync(string orgId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the organization with the specified <paramref name="orgId"/> as raw json.
+        /// </summary>
+        /// <param name="orgId">The organization's id.</param>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetOrganizationRawAsync(string orgId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets a summary view of all organizations.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<Organization>> GetOrganizationsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets organizations using the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="options">The organizations retrieval options.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<Organization>> GetOrganizationsAsync(OrganizationsRetrievalOptions options, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets organizations as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetOrganizationsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets a summary view of the root organization.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Organization> GetRootOrganizationAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the root organization using the specified <paramref name="view"/>.
+        /// </summary>
+        /// <param name="view">The view of the organization to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Organization> GetRootOrganizationAsync(OrganizationView view, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the root organization using the specified <paramref name="view"/>.
+        /// </summary>
+        /// <param name="view">The view of the organization to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Organization> GetRootOrganizationAsync(string view, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the root organization as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to send in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetRootOrganizationRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Organizations Apis
+    /// </summary>
+    public sealed class Organizations : ApiObject, IOrganizations
     {
         internal Organizations(EncompassRestClient client)
             : base(client, "encompass/v1/organizations")

--- a/src/EncompassRest/Schema/Schema.cs
+++ b/src/EncompassRest/Schema/Schema.cs
@@ -11,7 +11,132 @@ namespace EncompassRest.Schema
     /// <summary>
     /// The Schema Apis.
     /// </summary>
-    public sealed class Schema : ApiObject
+    public interface ISchema : IApiObject
+    {
+        /// <summary>
+        /// Generates the loan contract from the specified <paramref name="fieldValues"/>.
+        /// </summary>
+        /// <param name="fieldValues">The field values to generate the loan contract.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Loan> GenerateContractAsync(IDictionary<string, object> fieldValues, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Generates the loan contract from the specified <paramref name="fieldValues"/>.
+        /// </summary>
+        /// <param name="fieldValues">The field values to generate the loan contract.</param>
+        /// <param name="ignoreInvalidFields">Indicates whether to ignore invalid loan fields if specified in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Loan> GenerateContractAsync(IDictionary<string, object> fieldValues, bool? ignoreInvalidFields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Generates the loan contract as raw json from the specified <paramref name="fieldValues"/>.
+        /// </summary>
+        /// <param name="fieldValues">The field values to generate the loan contract as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GenerateContractRawAsync(string fieldValues, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the paths to be used in webhook filter attributes for the specified <paramref name="fieldIds"/>.
+        /// </summary>
+        /// <param name="fieldIds">The field id's for the paths to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Dictionary<string, string>> GeneratePathsAsync(IEnumerable<string> fieldIds, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the paths to be used in webhook filter attributes for the specified <paramref name="fieldIds"/> and optionally ignores invalid fields.
+        /// </summary>
+        /// <param name="fieldIds">The field id's for the paths to get.</param>
+        /// <param name="ignoreInvalidFields">Indicates whether to ignore invalid loan fields if specified in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Dictionary<string, string>> GeneratePathsAsync(IEnumerable<string> fieldIds, bool? ignoreInvalidFields, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the paths to be used in webhook filter attributes that match the specified <paramref name="fieldNamePattern"/>.
+        /// </summary>
+        /// <param name="fieldNamePattern">Specifies the pattern of field name to search.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Dictionary<string, string>> GeneratePathsAsync(string fieldNamePattern, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the paths to be used in webhook filter attributes for the specified <paramref name="fieldIds"/> or field name pattern as raw json.
+        /// </summary>
+        /// <param name="fieldIds">The field id's for the paths to get as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GeneratePathsRawAsync(string fieldIds, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for the specified <paramref name="fieldId"/>.
+        /// </summary>
+        /// <param name="fieldId">The field id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetFieldSchemaAsync(string fieldId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for the specified <paramref name="fieldId"/> as raw json.
+        /// </summary>
+        /// <param name="fieldId">The field id.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetFieldSchemaRawAsync(string fieldId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for all entities.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetLoanSchemaAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for all entities and optionally includes field extensions.
+        /// </summary>
+        /// <param name="includeFieldExtensions">Include field extensions.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetLoanSchemaAsync(bool includeFieldExtensions, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for the specified <paramref name="entities"/> and optionally includes field extensions.
+        /// </summary>
+        /// <param name="includeFieldExtensions">Include field extensions.</param>
+        /// <param name="entities">Entities to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetLoanSchemaAsync(bool includeFieldExtensions, IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for the specified <paramref name="entities"/> and optionally includes field extensions.
+        /// </summary>
+        /// <param name="includeFieldExtensions">Include field extensions.</param>
+        /// <param name="entities">Entities to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetLoanSchemaAsync(bool includeFieldExtensions, IEnumerable<string> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for the specified <paramref name="entities"/>.
+        /// </summary>
+        /// <param name="entities">Entities to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetLoanSchemaAsync(IEnumerable<LoanEntity> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema for the specified <paramref name="entities"/>.
+        /// </summary>
+        /// <param name="entities">Entities to include.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<LoanSchema> GetLoanSchemaAsync(IEnumerable<string> entities, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the loan schema as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetLoanSchemaRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Schema Apis.
+    /// </summary>
+    public sealed class Schema : ApiObject, ISchema
     {
         internal Schema(EncompassRestClient client)
             : base(client, "encompass/v1/schema/loan")
@@ -185,7 +310,7 @@ namespace EncompassRest.Schema
             {
                 queryParameters.Add("ignoreInvalidFields", ignoreInvalidFields.ToString().ToLower());
             }
-            
+
             var loan = await PostAsync<Loan>("contractGenerator", queryParameters.ToString(), JsonStreamContent.Create(fieldValues), nameof(GenerateContractAsync), null, cancellationToken).ConfigureAwait(false);
             loan.Client = Client;
             return loan;

--- a/src/EncompassRest/Services/Services.cs
+++ b/src/EncompassRest/Services/Services.cs
@@ -7,7 +7,57 @@ namespace EncompassRest.Services
     /// <summary>
     /// The Services Apis.
     /// </summary>
-    public sealed class Services : ApiObject
+    public interface IServices : IApiObject
+    {
+        /// <summary>
+        /// Retrieves details on a service order transaction.
+        /// </summary>
+        /// <param name="partnerId">Ellie Mae's unique identifier for the Partner service provider.</param>
+        /// <param name="transactionId">The unique identifier of the transaction provided in the response header when the order was submitted.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ServiceTransaction> GetServiceOrderStatusAsync(string partnerId, string transactionId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves details on a service order transaction.
+        /// </summary>
+        /// <param name="partnerId">Ellie Mae's unique identifier for the Partner service provider.</param>
+        /// <param name="transactionId">The unique identifier of the transaction provided in the response header when the order was submitted.</param>
+        /// <param name="generateFileUrls">Generates temporary URL's for the resources returned by the service provider as part of their response.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<ServiceTransaction> GetServiceOrderStatusAsync(string partnerId, string transactionId, bool? generateFileUrls, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves details on a service order transaction as raw json.
+        /// </summary>
+        /// <param name="partnerId">Ellie Mae's unique identifier for the Partner service provider.</param>
+        /// <param name="transactionId">The unique identifier of the transaction provided in the response header when the order was submitted.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetServiceOrderStatusRawAsync(string partnerId, string transactionId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Submits an order for a service and creates a transaction object and returns the transaction id.
+        /// </summary>
+        /// <param name="partnerId">Ellie Mae's unique identifier for the Partner service provider.</param>
+        /// <param name="parameters">The parameters for ordering a service.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> OrderServiceAsync(string partnerId, OrderServiceParameters parameters, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Submits an order for a service from raw json and creates a transaction object and returns the response body if not empty else the transaction id.
+        /// </summary>
+        /// <param name="partnerId">Ellie Mae's unique identifier for the Partner service provider.</param>
+        /// <param name="parameters">The parameters for ordering a service as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> OrderServiceRawAsync(string partnerId, string parameters, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Services Apis.
+    /// </summary>
+    public sealed class Services : ApiObject, IServices
     {
         internal Services(EncompassRestClient client)
             : base(client, "services/v1/partners")

--- a/src/EncompassRest/Settings/Contacts/BorrowerContactsSettings.cs
+++ b/src/EncompassRest/Settings/Contacts/BorrowerContactsSettings.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Borrower Contacts Settings Apis.
     /// </summary>
-    public sealed class BorrowerContactsSettings : ContactsSettings
+    public interface IBorrowerContactsSettings : IContactsSettings
+    {
+    }
+
+    /// <summary>
+    /// The Borrower Contacts Settings Apis.
+    /// </summary>
+    public sealed class BorrowerContactsSettings : ContactsSettings, IBorrowerContactsSettings
     {
         internal BorrowerContactsSettings(EncompassRestClient client)
             : base(client, "encompass/v1/settings/borrowerContacts")

--- a/src/EncompassRest/Settings/Contacts/BusinessContactsSettings.cs
+++ b/src/EncompassRest/Settings/Contacts/BusinessContactsSettings.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Business Contacts Settings Apis.
     /// </summary>
-    public sealed class BusinessContactsSettings : ContactsSettings
+    public interface IBusinessContactsSettings : IContactsSettings
+    {
+    }
+
+    /// <summary>
+    /// The Business Contacts Settings Apis.
+    /// </summary>
+    public sealed class BusinessContactsSettings : ContactsSettings, IBusinessContactsSettings
     {
         internal BusinessContactsSettings(EncompassRestClient client)
             : base(client, "encompass/v1/settings/businessContacts")

--- a/src/EncompassRest/Settings/Contacts/ContactsSettings.cs
+++ b/src/EncompassRest/Settings/Contacts/ContactsSettings.cs
@@ -7,7 +7,27 @@ namespace EncompassRest.Settings.Contacts
     /// <summary>
     /// Base Contacts Settings Apis.
     /// </summary>
-    public abstract class ContactsSettings : ApiObject
+    public interface IContactsSettings : IApiObject
+    {
+        /// <summary>
+        /// Returns a list of canonical field names for contact fields.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<ContactFieldDefinition>> GetCanonicalNamesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of canonical field names for contact fields as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCanonicalNamesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Base Contacts Settings Apis.
+    /// </summary>
+    public abstract class ContactsSettings : ApiObject, IContactsSettings
     {
         internal ContactsSettings(EncompassRestClient client, string baseApiPath)
             : base(client, baseApiPath)

--- a/src/EncompassRest/Settings/Loan/CustomFieldDefinitions.cs
+++ b/src/EncompassRest/Settings/Loan/CustomFieldDefinitions.cs
@@ -8,7 +8,42 @@ namespace EncompassRest.Settings.Loan
     /// <summary>
     /// The Loan Custom Fields Apis.
     /// </summary>
-    public sealed class CustomFieldDefinitions : ApiObject
+    public interface ICustomFieldDefinitions : IApiObject
+    {
+        /// <summary>
+        /// Gets the custom field definition with the specified <paramref name="fieldId"/>.
+        /// </summary>
+        /// <param name="fieldId">The field id of the custom field definition to get.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<CustomFieldDefinition> GetCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets the custom field definition with the specified <paramref name="fieldId"/> as raw json.
+        /// </summary>
+        /// <param name="fieldId">The field id of the custom field definition to get.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCustomFieldRawAsync(string fieldId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets all custom field definitions.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<CustomFieldDefinition>> GetCustomFieldsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets all custom field definitions as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetCustomFieldsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Loan Custom Fields Apis.
+    /// </summary>
+    public sealed class CustomFieldDefinitions : ApiObject, ICustomFieldDefinitions
     {
         internal CustomFieldDefinitions(EncompassRestClient client)
             : base(client, "encompass/v1/settings/loan/customFields")

--- a/src/EncompassRest/Settings/Loan/LoanSettings.cs
+++ b/src/EncompassRest/Settings/Loan/LoanSettings.cs
@@ -5,7 +5,18 @@ namespace EncompassRest.Settings.Loan
     /// <summary>
     /// The Loan Settings Apis.
     /// </summary>
-    public sealed class LoanSettings : ApiObject
+    public interface ILoanSettings : IApiObject
+    {
+        /// <summary>
+        /// The Loan Custom Fields Apis.
+        /// </summary>
+        ICustomFieldDefinitions CustomFields { get; }
+    }
+
+    /// <summary>
+    /// The Loan Settings Apis.
+    /// </summary>
+    public sealed class LoanSettings : ApiObject, ILoanSettings
     {
         private CustomFieldDefinitions _customFields;
 
@@ -20,6 +31,8 @@ namespace EncompassRest.Settings.Loan
                 return customFields ?? Interlocked.CompareExchange(ref _customFields, (customFields = new CustomFieldDefinitions(Client)), null) ?? customFields;
             }
         }
+
+        ICustomFieldDefinitions ILoanSettings.CustomFields => CustomFields;
 
         internal LoanSettings(EncompassRestClient client)
             : base(client, "encompass/v1/settings/loan")

--- a/src/EncompassRest/Settings/Personas/Personas.cs
+++ b/src/EncompassRest/Settings/Personas/Personas.cs
@@ -9,7 +9,58 @@ namespace EncompassRest.Settings.Personas
     /// <summary>
     /// The Personas Apis.
     /// </summary>
-    public sealed class Personas : ApiObject
+    public interface IPersonas : IApiObject
+    {
+        /// <summary>
+        /// Returns details for a specified persona.
+        /// </summary>
+        /// <param name="id">Unique Identifier of the persona.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Persona> GetPersonaAsync(string id, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns details for a specified persona.
+        /// </summary>
+        /// <param name="id">Unique Identifier of the persona.</param>
+        /// <param name="categories">The Persona Categories.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Persona> GetPersonaAsync(string id, IEnumerable<PersonaCategory> categories, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns details for a specified persona.
+        /// </summary>
+        /// <param name="id">Unique Identifier of the persona.</param>
+        /// <param name="categories">The Persona Categories.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<Persona> GetPersonaAsync(string id, IEnumerable<string> categories, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns details for a specified persona as raw json.
+        /// </summary>
+        /// <param name="id">Unique Identifier of the persona.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetPersonaRawAsync(string id, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the list of all personas on the Encompass instance.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<Persona>> GetPersonasAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the list of all personas on the Encompass instance as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetPersonasRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Personas Apis.
+    /// </summary>
+    public sealed class Personas : ApiObject, IPersonas
     {
         internal Personas(EncompassRestClient client)
             : base(client, "encompass/v1/settings/personas")

--- a/src/EncompassRest/Settings/Settings.cs
+++ b/src/EncompassRest/Settings/Settings.cs
@@ -7,7 +7,34 @@ namespace EncompassRest.Settings
     /// <summary>
     /// The Settings Apis.
     /// </summary>
-    public sealed class Settings : ApiObject
+    public interface ISettings : IApiObject
+    {
+        /// <summary>
+        /// The Borrower Contacts Settings Apis.
+        /// </summary>
+        IBorrowerContactsSettings BorrowerContacts { get; }
+        /// <summary>
+        /// The Business Contacts Settings Apis.
+        /// </summary>
+        IBusinessContactsSettings BusinessContacts { get; }
+        /// <summary>
+        /// The Loan Settings Apis.
+        /// </summary>
+        ILoanSettings Loan { get; }
+        /// <summary>
+        /// The Personas Apis.
+        /// </summary>
+        Personas.IPersonas Personas { get; }
+        /// <summary>
+        /// The Templates Apis.
+        /// </summary>
+        Templates.ITemplates Templates { get; }
+    }
+
+    /// <summary>
+    /// The Settings Apis.
+    /// </summary>
+    public sealed class Settings : ApiObject, ISettings
     {
         private Templates.Templates _templates;
         private BorrowerContactsSettings _borrowerContacts;
@@ -27,6 +54,8 @@ namespace EncompassRest.Settings
             }
         }
 
+        Templates.ITemplates ISettings.Templates => Templates;
+
         /// <summary>
         /// The Borrower Contacts Settings Apis.
         /// </summary>
@@ -38,6 +67,8 @@ namespace EncompassRest.Settings
                 return borrowerContacts ?? Interlocked.CompareExchange(ref _borrowerContacts, (borrowerContacts = new BorrowerContactsSettings(Client)), null) ?? borrowerContacts;
             }
         }
+
+        IBorrowerContactsSettings ISettings.BorrowerContacts => BorrowerContacts;
 
         /// <summary>
         /// The Business Contacts Settings Apis.
@@ -51,6 +82,8 @@ namespace EncompassRest.Settings
             }
         }
 
+        IBusinessContactsSettings ISettings.BusinessContacts => BusinessContacts;
+
         /// <summary>
         /// The Loan Settings Apis.
         /// </summary>
@@ -63,6 +96,8 @@ namespace EncompassRest.Settings
             }
         }
 
+        ILoanSettings ISettings.Loan => Loan;
+
         /// <summary>
         /// The Personas Apis.
         /// </summary>
@@ -74,6 +109,8 @@ namespace EncompassRest.Settings
                 return personas ?? Interlocked.CompareExchange(ref _personas, (_personas = new Personas.Personas(Client)), null) ?? personas;
             }
         }
+
+        Personas.IPersonas ISettings.Personas => Personas;
 
         internal Settings(EncompassRestClient client)
             : base(client, "encompass/v1/settings")

--- a/src/EncompassRest/Settings/Templates/LoanTemplateSet.cs
+++ b/src/EncompassRest/Settings/Templates/LoanTemplateSet.cs
@@ -3,7 +3,14 @@
     /// <summary>
     /// The Loan Template Set Apis.
     /// </summary>
-    public sealed class LoanTemplateSet : TemplateApiObject
+    public interface ILoanTemplateSet : ITemplateApiObject
+    {
+    }
+
+    /// <summary>
+    /// The Loan Template Set Apis.
+    /// </summary>
+    public sealed class LoanTemplateSet : TemplateApiObject, ILoanTemplateSet
     {
         internal LoanTemplateSet(EncompassRestClient client)
             : base(client, "loanTemplateSet")

--- a/src/EncompassRest/Settings/Templates/TemplateApiObject.cs
+++ b/src/EncompassRest/Settings/Templates/TemplateApiObject.cs
@@ -6,9 +6,45 @@ using EncompassRest.Utilities;
 namespace EncompassRest.Settings.Templates
 {
     /// <summary>
+    /// The base interface for Template Apis.
+    /// </summary>
+    public interface ITemplateApiObject : IApiObject
+    {
+        /// <summary>
+        /// Retrieves a list of template files from the specified template path.
+        /// </summary>
+        /// <param name="path">Path to where the template files are located.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<EntityReference>> GetTemplateFilesAsync(string path, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of template files from the specified template path as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request. This should include a path parameter.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetTemplateFilesRawAsync(string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of template folders from the specified location.
+        /// </summary>
+        /// <param name="path">Location of the loan template folder. The default parent path starts with public or personal.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<EntityReference>> GetTemplateFoldersAsync(string path, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of template folders from the specified location as raw json.
+        /// </summary>
+        /// <param name="path">Location of the loan template folder. The default parent path starts with public or personal.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetTemplateFoldersRawAsync(string path, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
     /// The base class for Template Apis.
     /// </summary>
-    public abstract class TemplateApiObject : ApiObject
+    public abstract class TemplateApiObject : ApiObject, ITemplateApiObject
     {
         internal TemplateApiObject(EncompassRestClient client, string baseApiPath)
             : base(client, $"encompass/v1/settings/templates{baseApiPath?.PrecedeWith("/")}")

--- a/src/EncompassRest/Settings/Templates/Templates.cs
+++ b/src/EncompassRest/Settings/Templates/Templates.cs
@@ -5,7 +5,18 @@ namespace EncompassRest.Settings.Templates
     /// <summary>
     /// The Templates Apis.
     /// </summary>
-    public sealed class Templates : ApiObject
+    public interface ITemplates : IApiObject
+    {
+        /// <summary>
+        /// The Loan Template Set Apis.
+        /// </summary>
+        ILoanTemplateSet LoanTemplateSet { get; }
+    }
+
+    /// <summary>
+    /// The Templates Apis.
+    /// </summary>
+    public sealed class Templates : ApiObject, ITemplates
     {
         private LoanTemplateSet _loanTemplateSet;
 
@@ -20,6 +31,8 @@ namespace EncompassRest.Settings.Templates
                 return loanTemplateSet ?? Interlocked.CompareExchange(ref _loanTemplateSet, (loanTemplateSet = new LoanTemplateSet(Client)), null) ?? loanTemplateSet;
             }
         }
+
+        ILoanTemplateSet ITemplates.LoanTemplateSet => LoanTemplateSet;
 
         internal Templates(EncompassRestClient client)
             : base(client, "encompass/v1/settings/templates")

--- a/src/EncompassRest/Token/AccessToken.cs
+++ b/src/EncompassRest/Token/AccessToken.cs
@@ -15,13 +15,47 @@ namespace EncompassRest.Token
     /// <summary>
     /// The access token and related Apis.
     /// </summary>
-    public sealed class AccessToken : ApiObject
+    public interface IAccessToken : IApiObject
+    {
+        /// <summary>
+        /// The access token.
+        /// </summary>
+        string Token { get; }
+        /// <summary>
+        /// The access token type.
+        /// </summary>
+        string Type { get; }
+
+        /// <summary>
+        /// Checks the status of the access token and retrieves the associated metadata.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<TokenIntrospectionResponse> IntrospectAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Checks the status of the access token and retrieves the associated metadata as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> IntrospectRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Revokes the access token.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> RevokeAsync(CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The access token and related Apis.
+    /// </summary>
+    public sealed class AccessToken : ApiObject, IAccessToken
     {
         private HttpClient _tokenClient;
         private readonly string _apiClientId;
         private readonly string _apiClientSecret;
 
-        #region Properties
         /// <summary>
         /// The access token.
         /// </summary>
@@ -49,7 +83,6 @@ namespace EncompassRest.Token
                 return tokenClient;
             }
         }
-        #endregion
 
         internal AccessToken(string apiClientId, string apiClientSecret, EncompassRestClient client)
             : base(client, "oauth2/v1/token")
@@ -58,7 +91,6 @@ namespace EncompassRest.Token
             _apiClientSecret = apiClientSecret;
         }
 
-        #region Public Methods
         /// <summary>
         /// Checks the status of the access token and retrieves the associated metadata.
         /// </summary>
@@ -118,6 +150,5 @@ namespace EncompassRest.Token
         {
             public string AccessToken { get; set; }
         }
-        #endregion
     }
 }

--- a/src/EncompassRest/Webhook/Webhook.cs
+++ b/src/EncompassRest/Webhook/Webhook.cs
@@ -10,7 +10,153 @@ namespace EncompassRest.Webhook
     /// <summary>
     /// The Webhook Apis.
     /// </summary>
-    public sealed class Webhook : ApiObject
+    public interface IWebhook : IApiObject
+    {
+        /// <summary>
+        /// Creates a new subscription for specified Encompass instance and returns the created subscription's id.
+        /// </summary>
+        /// <param name="subscription">The webhook subscription to create.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateSubscriptionAsync(WebhookSubscription subscription, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Creates a new subscription for specified Encompass instance from raw json and returns the created subscription's id.
+        /// </summary>
+        /// <param name="subscription">The webhook subscription to create as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> CreateSubscriptionRawAsync(string subscription, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Deletes the specified subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> DeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified webhook resource and events that are available.
+        /// </summary>
+        /// <param name="resourceName">Name of the resource for which to return results.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<WebhookResource> GetResourceAsync(string resourceName, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified webhook resource and events that are available.
+        /// </summary>
+        /// <param name="resourceName">Name of the resource for which to return results.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<WebhookResource> GetResourceAsync(WebhookResourceType resourceName, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified webhook resource events that are available.
+        /// </summary>
+        /// <param name="resourceName">The resource name.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<WebhookResourceEventObject>> GetResourceEventsAsync(string resourceName, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified webhook resource events that are available.
+        /// </summary>
+        /// <param name="resourceName">The resource name.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<WebhookResourceEventObject>> GetResourceEventsAsync(WebhookResourceType resourceName, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified webhook resource events that are available as raw json.
+        /// </summary>
+        /// <param name="resourceName">The resource name.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetResourceEventsRawAsync(string resourceName, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified webhook resource and events that are available as raw json.
+        /// </summary>
+        /// <param name="resourceName">Name of the resource for which to return results.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetResourceRawAsync(string resourceName, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns all available webhook resources and events that are available for subscription.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<WebhookResource>> GetResourcesAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns all available webhook resources and events that are available for subscription as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetResourcesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<WebhookSubscription> GetSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns the specified subscription as raw json.
+        /// </summary>
+        /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetSubscriptionRawAsync(string subscriptionId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of subscriptions.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<WebhookSubscription>> GetSubscriptionsAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of subscriptions.
+        /// </summary>
+        /// <param name="resources">Resource names to include.</param>
+        /// <param name="events">Include subscriptions with these specified events.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<WebhookSubscription>> GetSubscriptionsAsync(IEnumerable<string> resources, IEnumerable<string> events, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of subscriptions.
+        /// </summary>
+        /// <param name="resources">Resource names to include.</param>
+        /// <param name="events">Include subscriptions with these specified events.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<List<WebhookSubscription>> GetSubscriptionsAsync(IEnumerable<WebhookResourceType> resources, IEnumerable<WebhookResourceEvent> events, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns a list of subscriptions as raw json.
+        /// </summary>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> GetSubscriptionsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified subscription.
+        /// </summary>
+        /// <param name="subscription">The webhook subscription to update.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UpdateSubscriptionAsync(WebhookSubscription subscription, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Updates the specified subscription from raw json.
+        /// </summary>
+        /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
+        /// <param name="subscription">The webhook subscription to update as raw json.</param>
+        /// <param name="queryString">The query string to include in the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<string> UpdateSubscriptionRawAsync(string subscriptionId, string subscription, string queryString = null, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// The Webhook Apis.
+    /// </summary>
+    public sealed class Webhook : ApiObject, IWebhook
     {
         internal Webhook(EncompassRestClient client)
             : base(client, "webhook/v1")


### PR DESCRIPTION
Added interfaces to ApiObjects throughout to support mocking.

Api's that are defined on entities are not supported such as Loan.LoanApis, Contact.Notes, and the LoanAttachment.Download* methods and if mocking those are required then use the alternatives ILoans.GetLoanApis(loanId), IContacts.GetContactNotes(contactId), and ILoanAttachments.Download* methods instead.

The methods being added in #282 will need to be supported later once this or the other PR is merged.

Closes #283