### PR TITLE
Updated delete api's throughout to throw on unsuccessful status code

### DIFF
--- a/src/EncompassRest.Tests/BaseApiClientTests.cs
+++ b/src/EncompassRest.Tests/BaseApiClientTests.cs
@@ -38,7 +38,7 @@ namespace EncompassRest.Tests
             cdo2.DataObject = Encoding.UTF8.GetBytes(secondText);
             cdo2 = await baseApiClient.PatchAsync<CustomDataObject>($"https://api.elliemae.com/encompass/v1/company/customObjects/{cdo.Name}?view=entity", cdo2);
             Assert.AreEqual($"{firstText}{secondText}", Encoding.UTF8.GetString(cdo2.DataObject));
-            Assert.IsTrue(await baseApiClient.TryDeleteAsync($"https://api.elliemae.com/encompass/v1/company/customObjects/{cdo.Name}"));
+            await baseApiClient.DeleteAsync($"https://api.elliemae.com/encompass/v1/company/customObjects/{cdo.Name}");
         }
     }
 }

--- a/src/EncompassRest.Tests/BorrowerPairsTests.cs
+++ b/src/EncompassRest.Tests/BorrowerPairsTests.cs
@@ -66,7 +66,7 @@ namespace EncompassRest.Tests
                 Assert.AreEqual("Jane Doe", borrowerPairs[1].Coborrower.FullName);
 
                 oldCount = loan.Applications.Count;
-                Assert.IsTrue(await loan.LoanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
+                await loan.LoanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId);
                 Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(oldCount - 1, loan.Applications.Count);
                 Assert.IsNull(loan.Applications.FirstOrDefault(a => a.Id == applicationId));
@@ -120,7 +120,7 @@ namespace EncompassRest.Tests
                 await loanApis.BorrowerPairs.UpdateBorrowerPairAsync(newApplication);
                 Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(0, loan.Applications.Count);
-                Assert.IsTrue(await loanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId));
+                await loanApis.BorrowerPairs.DeleteBorrowerPairAsync(applicationId);
                 Assert.AreEqual($@"{{""encompassId"":""{loan.EncompassId}""}}", loan.ToString(SerializationOptions.Dirty));
                 Assert.AreEqual(0, loan.Applications.Count);
             }

--- a/src/EncompassRest.Tests/ContactNoteTests.cs
+++ b/src/EncompassRest.Tests/ContactNoteTests.cs
@@ -48,8 +48,8 @@ namespace EncompassRest.Tests
                 Assert.AreEqual(note.Subject, retrievedNote.Subject);
                 Assert.AreEqual(note.Details, retrievedNote.Details);
 
-                Assert.IsTrue(await businessContact.Notes.DeleteNoteAsync(noteId));
-                Assert.IsFalse(await businessContact.Notes.DeleteNoteAsync(noteId));
+                Assert.IsTrue(await businessContact.Notes.TryDeleteNoteAsync(noteId));
+                Assert.IsFalse(await businessContact.Notes.TryDeleteNoteAsync(noteId));
             }
             finally
             {

--- a/src/EncompassRest.Tests/CustomFieldDefinitionsTests.cs
+++ b/src/EncompassRest.Tests/CustomFieldDefinitionsTests.cs
@@ -36,7 +36,7 @@ namespace EncompassRest.Tests
         {
             var client = await GetTestClientAsync();
             const string fieldId = "CX.ABC";
-            await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId);
+            await client.Settings.Loan.CustomFields.TryDeleteCustomFieldAsync(fieldId);
             var description = "A, B, C";
             var format = LoanFieldFormat.DATE;
             var customField = new CustomFieldDefinition(fieldId, description, format);
@@ -52,7 +52,7 @@ namespace EncompassRest.Tests
             Assert.AreEqual(fieldId, customField.Id);
             Assert.AreEqual(description, customField.Description);
             Assert.AreEqual(format, customField.Format.EnumValue);
-            Assert.IsTrue(await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId));
+            await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace EncompassRest.Tests
         {
             var client = await GetTestClientAsync();
             const string fieldId = "CX.PETS";
-            await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId);
+            await client.Settings.Loan.CustomFields.TryDeleteCustomFieldAsync(fieldId);
             var description = "Borrower's own pets";
             var format = LoanFieldFormat.DROPDOWNLIST;
             var options = new[] { "Dog", "Cat", "Other", "Multiple" };
