### PR TITLE
add includeArchivedLoans parameter

### DIFF
--- a/src/EncompassRest/Cursor.cs
+++ b/src/EncompassRest/Cursor.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EncompassRest.Utilities;
+using Newtonsoft.Json;
 
 namespace EncompassRest
 {
@@ -129,13 +130,20 @@ namespace EncompassRest
         /// <inheritdoc/>
         public IEnumerable<string> Fields { get; }
 
-        internal Cursor(ApiObject apiObject, EncompassRestClient client, string? cursorId, int count, IEnumerable<string>? fields)
+        /// <summary>
+        /// Include Archived Loans
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IncludeArchivedLoans { get; }
+        
+        internal Cursor(ApiObject apiObject, EncompassRestClient client, string? cursorId, int count, IEnumerable<string>? fields, bool? includeArchivedLoans = null)
         {
             _apiObject = apiObject;
             Client = client;
             CursorId = cursorId;
             Count = count;
             Fields = fields ?? Array<string>.Empty;
+            IncludeArchivedLoans = includeArchivedLoans;
         }
 
         /// <inheritdoc/>
@@ -177,7 +185,7 @@ namespace EncompassRest
             {
                 queryParameters.Add("limit", limit.ToString());
             }
-            var content = JsonStreamContent.Create(new { Fields = fields ?? Fields });
+            var content = JsonStreamContent.Create(new { Fields = fields ?? Fields, IncludeArchivedLoans });
 
             return _apiObject.PostAsync<List<TItem>>(null, queryParameters.ToString(), content, nameof(GetItemsAsync), null, cancellationToken);
         }
@@ -205,7 +213,7 @@ namespace EncompassRest
             {
                 queryParameters.Add("limit", limit.ToString());
             }
-            var content = JsonStreamContent.Create(new { Fields = fields ?? Fields });
+            var content = JsonStreamContent.Create(new { Fields = fields ?? Fields, IncludeArchivedLoans });
 
             return _apiObject.PostRawAsync(null, queryParameters.ToString(), content, nameof(GetItemsRawAsync), null, cancellationToken);
         }

--- a/src/EncompassRest/LoanPipeline/LoanPipelineCursor.cs
+++ b/src/EncompassRest/LoanPipeline/LoanPipelineCursor.cs
@@ -14,8 +14,9 @@ namespace EncompassRest.LoanPipeline
     /// </summary>
     public sealed class LoanPipelineCursor : Cursor<LoanPipelineData>, ILoanPipelineCursor
     {
-        internal LoanPipelineCursor(EncompassRestClient client, string? cursorId, int count, IEnumerable<string>? fields)
-            : base(client.Pipeline, client, cursorId, count, fields)
+        internal LoanPipelineCursor(EncompassRestClient client, string? cursorId, int count,
+            IEnumerable<string>? fields, bool? includeArchivedLoans)
+            : base(client.Pipeline, client, cursorId, count, fields, includeArchivedLoans: includeArchivedLoans)
         {
         }
     }

--- a/src/EncompassRest/LoanPipeline/Pipeline.cs
+++ b/src/EncompassRest/LoanPipeline/Pipeline.cs
@@ -148,7 +148,7 @@ namespace EncompassRest.LoanPipeline
                     }
                     cursorId = cursorIds.First();
                 }
-                return new LoanPipelineCursor(Client, cursorId, count, parameters.Fields);
+                return new LoanPipelineCursor(Client, cursorId, count, parameters.Fields, parameters.IncludeArchivedLoans);
             });
         }
 

--- a/src/EncompassRest/LoanPipeline/PipelineParameters.cs
+++ b/src/EncompassRest/LoanPipeline/PipelineParameters.cs
@@ -36,7 +36,11 @@ namespace EncompassRest.LoanPipeline
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<FieldSort>? SortOrder { get; }
 
-        public bool IncludeArchivedLoans { get; }
+        /// <summary>
+        /// Include Archived Loans
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IncludeArchivedLoans { get; }
 
         /// <summary>
         /// Pipeline parameters constructor.
@@ -45,7 +49,7 @@ namespace EncompassRest.LoanPipeline
         /// <param name="fields">Canonical field names to include.</param>
         /// <param name="sortOrder">Specifies how the results should be ordered.</param>
         /// <param name="includeArchivedLoans"></param>
-        public PipelineParameters(Filter filter, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null, bool includeArchivedLoans = false)
+        public PipelineParameters(Filter filter, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null, bool? includeArchivedLoans = null)
         {
             Preconditions.NotNull(filter, nameof(filter));
 
@@ -62,7 +66,7 @@ namespace EncompassRest.LoanPipeline
         /// <param name="fields">Canonical field names to include.</param>
         /// <param name="sortOrder">Specifies how the results should be ordered.</param>
         /// <param name="includeArchivedLoans"></param>
-        public PipelineParameters(IEnumerable<string> loanGuids, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null, bool includeArchivedLoans = false)
+        public PipelineParameters(IEnumerable<string> loanGuids, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null, bool? includeArchivedLoans = null)
         {
             Preconditions.NotNullOrEmpty(loanGuids, nameof(loanGuids));
 

--- a/src/EncompassRest/LoanPipeline/PipelineParameters.cs
+++ b/src/EncompassRest/LoanPipeline/PipelineParameters.cs
@@ -36,19 +36,23 @@ namespace EncompassRest.LoanPipeline
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<FieldSort>? SortOrder { get; }
 
+        public bool IncludeArchivedLoans { get; }
+
         /// <summary>
         /// Pipeline parameters constructor.
         /// </summary>
         /// <param name="filter">Pipeline filter.</param>
         /// <param name="fields">Canonical field names to include.</param>
         /// <param name="sortOrder">Specifies how the results should be ordered.</param>
-        public PipelineParameters(Filter filter, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null)
+        /// <param name="includeArchivedLoans"></param>
+        public PipelineParameters(Filter filter, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null, bool includeArchivedLoans = false)
         {
             Preconditions.NotNull(filter, nameof(filter));
 
             Filter = filter;
             Fields = fields != null ? new ReadOnlyCollection<string>(fields.ToList()) : null;
             SortOrder = sortOrder != null ? new ReadOnlyCollection<FieldSort>(sortOrder.ToList()) : null;
+            IncludeArchivedLoans = includeArchivedLoans;
         }
 
         /// <summary>
@@ -57,13 +61,15 @@ namespace EncompassRest.LoanPipeline
         /// <param name="loanGuids">Guids of loans to include.</param>
         /// <param name="fields">Canonical field names to include.</param>
         /// <param name="sortOrder">Specifies how the results should be ordered.</param>
-        public PipelineParameters(IEnumerable<string> loanGuids, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null)
+        /// <param name="includeArchivedLoans"></param>
+        public PipelineParameters(IEnumerable<string> loanGuids, IEnumerable<string>? fields = null, IEnumerable<FieldSort>? sortOrder = null, bool includeArchivedLoans = false)
         {
             Preconditions.NotNullOrEmpty(loanGuids, nameof(loanGuids));
 
             LoanGuids = new ReadOnlyCollection<string>(loanGuids.ToList());
             Fields = fields != null ? new ReadOnlyCollection<string>(fields.ToList()) : null;
             SortOrder = sortOrder != null ? new ReadOnlyCollection<FieldSort>(sortOrder.ToList()) : null;
+            IncludeArchivedLoans = includeArchivedLoans;
         }
     }
 }


### PR DESCRIPTION
There was a breaking change introduced to the Encompass Api, where archived loans are not returned unless specified in the request. This adds the option to opt in to include archived loans, as was the old behavior.