### PR TITLE
Added support for checking the api limits

### DIFF
--- a/src/EncompassRest/ApiResponseEventArgs.cs
+++ b/src/EncompassRest/ApiResponseEventArgs.cs
@@ -30,6 +30,31 @@ namespace EncompassRest
         /// </summary>
         public string CorrelationId => Response.Headers.TryGetValues("X-Correlation-ID", out var values) ? values.FirstOrDefault() : null;
 
+        /// <summary>
+        /// The concurrency limit as specified in the X-Concurrency-Limit-Limit header.
+        /// </summary>
+        public int? ConcurrencyLimit => Response.Headers.TryGetValues("X-Concurrency-Limit-Limit", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The concurrency limit remaining as specified in the X-Concurrency-Limit-Remaining header.
+        /// </summary>
+        public int? ConcurrencyLimitRemaining => Response.Headers.TryGetValues("X-Concurrency-Limit-Remaining", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The rate limit as specified in the X-Rate-Limit-Limit header.
+        /// </summary>
+        public int? RateLimit => Response.Headers.TryGetValues("X-Rate-Limit-Limit", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The rate limit remaining as specified in the X-Rate-Limit-Remaining header.
+        /// </summary>
+        public int? RateLimitRemaining => Response.Headers.TryGetValues("X-Rate-Limit-Remaining", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The rate limit reset date and time as specified in the X-Rate-Limit-Reset header.
+        /// </summary>
+        public DateTime? RateLimitReset => Response.Headers.TryGetValues("X-Rate-Limit-Reset", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(value) : default;
+
         internal ApiResponseEventArgs(HttpResponseMessage response)
         {
             Response = response;

--- a/src/EncompassRest/EncompassRestException.cs
+++ b/src/EncompassRest/EncompassRestException.cs
@@ -81,6 +81,31 @@ namespace EncompassRest
         /// </summary>
         public string CorrelationId => Response.Headers.TryGetValues("X-Correlation-ID", out var values) ? values.FirstOrDefault() : null;
 
+        /// <summary>
+        /// The concurrency limit as specified in the X-Concurrency-Limit-Limit header.
+        /// </summary>
+        public int? ConcurrencyLimit => Response.Headers.TryGetValues("X-Concurrency-Limit-Limit", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The concurrency limit remaining as specified in the X-Concurrency-Limit-Remaining header.
+        /// </summary>
+        public int? ConcurrencyLimitRemaining => Response.Headers.TryGetValues("X-Concurrency-Limit-Remaining", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The rate limit as specified in the X-Rate-Limit-Limit header.
+        /// </summary>
+        public int? RateLimit => Response.Headers.TryGetValues("X-Rate-Limit-Limit", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The rate limit remaining as specified in the X-Rate-Limit-Remaining header.
+        /// </summary>
+        public int? RateLimitRemaining => Response.Headers.TryGetValues("X-Rate-Limit-Remaining", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? value : default;
+
+        /// <summary>
+        /// The rate limit reset date and time as specified in the X-Rate-Limit-Reset header.
+        /// </summary>
+        public DateTime? RateLimitReset => Response.Headers.TryGetValues("X-Rate-Limit-Reset", out var values) && int.TryParse(values.FirstOrDefault() ?? string.Empty, out var value) ? new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(value) : default;
+
         private EncompassRestException(string message, HttpResponseMessage response, string responseContent, string requestContent)
             : base(BuildBaseMessage(message, response, responseContent))
         {


### PR DESCRIPTION
Added support for checking the api limits from the `ApiResponse` event or from an `EncompassRestException`.