@@ -75,7 +75,7 @@ namespace EncompassRest.Tests
             Assert.AreEqual(description, customField.Description);
             Assert.AreEqual(format, customField.Format.EnumValue);
             CollectionAssert.AreEqual(options, customField.Options.ToList());
-            Assert.IsTrue(await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId));
+            await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace EncompassRest.Tests
         {
             var client = await GetTestClientAsync();
             const string fieldId = "CX.AUDIT364";
-            await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId);
+            await client.Settings.Loan.CustomFields.TryDeleteCustomFieldAsync(fieldId);
             var description = "AUDIT user id field for 364";
             var format = LoanFieldFormat.AUDIT;
             var audit = new FieldAudit("364", AuditData.UserID);
@@ -99,7 +99,7 @@ namespace EncompassRest.Tests
             Assert.AreEqual(format, customField.Format.EnumValue);
             Assert.AreEqual(audit.FieldId, customField.Audit.FieldId);
             Assert.AreEqual(audit.Data.EnumValue, customField.Audit.Data.EnumValue);
-            Assert.IsTrue(await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId));
+            await client.Settings.Loan.CustomFields.DeleteCustomFieldAsync(fieldId);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/EncompassRest.Tests/GlobalCustomDataObjectsTests.cs
+++ b/src/EncompassRest.Tests/GlobalCustomDataObjectsTests.cs
@@ -26,7 +26,7 @@ namespace EncompassRest.Tests
             cdo2.DataObject = Encoding.UTF8.GetBytes(secondText);
             await client.Company.GlobalCustomDataObjects.AppendToCustomDataObjectAsync(cdo2, true);
             Assert.AreEqual($"{firstText}{secondText}", Encoding.UTF8.GetString(cdo2.DataObject));
-            Assert.IsTrue(await client.Company.GlobalCustomDataObjects.DeleteCustomDataObjectAsync(cdo.Name));
+            await client.Company.GlobalCustomDataObjects.DeleteCustomDataObjectAsync(cdo.Name);
         }
     }
 }

--- a/src/EncompassRest.Tests/LoanTests.cs
+++ b/src/EncompassRest.Tests/LoanTests.cs
@@ -298,7 +298,7 @@ namespace EncompassRest.Tests
             Assert.IsNotNull(loanId);
             Assert.AreEqual(loanId, loan.EncompassId);
             await Task.Delay(5000);
-            Assert.IsTrue(await client.Loans.TryDeleteLoanAsync(loanId));
+            await client.Loans.DeleteLoanAsync(loanId);
         }
 
         [TestMethod]
@@ -310,7 +310,7 @@ namespace EncompassRest.Tests
             Assert.IsNotNull(loanId);
             Assert.IsFalse(loanId.StartsWith("{"));
             await Task.Delay(5000);
-            Assert.IsTrue(await client.Loans.TryDeleteLoanAsync(loanId));
+            await client.Loans.DeleteLoanAsync(loanId);
 
             var json = await client.Loans.CreateLoanRawAsync("{}", "?view=entity");
             Assert.IsNotNull(json);
@@ -318,7 +318,7 @@ namespace EncompassRest.Tests
             var loan = JToken.Parse(json);
             loanId = loan["encompassId"].ToString();
             await Task.Delay(5000);
-            Assert.IsTrue(await client.Loans.TryDeleteLoanAsync(loanId));
+            await client.Loans.DeleteLoanAsync(loanId);
         }
 
         [TestMethod]
@@ -442,7 +442,7 @@ namespace EncompassRest.Tests
                 var loanId = await client.Loans.CreateLoanAsync(loan, new CreateLoanOptions { LoanTemplate = @"Public:\\Companywide\Example Purchase Loan Template", Populate = true });
                 var metaData = await loan.LoanApis.GetMetadataAsync();
                 await Task.Delay(5000);
-                Assert.IsTrue(await client.Loans.TryDeleteLoanAsync(loanId));
+                await client.Loans.DeleteLoanAsync(loanId);
             }
         }
 
