### PR TITLE
Fix issue with authenticating with a % sign in the api client secret.

### DIFF
--- a/src/EncompassRest/Token/AccessToken.cs
+++ b/src/EncompassRest/Token/AccessToken.cs
@@ -76,7 +76,7 @@ namespace EncompassRest.Token
                     {
                         Timeout = Client.Timeout
                     };
-                    tokenClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_apiClientId}:{_apiClientSecret}")));
+                    tokenClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_apiClientId}:{_apiClientSecret.Replace("%", "%25")}")));
                     tokenClient = Interlocked.CompareExchange(ref _tokenClient, tokenClient, null) ?? tokenClient;
                 }
                 return tokenClient;


### PR DESCRIPTION
% sign is the url escape sequence and if it occurs in your api client secret it must be url encoded. Otherwise you get this error.

```js
{
    "error_description": "unable to parse Authorization header java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern",
    "error": "invalid_client"
}
```

Url encoding was removed in #288 due to other issues it was causing and so this will just fix this specific case.