### PR TITLE
A BaseAddress URL can be set for API calls

### DIFF
--- a/src/EncompassRest/ApiObject.cs
+++ b/src/EncompassRest/ApiObject.cs
@@ -166,7 +166,7 @@ namespace EncompassRest
 
         internal virtual HttpClient GetHttpClient() => Client.HttpClient;
 
-        internal virtual string? BaseAddress => "https://api.elliemae.com/";
+        internal virtual string? BaseAddress => Client.BaseAddress;
 
         private string GetFullUri(string? requestUri) => $"{BaseAddress}{_baseApiPath}{((BaseAddress?.Length ?? _baseApiPath?.Length ?? 0) == 0 ? requestUri : requestUri?.PrecedeWith("/"))}";
 

--- a/src/EncompassRest/ClientParameters.cs
+++ b/src/EncompassRest/ClientParameters.cs
@@ -71,6 +71,11 @@ namespace EncompassRest
         public UndefinedCustomFieldHandling UndefinedCustomFieldHandling { get; set; }
 
         /// <summary>
+        /// The URL to call for API calls.Defaults to "https://api.elliemae.com/".
+        /// </summary>
+        public string BaseAddress { get; set; } = "https://api.elliemae.com/";
+
+        /// <summary>
         /// The client parameters constructor.
         /// </summary>
         /// <param name="apiClientId">The Api Client Id.</param>

--- a/src/EncompassRest/ClientParameters.cs
+++ b/src/EncompassRest/ClientParameters.cs
@@ -71,9 +71,9 @@ namespace EncompassRest
         public UndefinedCustomFieldHandling UndefinedCustomFieldHandling { get; set; }
 
         /// <summary>
-        /// The URL to call for API calls.Defaults to "https://api.elliemae.com/".
+        /// The URL to call for API calls. Defaults to "https://api.elliemae.com/".
         /// </summary>
-        public string BaseAddress { get; set; } = "https://api.elliemae.com/";
+        public string? BaseAddress { get; set; }
 
         /// <summary>
         /// The client parameters constructor.

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -98,9 +98,9 @@ namespace EncompassRest
         CommonCache CommonCache { get; }
 
         /// <summary>
-        /// Set by ClientParameters.BaseAddress.  The URL to call for API calls.  Defaults to "https://api.elliemae.com/".
+        /// Set by ClientParameters.BaseAddress. The URL to call for API calls. Defaults to "https://api.elliemae.com/".
         /// </summary>
-        string BaseAddress { get; }
+        string? BaseAddress { get; set; }
 
         /// <summary>
         /// An event that occurs when an Api response is received.
@@ -531,7 +531,10 @@ namespace EncompassRest
 
         IBaseApiClient IEncompassRestClient.BaseApiClient => BaseApiClient;
 
-        public string BaseAddress { get; }
+        /// <summary>
+        /// Set by ClientParameters.BaseAddress. The URL to call for API calls. Defaults to "https://api.elliemae.com/".
+        /// </summary>
+        public string? BaseAddress { get; set; }
         #endregion
 
         /// <summary>
@@ -548,7 +551,7 @@ namespace EncompassRest
             ApiResponse = parameters.ApiResponse;
             CommonCache = parameters.CommonCache ?? (parameters.CommonCache = new CommonCache());
             UndefinedCustomFieldHandling = parameters.UndefinedCustomFieldHandling;
-            BaseAddress = parameters.BaseAddress;
+            BaseAddress = (parameters.BaseAddress?.Length ?? 0) == 0 ? "https://api.elliemae.com/" : parameters.BaseAddress;
         }
 
 #if IASYNC_DISPOSABLE

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -100,7 +100,7 @@ namespace EncompassRest
         /// <summary>
         /// Set by ClientParameters.BaseAddress. The URL to call for API calls. Defaults to "https://api.elliemae.com/".
         /// </summary>
-        string? BaseAddress { get; set; }
+        string BaseAddress { get; set; }
 
         /// <summary>
         /// An event that occurs when an Api response is received.
@@ -534,7 +534,7 @@ namespace EncompassRest
         /// <summary>
         /// Set by ClientParameters.BaseAddress. The URL to call for API calls. Defaults to "https://api.elliemae.com/".
         /// </summary>
-        public string? BaseAddress { get; set; }
+        public string BaseAddress { get; set; }
         #endregion
 
         /// <summary>
@@ -551,7 +551,7 @@ namespace EncompassRest
             ApiResponse = parameters.ApiResponse;
             CommonCache = parameters.CommonCache ?? (parameters.CommonCache = new CommonCache());
             UndefinedCustomFieldHandling = parameters.UndefinedCustomFieldHandling;
-            BaseAddress = (parameters.BaseAddress?.Length ?? 0) == 0 ? "https://api.elliemae.com/" : parameters.BaseAddress;
+            BaseAddress = (parameters.BaseAddress?.Length ?? 0) == 0 ? "https://api.elliemae.com/" : parameters.BaseAddress!;
         }
 
 #if IASYNC_DISPOSABLE

--- a/src/EncompassRest/EncompassRestClient.cs
+++ b/src/EncompassRest/EncompassRestClient.cs
@@ -98,6 +98,11 @@ namespace EncompassRest
         CommonCache CommonCache { get; }
 
         /// <summary>
+        /// Set by ClientParameters.BaseAddress.  The URL to call for API calls.  Defaults to "https://api.elliemae.com/".
+        /// </summary>
+        string BaseAddress { get; }
+
+        /// <summary>
         /// An event that occurs when an Api response is received.
         /// </summary>
         event EventHandler<ApiResponseEventArgs> ApiResponse;
@@ -525,6 +530,8 @@ namespace EncompassRest
         }
 
         IBaseApiClient IEncompassRestClient.BaseApiClient => BaseApiClient;
+
+        public string BaseAddress { get; }
         #endregion
 
         /// <summary>
@@ -541,6 +548,7 @@ namespace EncompassRest
             ApiResponse = parameters.ApiResponse;
             CommonCache = parameters.CommonCache ?? (parameters.CommonCache = new CommonCache());
             UndefinedCustomFieldHandling = parameters.UndefinedCustomFieldHandling;
+            BaseAddress = parameters.BaseAddress;
         }
 
 #if IASYNC_DISPOSABLE


### PR DESCRIPTION
ClientParameters now has a BaseAddress property that is used to set the BaseAddress value on the EncompassRestClient.  The ApiObject then uses the BaseAddress property to set its URL for API callouts.  The default value is "https://api.elliemae.com/".