@@ -458,7 +458,7 @@ namespace EncompassRest.Tests
                 await client.Loans.UpdateLoanAsync(loan, new UpdateLoanOptions { LoanTemplate = @"Public:\\Companywide\Example Purchase Loan Template", Populate = true });
                 var metaData = await loan.LoanApis.GetMetadataAsync();
                 await Task.Delay(5000);
-                Assert.IsTrue(await client.Loans.TryDeleteLoanAsync(loanId));
+                await client.Loans.DeleteLoanAsync(loanId);
             }
         }
 

--- a/src/EncompassRest.Tests/ResourceLocksTest.cs
+++ b/src/EncompassRest.Tests/ResourceLocksTest.cs
@@ -33,7 +33,7 @@ namespace EncompassRest.Tests
                 Assert.IsNotNull(testLock);
                 Assert.IsTrue(locks.Count == 1);
 
-                Assert.IsTrue(await loan.LoanApis.UnlockAsync(lockId));
+                await loan.LoanApis.UnlockAsync(lockId);
 
                 Assert.IsTrue((await loan.LoanApis.GetLocksAsync()).Count == 0);
             }

--- a/src/EncompassRest.Tests/WebhookTests.cs
+++ b/src/EncompassRest.Tests/WebhookTests.cs
@@ -89,7 +89,7 @@ namespace EncompassRest.Tests
             }
             var subscriptionId = await client.Webhook.CreateSubscriptionRawAsync($@"{{""endpoint"":""{endpoint}""}}");
             Assert.IsFalse(string.IsNullOrEmpty(subscriptionId));
-            Assert.IsTrue(await client.Webhook.DeleteSubscriptionAsync(subscriptionId));
+            await client.Webhook.DeleteSubscriptionAsync(subscriptionId);
         }
 
         [TestMethod]

--- a/src/EncompassRest/Contacts/ContactGroups.cs
+++ b/src/EncompassRest/Contacts/ContactGroups.cs
@@ -67,7 +67,7 @@ namespace EncompassRest.Contacts
         /// <param name="groupId">The unique identifier of the contact group to delete.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default);
+        Task DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Retrieves information about the specified contact group.
         /// </summary>
@@ -123,6 +123,13 @@ namespace EncompassRest.Contacts
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         Task<string> GetGroupsRawAsync(string queryString, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently removes the specified contact group from the Encompass contacts database.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> TryDeleteGroupAsync(string groupId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Updates the details of the specified contact group.
         /// </summary>
@@ -396,11 +403,24 @@ namespace EncompassRest.Contacts
         /// <param name="groupId">The unique identifier of the contact group to delete.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteGroupAsync(string groupId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(groupId, nameof(groupId));
 
             return TryDeleteAsync(groupId, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Permanently removes the specified contact group from the Encompass contacts database.
+        /// </summary>
+        /// <param name="groupId">The unique identifier of the contact group to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(groupId, nameof(groupId));
+
+            return DeleteAsync(groupId, null, cancellationToken);
         }
     }
 }

--- a/src/EncompassRest/Contacts/ContactNotes.cs
+++ b/src/EncompassRest/Contacts/ContactNotes.cs
@@ -31,7 +31,7 @@ namespace EncompassRest.Contacts
         /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> DeleteNoteAsync(string noteId, CancellationToken cancellationToken = default);
