### PR TITLE
Loans.V3 - Employment.cs - MonthlyIncomeAmount

### DIFF
--- a/src/EncompassRest.Loans.v3/Loans/v3/Employment.cs
+++ b/src/EncompassRest.Loans.v3/Loans/v3/Employment.cs
@@ -222,7 +222,7 @@ public sealed partial class Employment : DirtyExtensibleObject, IIdentifiable
     /// <summary>
     /// Employment MonthlyIncomeAmount
     /// </summary>
-    public int? MonthlyIncomeAmount { get => GetValue<int?>(); set => SetValue(value); }
+    public decimal? MonthlyIncomeAmount { get => GetValue<decimal?>(); set => SetValue(value); }
 
     /// <summary>
     /// Employment NoLinkToDocTrackIndicator [BE0097], [CE0097]


### PR DESCRIPTION
MonthlyIncomeAmount was coming in as a float and property was set to int and that was causing it to throw an error, changing property to decimal.