### PR TITLE
Added support for assigning an attachment to a document upon upload

### DIFF
--- a/src/EncompassRest.Tests/LoanDocumentTests.cs
+++ b/src/EncompassRest.Tests/LoanDocumentTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using EncompassRest.Loans;
 using EncompassRest.Loans.Attachments;
 using EncompassRest.Loans.Documents;
-using EncompassRest.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EncompassRest.Tests
@@ -59,7 +58,10 @@ namespace EncompassRest.Tests
                 Assert.AreEqual("All", document.ApplicationId);
                 Assert.AreEqual(0, document.Attachments.Count);
 
-                var attachment = new LoanAttachment("Testing Attachment", "Text.txt", AttachmentCreateReason.Upload);
+                var attachment = new LoanAttachment("Testing Attachment", "Text.txt", AttachmentCreateReason.Upload)
+                {
+                    DocumentRefId = documentId
+                };
                 var text = "TESTING, TESTING, 1, 2, 3";
                 var attachmentId = await loan.LoanApis.Attachments.UploadAttachmentAsync(attachment, Encoding.UTF8.GetBytes(text), true);
                 Assert.IsFalse(string.IsNullOrEmpty(attachmentId));
@@ -72,15 +74,12 @@ namespace EncompassRest.Tests
                     Assert.AreEqual(text, sr.ReadToEnd());
                 }
 
-                var entityReference = new EntityReference(attachmentId, EntityType.Attachment);
-                await loan.LoanApis.Documents.AssignDocumentAttachmentsAsync(documentId, AssignmentAction.Add, new[] { entityReference });
-
                 document = await loan.LoanApis.Documents.GetDocumentAsync(documentId);
                 Assert.AreEqual("Updated Title", document.Title);
                 Assert.AreEqual("All", document.ApplicationId);
                 Assert.AreEqual(1, document.Attachments.Count);
                 Assert.AreEqual(attachmentId, document.Attachments[0].EntityId);
-                Assert.AreEqual(entityReference.EntityType.EnumValue, document.Attachments[0].EntityType.EnumValue);
+                Assert.AreEqual(EntityType.Attachment, document.Attachments[0].EntityType.EnumValue);
             }
             finally
             {

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -27,6 +27,7 @@ namespace EncompassRest.Loans.Attachments
         private DirtyValue<int?> _rotation;
         private DirtyValue<string> _title;
         private DirtyValue<string> _fileWithExtension;
+        private DirtyValue<string> _documentRefId;
         private DirtyValue<EntityReference> _document;
         private NeverSerializeValue<string> _mediaUrl;
 
@@ -91,6 +92,11 @@ namespace EncompassRest.Loans.Attachments
         /// The attachment's file name and extension.
         /// </summary>
         public string FileWithExtension { get => _fileWithExtension; set => SetField(ref _fileWithExtension, value); }
+
+        /// <summary>
+        /// Reference to the document object upon upload.
+        /// </summary>
+        public string DocumentRefId { get => _documentRefId; set => SetField(ref _documentRefId, value); }
 
         /// <summary>
         /// LoanAttachment Document


### PR DESCRIPTION
Added support for assigning an attachment to a document upon upload with the `DocumentRefId` property.

Closes #296 