+        Task DeleteNoteAsync(string noteId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Retrieves the specified note from the contact.
         /// </summary>
@@ -60,6 +60,13 @@ namespace EncompassRest.Contacts
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         Task<string> GetNotesRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently deletes the specified note from the contact.
+        /// </summary>
+        /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> TryDeleteNoteAsync(string noteId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Updates the specified note with the values provided.
         /// </summary>
@@ -201,11 +208,24 @@ namespace EncompassRest.Contacts
         /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> DeleteNoteAsync(string noteId, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteNoteAsync(string noteId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(noteId, nameof(noteId));
 
             return TryDeleteAsync(noteId, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Permanently deletes the specified note from the contact.
+        /// </summary>
+        /// <param name="noteId">Unique identifier of the note assigned to the note when it was created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task DeleteNoteAsync(string noteId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(noteId, nameof(noteId));
+
+            return DeleteAsync(noteId, null, cancellationToken);
         }
     }
 }

--- a/src/EncompassRest/Contacts/Contacts.cs
+++ b/src/EncompassRest/Contacts/Contacts.cs
@@ -161,7 +161,7 @@ namespace EncompassRest.Contacts
         /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> DeleteContactAsync(string contactId, CancellationToken cancellationToken = default);
+        Task DeleteContactAsync(string contactId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Gets the Contact Notes Apis for the contact with the specified <paramref name="contactId"/>.
         /// </summary>
@@ -176,6 +176,13 @@ namespace EncompassRest.Contacts
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         Task<string> GetContactRawAsync(string contactId, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently deletes the specified contact.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> TryDeleteContactAsync(string contactId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Updates contact information for the specified contact ID from raw json.
         /// </summary>
@@ -338,11 +345,24 @@ namespace EncompassRest.Contacts
         /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> DeleteContactAsync(string contactId, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteContactAsync(string contactId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(contactId, nameof(contactId));
 
             return TryDeleteAsync(contactId, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Permanently deletes the specified contact.
+        /// </summary>
+        /// <param name="contactId">The unique identifier that is returned in the response when the contact is created.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task DeleteContactAsync(string contactId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(contactId, nameof(contactId));
+
+            return DeleteAsync(contactId, null, cancellationToken);
         }
     }
 }

--- a/src/EncompassRest/CustomDataObjects/CustomDataObjects.cs
+++ b/src/EncompassRest/CustomDataObjects/CustomDataObjects.cs
@@ -56,7 +56,7 @@ namespace EncompassRest.CustomDataObjects
         /// <param name="objectName">Name of the custom data object to delete.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> DeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default);
+        Task DeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default);
         /// <summary>
         /// Retrieves the contents of a custom data object. Contents are retrieved as a Base64 string.
         /// </summary>
@@ -85,6 +85,13 @@ namespace EncompassRest.CustomDataObjects
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         Task<string> GetCustomDataObjectsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Removes a custom data object.
+        /// </summary>
+        /// <param name="objectName">Name of the custom data object to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> TryDeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -175,11 +182,24 @@ namespace EncompassRest.CustomDataObjects
         /// <param name="objectName">Name of the custom data object to delete.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> DeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(objectName, nameof(objectName));
 
             return TryDeleteAsync(objectName, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Removes a custom data object.
+        /// </summary>
+        /// <param name="objectName">Name of the custom data object to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task DeleteCustomDataObjectAsync(string objectName, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(objectName, nameof(objectName));
+
+            return DeleteAsync(objectName, null, cancellationToken);
         }
 
         /// <summary>

--- a/src/EncompassRest/Loans/Apis/BorrowerPairs.cs
+++ b/src/EncompassRest/Loans/Apis/BorrowerPairs.cs
@@ -33,7 +33,7 @@ namespace EncompassRest.Loans.Apis
         /// <param name="applicationId">The application id of the borrower pair to delete.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> DeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default);
+        Task DeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Retrieves the loan's borrower pair with the specified <paramref name="applicationId"/>.
         /// </summary>
@@ -77,6 +77,13 @@ namespace EncompassRest.Loans.Apis
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         Task MoveBorrowerPairsRawAsync(string applications, string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Permanently deletes the borrower pair with the specified <paramref name="applicationId"/> from the loan.
+        /// </summary>
+        /// <param name="applicationId">The application id of the borrower pair to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> TryDeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Updates an existing borrower pair for the loan.
         /// </summary>
@@ -217,7 +224,20 @@ namespace EncompassRest.Loans.Apis
         /// <param name="applicationId">The application id of the borrower pair to delete.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> DeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(applicationId, nameof(applicationId));
+
+            return TryDeleteAsync(applicationId, cancellationToken);
+        }
+
+        /// <summary>
+        /// Permanently deletes the borrower pair with the specified <paramref name="applicationId"/> from the loan.
+        /// </summary>
+        /// <param name="applicationId">The application id of the borrower pair to delete.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task DeleteBorrowerPairAsync(string applicationId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(applicationId, nameof(applicationId));
 

--- a/src/EncompassRest/Loans/Associates/LoanAssociates.cs
+++ b/src/EncompassRest/Loans/Associates/LoanAssociates.cs
@@ -70,7 +70,14 @@ namespace EncompassRest.Loans.Associates
         /// <param name="logId">The milestone or milestone-free log ID.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> UnassignAssociateAsync(string logId, CancellationToken cancellationToken = default);
+        Task<bool> TryUnassignAssociateAsync(string logId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Unassigns a loan associate from a milestone based on the specified milestone or milestone-free ID.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UnassignAssociateAsync(string logId, CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -187,11 +194,25 @@ namespace EncompassRest.Loans.Associates
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         [Obsolete("Undocumented API")]
-        public Task<bool> UnassignAssociateAsync(string logId, CancellationToken cancellationToken = default)
+        public Task<bool> TryUnassignAssociateAsync(string logId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(logId, nameof(logId));
 
             return TryDeleteAsync(logId, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Unassigns a loan associate from a milestone based on the specified milestone or milestone-free ID.
+        /// </summary>
+        /// <param name="logId">The milestone or milestone-free log ID.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        [Obsolete("Undocumented API")]
+        public Task UnassignAssociateAsync(string logId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(logId, nameof(logId));
+
+            return DeleteAsync(logId, null, cancellationToken);
         }
     }
 }

--- a/src/EncompassRest/Loans/LoanApiObject.cs
+++ b/src/EncompassRest/Loans/LoanApiObject.cs
@@ -134,19 +134,33 @@ namespace EncompassRest.Loans
             }
         }
 
-        internal async Task<bool> DeleteAsync(string id, CancellationToken cancellationToken)
+        internal async Task<bool> TryDeleteAsync(string id, CancellationToken cancellationToken)
         {
             var success = await TryDeleteAsync(id, null, cancellationToken).ConfigureAwait(false);
             if (success && LoanObjectBoundApis?.ReflectToLoanObject == true)
             {
-                var list = GetInLoan(LoanObjectBoundApis.Loan);
-                var index = list.IndexOf(id);
-                if (index >= 0)
-                {
-                    list.RemoveAt(index);
-                }
+                DeleteFromLoanObject(id);
             }
             return success;
+        }
+
+        internal async Task DeleteAsync(string id, CancellationToken cancellationToken)
+        {
+            await DeleteAsync(id, null, cancellationToken).ConfigureAwait(false);
+            if (LoanObjectBoundApis?.ReflectToLoanObject == true)
+            {
+                DeleteFromLoanObject(id);
+            }
+        }
+
+        private void DeleteFromLoanObject(string id)
+        {
+            var list = GetInLoan(LoanObjectBoundApis.Loan);
+            var index = list.IndexOf(id);
+            if (index >= 0)
+            {
+                list.RemoveAt(index);
+            }
         }
     }
 }

--- a/src/EncompassRest/Loans/LoanApis.cs
+++ b/src/EncompassRest/Loans/LoanApis.cs
@@ -118,7 +118,7 @@ namespace EncompassRest.Loans
         /// <param name="lockId">The lock id to unlock.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> UnlockAsync(string lockId, CancellationToken cancellationToken = default);
+        Task<bool> TryUnlockAsync(string lockId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
         /// </summary>
@@ -126,7 +126,22 @@ namespace EncompassRest.Loans
         /// <param name="force">Forcefully unlocks a loan. This parameter allows an administrator to unlock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default);
+        Task<bool> TryUnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id to unlock.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UnlockAsync(string lockId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id to unlock.</param>
+        /// <param name="force">Forcefully unlocks a loan. This parameter allows an administrator to unlock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -282,7 +297,7 @@ namespace EncompassRest.Loans
         /// <param name="lockId">The lock id to unlock.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> UnlockAsync(string lockId, CancellationToken cancellationToken = default) => UnlockAsync(lockId, false, cancellationToken);
+        public Task<bool> TryUnlockAsync(string lockId, CancellationToken cancellationToken = default) => TryUnlockAsync(lockId, false, cancellationToken);
 
         /// <summary>
         /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
@@ -291,6 +306,23 @@ namespace EncompassRest.Loans
         /// <param name="force">Forcefully unlocks a loan. This parameter allows an administrator to unlock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.UnlockResourceAsync(lockId, LoanId, EntityType.Loan.GetValue(), force, cancellationToken);
+        public Task<bool> TryUnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.TryUnlockResourceAsync(lockId, LoanId, EntityType.Loan.GetValue(), force, cancellationToken);
+
+        /// <summary>
+        /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id to unlock.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task UnlockAsync(string lockId, CancellationToken cancellationToken = default) => UnlockAsync(lockId, false, cancellationToken);
+
+        /// <summary>
+        /// Unlocks the loan in Encompass with the specified <paramref name="lockId"/>.
+        /// </summary>
+        /// <param name="lockId">The lock id to unlock.</param>
+        /// <param name="force">Forcefully unlocks a loan. This parameter allows an administrator to unlock a loan that holds an exclusive lock. When set to <c>true</c>, the exclusive lock is released from the loan. The user holding the exclusive lock is notified about the lock being released and that changes cannot be saved. The default value is <c>false</c>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task UnlockAsync(string lockId, bool force, CancellationToken cancellationToken = default) => Client.ResourceLocks.UnlockResourceAsync(lockId, LoanId, EntityType.Loan.GetValue(), force, cancellationToken);
     }
 }

--- a/src/EncompassRest/ResourceLocks/ResourceLocks.cs
+++ b/src/EncompassRest/ResourceLocks/ResourceLocks.cs
@@ -111,16 +111,16 @@ namespace EncompassRest.ResourceLocks
             return PostAsync(null, queryString, new JsonStringContent(resourceLock), nameof(LockResourceRawAsync), null, cancellationToken, ReadAsStringElseLocationFunc);
         }
 
-        public Task<bool> UnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) =>
-            UnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
+        public Task<bool> TryUnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) =>
+            TryUnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
 
