### PR TITLE
Attachment initialize bug

### DIFF
--- a/src/EncompassRest.Tests/LoanAttachmentTests.cs
+++ b/src/EncompassRest.Tests/LoanAttachmentTests.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Threading.Tasks;
 using EncompassRest.Loans;
 using EncompassRest.Loans.Attachments;
-using EncompassRest.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EncompassRest.Tests

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -16,8 +16,6 @@ namespace EncompassRest.Loans.Attachments
     /// </summary>
     public sealed class LoanAttachment : DirtyExtensibleObject, IIdentifiable
     {
-        private ILoanAttachments? _attachments;
-
         private NeverSerializeValue<string?>? _attachmentId;
         private DirtyValue<DateTime?>? _dateCreated;
         private DirtyValue<string?>? _createdBy;
@@ -120,7 +118,7 @@ namespace EncompassRest.Loans.Attachments
         /// The <see cref="ILoanAttachments"/> associated with this object.
         /// </summary>
         [JsonIgnore]
-        public ILoanAttachments Attachments => _attachments ?? throw new InvalidOperationException("LoanAttachment object must be initialized to use Attachments");
+        public ILoanAttachments? Attachments { get; private set; }
 
         /// <summary>
         /// Loan attachment creation constructor.
@@ -167,10 +165,7 @@ namespace EncompassRest.Loans.Attachments
         {
             Preconditions.NotNull(attachments, nameof(attachments));
 
-            if (!ReferenceEquals(Attachments, attachments))
-            {
-                _attachments = attachments;
-            }
+            Attachments = attachments;
         }
 
         /// <summary>
@@ -185,10 +180,10 @@ namespace EncompassRest.Loans.Attachments
             var mediaUrl = MediaUrl;
             if (string.IsNullOrEmpty(mediaUrl))
             {
-                mediaUrl = (await Attachments.GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
+                mediaUrl = (await GetAttachments().GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
                 MediaUrl = mediaUrl;
             }
-            return await Attachments.DownloadAttachmentFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
+            return await GetAttachments().DownloadAttachmentFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,10 +198,12 @@ namespace EncompassRest.Loans.Attachments
             var mediaUrl = MediaUrl;
             if (string.IsNullOrEmpty(mediaUrl))
             {
-                mediaUrl = (await Attachments.GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
+                mediaUrl = (await GetAttachments().GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
                 MediaUrl = mediaUrl;
             }
-            return await Attachments.DownloadAttachmentStreamFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
+            return await GetAttachments().DownloadAttachmentStreamFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
         }
+
+        private ILoanAttachments GetAttachments() => Attachments ?? throw new InvalidOperationException("LoanAttachment object must be initialized to use Attachments");
     }
 }

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -177,13 +177,14 @@ namespace EncompassRest.Loans.Attachments
         {
             Preconditions.NotNullOrEmpty(AttachmentId, nameof(AttachmentId));
 
+            var attachments = GetAttachments();
             var mediaUrl = MediaUrl;
             if (string.IsNullOrEmpty(mediaUrl))
             {
-                mediaUrl = (await GetAttachments().GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
+                mediaUrl = (await attachments.GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
                 MediaUrl = mediaUrl;
             }
-            return await GetAttachments().DownloadAttachmentFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
+            return await attachments.DownloadAttachmentFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -195,13 +196,14 @@ namespace EncompassRest.Loans.Attachments
         {
             Preconditions.NotNullOrEmpty(AttachmentId, nameof(AttachmentId));
 
+            var attachments = GetAttachments();
             var mediaUrl = MediaUrl;
             if (string.IsNullOrEmpty(mediaUrl))
             {
-                mediaUrl = (await GetAttachments().GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
+                mediaUrl = (await attachments.GetDownloadAttachmentUrlAsync(AttachmentId, cancellationToken).ConfigureAwait(false)).MediaUrl;
                 MediaUrl = mediaUrl;
             }
-            return await GetAttachments().DownloadAttachmentStreamFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
+            return await attachments.DownloadAttachmentStreamFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
         }
 
         private ILoanAttachments GetAttachments() => Attachments ?? throw new InvalidOperationException("LoanAttachment object must be initialized to use Attachments");

--- a/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
+++ b/src/EncompassRest/Loans/Attachments/LoanAttachment.cs
@@ -206,6 +206,6 @@ namespace EncompassRest.Loans.Attachments
             return await attachments.DownloadAttachmentStreamFromMediaUrlAsync(mediaUrl!, cancellationToken).ConfigureAwait(false);
         }
 
-        private ILoanAttachments GetAttachments() => Attachments ?? throw new InvalidOperationException("LoanAttachment object must be initialized to use Attachments");
+        private ILoanAttachments GetAttachments() => Attachments ?? throw new InvalidOperationException("LoanAttachment object must be initialized to download the attachment contents");
     }
 }


### PR DESCRIPTION
Fix attachment initialize bug. Unit tests were already failing so no need to add more. This bug was introduced since our last NuGet package release so it's not a big deal.