-        public Task<bool> UnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, bool force, CancellationToken cancellationToken = default) =>
-            UnlockResourceAsync(lockId, resourceId, resourceType.Validate(nameof(resourceType)).GetName(), force, cancellationToken);
+        public Task<bool> TryUnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, bool force, CancellationToken cancellationToken = default) =>
+            TryUnlockResourceAsync(lockId, resourceId, resourceType.Validate(nameof(resourceType)).GetName(), force, cancellationToken);
 
-        public Task<bool> UnlockResourceAsync(string lockId, string resourceId, string resourceType, CancellationToken cancellationToken = default) =>
-            UnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
+        public Task<bool> TryUnlockResourceAsync(string lockId, string resourceId, string resourceType, CancellationToken cancellationToken = default) =>
+            TryUnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
 
-        public Task<bool> UnlockResourceAsync(string lockId, string resourceId, string resourceType, bool force, CancellationToken cancellationToken = default)
+        public Task<bool> TryUnlockResourceAsync(string lockId, string resourceId, string resourceType, bool force, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(lockId, nameof(lockId));
             Preconditions.NotNullOrEmpty(resourceId, nameof(resourceId));
@@ -137,9 +137,45 @@ namespace EncompassRest.ResourceLocks
             return TryDeleteAsync(lockId, queryParameters.ToString(), cancellationToken);
         }
 
-        public Task<bool> UnlockResourceAsync(ResourceLock resourceLock, CancellationToken cancellationToken = default) => UnlockResourceAsync(resourceLock, false, cancellationToken);
+        public Task<bool> TryUnlockResourceAsync(ResourceLock resourceLock, CancellationToken cancellationToken = default) => TryUnlockResourceAsync(resourceLock, false, cancellationToken);
 
-        public Task<bool> UnlockResourceAsync(ResourceLock resourceLock, bool force, CancellationToken cancellationToken = default)
+        public Task<bool> TryUnlockResourceAsync(ResourceLock resourceLock, bool force, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNull(resourceLock, nameof(resourceLock));
+            Preconditions.NotNull(resourceLock, $"{nameof(resourceLock)}.{nameof(resourceLock.Resource)}");
+
+            return TryUnlockResourceAsync(resourceLock.Id, resourceLock.Resource.EntityId, resourceLock.Resource.EntityType, force, cancellationToken);
+        }
+
+        public Task UnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, CancellationToken cancellationToken = default) =>
+            UnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
+
+        public Task UnlockResourceAsync(string lockId, string resourceId, EntityType resourceType, bool force, CancellationToken cancellationToken = default) =>
+            UnlockResourceAsync(lockId, resourceId, resourceType.Validate(nameof(resourceType)).GetName(), force, cancellationToken);
+
+        public Task UnlockResourceAsync(string lockId, string resourceId, string resourceType, CancellationToken cancellationToken = default) =>
+            UnlockResourceAsync(lockId, resourceId, resourceType, false, cancellationToken);
+
+        public Task UnlockResourceAsync(string lockId, string resourceId, string resourceType, bool force, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(lockId, nameof(lockId));
+            Preconditions.NotNullOrEmpty(resourceId, nameof(resourceId));
+            Preconditions.NotNullOrEmpty(resourceType, nameof(resourceType));
+
+            var queryParameters = new QueryParameters(
+                new QueryParameter("resourceType", resourceType),
+                new QueryParameter("resourceId", resourceId));
+            if (force)
+            {
+                queryParameters.Add("force", "true");
+            }
+
+            return DeleteAsync(lockId, queryParameters.ToString(), cancellationToken);
+        }
+
+        public Task UnlockResourceAsync(ResourceLock resourceLock, CancellationToken cancellationToken = default) => UnlockResourceAsync(resourceLock, false, cancellationToken);
+
+        public Task UnlockResourceAsync(ResourceLock resourceLock, bool force, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNull(resourceLock, nameof(resourceLock));
             Preconditions.NotNull(resourceLock, $"{nameof(resourceLock)}.{nameof(resourceLock.Resource)}");

--- a/src/EncompassRest/Settings/Loan/CustomFieldDefinitions.cs
+++ b/src/EncompassRest/Settings/Loan/CustomFieldDefinitions.cs
@@ -49,7 +49,9 @@ namespace EncompassRest.Settings.Loan
         [Obsolete("Undocumented API")]
         Task UpdateCustomFieldRawAsync(string fieldId, string customField, string queryString = null, CancellationToken cancellationToken = default);
         [Obsolete("Undocumented API")]
-        Task<bool> DeleteCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default);
+        Task DeleteCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default);
+        [Obsolete("Undocumented API")]
+        Task<bool> TryDeleteCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default);
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 
@@ -143,11 +145,19 @@ namespace EncompassRest.Settings.Loan
         }
 
         [Obsolete("Undocumented API")]
-        public Task<bool> DeleteCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(fieldId, nameof(fieldId));
 
             return TryDeleteAsync(fieldId, null, cancellationToken);
+        }
+
+        [Obsolete("Undocumented API")]
+        public Task DeleteCustomFieldAsync(string fieldId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(fieldId, nameof(fieldId));
+
+            return DeleteAsync(fieldId, null, cancellationToken);
         }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }

--- a/src/EncompassRest/Webhook/Webhook.cs
+++ b/src/EncompassRest/Webhook/Webhook.cs
@@ -33,7 +33,7 @@ namespace EncompassRest.Webhook
         /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        Task<bool> DeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default);
+        Task DeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Returns the specified webhook resource and events that are available.
         /// </summary>
@@ -135,6 +135,13 @@ namespace EncompassRest.Webhook
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
         Task<string> GetSubscriptionsRawAsync(string queryString = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Deletes the specified subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        Task<bool> TryDeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default);
         /// <summary>
         /// Updates the specified subscription.
         /// </summary>
@@ -389,11 +396,24 @@ namespace EncompassRest.Webhook
         /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns></returns>
-        public Task<bool> DeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default)
+        public Task<bool> TryDeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default)
         {
             Preconditions.NotNullOrEmpty(subscriptionId, nameof(subscriptionId));
 
             return TryDeleteAsync($"subscriptions/{subscriptionId}", null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Deletes the specified subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Unique identifier assigned to the subscription.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns></returns>
+        public Task DeleteSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default)
+        {
+            Preconditions.NotNullOrEmpty(subscriptionId, nameof(subscriptionId));
+
+            return DeleteAsync($"subscriptions/{subscriptionId}", null, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Updated delete api's throughout to throw on unsuccessful status code and added trydelete api equivalents to the existing.

Closes #298 